### PR TITLE
Redesign error decorator, so it fits needs of both API versions (#374 part5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "main": "lib/index",
   "bin": {
     "testcafe": "./bin/testcafe"
@@ -12,13 +12,14 @@
     "babel-preset-es2015-node4": "^2.0.2",
     "babel-preset-stage-2": "^6.3.13",
     "babel-runtime": "^6.3.19",
-    "callsite-record": "^1.0.2",
+    "callsite-record": "^2.0.0",
     "chalk": "^1.1.0",
     "commander": "^2.8.1",
     "dedent": "^0.4.0",
     "elegant-spinner": "^1.0.1",
     "endpoint-utils": "^1.0.0",
     "globby": "^3.0.1",
+    "highlight-es": "^1.0.0",
     "indent-string": "^1.2.2",
     "is-glob": "^2.0.1",
     "lodash": "^4.5.1",
@@ -106,6 +107,7 @@
       "elegant-spinner",
       "endpoint-utils",
       "globby",
+      "highlight-es",
       "indent-string",
       "is-glob",
       "lodash",

--- a/src/legacy/test-run-error/formattable-adapter.js
+++ b/src/legacy/test-run-error/formattable-adapter.js
@@ -1,10 +1,31 @@
+import { escape as escapeHtml } from 'lodash';
+import highlight from 'highlight-es';
 import TestRunErrorFormattableAdapter from '../../errors/test-run/formattable-adapter';
 import TEMPLATES from './templates';
 
+const NEWLINE = /\r\n|[\n\r\u2028\u2029]/;
+
+var renderer = ['string', 'punctuator', 'keyword', 'number', 'regex', 'comment', 'invalid'].reduce((syntaxRenderer, tokenType) => {
+    syntaxRenderer[tokenType] = str => `<span class="syntax-${tokenType}">${escapeHtml(str)}</span>`;
+
+    return syntaxRenderer;
+}, {});
+
 export default class LegacyTestRunErrorFormattableAdapter extends TestRunErrorFormattableAdapter {
-    constructor (err, userAgent) {
-        super(err, userAgent);
+    constructor (err, userAgent, screenshotPath, callsite) {
+        super(err, userAgent, screenshotPath, callsite);
 
         this.TEMPLATES = TEMPLATES;
+    }
+
+    getCallsiteMarkup () {
+        var code     = highlight(this.callsite, renderer);
+        var lines    = code.split(NEWLINE);
+        var lastLine = lines.pop();
+
+        lastLine = `<div class="code-line-last">${lastLine}</div>`;
+        lines    = lines.map(line => `<div class="code-line"><div class="code-line-src">${line}</div></div>`);
+
+        return `<div class="code-frame">${lines.join('')}${lastLine}</div>`;
     }
 }

--- a/src/legacy/test-run-error/templates.js
+++ b/src/legacy/test-run-error/templates.js
@@ -8,19 +8,10 @@ function escapeNewLines (str) {
     return escapeHtml(str).replace(/(\r\n|\n|\r)/gm, '\\n');
 }
 
-function getStepCode (str) {
-    var lines = escapeHtml(str).split(/\r?\n/g);
-    var last  = lines.pop();
-
-    return lines
-        .reduceRight((prev, line) => `<span data-type="code-line">${line}</span>${prev}`,
-        `<span data-type="last-code-line">${last}</span>`);
-}
-
 function getMsgPrefix (err, category) {
     return dedent(`
-        <span data-type="user-agent">${err.userAgent}</span>
-        <span data-type="category">${category}</span>
+        <span class="user-agent">${err.userAgent}</span>
+        <span class="category">${category}</span>
     `);
 }
 
@@ -45,16 +36,16 @@ function getDiffHeader (err) {
 
 function getScreenshotInfoStr (err) {
     if (err.screenshotPath)
-        return `<div data-type="screenshot-info">Screenshot: <a data-type="screenshot-path">${escapeHtml(err.screenshotPath)}</a></div>`;
+        return `<div class="screenshot-info">Screenshot: <a class="screenshot-path">${escapeHtml(err.screenshotPath)}</a></div>`;
 
     return '';
 }
 
 export default {
     [TYPE.okAssertion]: err => dedent(`
-        ${getAssertionMsgPrefix(err)} failed at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getAssertionMsgPrefix(err)} failed at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+        ${err.getCallsiteMarkup()}
 
         <strong>Expected: </strong>not <code>null</code>, not <code>undefined</code>, not <code>false</code>, not <code>NaN</code> and not <code>''</code>
         <strong>Actual:   </strong><code>${escapeNewLines(err.actual)}</code>
@@ -63,9 +54,9 @@ export default {
     `),
 
     [TYPE.notOkAssertion]: err => dedent(`
-        ${getAssertionMsgPrefix(err)} failed at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getAssertionMsgPrefix(err)} failed at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+        ${err.getCallsiteMarkup()}
 
         <strong>Expected: </strong><code>null</code>, <code>undefined</code>, <code>false</code>, <code>NaN</code> or <code>''</code>
         <strong>Actual:   </strong><code>${escapeNewLines(err.actual)}</code>
@@ -78,9 +69,9 @@ export default {
         var diffMarkerStr = diff.marker ? `          ${diff.marker}` : '';
 
         return dedent(`
-            ${getAssertionMsgPrefix(err)} failed at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+            ${getAssertionMsgPrefix(err)} failed at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-            <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+            ${err.getCallsiteMarkup()}
 
             ${getDiffHeader(err)}
 
@@ -93,9 +84,9 @@ export default {
     },
 
     [TYPE.notEqAssertion]: err => dedent(`
-        ${getAssertionMsgPrefix(err)} failed at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getAssertionMsgPrefix(err)} failed at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+        ${err.getCallsiteMarkup()}
 
         <strong>Expected: </strong>not <code>${escapeNewLines(err.actual)}</code>
         <strong>Actual:   </strong><code>${escapeNewLines(err.actual)}</code>
@@ -110,7 +101,7 @@ export default {
     `),
 
     [TYPE.inIFrameTargetLoadingTimeout]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.timeout)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.timeout)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
         IFrame target loading timed out.
 
         ${getScreenshotInfoStr(err)}
@@ -133,192 +124,192 @@ export default {
     },
 
     [TYPE.uncaughtJSErrorInTestCodeStep]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.unhandledException)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.unhandledException)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
         Uncaught JavaScript error in test code - <code>${escapeHtml(err.scriptErr)}</code>.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.storeDomNodeOrJqueryObject]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.unhandledException)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.unhandledException)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
         It is not allowed to share the DOM element, jQuery object or a function between test steps via "this" object.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.emptyFirstArgument]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+        ${err.getCallsiteMarkup()}
 
