### PR TITLE
"Wait for element" progress bar is not shown (#161) afterfix

### DIFF
--- a/src/client/runner/runner-base.js
+++ b/src/client/runner/runner-base.js
@@ -277,6 +277,9 @@ RunnerBase.prototype._initIFrameBehavior = function () {
                 break;
 
             case RunnerBase.IFRAME_BEFORE_UNLOAD_REQUEST_CMD:
+                runner.actionTargetWaitingStarted = false;
+                runner._onActionRun();
+
                 runner._onBeforeUnload(true, function (res) {
                     msg = {
                         cmd: RunnerBase.IFRAME_BEFORE_UNLOAD_RESPONSE_CMD,
@@ -354,8 +357,9 @@ RunnerBase.prototype.on = function (event, handler) {
 };
 
 function pingIframe (iframe, callback) {
-    messageSandbox.pingIframe(iframe, CROSS_DOMAIN_MESSAGES.IFRAME_TEST_RUNNER_PING_DISPATCHER_CMD).
-        then(callback);
+    messageSandbox
+        .pingIframe(iframe, CROSS_DOMAIN_MESSAGES.IFRAME_TEST_RUNNER_PING_DISPATCHER_CMD)
+        .then(callback);
 }
 
 RunnerBase.prototype._runInIFrame = function (iframe, stepName, step, stepNum) {


### PR DESCRIPTION
This is an afterfix for the #161 issue. Here is fixed the following scenario:
```
- start a step in an iframe
- start waiting for the element for the action (progress panel is shown)
- iframe reloading (it's maybe document.location changing on timeout) -- here we should close the panel
- start the next step 
```
We have the functional test for this

/cc @inikulin @helen-dikareva 