### PR TITLE
Add 'test-run-start' event to the BrowserJob (fixes #186)

### DIFF
--- a/src/runner/browser-job.js
+++ b/src/runner/browser-job.js
@@ -87,6 +87,7 @@ export default class BrowserJob extends EventEmitter {
                                  () => this._testRunDoneInQuarantineMode(testRun) :
                                  () => this._testRunDone(testRun);
 
+        testRun.once('start', () => this.emit('test-run-start', testRun));
         testRun.once('done', done);
 
         return testRun;


### PR DESCRIPTION
\cc @AlexanderMoskovkin @churkin 

Unfortunately there is no way to test it :cry:  Because currently reporting testing involves having mocking and functional test are not ready yet. 