-        A target element of the <code data-type="api">${err.action}</code> action has not been found in the DOM tree.
-        If this element should be created after animation or a time-consuming operation is finished, use the <code data-type="api">waitFor</code> action (available for use in code) to pause test execution until this element appears.
+        A target element of the <code class="api">${err.action}</code> action has not been found in the DOM tree.
+        If this element should be created after animation or a time-consuming operation is finished, use the <code class="api">waitFor</code> action (available for use in code) to pause test execution until this element appears.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.invisibleActionElement]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+        ${err.getCallsiteMarkup()}
 
-        A target element <code>${escapeHtml(err.element)}</code> of the <code data-type="api">${err.action}</code> action is not visible.
-        If this element should appear when you are hovering over another element, make sure that you properly recorded the <code data-type="api">hover</code> action.
+        A target element <code>${escapeHtml(err.element)}</code> of the <code class="api">${err.action}</code> action is not visible.
+        If this element should appear when you are hovering over another element, make sure that you properly recorded the <code class="api">hover</code> action.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.incorrectDraggingSecondArgument]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+        ${err.getCallsiteMarkup()}
 
-        <code data-type="api">drag</code> action drop target is incorrect.
+        <code class="api">drag</code> action drop target is incorrect.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.incorrectPressActionArgument]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+        ${err.getCallsiteMarkup()}
 
