### PR TITLE
Switch 'test-client-travis' gulp task to 'stable' nodejs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     env: GULP_TASK="test-server"
   - node_js: "stable"
     env: GULP_TASK="test-server"
-  - node_js: "0.10"
+  - node_js: "stable"
     env: GULP_TASK="test-client-travis"
  fast_finish: true
 


### PR DESCRIPTION
/cc @georgiy-abbasov It's necessary right now to stable qunit tests in opened pull requests