### PR TITLE
Docs - Introduce links that are navigable when browsing the repo

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,5 @@
 {
+    "MD009": { "br_spaces": 2 },
     "MD013": false,
     "MD036": false
 }

--- a/docs/articles/documentation/index.md
+++ b/docs/articles/documentation/index.md
@@ -8,6 +8,6 @@ inMainMenu: true
 
 * [Getting Started](.)
 * [Test API](.)
-* [Using TestCafe](/testcafe/documentation/using-testcafe)
+* [Using TestCafe](using-testcafe/index.md)
 * [Extending TestCafe](.)
 * [Recipes](.)

--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Command Line Interface
-permalink: /documentation/using-testcafe/command-line-interface/
+permalink: /documentation/using-testcafe/command-line-interface
 ---
 # Command Line Interface
 
@@ -15,8 +15,8 @@ The `browser-list-comma-separated` argument specifies the list of browsers (sepa
 
 ### Local Browsers
 
-You can specify local browsers by using paths or [aliases](/testcafe/documentation/using-testcafe/common-concepts/browser-aliases).
-A list of all the available aliases can be obtained by the [--list-browsers](#b-list-browsers) command.
+You can specify local browsers by using paths or [aliases](common-concepts/browser-aliases.md).
+A list of all the available aliases can be obtained by the [--list-browsers](#-b---list-browsers) command.
 
 The following example demonstrates how to run a test in several browsers.
 The browsers are specified differently: one by using the alias, the other by using the path.
@@ -48,7 +48,7 @@ testcafe 3remote tests/sample-fixture.js
 
 TestCafe will provide URLs that you need to open in required browsers on your remote device.
 
-You can also use the [--qr-code](#qr-code) option to display QR-codes that represent the same URLs.
+You can also use the [--qr-code](#--qr-code) option to display QR-codes that represent the same URLs.
 Scan the QR-codes by a device on which you are going to test the application.
 As a result, the browsers will be connected to TestCafe and tests will start.
 
@@ -97,7 +97,7 @@ testcafe --version
 
 ### -b, --list-browsers
 
-Lists [aliases](/testcafe/documentation/using-testcafe/common-concepts/browser-aliases) of the browsers available on this computer.
+Lists [aliases](common-concepts/browser-aliases.md) of the browsers available on this computer.
 
 ```sh
 testcafe --list-browsers

--- a/docs/articles/documentation/using-testcafe/common-concepts/browser-aliases.md
+++ b/docs/articles/documentation/using-testcafe/common-concepts/browser-aliases.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 title: Browser Aliases
-permalink: /documentation/using-testcafe/common-concepts/browser-aliases/
+permalink: /documentation/using-testcafe/common-concepts/browser-aliases
 ---
 # Browser Aliases
 
@@ -20,8 +20,8 @@ Mozilla Firefox   | `ff`
 Opera             | `opera`
 Safari            | `safari`
 
-You can use these aliases when working both through the [command line](/testcafe/documentation/using-testcafe/command-line-interface/#local-browsers)
-and [programmatically](/testcafe/documentation/using-testcafe/programming-interface/Runner/#browsers).
+You can use these aliases when working both through the [command line](../command-line-interface.md#local-browsers)
+and [programmatically](../programming-interface/Runner.md#browsers).
 
 To obtain the list of browsers installed on the current machine, run TestCafe
-from the command line with the [-b option](/testcafe/documentation/using-testcafe/command-line-interface/#b-list-browsers).
+from the command line with the [-b option](../command-line-interface.md#-b---list-browsers).

--- a/docs/articles/documentation/using-testcafe/common-concepts/index.md
+++ b/docs/articles/documentation/using-testcafe/common-concepts/index.md
@@ -5,4 +5,4 @@ permalink: /documentation/using-testcafe/common-concepts/
 ---
 # Common Concepts
 
-* [Browser Aliases](/testcafe/documentation/using-testcafe/common-concepts/browser-aliases)
+* [Browser Aliases](browser-aliases.md)

--- a/docs/articles/documentation/using-testcafe/index.md
+++ b/docs/articles/documentation/using-testcafe/index.md
@@ -5,6 +5,6 @@ permalink: /documentation/using-testcafe/
 ---
 # Using TestCafe
 
-* [Command Line Interface](/testcafe/documentation/using-testcafe/command-line-interface)
-* [Programming Interface](/testcafe/documentation/using-testcafe/programming-interface)
-* [Common Concepts](/testcafe/documentation/using-testcafe/common-concepts)
+* [Command Line Interface](command-line-interface.md)
+* [Programming Interface](programming-interface/index.md)
+* [Common Concepts](common-concepts/index.md)

--- a/docs/articles/documentation/using-testcafe/programming-interface/BrowserConnection.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/BrowserConnection.md
@@ -1,13 +1,13 @@
 ---
 layout: docs
 title: BrowserConnection Class
-permalink: /documentation/using-testcafe/programming-interface/BrowserConnection/
+permalink: /documentation/using-testcafe/programming-interface/BrowserConnection
 ---
 # BrowserConnection Class
 
 Connection to a remote browser.
 
-Created by the [testCafe.createBrowserConnection](/testcafe/documentation/using-testcafe/programming-interface/TestCafe/#createBrowserConnection) function.
+Created by the [testCafe.createBrowserConnection](TestCafe.md#createBrowserConnection) function.
 
 **Example**
 
@@ -45,6 +45,6 @@ browserConnection.once('ready', callback)
 ```
 
 Typically, you do not need to wait for the **ready** event to fire.
-The [runner.run](/testcafe/documentation/using-testcafe/programming-interface/Runner/#run) method automatically waits for all browser connections to be established.
+The [runner.run](Runner.md#run) method automatically waits for all browser connections to be established.
 If this does not happen within *30* seconds, an error is thrown.
 Thus, you need to wait for the **ready** event only if there is a chance that any of your remote connections can take a significant amount of time (more than 30 sec) to establish.

--- a/docs/articles/documentation/using-testcafe/programming-interface/Runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/Runner.md
@@ -1,13 +1,13 @@
 ---
 layout: docs
 title: Runner Class
-permalink: /documentation/using-testcafe/programming-interface/Runner/
+permalink: /documentation/using-testcafe/programming-interface/Runner
 ---
 # Runner Class
 
 An object that configures and launches test runs.
 
-Created by the [testCafe.createRunner](/testcafe/documentation/using-testcafe/programming-interface/TestCafe/#createRunner) function.
+Created by the [testCafe.createRunner](TestCafe.md#createRunner) function.
 
 **Example**
 
@@ -92,10 +92,10 @@ Each `browser` parameter can be one of the following.
 
 Type                                                                                                 | Description                                                                                                                                                           | Local/Remote
 ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------
-String                                                                                               | The browser's short name - *alias*. Find the list of aliases in the [Browser Aliases](/testcafe/documentation/using-testcafe/common-concepts/browser-aliases/) topic. | Local browser
+String                                                                                               | The browser's short name - *alias*. Find the list of aliases in the [Browser Aliases](../common-concepts/browser-aliases.md) topic.                                   | Local browser
 String                                                                                               | The path to the browser executable.                                                                                                                                   | Local browser
 `{path: String, cmd: String}`                                                                        | The path to the browser executable (`path`) with command line parameters (`cmd`).                                                                                     | Local browser
-[BrowserConnection](/testcafe/documentation/using-testcafe/programming-interface/BrowserConnection/) | The remote browser connection.                                                                                                                                        | Remote browser
+[BrowserConnection](BrowserConnection.md)                                                            | The remote browser connection.                                                                                                                                        | Remote browser
 
 You are free to mix different types of objects in one function call. The `browsers` function concatenates the settings when called several times.
 

--- a/docs/articles/documentation/using-testcafe/programming-interface/TestCafe.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/TestCafe.md
@@ -1,13 +1,13 @@
 ---
 layout: docs
 title: TestCafe Class
-permalink: /documentation/using-testcafe/programming-interface/TestCafe/
+permalink: /documentation/using-testcafe/programming-interface/TestCafe
 ---
 # TestCafe Class
 
 A TestCafe server.
 
-To create an instance, use the [createTestCafe](/testcafe/documentation/using-testcafe/programming-interface/createTestCafe/) factory function.
+To create an instance, use the [createTestCafe](createTestCafe.md) factory function.
 
 **Example**
 
@@ -20,13 +20,13 @@ const testCafe       = await createTestCafe('localhost', 1337, 1338);
 
 ### createBrowserConnection
 
-Creates a [remote browser connection](/testcafe/documentation/using-testcafe/programming-interface/BrowserConnection/).
+Creates a [remote browser connection](BrowserConnection.md).
 
 ```text
 createBrowserConnection() → BrowserConnection
 ```
 
-To connect a remote browser, navigate it to [BrowserConnection.url](/testcafe/documentation/using-testcafe/programming-interface/BrowserConnection/#url).
+To connect a remote browser, navigate it to [BrowserConnection.url](BrowserConnection.md#url).
 
 **Example**
 
@@ -49,7 +49,7 @@ remoteConnection.once('ready', async () => {
 
 ### createRunner
 
-Creates the [test runner](/testcafe/documentation/using-testcafe/programming-interface/Runner/) that is used to configure and launch test runs.
+Creates the [test runner](Runner.md) that is used to configure and launch test runs.
 
 ```text
 createRunner() → Runner

--- a/docs/articles/documentation/using-testcafe/programming-interface/createTestCafe.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/createTestCafe.md
@@ -1,11 +1,11 @@
 ---
 layout: docs
 title: createTestCafe
-permalink: /documentation/using-testcafe/programming-interface/createTestCafe/
+permalink: /documentation/using-testcafe/programming-interface/createTestCafe
 ---
 # createTestCafe Factory
 
-Creates a [TestCafe](/testcafe/documentation/using-testcafe/programming-interface/TestCafe/) server instance.
+Creates a [TestCafe](TestCafe.md) server instance.
 
 ```text
 createTestCafe([hostname], [port1], [port2]) → Promise<TestCafe>
@@ -25,4 +25,4 @@ const testCafe       = await createTestCafe('localhost', 1337, 1338);
 
 ## See Also
 
-* [TestCafe Class](/testcafe/documentation/using-testcafe/programming-interface/TestCafe/)
+* [TestCafe Class](TestCafe.md)

--- a/docs/articles/documentation/using-testcafe/programming-interface/index.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/index.md
@@ -7,8 +7,8 @@ permalink: /documentation/using-testcafe/programming-interface/
 
 This section describes the API that allows you to use TestCafe from your NodeJS applications.
 
-The thing to start with is creating the [TestCafe server](/testcafe/documentation/using-testcafe/programming-interface/TestCafe/) instance.
-Use the [createTestCafe](/testcafe/documentation/using-testcafe/programming-interface/createTestCafe/) factory function for this.
+The thing to start with is creating the [TestCafe server](TestCafe.md) instance.
+Use the [createTestCafe](createTestCafe.md) factory function for this.
 
 ```js
 const createTestCafe = require('testcafe');
@@ -16,18 +16,18 @@ const testCafe       = await createTestCafe('localhost', 1337, 1338);
 ```
 
 This is the main point of access to TestCafe. You can now use it to create other entities required to execute tests:
-the [remote browser connections](/testcafe/documentation/using-testcafe/programming-interface/BrowserConnection/)
-and the [test runner](/testcafe/documentation/using-testcafe/programming-interface/Runner/).
+the [remote browser connections](BrowserConnection.md)
+and the [test runner](Runner.md).
 
 ```js
 const remoteConnection = testcafe.createBrowserConnection();
 const runner           = testcafe.createRunner();
 ```
 
-[Remote browser connections](/testcafe/documentation/using-testcafe/programming-interface/BrowserConnection/), as the name implies,
+[Remote browser connections](BrowserConnection.md), as the name implies,
 are used when you need to run tests on a remote device.
 
-The [test runner](/testcafe/documentation/using-testcafe/programming-interface/Runner/) is used to configure and launch test runs.
+The [test runner](Runner.md) is used to configure and launch test runs.
 Here is how you can have it run tests from a `myFixture.js` fixture in the local Chrome and another remote browser
 with the report provided in the JSON format.
 
@@ -44,7 +44,7 @@ For details, see the reference topics below.
 
 ## Reference
 
-* [createTestCafe factory function](/testcafe/documentation/using-testcafe/programming-interface/createTestCafe/)
-* [TestCafe Class](/testcafe/documentation/using-testcafe/programming-interface/TestCafe/)
-* [Runner Class](/testcafe/documentation/using-testcafe/programming-interface/Runner/)
-* [BrowserConnection Class](/testcafe/documentation/using-testcafe/programming-interface/BrowserConnection/)
+* [createTestCafe factory function](createTestCafe.md)
+* [TestCafe Class](TestCafe.md)
+* [Runner Class](Runner.md)
+* [BrowserConnection Class](BrowserConnection.md)

--- a/docs/nav/nav-menu.yml
+++ b/docs/nav/nav-menu.yml
@@ -1,39 +1,53 @@
 - item: GETTING STARTED
   url: .
 - folder: TEST API
-  url: .
+  url: /testcafe/documentation/test-api/
   content:
-  - item: Test Structure
-    url: .
+  - item: Fixtures and Tests
+    url: /testcafe/documentation/test-api/fixtures-and-tests.html
   - item: Actions
-    url: .
+    url: /testcafe/documentation/test-api/actions.html
   - item: Assertions
-    url: .
+    url: /testcafe/documentation/test-api/assertions.html
   - item: Hybrid Functions
-    url: .  
+    url: /testcafe/documentation/test-api/hybrid-functions.html
   - item: Roles
-    url: .
+    url: /testcafe/documentation/test-api/roles.html
+  - item: Wait Functions
+    url: /testcafe/documentation/test-api/wait-functions.html
+  - item: Conditional Functions
+    url: /testcafe/documentation/test-api/conditional-functions.html
+  - item: Handling Native Dialogs
+    url: /testcafe/documentation/test-api/handling-native-dialogs.html
+  - item: HTTP Authentication
+    url: /testcafe/documentation/test-api/http-authentication.html
+  - item: Switching Frames
+    url: /testcafe/documentation/test-api/switching-frames.html
+  - item: Injecting Scripts
+    url: /testcafe/documentation/test-api/injecting-scripts.html
+  - item: Identifying Webpage Elements
+    url: /testcafe/documentation/test-api/identifying-webpage-elements.html
 - folder: USING TESTCAFE
-  url: /testcafe/documentation/using-testcafe
+  url: /testcafe/documentation/using-testcafe/
   content:
   - item: Command Line Interface
-    url: /testcafe/documentation/using-testcafe/command-line-interface
+    url: /testcafe/documentation/using-testcafe/command-line-interface.html
   - folder: Programming Interface
-    url: /testcafe/documentation/using-testcafe/programming-interface
+    url: /testcafe/documentation/using-testcafe/programming-interface/
     content:
     - item: TestCafe Class
-      url: /testcafe/documentation/using-testcafe/programming-interface/testCafe
+      url: /testcafe/documentation/using-testcafe/programming-interface/testCafe.html
     - item: BrowserConnection Class
-      url: /testcafe/documentation/using-testcafe/programming-interface/browserConnection
+      url: /testcafe/documentation/using-testcafe/programming-interface/browserConnection.html
     - item: Runner Class
-      url: /testcafe/documentation/using-testcafe/programming-interface/runner
+      url: /testcafe/documentation/using-testcafe/programming-interface/runner.html
     - item: createTestCafe Factory
-      url: /testcafe/documentation/using-testcafe/programming-interface/createTestCafe
+      url: /testcafe/documentation/using-testcafe/programming-interface/createTestCafe.html
   - folder: Common Concepts
-    url: /testcafe/documentation/using-testcafe/common-concepts
+    url: /testcafe/documentation/using-testcafe/common-concepts/
     content: 
     - item: Browser Aliases
-      url: /testcafe/documentation/using-testcafe/common-concepts/browser-aliases
+      url: /testcafe/documentation/using-testcafe/common-concepts/browser-aliases.html
 - folder: EXTENDING TESTCAFE
   url: .  
   content:


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs 
Second part of #311 