-        <code data-type="api">press</code> action parameter contains incorrect key code.
+        <code class="api">press</code> action parameter contains incorrect key code.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.emptyTypeActionArgument]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+        ${err.getCallsiteMarkup()}
 
-        The <code data-type="api">type<code> action's parameter text is empty.
+        The <code class="api">type<code> action's parameter text is empty.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.unexpectedDialog]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.nativeDialogError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.nativeDialogError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
         Unexpected system <code>${err.dialog}</code> dialog <code>${escapeHtml(err.message)}</code> appeared.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.expectedDialogDoesntAppear]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.nativeDialogError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.nativeDialogError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
         The expected system <code>${err.dialog}</code> dialog did not appear.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.incorrectSelectActionArguments]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+        ${err.getCallsiteMarkup()}
 
-        <code data-type="api">select</code> action's parameters contain an incorrect value.
+        <code class="api">select</code> action's parameters contain an incorrect value.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.incorrectWaitActionMillisecondsArgument]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+        ${err.getCallsiteMarkup()}
 
-        <code data-type="api">wait</code> action's "milliseconds" parameter should be a positive number.
+        <code class="api">wait</code> action's "milliseconds" parameter should be a positive number.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.incorrectWaitForActionEventArgument]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+        ${err.getCallsiteMarkup()}
 
-        <code data-type="api">waitFor</code> action's first parameter should be a function, a CSS selector or an array of CSS selectors.
+        <code class="api">waitFor</code> action's first parameter should be a function, a CSS selector or an array of CSS selectors.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.incorrectWaitForActionTimeoutArgument]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+        ${err.getCallsiteMarkup()}
 
-        <code data-type="api">waitFor</code> action's "timeout" parameter should be a positive number.
+        <code class="api">waitFor</code> action's "timeout" parameter should be a positive number.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.waitForActionTimeoutExceeded]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.timeout)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.timeout)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+        ${err.getCallsiteMarkup()}
 
