### PR TITLE
Binding to document.ready event implemented without jQuery (partial of #56)

### DIFF
--- a/src/client/core/utils/event.js
+++ b/src/client/core/utils/event.js
@@ -2,6 +2,7 @@ import hammerhead from '../deps/hammerhead';
 import * as domUtils from './dom';
 
 
+var Promise       = hammerhead.Promise;
 var nativeMethods = hammerhead.nativeMethods;
 
 export const RECORDING_LISTENED_EVENTS = [
@@ -16,7 +17,7 @@ export const BUTTONS_PARAMETER = hammerhead.utils.event.BUTTONS_PARAMETER;
 export const DOM_EVENTS        = hammerhead.utils.event.DOM_EVENTS;
 export const WHICH_PARAMETER   = hammerhead.utils.event.WHICH_PARAMETER;
 
-export var preventDefault  = hammerhead.utils.event.preventDefault;
+export var preventDefault = hammerhead.utils.event.preventDefault;
 
 export function bind (el, event, handler, useCapture) {
     if (domUtils.isWindowInstance(el))
@@ -30,4 +31,39 @@ export function unbind (el, event, handler, useCapture) {
         nativeMethods.windowRemoveEventListener.call(el, event, handler, useCapture);
     else
         nativeMethods.removeEventListener.call(el, event, handler, useCapture);
+}
+
+
+export function documentReady () {
+    return new Promise(resolve => {
+        var isReady = false;
+
+        function ready () {
+            if (isReady)
+                return;
+
+            if (!document.body) {
+                window.setTimeout(ready, 1);
+                return;
+            }
+
+            isReady = true;
+
+            window.removeEventListener('load', ready);
+
+            resolve();
+        }
+
+        function onContentLoaded () {
+            document.removeEventListener('DOMContentLoaded', onContentLoaded);
+            ready();
+        }
+
+
+        if (document.readyState === 'complete')
+            return window.setTimeout(ready, 1);
+
+        document.addEventListener('DOMContentLoaded', onContentLoaded);
+        window.addEventListener('load', ready);
+    });
 }

--- a/src/client/runner/api/actions.js
+++ b/src/client/runner/api/actions.js
@@ -229,7 +229,7 @@ export function parseActionArgument (item, actionName) {
     else if (actionName && actionName === 'select' && domUtils.isTextNode(item))
         return [item];
     else if (typeof item === 'string')
-        return $(item).get();
+        return arrayUtils.toArray($(item));
     else if (isJQueryObj(item)) {
         item.each(function () {
             elements.push(this);

--- a/src/client/runner/iframe-dispatcher.js
+++ b/src/client/runner/iframe-dispatcher.js
@@ -9,10 +9,10 @@ import RunnerBase from './runner-base';
 import IFrameRunner from './iframe-runner';
 
 var messageSandbox        = hammerhead.eventSandbox.message;
-var $                     = testCafeCore.$;
 var CROSS_DOMAIN_MESSAGES = testCafeCore.CROSS_DOMAIN_MESSAGES;
 var serviceUtils          = testCafeCore.serviceUtils;
 var domUtils              = testCafeCore.domUtils;
+var eventUtils            = testCafeCore.eventUtils;
 var cursor                = testCafeUI.cursor;
 
 
@@ -111,12 +111,14 @@ function waitPageLoad (callback) {
             }
         };
 
-    $(window).load(callbackWrapper);
-    $(document).ready(function () {
-        //NOTE: an iFrame may be removed in this moment
-        if (domUtils.isIFrameWindowInDOM(window))
-            window.setTimeout(callbackWrapper, PAGE_LOAD_TIMEOUT);
-    });
+    eventUtils.bind(window, 'load', callbackWrapper);
+    eventUtils
+        .documentReady()
+        .then(() => {
+            //NOTE: an iFrame may be removed in this moment
+            if (domUtils.isIFrameWindowInDOM(window))
+                window.setTimeout(callbackWrapper, PAGE_LOAD_TIMEOUT);
+        });
 }
 
 

--- a/src/client/runner/runner-base.js
+++ b/src/client/runner/runner-base.js
@@ -13,7 +13,6 @@ import * as actionBarrier from './action-barrier/action-barrier';
 var messageSandbox = hammerhead.eventSandbox.message;
 
 var SETTINGS                 = testCafeCore.SETTINGS;
-var $                        = testCafeCore.$;
 var COMMAND                  = testCafeCore.COMMAND;
 var ERROR_TYPE               = testCafeCore.ERROR_TYPE;
 var CROSS_DOMAIN_MESSAGES    = testCafeCore.CROSS_DOMAIN_MESSAGES;
@@ -21,6 +20,7 @@ var jQuerySelectorExtensions = testCafeCore.jQuerySelectorExtensions;
 var transport                = testCafeCore.transport;
 var serviceUtils             = testCafeCore.serviceUtils;
 var domUtils                 = testCafeCore.domUtils;
+var eventUtils               = testCafeCore.eventUtils;
 
 var cursor          = testCafeUI.cursor;
 var modalBackground = testCafeUI.modalBackground;
@@ -42,12 +42,14 @@ function waitPageLoad (callback) {
             }
         };
 
-    $(window).load(callbackWrapper);
-    $(document).ready(function () {
-        //NOTE: an iFrame may be removed in this moment
-        if (domUtils.isIFrameWindowInDOM(window) || domUtils.isTopWindow(window))
-            window.setTimeout(callbackWrapper, PAGE_LOAD_TIMEOUT);
-    });
+    eventUtils.bind(window, 'load', callbackWrapper);
+    eventUtils
+        .documentReady()
+        .then(() => {
+            //NOTE: an iFrame may be removed in this moment
+            if (domUtils.isIFrameWindowInDOM(window) || domUtils.isTopWindow(window))
+                window.setTimeout(callbackWrapper, PAGE_LOAD_TIMEOUT);
+        });
 }
 
 //Init

--- a/src/client/ui/modal-background.js
+++ b/src/client/ui/modal-background.js
@@ -3,7 +3,6 @@ import testCafeCore from './deps/testcafe-core';
 
 var shadowUI = hammerhead.shadowUI;
 
-var $          = testCafeCore.$;
 var eventUtils = testCafeCore.eventUtils;
 var styleUtils = testCafeCore.styleUtils;
 
@@ -118,10 +117,12 @@ export function initAndShowLoadingText () {
     tryShowBeforeReady();
 
     //NOTE: ensure that background was shown on ready
-    $(document).ready(function () {
-        if (!shown)
-            initAndShow();
-    });
+    eventUtils
+        .documentReady()
+        .then(() => {
+            if (!shown)
+                initAndShow();
+        });
 }
 
 export function show (transparent) {

--- a/src/client/ui/progress-panel/index.js
+++ b/src/client/ui/progress-panel/index.js
@@ -6,7 +6,6 @@ var shadowUI = hammerhead.shadowUI;
 
 var eventUtils = testCafeCore.eventUtils;
 var styleUtils = testCafeCore.styleUtils;
-var $          = testCafeCore.$;
 
 
 const PANEL_CLASS   = 'progress-panel';


### PR DESCRIPTION
This PR'll close item "Get rid of jquery binding for 'ready' and 'load' events" from https://github.com/DevExpress/testcafe/issues/56 checklist
Wait for all qunit tests