### PR TITLE
Don't modify package.json if we don't have greenkeeper ignore changes.

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -26,6 +26,7 @@ var serveStatic  = require('serve-static');
 var Promise      = require('pinkie');
 var promisify    = require('pify');
 var markdownlint = require('markdownlint');
+var isEqual      = require('lodash').isEqual;
 
 
 var readFile = promisify(fs.readFile, Promise);
@@ -285,13 +286,13 @@ gulp.task('update-greenkeeper', function () {
                     return !watchDepsRe.test(dep);
                 });
 
-            config.greenkeeper = {
-                ignore: ignoredDeps
-            };
+            if (!isEqual(config.greenkeeper.ignore, ignoredDeps)) {
+                config.greenkeeper.ignore = ignoredDeps;
 
-            // NOTE: We should write to the file synchronously to avoid collision
-            // with other tasks that may be reading from it asynchronously (GH-315)
-            fs.writeFileSync('package.json', JSON.stringify(config, null, 2) + '\n');
+                // NOTE: We should write to the file synchronously to avoid collision
+                // with other tasks that may be reading from it asynchronously (GH-315)
+                fs.writeFileSync('package.json', JSON.stringify(config, null, 2) + '\n');
+            }
         });
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe",
-  "version": "0.0.12",
+  "version": "0.0.14",
   "main": "lib/index",
   "bin": {
     "testcafe": "./bin/testcafe"


### PR DESCRIPTION
\cc @AlexanderMoskovkin 

This breaks `gulp publish` because we always have uncommitted changes in the working tree.