-        <code data-type="api">waitFor</code> action's timeout exceeded.
+        <code class="api">waitFor</code> action's timeout exceeded.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.incorrectGlobalWaitForActionEventArgument]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="api">__waitFor</code> action's first parameter should be a function.
+        <code class="api">__waitFor</code> action's first parameter should be a function.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.incorrectGlobalWaitForActionTimeoutArgument]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="api">__waitFor</code> action's "timeout" parameter should be a positive number.
+        <code class="api">__waitFor</code> action's "timeout" parameter should be a positive number.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.globalWaitForActionTimeoutExceeded]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.timeout)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.timeout)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="api">__waitFor</code> action's timeout exceeded.
+        <code class="api">__waitFor</code> action's timeout exceeded.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.emptyIFrameArgument]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.inIFrameSelectorError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
-        The selector within the <code data-type="api">inIFrame</code> function returns an empty value.
+        ${getMsgPrefix(err, CATEGORY.inIFrameSelectorError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
+        The selector within the <code class="api">inIFrame</code> function returns an empty value.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.iframeArgumentIsNotIFrame]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.inIFrameSelectorError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
-        The selector within the <code data-type="api">inIFrame</code> function doesn’t return an iframe element.
+        ${getMsgPrefix(err, CATEGORY.inIFrameSelectorError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
+        The selector within the <code class="api">inIFrame</code> function doesn’t return an iframe element.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.multipleIFrameArgument]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.inIFrameSelectorError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
-        The selector within the <code data-type="api">inIFrame</code> function returns more than one iframe element.
+        ${getMsgPrefix(err, CATEGORY.inIFrameSelectorError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
+        The selector within the <code class="api">inIFrame</code> function returns more than one iframe element.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.incorrectIFrameArgument]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.inIFrameSelectorError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
-        The <code data-type="api">inIFrame</code> function contains an invalid argument.
+        ${getMsgPrefix(err, CATEGORY.inIFrameSelectorError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
+        The <code class="api">inIFrame</code> function contains an invalid argument.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.uploadCanNotFindFileToUpload]: err => {
         var msg = dedent(`
-            ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+            ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-            <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+            ${err.getCallsiteMarkup()}
 
             Cannot find the following file(s) to upload:
         `);
@@ -329,21 +320,21 @@ export default {
     },
 
     [TYPE.uploadElementIsNotFileInput]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+        ${err.getCallsiteMarkup()}
 
-        <code data-type="api">upload</code> action argument does not contain a file input element.
+        <code class="api">upload</code> action argument does not contain a file input element.
 
         ${getScreenshotInfoStr(err)}
     `),
 
     [TYPE.uploadInvalidFilePathArgument]: err => dedent(`
-        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span data-type="step-name">${escapeHtml(err.stepName)}</span>:
+        ${getMsgPrefix(err, CATEGORY.actionError)}Error at step <span class="step-name">${escapeHtml(err.stepName)}</span>:
 
-        <code data-type="step-source">${getStepCode(err.relatedSourceCode)}</code>
+        ${err.getCallsiteMarkup()}
 
-        <code data-type="api">upload</code> action's "path" parameter should be a string or an array of strings.
+        <code class="api">upload</code> action's "path" parameter should be a string or an array of strings.
 
         ${getScreenshotInfoStr(err)}
     `),

--- a/src/legacy/test-run/index.js
+++ b/src/legacy/test-run/index.js
@@ -75,20 +75,22 @@ export default class LegacyTestRun extends Session {
     }
 
     async _addError (err) {
-        if (err.__sourceIndex !== void 0 && err.__sourceIndex !== null) {
-            err.relatedSourceCode = this.test.sourceIndex[err.__sourceIndex];
-            delete err.__sourceIndex;
-        }
+        var screenshotPath = null;
+        var callsite       = err.__sourceIndex !== void 0 &&
+                             err.__sourceIndex !== null &&
+                             this.test.sourceIndex[err.__sourceIndex];
 
         try {
-            err.screenshotPath = await this.screenshotCapturer.captureError(err);
+            screenshotPath = await this.screenshotCapturer.captureError(err);
         }
         catch (e) {
             // NOTE: swallow the error silently if we can't take screenshots for some
             // reason (e.g. we don't have permissions to write a screenshot file).
         }
 
-        this.errs.push(new LegacyTestRunErrorFormattableAdapter(err, this.browserConnection.userAgent));
+        var errAdapter = new LegacyTestRunErrorFormattableAdapter(err, this.browserConnection.userAgent, screenshotPath, callsite);
+
+        this.errs.push(errAdapter);
     }
 
     async _fatalError (err) {

--- a/src/reporter/plugin-host.js
+++ b/src/reporter/plugin-host.js
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import indentString from 'indent-string';
-import { escape as escapeHtml, assignIn } from 'lodash';
+import { identity, escape as escapeHtml, assignIn } from 'lodash';
 import moment from 'moment';
 import 'moment-duration-format';
 import OS from 'os-family';
@@ -40,18 +40,39 @@ export default class ReporterPluginHost {
     // Error decorator
     createErrorDecorator () {
         return {
-            'span category':       () => '',
-            'span step-name':      str => `"${str}"`,
-            'span user-agent':     str => this.chalk.gray(str),
-            'div screenshot-info': str => str,
+            'span category':   () => '',
+            'span step-name':  str => `"${str}"`,
+            'span user-agent': str => this.chalk.gray(str),
+
+            'div screenshot-info': identity,
             'a screenshot-path':   str => this.chalk.underline(str),
-            'code':                str => this.chalk.yellow(str),
-            'code step-source':    str => this.chalk.magenta(this.indentString(str, 4)),
-            'span code-line':      str => `${str}\n`,
-            'span last-code-line': str => str,
-            'code api':            str => this.chalk.yellow(str),
-            'strong':              str => this.chalk.cyan(str),
-            'a':                   str => this.chalk.yellow(`"${str}"`)
+
+            'code':     str => this.chalk.yellow(str),
+            'code api': str => this.chalk.yellow(str),
+
+            'span syntax-string':     str => this.chalk.green(str),
+            'span syntax-punctuator': str => this.chalk.grey(str),
+            'span syntax-keyword':    str => this.chalk.cyan(str),
+            'span syntax-number':     str => this.chalk.magenta(str),
+            'span syntax-regex':      str => this.chalk.magenta(str),
+            'span syntax-comment':    str => this.chalk.grey.bold(str),
+            'span syntax-invalid':    str => this.chalk.inverse(str),
+
+            'div code-frame':         identity,
+            'div code-line':          str => str + '\n',
+            'div code-line-last':     identity,
+            'div code-line-num':      str => `   ${str} |`,
+            'div code-line-num-base': str => this.chalk.bgRed(` > ${str} `) + '|',
+            'div code-line-src':      identity,
+
+            'div stack':               str => '\n\n' + str,
+            'div stack-line':          str => str + '\n',
+            'div stack-line-last':     identity,
+            'div stack-line-name':     str => `   at ${this.chalk.bold(str)}`,
+            'div stack-line-location': str => ` (${this.chalk.grey.underline(str)})`,
+
+            'strong': str => this.chalk.cyan(str),
+            'a':      str => `"${this.chalk.underline(str)}"`
         };
     }
 

--- a/test/server/data/expected-legacy-test-run-errors/empty-first-argument
+++ b/test/server/data/expected-legacy-test-run-errors/empty-first-argument
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|actionError
 Error at step "Step with <tag>":
 
-    code and <tag>
+code and <tag>
 
 A target element of the testAction action has not been found in the DOM tree.
 If this element should be created after animation or a time-consuming

--- a/test/server/data/expected-legacy-test-run-errors/empty-type-action-argument
+++ b/test/server/data/expected-legacy-test-run-errors/empty-type-action-argument
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|actionError
 Error at step "Step with <tag>":
 
-    code and <tag>
+code and <tag>
 
 The type action's parameter text is empty.
 

--- a/test/server/data/expected-legacy-test-run-errors/eq-assertion
+++ b/test/server/data/expected-legacy-test-run-errors/eq-assertion
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|failedAssertion
 "<tagged> message" assertion failed at step "Step with <tag>":
 
-    eq({"<tag>": "<some-tag>"}, {"<tag>": "<another-tag>"})
+eq({"<tag>": "<some-tag>"}, {"<tag>": "<another-tag>"})
 
 Objects differ at the <tag> field:
 

--- a/test/server/data/expected-legacy-test-run-errors/incorrect-dragging-second-argument
+++ b/test/server/data/expected-legacy-test-run-errors/incorrect-dragging-second-argument
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|actionError
 Error at step "Step with <tag>":
 
-    code and <tag>
+code and <tag>
 
 drag action drop target is incorrect.
 

--- a/test/server/data/expected-legacy-test-run-errors/incorrect-press-action-argument
+++ b/test/server/data/expected-legacy-test-run-errors/incorrect-press-action-argument
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|actionError
 Error at step "Step with <tag>":
 
-    code and <tag>
+code and <tag>
 
 press action parameter contains incorrect key code.
 

--- a/test/server/data/expected-legacy-test-run-errors/incorrect-select-action-arguments
+++ b/test/server/data/expected-legacy-test-run-errors/incorrect-select-action-arguments
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|actionError
 Error at step "Step with <tag>":
 
-    code and <tag>
+code and <tag>
 
 select action's parameters contain an incorrect value.
 

--- a/test/server/data/expected-legacy-test-run-errors/incorrect-wait-action-milliseconds-arguments
+++ b/test/server/data/expected-legacy-test-run-errors/incorrect-wait-action-milliseconds-arguments
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|actionError
 Error at step "Step with <tag>":
 
-    code and <tag>
+code and <tag>
 
 wait action's "milliseconds" parameter should be a positive number.
 

--- a/test/server/data/expected-legacy-test-run-errors/incorrect-wait-for-action-event-argument
+++ b/test/server/data/expected-legacy-test-run-errors/incorrect-wait-for-action-event-argument
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|actionError
 Error at step "Step with <tag>":
 
-    code and <tag>
+code and <tag>
 
 waitFor action's first parameter should be a function, a CSS selector or an
 array of CSS selectors.

--- a/test/server/data/expected-legacy-test-run-errors/incorrect-wait-for-action-timeout-argument
+++ b/test/server/data/expected-legacy-test-run-errors/incorrect-wait-for-action-timeout-argument
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|actionError
 Error at step "Step with <tag>":
 
-    code and <tag>
+code and <tag>
 
 waitFor action's "timeout" parameter should be a positive number.
 

--- a/test/server/data/expected-legacy-test-run-errors/invisible-action-element
+++ b/test/server/data/expected-legacy-test-run-errors/invisible-action-element
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|actionError
 Error at step "Step with <tag>":
 
-    code and <tag>
+code and <tag>
 
 A target element <element> of the test-action action is not visible.
 If this element should appear when you are hovering over another element,

--- a/test/server/data/expected-legacy-test-run-errors/not-eq-assertion
+++ b/test/server/data/expected-legacy-test-run-errors/not-eq-assertion
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|failedAssertion
 "<tagged> message" assertion failed at step "Step with <tag>":
 
-    notEq("<test>", "<test>")
+notEq("<test>", "<test>")
 
 Expected: not "<test>"
 Actual:   "<test>"

--- a/test/server/data/expected-legacy-test-run-errors/not-ok-assertion
+++ b/test/server/data/expected-legacy-test-run-errors/not-ok-assertion
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|failedAssertion
 "<tagged> message" assertion failed at step "Step with <tag>":
 
-    notOk("<test>")
+notOk("<test>")
 
 Expected: null, undefined, false, NaN or ''
 Actual:   "<test>"

--- a/test/server/data/expected-legacy-test-run-errors/ok-assertion
+++ b/test/server/data/expected-legacy-test-run-errors/ok-assertion
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|failedAssertion
 "<tagged> message" assertion failed at step "Step with <tag>":
 
-    ok("<test>" === "<best>")
+ok("<test>" === "<best>")
 
 Expected: not null, not undefined, not false, not NaN and not ''
 Actual:   false

--- a/test/server/data/expected-legacy-test-run-errors/upload-can-not-find-file-to-upload
+++ b/test/server/data/expected-legacy-test-run-errors/upload-can-not-find-file-to-upload
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|actionError
 Error at step "Step with <tag>":
 
-    code and <tag>
+code and <tag>
 
 Cannot find the following file(s) to upload:
     /unix/path/with/<tag>,

--- a/test/server/data/expected-legacy-test-run-errors/upload-element-is-not-file-input
+++ b/test/server/data/expected-legacy-test-run-errors/upload-element-is-not-file-input
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|actionError
 Error at step "Step with <tag>":
 
-    code and <tag>
+code and <tag>
 
 upload action argument does not contain a file input element.
 

--- a/test/server/data/expected-legacy-test-run-errors/upload-invalid-file-path-argument
+++ b/test/server/data/expected-legacy-test-run-errors/upload-invalid-file-path-argument
@@ -2,7 +2,7 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|actionError
 Error at step "Step with <tag>":
 
-    code and <tag>
+code and <tag>
 
 upload action's "path" parameter should be a string or an array of strings.
 

--- a/test/server/data/expected-legacy-test-run-errors/wait-for-action-timeout-exceeded
+++ b/test/server/data/expected-legacy-test-run-errors/wait-for-action-timeout-exceeded
@@ -2,10 +2,10 @@ Chrome 15.0.874 / Mac OS X 10.8.1
 CATEGORY=legacy|timeout
 Error at step "Step with <tag>":
 
-    act.waitFor(function(cb) {
-        $("<iframe>");
-        cb();
-    }, 1000);
+act.waitFor(function(cb) {
+    $("<iframe>");
+    cb();
+}, 1000);
 
 waitFor action's timeout exceeded.
 


### PR DESCRIPTION
\cc @kirovboris @churkin 

@kirovboris note that `errorDecorator` has been changed. I've bumped the version already, so once we've done with this PR you will be able to update it for the studio.