### PR TITLE
Make word wrapping optional in `formatError` (fixes #228). Bump version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe",
-  "version": "0.0.7-alpha",
+  "version": "0.0.9-alpha",
   "main": "lib/index",
   "bin": {
     "testcafe": "./bin/testcafe"
@@ -26,6 +26,7 @@
     "noop-fn": "^1.0.0",
     "os-family": "^1.0.0",
     "parse5": "^1.5.0",
+    "pify": "^2.3.0",
     "pinkie": "^2.0.1",
     "promisify-event": "^1.0.0",
     "qrcode-terminal": "^0.10.0",
@@ -62,7 +63,6 @@
     "gulp-uglify": "^1.5.1",
     "gulp-util": "^3.0.7",
     "gulp-webmake": "0.0.4",
-    "pify": "^2.3.0",
     "publish-please": "^1.0.1",
     "request": "^2.58.0",
     "tmp": "0.0.28"

--- a/src/reporter/plugin-host.js
+++ b/src/reporter/plugin-host.js
@@ -74,7 +74,8 @@ export default class ReporterPluginHost {
         var maxMsgLength = this[viewportWidth] - this[indent] - prefix.length;
         var msg          = format(err, this[errorDecorator], maxMsgLength);
 
-        msg = wordWrap(msg, prefix.length, maxMsgLength);
+        if (this[wordWrapEnabled])
+            msg = wordWrap(msg, prefix.length, maxMsgLength);
 
         return prefix + msg.substr(prefix.length);
     }

--- a/test/server/error-formatter-test.js
+++ b/test/server/error-formatter-test.js
@@ -81,7 +81,9 @@ function assertErrorMessage (file, err) {
     var outStreamMock = createOutStreamMock();
     var plugin        = new ReporterPluginHost(reporterPluginMock, outStreamMock);
 
-    plugin.write(plugin.formatError(err));
+    plugin
+        .useWordWrap(true)
+        .write(plugin.formatError(err));
 
     var expectedMsg = read('./data/expected-test-errors/' + file)
         .replace(/(\r\n)/gm, '\n')


### PR DESCRIPTION
\сс @kirovboris @AlexanderMoskovkin 