### PR TITLE
Fixed behavior for functional tests with attributes 'SKIP' and 'ONLY' (closes #444)

### DIFF
--- a/test/functional/assertion-helper.js
+++ b/test/functional/assertion-helper.js
@@ -1,0 +1,8 @@
+var expect = require('chai').expect;
+
+
+exports.errorInEachBrowserContains = function errorInEachBrowserContains (testError, message, errorIndex) {
+    Object.keys(testError).forEach(function (key) {
+        expect(testError[key][errorIndex]).contains(message);
+    });
+};

--- a/test/functional/fixtures/api/es-next/before-after-each-hooks/test.js
+++ b/test/functional/fixtures/api/es-next/before-after-each-hooks/test.js
@@ -1,57 +1,57 @@
 var expect = require('chai').expect;
 
 // NOTE: we run tests in chrome only, because we mainly test server API functionality.
-describe('[API] beforeEach/afterEach hooks [ONLY:chrome]', function () {
+describe('[API] beforeEach/afterEach hooks', function () {
     it('Should run hooks for all tests', function () {
         var test1Err = null;
 
-        return runTests('./testcafe-fixtures/run-all.js', 'Test1', { shouldFail: true })
-            .catch(function (err) {
-                test1Err = err;
-                return runTests('./testcafe-fixtures/run-all.js', 'Test2', { shouldFail: true });
+        return runTests('./testcafe-fixtures/run-all.js', 'Test1', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                test1Err = errs[0];
+                return runTests('./testcafe-fixtures/run-all.js', 'Test2', { shouldFail: true, only: 'chrome' });
             })
-            .catch(function (err) {
-                expect(err).eql(test1Err);
+            .catch(function (errs) {
+                expect(errs[0]).eql(test1Err);
 
-                expect(err.indexOf(
+                expect(errs[0].indexOf(
                     '- Error in afterEach hook - ' +
                     'Error on page "http://localhost:3000/api/es-next/before-after-each-hooks/pages/index.html":  ' +
                     'Uncaught Error: [beforeEach][test][afterEach]'
                 )).eql(0);
 
-                expect(err).contains(">  7 |            .click('#failAndReport');");
+                expect(errs[0]).contains(">  7 |            .click('#failAndReport');");
             });
     });
 
-    it('Should not run test and afterEach if fails in beforeEach [ONLY:chrome]', function () {
-        return runTests('./testcafe-fixtures/fail-in-before-each.js', 'Test', { shouldFail: true })
-            .catch(function (err) {
-                expect(err.indexOf(
+    it('Should not run test and afterEach if fails in beforeEach', function () {
+        return runTests('./testcafe-fixtures/fail-in-before-each.js', 'Test', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                expect(errs[0].indexOf(
                     '- Error in beforeEach hook - ' +
                     'Error on page "http://localhost:3000/api/es-next/before-after-each-hooks/pages/index.html":  ' +
                     'Uncaught Error: [beforeEach]'
                 )).eql(0);
 
-                expect(err).contains(">  6 |            .click('#failAndReport');");
+                expect(errs[0]).contains(">  6 |            .click('#failAndReport');");
             });
     });
 
-    it('Should run test and afterEach and beforeEach if test fails [ONLY:chrome]', function () {
-        return runTests('./testcafe-fixtures/fail-in-test.js', 'Test', { shouldFail: true })
-            .catch(function (err) {
-                expect(err.indexOf(
+    it('Should run test and afterEach and beforeEach if test fails', function () {
+        return runTests('./testcafe-fixtures/fail-in-test.js', 'Test', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                expect(errs[0].indexOf(
                     'Error on page "http://localhost:3000/api/es-next/before-after-each-hooks/pages/index.html":  ' +
                     'Uncaught Error: [beforeEach] '
                 )).eql(0);
 
-                expect(err.indexOf(
+                expect(errs[1].indexOf(
                     '- Error in afterEach hook - ' +
                     'Error on page "http://localhost:3000/api/es-next/before-after-each-hooks/pages/index.html":  ' +
                     'Uncaught Error: [beforeEach][afterEach]'
-                )).to.be.above(0);
+                )).eql(0);
 
-                expect(err).contains("> 10 |test('Test', async t => await t.click('#failAndReport'));");
-                expect(err).contains(">  7 |            .click('#failAndReport');");
+                expect(errs[0]).contains("> 10 |test('Test', async t => await t.click('#failAndReport'));");
+                expect(errs[1]).contains(">  7 |            .click('#failAndReport');");
             });
     });
 });

--- a/test/functional/fixtures/api/es-next/click/test.js
+++ b/test/functional/fixtures/api/es-next/click/test.js
@@ -3,11 +3,11 @@ var expect = require('chai').expect;
 // NOTE: we run tests in chrome only, because we mainly test server API functionality.
 // Actions functionality is tested in lower-level raw API.
 describe('[API] t.click()', function () {
-    it('Should make click on a button [ONLY:chrome]', function () {
-        return runTests('./testcafe-fixtures/click-test.js', 'Click button', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Button clicked');
-                expect(err).to.contains(
+    it('Should make click on a button', function () {
+        return runTests('./testcafe-fixtures/click-test.js', 'Click button', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                expect(errs[0]).to.contains('Button clicked');
+                expect(errs[0]).to.contains(
                     ' 10 |test(\'Incorrect action option\', async t => {' +
                     ' 11 |    await t.click(\'#btn\', { offsetX: -3 });' +
                     ' 12 |});' +
@@ -20,11 +20,11 @@ describe('[API] t.click()', function () {
             });
     });
 
-    it('Should validate options [ONLY:chrome]', function () {
-        return runTests('./testcafe-fixtures/click-test.js', 'Incorrect action option', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Action option offsetX is expected to be a positive integer, but it was -3.');
-                expect(err).to.contains(
+    it('Should validate options', function () {
+        return runTests('./testcafe-fixtures/click-test.js', 'Incorrect action option', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                expect(errs[0]).to.contains('Action option offsetX is expected to be a positive integer, but it was -3.');
+                expect(errs[0]).to.contains(
                     ' 6 |test(\'Incorrect action selector\', async t => {' +
                     ' 7 |    await t.click(123);' +
                     ' 8 |});' +
@@ -39,11 +39,11 @@ describe('[API] t.click()', function () {
             });
     });
 
-    it('Should validate selector [ONLY:chrome]', function () {
-        return runTests('./testcafe-fixtures/click-test.js', 'Incorrect action selector', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Action selector is expected to be a string, but it was number.');
-                expect(err).to.contains(
+    it('Should validate selector', function () {
+        return runTests('./testcafe-fixtures/click-test.js', 'Incorrect action selector', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                expect(errs[0]).to.contains('Action selector is expected to be a string, but it was number.');
+                expect(errs[0]).to.contains(
                     '2 |' +
                     ' 3 |fixture `Click`' +
                     ' 4 |    .page `http://localhost:3000/api/es-next/click/pages/index.html`;' +

--- a/test/functional/fixtures/api/es-next/double-click/test.js
+++ b/test/functional/fixtures/api/es-next/double-click/test.js
@@ -2,26 +2,26 @@ var expect = require('chai').expect;
 
 describe('[API] Double click action', function () {
     it('Should make double click on a button', function () {
-        return runTests('./testcafe-fixtures/double-click-test.js', 'Double click on a button', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Click on button raised 2 times. Double click on button raised.');
-                expect(err).to.contains(' >  7 |    await t.doubleClick(\'#button\');');
+        return runTests('./testcafe-fixtures/double-click-test.js', 'Double click on a button', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                expect(errs[0]).to.contains('Click on button raised 2 times. Double click on button raised.');
+                expect(errs[0]).to.contains(' >  7 |    await t.doubleClick(\'#button\');');
             });
     });
 
-    it('Should validate options [ONLY:chrome]', function () {
-        return runTests('./testcafe-fixtures/double-click-test.js', 'Incorrect action option', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Action option offsetX is expected to be a positive integer, but it was 3.14.');
-                expect(err).to.contains(' > 15 |    await t.doubleClick(\'#button\', { offsetX: 3.14 });');
+    it('Should validate options', function () {
+        return runTests('./testcafe-fixtures/double-click-test.js', 'Incorrect action option', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                expect(errs[0]).to.contains('Action option offsetX is expected to be a positive integer, but it was 3.14.');
+                expect(errs[0]).to.contains(' > 15 |    await t.doubleClick(\'#button\', { offsetX: 3.14 });');
             });
     });
 
-    it('Should validate selector [ONLY:chrome]', function () {
-        return runTests('./testcafe-fixtures/double-click-test.js', 'Incorrect action selector', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Action selector is expected to be a string, but it was object.');
-                expect(err).to.contains(' > 11 |    await t.doubleClick(null);');
+    it('Should validate selector', function () {
+        return runTests('./testcafe-fixtures/double-click-test.js', 'Incorrect action selector', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                expect(errs[0]).to.contains('Action selector is expected to be a string, but it was object.');
+                expect(errs[0]).to.contains(' > 11 |    await t.doubleClick(null);');
             });
     });
 });

--- a/test/functional/fixtures/api/es-next/generic-errors/test.js
+++ b/test/functional/fixtures/api/es-next/generic-errors/test.js
@@ -4,56 +4,63 @@ var expect = require('chai').expect;
 // Actions functionality is tested in lower-level raw API.
 describe('[API] Generic errors', function () {
     describe('Error in test code', function () {
-        it('Should handle error thrown by test code [ONLY:chrome]', function () {
-            return runTests('./testcafe-fixtures/error-in-test-code-test.js', 'Test code throws Error', { shouldFail: true })
-                .catch(function (err) {
-                    expect(err).to.contains('Error: Yo!');
-                    expect(err).to.contains('>  8 |    throw new Error(\'Yo!\')');
+        it('Should handle error thrown by test code', function () {
+            return runTests('./testcafe-fixtures/error-in-test-code-test.js', 'Test code throws Error',
+                { shouldFail: true, only: 'chrome' })
+                .catch(function (errs) {
+                    expect(errs[0]).to.contains('Error: Yo!');
+                    expect(errs[0]).to.contains('>  8 |    throw new Error(\'Yo!\')');
                 });
         });
 
-        it('Should handle non-Error object thrown by test code [ONLY:chrome]', function () {
-            return runTests('./testcafe-fixtures/error-in-test-code-test.js', 'Test code throws non-Error object', { shouldFail: true })
-                .catch(function (err) {
-                    expect(err).eql('Uncaught number "42" was thrown. Throw Error instead.');
+        it('Should handle non-Error object thrown by test code', function () {
+            return runTests('./testcafe-fixtures/error-in-test-code-test.js', 'Test code throws non-Error object',
+                { shouldFail: true, only: 'chrome' })
+                .catch(function (errs) {
+                    expect(errs[0]).eql('Uncaught number "42" was thrown. Throw Error instead.');
                 });
         });
 
-        it('Should handle null thrown by test code [ONLY:chrome]', function () {
-            return runTests('./testcafe-fixtures/error-in-test-code-test.js', 'Test code throws null', { shouldFail: true })
-                .catch(function (err) {
-                    expect(err).eql('Uncaught object "null" was thrown. Throw Error instead.');
+        it('Should handle null thrown by test code', function () {
+            return runTests('./testcafe-fixtures/error-in-test-code-test.js', 'Test code throws null',
+                { shouldFail: true, only: 'chrome' })
+                .catch(function (errs) {
+                    expect(errs[0]).eql('Uncaught object "null" was thrown. Throw Error instead.');
                 });
         });
 
-        it('Should handle error thrown by helper code [ONLY:chrome]', function () {
-            return runTests('./testcafe-fixtures/error-in-test-code-test.js', 'Helper code throws Error', { shouldFail: true })
-                .catch(function (err) {
-                    expect(err).to.contains('Error: yo!');
-                    expect(err).to.contains('> 4 |    throw new Error(\'yo!\');');
+        it('Should handle error thrown by helper code', function () {
+            return runTests('./testcafe-fixtures/error-in-test-code-test.js', 'Helper code throws Error',
+                { shouldFail: true, only: 'chrome' })
+                .catch(function (errs) {
+                    expect(errs[0]).to.contains('Error: yo!');
+                    expect(errs[0]).to.contains('> 4 |    throw new Error(\'yo!\');');
                 });
         });
     });
 
     describe('External assertion library error', function () {
-        it('Should handle Node built-in assertion lib error [ONLY:chrome]', function () {
-            return runTests('./testcafe-fixtures/external-assertion-lib-errors-test.js', 'Built-in assertion lib error', { shouldFail: true })
-                .catch(function (err) {
-                    expect(err).to.contains("AssertionError: 'answer' === '42'");
+        it('Should handle Node built-in assertion lib error', function () {
+            return runTests('./testcafe-fixtures/external-assertion-lib-errors-test.js', 'Built-in assertion lib error',
+                { shouldFail: true, only: 'chrome' })
+                .catch(function (errs) {
+                    expect(errs[0]).to.contains("AssertionError: 'answer' === '42'");
                 });
         });
 
-        it('Should handle Chai assertion error [ONLY:chrome]', function () {
-            return runTests('./testcafe-fixtures/external-assertion-lib-errors-test.js', 'Chai assertion error', { shouldFail: true })
-                .catch(function (err) {
-                    expect(err).to.contains("AssertionError: expected 'answer' to deeply equal '42'");
+        it('Should handle Chai assertion error', function () {
+            return runTests('./testcafe-fixtures/external-assertion-lib-errors-test.js', 'Chai assertion error',
+                { shouldFail: true, only: 'chrome' })
+                .catch(function (errs) {
+                    expect(errs[0]).to.contains("AssertionError: expected 'answer' to deeply equal '42'");
                 });
         });
 
-        it('Should handle assertion errors in helper code [ONLY:chrome]', function () {
-            return runTests('./testcafe-fixtures/external-assertion-lib-errors-test.js', 'Assertion error in helper', { shouldFail: true })
-                .catch(function (err) {
-                    expect(err).to.contains('AssertionError: false == true');
+        it('Should handle assertion errors in helper code', function () {
+            return runTests('./testcafe-fixtures/external-assertion-lib-errors-test.js', 'Assertion error in helper',
+                { shouldFail: true, only: 'chrome' })
+                .catch(function (errs) {
+                    expect(errs[0]).to.contains('AssertionError: false == true');
                 });
         });
     });

--- a/test/functional/fixtures/api/es-next/right-click/test.js
+++ b/test/functional/fixtures/api/es-next/right-click/test.js
@@ -3,27 +3,27 @@ var expect = require('chai').expect;
 // NOTE: we run tests in chrome only, because we mainly test server API functionality.
 // Actions functionality is tested in lower-level raw API.
 describe('[API] t.rightClick()', function () {
-    it('Should make right click on a button [ONLY:chrome]', function () {
-        return runTests('./testcafe-fixtures/right-click-test.js', 'Right click button', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Right click on the button');
-                expect(err).to.contains(' >  7 |    await t.rightClick(\'#button\');');
+    it('Should make right click on a button', function () {
+        return runTests('./testcafe-fixtures/right-click-test.js', 'Right click button', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                expect(errs[0]).to.contains('Right click on the button');
+                expect(errs[0]).to.contains(' >  7 |    await t.rightClick(\'#button\');');
             });
     });
 
-    it('Should validate options [ONLY:chrome]', function () {
-        return runTests('./testcafe-fixtures/right-click-test.js', 'Incorrect action option', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Action option offsetX is expected to be a positive integer, but it was -3.');
-                expect(err).to.contains(' > 15 |    await t.rightClick(\'#button\', { offsetX: -3 });');
+    it('Should validate options', function () {
+        return runTests('./testcafe-fixtures/right-click-test.js', 'Incorrect action option', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                expect(errs[0]).to.contains('Action option offsetX is expected to be a positive integer, but it was -3.');
+                expect(errs[0]).to.contains(' > 15 |    await t.rightClick(\'#button\', { offsetX: -3 });');
             });
     });
 
-    it('Should validate selector [ONLY:chrome]', function () {
-        return runTests('./testcafe-fixtures/right-click-test.js', 'Incorrect action selector', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Action selector is expected to be a string, but it was number.');
-                expect(err).to.contains(' > 11 |    await t.rightClick(123);');
+    it('Should validate selector', function () {
+        return runTests('./testcafe-fixtures/right-click-test.js', 'Incorrect action selector', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                expect(errs[0]).to.contains('Action selector is expected to be a string, but it was number.');
+                expect(errs[0]).to.contains(' > 11 |    await t.rightClick(123);');
             });
     });
 });

--- a/test/functional/fixtures/api/es-next/test-controller/test.js
+++ b/test/functional/fixtures/api/es-next/test-controller/test.js
@@ -3,17 +3,17 @@ var expect = require('chai').expect;
 // NOTE: we run tests in chrome only, because we mainly test server API functionality.
 // Actions functionality is tested in lower-level raw API.
 describe('[API] TestController', function () {
-    it('Should support chaining [ONLY:chrome]', function () {
-        return runTests('./testcafe-fixtures/test-controller-test.js', 'Chaining', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('-btn1-btn2-btn3-page2-btn1-page2-btn2');
+    it('Should support chaining', function () {
+        return runTests('./testcafe-fixtures/test-controller-test.js', 'Chaining', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                expect(errs[0]).to.contains('-btn1-btn2-btn3-page2-btn1-page2-btn2');
             });
     });
 
-    it('Should produce correct callsites for chained calls [ONLY:chrome]', function () {
-        return runTests('./testcafe-fixtures/test-controller-test.js', 'Chaining callsites', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains(
+    it('Should produce correct callsites for chained calls', function () {
+        return runTests('./testcafe-fixtures/test-controller-test.js', 'Chaining callsites', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                expect(errs[0]).to.contains(
                     ' 16 |' +
                     ' 17 |test(\'Chaining callsites\', async t => {' +
                     ' 18 |    await t' +
@@ -30,51 +30,56 @@ describe('[API] TestController', function () {
         var missingAwaitErrMsg = 'A call to an async function is not awaited. Use the await keyword before actions, ' +
                                  'assertions or chains of them to ensure that they run in the right sequence.';
 
-        it('Should track missing `await` [ONLY:chrome]', function () {
-            return runTests('./testcafe-fixtures/test-controller-test.js', 'Missing await', { shouldFail: true })
-                .catch(function (err) {
-                    expect(err).to.contains(missingAwaitErrMsg);
-                    expect(err).to.contains("> 28 |    t.click(\'#page2-btn1\');");
+        it('Should track missing `await`', function () {
+            return runTests('./testcafe-fixtures/test-controller-test.js', 'Missing await', { shouldFail: true, only: 'chrome' })
+                .catch(function (errs) {
+                    expect(errs[0]).to.contains(missingAwaitErrMsg);
+                    expect(errs[0]).to.contains("> 28 |    t.click(\'#page2-btn1\');");
                 });
         });
 
-        it('Should track missing `await` in chain [ONLY:chrome]', function () {
-            return runTests('./testcafe-fixtures/test-controller-test.js', 'Missing await in chain', { shouldFail: true })
-                .catch(function (err) {
-                    expect(err).to.contains(missingAwaitErrMsg);
-                    expect(err).to.contains("> 38 |        .click('#page2-btn2');");
+        it('Should track missing `await` in chain', function () {
+            return runTests('./testcafe-fixtures/test-controller-test.js', 'Missing await in chain',
+                { shouldFail: true, only: 'chrome' })
+                .catch(function (errs) {
+                    expect(errs[0]).to.contains(missingAwaitErrMsg);
+                    expect(errs[0]).to.contains("> 38 |        .click('#page2-btn2');");
                 });
         });
 
-        it('Should track missing `await` in the end of test [ONLY:chrome]', function () {
-            return runTests('./testcafe-fixtures/test-controller-test.js', 'Missing await in the end of the test', { shouldFail: true })
-                .catch(function (err) {
-                    expect(err).to.contains(missingAwaitErrMsg);
-                    expect(err).to.contains("> 44 |    t.click('#btn3');");
+        it('Should track missing `await` in the end of test', function () {
+            return runTests('./testcafe-fixtures/test-controller-test.js', 'Missing await in the end of the test',
+                { shouldFail: true, only: 'chrome' })
+                .catch(function (errs) {
+                    expect(errs[0]).to.contains(missingAwaitErrMsg);
+                    expect(errs[0]).to.contains("> 44 |    t.click('#btn3');");
                 });
         });
 
-        it('Should track missing `await` for actions with error [ONLY:chrome]', function () {
-            return runTests('./testcafe-fixtures/test-controller-test.js', 'Error caused by action with missing await [ONLY:chrome]', { shouldFail: true })
-                .catch(function (err) {
-                    expect(err).to.contains(missingAwaitErrMsg);
-                    expect(err).to.contains("> 48 |    t.click('#error'); ");
+        it('Should track missing `await` for actions with error', function () {
+            return runTests('./testcafe-fixtures/test-controller-test.js', 'Error caused by action with missing await',
+                { shouldFail: true, only: 'chrome' })
+                .catch(function (errs) {
+                    expect(errs[0]).to.contains(missingAwaitErrMsg);
+                    expect(errs[0]).to.contains("> 48 |    t.click('#error'); ");
                 });
         });
 
-        it('Should track missing `await` with disrupted chain [ONLY:chrome]', function () {
-            return runTests('./testcafe-fixtures/test-controller-test.js', 'Missing await with disrupted chain', { shouldFail: true })
-                .catch(function (err) {
-                    expect(err).to.contains(missingAwaitErrMsg);
-                    expect(err).to.contains("> 58 |    t.click('#btn2');");
+        it('Should track missing `await` with disrupted chain', function () {
+            return runTests('./testcafe-fixtures/test-controller-test.js', 'Missing await with disrupted chain',
+                { shouldFail: true, only: 'chrome' })
+                .catch(function (errs) {
+                    expect(errs[0]).to.contains(missingAwaitErrMsg);
+                    expect(errs[0]).to.contains("> 58 |    t.click('#btn2');");
                 });
         });
 
-        it('Should track missing `await` in helper [ONLY:chrome]', function () {
-            return runTests('./testcafe-fixtures/test-controller-test.js', 'Missing await in helper', { shouldFail: true })
-                .catch(function (err) {
-                    expect(err).to.contains(missingAwaitErrMsg);
-                    expect(err).to.contains("> 2 |    t.click('#yo');");
+        it('Should track missing `await` in helper', function () {
+            return runTests('./testcafe-fixtures/test-controller-test.js', 'Missing await in helper',
+                { shouldFail: true, only: 'chrome' })
+                .catch(function (errs) {
+                    expect(errs[0]).to.contains(missingAwaitErrMsg);
+                    expect(errs[0]).to.contains("> 2 |    t.click('#yo');");
                 });
         });
     });

--- a/test/functional/fixtures/api/es-next/test-controller/testcafe-fixtures/test-controller-test.js
+++ b/test/functional/fixtures/api/es-next/test-controller/testcafe-fixtures/test-controller-test.js
@@ -44,7 +44,7 @@ test('Missing await in the end of the test', async t => {
     t.click('#btn3');
 });
 
-test('Error caused by action with missing await [ONLY:chrome]', async t => {
+test('Error caused by action with missing await', async t => {
     t.click('#error');
 
     await t.click('#btn2');

--- a/test/functional/fixtures/api/legacy/click/test.js
+++ b/test/functional/fixtures/api/legacy/click/test.js
@@ -4,7 +4,7 @@ var expect = require('chai').expect;
 describe('[Legacy API] act.click()', function () {
     it('Should fail if the first argument is invisible', function () {
         return runTests('testcafe-fixtures/click.test.js', 'Should fail if the first argument is invisible', { shouldFail: true })
-            .catch(function (err) {
+            .catch(function (errs) {
                 var expectedError = [
                     'Error at step "1.Click on invisible element":',
                     '',
@@ -15,11 +15,11 @@ describe('[Legacy API] act.click()', function () {
                     'element, make sure that you properly recorded the hover action.'
                 ].join(' ');
 
-                expect(err).eql(expectedError);
+                expect(errs[0]).eql(expectedError);
             });
     });
 
     it('Pointer events test (T191183) [ONLY:ie]', function () {
-        return runTests('testcafe-fixtures/click.test.js', 'Pointer events test (T191183) [ONLY:ie]');
+        return runTests('testcafe-fixtures/click.test.js', 'Pointer events test (T191183)', { only: 'ie' });
     });
 });

--- a/test/functional/fixtures/api/legacy/click/testcafe-fixtures/click.test.js
+++ b/test/functional/fixtures/api/legacy/click/testcafe-fixtures/click.test.js
@@ -9,7 +9,7 @@ var isIE11 = !!(navigator.appCodeName === 'Mozilla' &&
                 /trident\/7.0/.test(userAgent));
 
 
-'@test'['Pointer events test (T191183) [ONLY:ie]'] = {
+'@test'['Pointer events test (T191183)'] = {
     '1.Bind pointer event handlers and call click': function () {
         var input  = $('#input')[0];
         var shared = this;

--- a/test/functional/fixtures/api/raw/before-after-each-hooks/test.js
+++ b/test/functional/fixtures/api/raw/before-after-each-hooks/test.js
@@ -1,19 +1,19 @@
 var expect = require('chai').expect;
 
 // NOTE: we run tests in chrome only, because we mainly test server API functionality.
-describe('[Raw API] beforeEach/afterEach hooks [ONLY:chrome]', function () {
+describe('[Raw API] beforeEach/afterEach hooks', function () {
     it('Should run hooks for all tests', function () {
         var test1Err = null;
 
-        return runTests('./testcafe-fixtures/run-all.testcafe', 'Test1', { shouldFail: true })
-            .catch(function (err) {
-                test1Err = err;
-                return runTests('./testcafe-fixtures/run-all.testcafe', 'Test2', { shouldFail: true });
+        return runTests('./testcafe-fixtures/run-all.testcafe', 'Test1', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                test1Err = errs[0];
+                return runTests('./testcafe-fixtures/run-all.testcafe', 'Test2', { shouldFail: true, only: 'chrome' });
             })
-            .catch(function (err) {
-                expect(err).eql(test1Err);
+            .catch(function (errs) {
+                expect(errs[0]).eql(test1Err);
 
-                expect(err).eql('- Error in afterEach hook - ' +
+                expect(errs[0]).eql('- Error in afterEach hook - ' +
                                 'Error on page "http://localhost:3000/api/raw/before-after-each-hooks/pages/index.html":  ' +
                                 'Uncaught Error: [beforeEach][test][afterEach]'
                 );
@@ -21,10 +21,11 @@ describe('[Raw API] beforeEach/afterEach hooks [ONLY:chrome]', function () {
             });
     });
 
-    it('Should not run test and afterEach if fails in beforeEach [ONLY:chrome]', function () {
-        return runTests('./testcafe-fixtures/fail-in-before-each.testcafe', 'Test', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).eql('- Error in beforeEach hook - ' +
+    it('Should not run test and afterEach if fails in beforeEach', function () {
+        return runTests('./testcafe-fixtures/fail-in-before-each.testcafe', 'Test', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+
+                expect(errs[0]).eql('- Error in beforeEach hook - ' +
                                 'Error on page "http://localhost:3000/api/raw/before-after-each-hooks/pages/index.html":  ' +
                                 'Uncaught Error: [beforeEach]'
                 );
@@ -32,15 +33,14 @@ describe('[Raw API] beforeEach/afterEach hooks [ONLY:chrome]', function () {
             });
     });
 
-    it('Should run test and afterEach and beforeEach if test fails [ONLY:chrome]', function () {
-        return runTests('./testcafe-fixtures/fail-in-test.testcafe', 'Test', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Error on page "http://localhost:3000/api/raw/before-after-each-hooks/pages/index.html":  ' +
-                                        'Uncaught Error: [beforeEach] ' +
-                                        '- Error in afterEach hook - ' +
+    it('Should run test and afterEach and beforeEach if test fails', function () {
+        return runTests('./testcafe-fixtures/fail-in-test.testcafe', 'Test', { shouldFail: true, only: 'chrome' })
+            .catch(function (errs) {
+                expect(errs[0]).to.contains('Error on page "http://localhost:3000/api/raw/before-after-each-hooks/pages/index.html":  ' +
+                                        'Uncaught Error: [beforeEach]');
+                expect(errs[1]).to.contains('- Error in afterEach hook - ' +
                                         'Error on page "http://localhost:3000/api/raw/before-after-each-hooks/pages/index.html":  ' +
-                                        'Uncaught Error: [beforeEach][afterEach]'
-                );
+                                        'Uncaught Error: [beforeEach][afterEach]');
             });
     });
 });

--- a/test/functional/fixtures/api/raw/click/test.js
+++ b/test/functional/fixtures/api/raw/click/test.js
@@ -1,86 +1,88 @@
-var expect = require('chai').expect;
+var expect                     = require('chai').expect;
+var errorInEachBrowserContains = require('../../../../assertion-helper.js').errorInEachBrowserContains;
+
 
 describe('[Raw API] Click action', function () {
     it('Should make click on a button', function () {
         return runTests('./testcafe-fixtures/click.testcafe', 'Click simple button', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Click on input raised');
+            .catch(function (errs) {
+                errorInEachBrowserContains(errs, 'Click on input raised', 0);
             });
     });
 
     it('Should perform click on a submit button and wait for page redirect', function () {
         return runTests('./testcafe-fixtures/click.testcafe', 'Click submit button', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains("It's a submit page");
+            .catch(function (errs) {
+                errorInEachBrowserContains(errs, "It's a submit page", 0);
             });
     });
 
     it('Should wait for the page load barrier to finish after an action', function () {
         return runTests('./testcafe-fixtures/click.testcafe', 'Redirect after a timeout', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains("It's a submit page");
+            .catch(function (errs) {
+                errorInEachBrowserContains(errs, "It's a submit page", 0);
             });
     });
 
     it('Should fail when a js-error appears on page load', function () {
         return runTests('./testcafe-fixtures/page-with-error.testcafe', null, { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Error on page "http://localhost:3000/api/raw/click/pages/error.html":  Uncaught Error: Custom error');
-                expect(err).to.contains('[[Click on simple button callsite]]');
+            .catch(function (errs) {
+                errorInEachBrowserContains(errs, 'Error on page "http://localhost:3000/api/raw/click/pages/error.html":', 0);
+                errorInEachBrowserContains(errs, 'Custom error  [[Click on simple button callsite]]', 0);
             });
     });
 
     it('Should fail when a js-error appears during click execution', function () {
         return runTests('./testcafe-fixtures/click.testcafe', 'Click error button', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Error on page "http://localhost:3000/api/raw/click/pages/index.html":  Uncaught Error: Custom error');
-                expect(err).to.contains('[[Click error button callsite]]');
+            .catch(function (errs) {
+                errorInEachBrowserContains(errs, 'Error on page "http://localhost:3000/api/raw/click/pages/index.html":', 0);
+                errorInEachBrowserContains(errs, 'Custom error  [[Click error button callsite]]', 0);
             });
     });
 
     it('Should wait for xhr-requests after an aciton', function () {
         return runTests('./testcafe-fixtures/click.testcafe', 'Click xhr button', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Xhr requests are finished');
+            .catch(function (errs) {
+                errorInEachBrowserContains(errs, 'Xhr requests are finished', 0);
             });
     });
 
     it('Should wait for the next action element to appear', function () {
         return runTests('./testcafe-fixtures/click.testcafe', 'Wait for next action target appeared', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Click on the new button raised');
+            .catch(function (errs) {
+                errorInEachBrowserContains(errs, 'Click on the new button raised', 0);
             });
     });
 
     it("Should fail if an action target doesn't exist", function () {
         return runTests('./testcafe-fixtures/click.testcafe', 'Click non-existent button', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).eql('The specified selector does not match any element in the DOM tree.  ' +
-                                '[[Click non-existent button callsite]]');
+            .catch(function (errs) {
+                expect(errs[0]).eql('The specified selector does not match any element in the DOM tree.  ' +
+                                   '[[Click non-existent button callsite]]');
             });
     });
 
     it('Should fail if an action target is invisible', function () {
         return runTests('./testcafe-fixtures/click.testcafe', 'Click invisible button', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).eql('The element that matches the specified selector is not visible.  ' +
-                                '[[Click invisible button callsite]]');
+            .catch(function (errs) {
+                expect(errs[0]).eql('The element that matches the specified selector is not visible.  ' +
+                                   '[[Click invisible button callsite]]');
             });
     });
 
     it('Should fail if action has incorrect selector', function () {
         return runTests('./testcafe-fixtures/click.testcafe', 'Incorrect action selector', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).eql('Action selector is expected to be a string, but it was number.  ' +
-                                '[[Incorrect action selector callsite]]');
+            .catch(function (errs) {
+                expect(errs[0]).eql('Action selector is expected to be a string, but it was number.  ' +
+                                   '[[Incorrect action selector callsite]]');
             });
     });
 
     it('Should fail if action has an incorrect option', function () {
         return runTests('./testcafe-fixtures/click.testcafe', 'Incorrect action option', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).eql('Action option offsetX is expected to be a positive integer, but it was string.  ' +
-                                '[[Incorrect action option callsite]]');
+            .catch(function (errs) {
+                expect(errs[0]).eql('Action option offsetX is expected to be a positive integer, but it was string.  ' +
+                                   '[[Incorrect action option callsite]]');
             });
     });
 });

--- a/test/functional/fixtures/api/raw/double-click/test.js
+++ b/test/functional/fixtures/api/raw/double-click/test.js
@@ -1,10 +1,11 @@
-var expect = require('chai').expect;
+var errorInEachBrowserContains = require('../../../../assertion-helper.js').errorInEachBrowserContains;
+
 
 describe('[Raw API] Double click action', function () {
     it('Should make double click on a button', function () {
         return runTests('./testcafe-fixtures/double-click.testcafe', 'Double click simple button', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Click on input raised 2 times. Double click on input raised');
+            .catch(function (errs) {
+                errorInEachBrowserContains(errs, 'Click on input raised 2 times. Double click on input raised', 0);
             });
     });
 });

--- a/test/functional/fixtures/api/raw/hover/test.js
+++ b/test/functional/fixtures/api/raw/hover/test.js
@@ -1,10 +1,11 @@
-var expect = require('chai').expect;
+var errorInEachBrowserContains = require('../../../../assertion-helper.js').errorInEachBrowserContains;
+
 
 describe('[Raw API] Hover action', function () {
     it('Should make hover on a buttons', function () {
         return runTests('./testcafe-fixtures/hover.testcafe', 'Hover on simple buttons', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Hover on inputs raised');
+            .catch(function (errs) {
+                errorInEachBrowserContains(errs, 'Hover on inputs raised', 0);
             });
     });
 });

--- a/test/functional/fixtures/api/raw/right-click/test.js
+++ b/test/functional/fixtures/api/raw/right-click/test.js
@@ -1,10 +1,11 @@
-var expect = require('chai').expect;
+var errorInEachBrowserContains = require('../../../../assertion-helper.js').errorInEachBrowserContains;
+
 
 describe('[Raw API] Right click action', function () {
     it('Should make right click on a button', function () {
         return runTests('./testcafe-fixtures/right-click.testcafe', 'Right click simple button', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains('Right click on input raised');
+            .catch(function (errs) {
+                errorInEachBrowserContains(errs, 'Right click on input raised', 0);
             });
     });
 });

--- a/test/functional/fixtures/before-unload-handling/test.js
+++ b/test/functional/fixtures/before-unload-handling/test.js
@@ -8,25 +8,25 @@ describe('Before unload handling', function () {
 
     it("Should fail if the expected beforeUnload dialog doesn't appear", function () {
         return runTests('testcafe-fixtures/index.test.js', 'No expected beforeUnload dialog - should fail', { shouldFail: true })
-            .catch(function (err) {
+            .catch(function (errs) {
                 var expectedError = [
                     'Error at step "1.Click link "This page"":',
                     ' The expected system beforeUnload dialog did not appear.'
                 ].join('');
 
-                expect(err).eql(expectedError);
+                expect(errs[0]).eql(expectedError);
             });
     });
 
     it('Should fail if an unexpected beforeUnload dialog appears', function () {
         return runTests('testcafe-fixtures/index.test.js', 'Unexpected beforeUnload dialog - should fail', { shouldFail: true })
-            .catch(function (err) {
+            .catch(function (errs) {
                 var expectedError = [
                     'Error at step "2.Click link "This page"":',
                     ' Unexpected system beforeUnload dialog message appeared.'
                 ].join('');
 
-                expect(err).eql(expectedError);
+                expect(errs[0]).eql(expectedError);
             });
     });
 
@@ -36,25 +36,25 @@ describe('Before unload handling', function () {
 
     it("Should fail if the expected beforeUnload dialog doesn't appear in iframe", function () {
         return runTests('testcafe-fixtures/in-iframe.test.js', 'No expected beforeUnload dialog in iframe - should fail', { shouldFail: true })
-            .catch(function (err) {
+            .catch(function (errs) {
                 var expectedError = [
                     'Error at step "1.Click link "This page"":',
                     ' The expected system beforeUnload dialog did not appear.'
                 ].join('');
 
-                expect(err).eql(expectedError);
+                expect(errs[0]).eql(expectedError);
             });
     });
 
     it('Should fail if an unexpected beforeUnload dialog appears in iframe', function () {
         return runTests('testcafe-fixtures/in-iframe.test.js', 'Unexpected beforeUnload dialog in iframe - should fail', { shouldFail: true })
-            .catch(function (err) {
+            .catch(function (errs) {
                 var expectedError = [
                     'Error at step "2.Click link "This page"":',
                     ' Unexpected system beforeUnload dialog message appeared.'
                 ].join('');
 
-                expect(err).eql(expectedError);
+                expect(errs[0]).eql(expectedError);
             });
     });
 });

--- a/test/functional/fixtures/native-dialogs-handling/test.js
+++ b/test/functional/fixtures/native-dialogs-handling/test.js
@@ -12,97 +12,97 @@ describe('Native dialogs handling', function () {
 
     it('Should fail if an unexpected alert dialog appears after click on the fake link', function () {
         return runTests('testcafe-fixtures/index.test.js', 'Unexpected alert after click on the link without redirect - should fail', { shouldFail: true })
-            .catch(function (err) {
+            .catch(function (errs) {
                 var expectedError = [
                     'Error at step "1.Click alert button":',
                     'Unexpected system alert dialog Alert dialog appeared.'
                 ].join(' ');
 
-                expect(err).eql(expectedError);
+                expect(errs[0]).eql(expectedError);
             });
     });
 
     it('Should fail if two confirmation dialogs appear and only one is handled', function () {
         return runTests('testcafe-fixtures/index.test.js', 'No expected second confirm - should fail', { shouldFail: true })
-            .catch(function (err) {
+            .catch(function (errs) {
                 var expectedError = [
                     'Error at step "1.Click submit button "Confirm"":',
                     'Unexpected system confirm dialog Confirm dialog appeared.'
                 ].join(' ');
 
-                expect(err).eql(expectedError);
+                expect(errs[0]).eql(expectedError);
             });
     });
 
     it('Should fail when an unexpected confirmation dialog appears after an action', function () {
         return runTests('testcafe-fixtures/index.test.js', 'Unexpected confirm after action - should fail', { shouldFail: true })
-            .catch(function (err) {
+            .catch(function (errs) {
                 var expectedError = [
                     'Error at step "1.Click submit button "Confirm"":',
                     'Unexpected system confirm dialog Confirm dialog appeared.'
                 ].join(' ');
 
-                expect(err).eql(expectedError);
+                expect(errs[0]).eql(expectedError);
             });
     });
 
     it('Should fail when an unexpected prompt dialog appears after an action', function () {
         return runTests('testcafe-fixtures/index.test.js', 'Unexpected prompt after action - should fail', { shouldFail: true })
-            .catch(function (err) {
+            .catch(function (errs) {
                 var expectedError = [
                     'Error at step "1.Click prompt button":',
                     'Unexpected system prompt dialog Prompt dialog appeared.'
                 ].join(' ');
 
-                expect(err).eql(expectedError);
+                expect(errs[0]).eql(expectedError);
             });
     });
 
     it('Should fail when an unexpected alert dialog appears after an action', function () {
         return runTests('testcafe-fixtures/index.test.js', 'Unexpected alert after action - should fail')
-            .catch(function (err) {
+            .catch(function (errs) {
                 var expectedError = [
                     'Error at step "1.Click alert button":',
                     'Unexpected system alert dialog Alert dialog appeared.'
                 ].join(' ');
 
-                expect(err).eql(expectedError);
+                expect(errs[0]).eql(expectedError);
             });
     });
 
     it("Should fail if the expected confirmation dialog doesn't appear after an action", function () {
         return runTests('testcafe-fixtures/index.test.js', 'No expected confirm after action - should fail', { shouldFail: true })
-            .catch(function (err) {
+            .catch(function (errs) {
                 var expectedError = [
                     'Error at step "1.Click submit button "Button"":',
                     'The expected system confirm dialog did not appear.'
                 ].join(' ');
 
-                expect(err).eql(expectedError);
+                expect(errs[0]).eql(expectedError);
             });
     });
 
     it("Should fail if the expected prompt dialog doesn't appear after an action", function () {
         return runTests('testcafe-fixtures/index.test.js', 'No expected prompt after action - should fail', { shouldFail: true })
-            .catch(function (err) {
+            .catch(function (errs) {
                 var expectedError = [
                     'Error at step "1.Click submit button "Button"":',
                     'The expected system prompt dialog did not appear.'
                 ].join(' ');
 
-                expect(err).eql(expectedError);
+                expect(errs[0]).eql(expectedError);
             });
     });
 
     it("Should fail if the expected alert dialog doesn't appear after an action", function () {
         return runTests('testcafe-fixtures/index.test.js', 'No expected alert after action - should fail', { shouldFail: true })
-            .catch(function (err) {
+            .catch(function (errs) {
                 var expectedError = [
                     'Error at step "1.Click submit button "Button"":',
                     'The expected system alert dialog did not appear.'
                 ].join(' ');
 
-                expect(err).eql(expectedError);
+                expect(errs[0]).eql(expectedError);
             });
     });
 
@@ -113,25 +113,25 @@ describe('Native dialogs handling', function () {
 
         it('Should fail when an unexpected confirmation dialog appears', function () {
             return runTests('testcafe-fixtures/index.test.js', 'Unexpected confirm after redirect - should fail', { shouldFail: true })
-                .catch(function (err) {
+                .catch(function (errs) {
                     var expectedError = [
                         'Error at step "1.Click link "Confirm page"":',
                         'Unexpected system confirm dialog Confirm dialog appeared.'
                     ].join(' ');
 
-                    expect(err).eql(expectedError);
+                    expect(errs[0]).eql(expectedError);
                 });
         });
 
         it("Should fail if the expected confirmation dialog doesn't appear", function () {
             return runTests('testcafe-fixtures/index.test.js', 'No expected confirm after redirect - should fail', { shouldFail: true })
-                .catch(function (err) {
+                .catch(function (errs) {
                     var expectedError = [
                         'Error at step "1.Click link "This page"":',
                         'The expected system confirm dialog did not appear.'
                     ].join(' ');
 
-                    expect(err).eql(expectedError);
+                    expect(errs[0]).eql(expectedError);
                 });
         });
     });
@@ -143,25 +143,25 @@ describe('Native dialogs handling', function () {
 
         it('Should fail when an unexpected confirmation dialog appears after an action', function () {
             return runTests('testcafe-fixtures/in-iframe.test.js', 'Unexpected confirm after action in iframe - should fail', { shouldFail: true })
-                .catch(function (err) {
+                .catch(function (errs) {
                     var expectedError = [
                         'Error at step "1.Click submit button "Confirm"":',
                         'Unexpected system confirm dialog Confirm dialog appeared.'
                     ].join(' ');
 
-                    expect(err).eql(expectedError);
+                    expect(errs[0]).eql(expectedError);
                 });
         });
 
         it("Should fail if the expected confirmation dialog doesn't appear after an action", function () {
             return runTests('testcafe-fixtures/in-iframe.test.js', 'No expected confirm after action in iframe - should fail', { shouldFail: true })
-                .catch(function (err) {
+                .catch(function (errs) {
                     var expectedError = [
                         'Error at step "1.Click submit button "Button"":',
                         'The expected system confirm dialog did not appear.'
                     ].join(' ');
 
-                    expect(err).eql(expectedError);
+                    expect(errs[0]).eql(expectedError);
                 });
         });
 
@@ -171,25 +171,25 @@ describe('Native dialogs handling', function () {
 
         it('Should fail when an unexpected confirmation dialog appears after redirect', function () {
             return runTests('testcafe-fixtures/in-iframe.test.js', 'Unexpected confirm after redirect in iframe - should fail', { shouldFail: true })
-                .catch(function (err) {
+                .catch(function (errs) {
                     var expectedError = [
                         'Error at step "1.Click link "Confirm page"":',
                         'Unexpected system confirm dialog Confirm dialog appeared.'
                     ].join(' ');
 
-                    expect(err).eql(expectedError);
+                    expect(errs[0]).eql(expectedError);
                 });
         });
 
         it("Should fail if the expected confirmation dialog doesn't appear after redirect", function () {
             return runTests('testcafe-fixtures/in-iframe.test.js', 'No expected confirm after redirect in iframe - should fail', { shouldFail: true })
-                .catch(function (err) {
+                .catch(function (errs) {
                     var expectedError = [
                         'Error at step "1.Click link "This page"":',
                         'The expected system confirm dialog did not appear.'
                     ].join(' ');
 
-                    expect(err).eql(expectedError);
+                    expect(errs[0]).eql(expectedError);
                 });
         });
     });

--- a/test/functional/fixtures/quarantine-mode/test.js
+++ b/test/functional/fixtures/quarantine-mode/test.js
@@ -1,6 +1,7 @@
-var expect                = require('chai').expect;
-var config                = require('../../config');
-var quarantineModeTracker = require('../../quarantine-mode-tracker');
+var expect                     = require('chai').expect;
+var config                     = require('../../config');
+var quarantineModeTracker      = require('../../quarantine-mode-tracker');
+var errorInEachBrowserContains = require('../../assertion-helper.js').errorInEachBrowserContains;
 
 
 function checkQuarantineTestRuns (quarantineState) {
@@ -38,14 +39,18 @@ describe('Quarantine mode tests', function () {
     });
 
     it('Should fail if an unstable test fails in most of runs', function () {
-        return runTests('testcafe-fixtures/failing-quarantine.test.js', 'Wait 200ms', { shouldFail: true, quarantineMode: true })
-            .catch(function (err) {
-                var expectedError = 'Uncaught JavaScript error Uncaught Error: Failed by request! on page';
+        return runTests('testcafe-fixtures/failing-quarantine.test.js', 'Wait 200ms', {
+            shouldFail:     true,
+            quarantineMode: true
+        })
+            .catch(function (errs) {
+                var expectedError = 'Failed by request! on page';
 
                 checkQuarantineTestRuns('failed-quarantine');
 
                 expect(testReport.unstable).to.be.true;
-                expect(err).contains(expectedError);
+
+                errorInEachBrowserContains(errs, expectedError, 0);
             });
     });
 });

--- a/test/functional/fixtures/regression/gh-414/test.js
+++ b/test/functional/fixtures/regression/gh-414/test.js
@@ -8,7 +8,7 @@ describe("[Regression](GH-414) Should restart a test step if redirect occurs whi
 
     it('Should fail when redirected before the target element for the click action appears', function () {
         return runTests('testcafe-fixtures/index.test.js', 'Redirect before the target element appears - should fail', { shouldFail: true })
-            .catch(function (err) {
+            .catch(function (errs) {
                 var expectedError = [
                     'Error at step "2.Click div "The second div"":',
                     " act.click('#div2'); ",
@@ -17,7 +17,7 @@ describe("[Regression](GH-414) Should restart a test step if redirect occurs whi
                     'operation is finished, use the waitFor action (available for use in code)',
                     'to pause test execution until this element appears.'].join(' ');
 
-                expect(err).eql(expectedError);
+                expect(errs[0]).eql(expectedError);
             });
     });
 

--- a/test/functional/fixtures/regression/t200501/test.js
+++ b/test/functional/fixtures/regression/t200501/test.js
@@ -3,13 +3,13 @@ var expect = require('chai').expect;
 
 it('[Regression](T200501) Wait parameters are not verified', function () {
     return runTests('testcafe-fixtures/index.test.js', null, { shouldFail: true })
-        .catch(function (err) {
+        .catch(function (errs) {
             var expectedError = [
                 'Error at step "1.Wait with mixed up parameters":',
                 ' act.wait(function () { return false; }, 500); ',
                 'wait action\'s "milliseconds" parameter should be a positive number.'
             ].join(' ');
 
-            expect(err).eql(expectedError);
+            expect(errs[0]).eql(expectedError);
         });
 });

--- a/test/functional/fixtures/uncaught-js-errors/test.js
+++ b/test/functional/fixtures/uncaught-js-errors/test.js
@@ -1,34 +1,33 @@
-var expect = require('chai').expect;
-
-var CUSTOM_JS_ERROR = '%TC_TEST_ERR%';
+var CUSTOM_JS_ERROR            = '%TC_TEST_ERR%';
+var errorInEachBrowserContains = require('../../assertion-helper.js').errorInEachBrowserContains;
 
 
 describe('Uncaught js errors', function () {
     it('Should fail if there is no onerror handler', function () {
         return runTests('testcafe-fixtures/no-handler.test.js', null, { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains(CUSTOM_JS_ERROR);
+            .catch(function (errs) {
+                errorInEachBrowserContains(errs, CUSTOM_JS_ERROR, 0);
             });
     });
 
     it('Should fail if the onerror handler returns undefined', function () {
         return runTests('testcafe-fixtures/handler-returns-undefined.test.js', null, { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains(CUSTOM_JS_ERROR);
+            .catch(function (errs) {
+                errorInEachBrowserContains(errs, CUSTOM_JS_ERROR, 0);
             });
     });
 
     it("Should fail if iframe's onerror handler returns undefined", function () {
         return runTests('testcafe-fixtures/same-domain-iframe.test.js', null, { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains(CUSTOM_JS_ERROR);
+            .catch(function (errs) {
+                errorInEachBrowserContains(errs, CUSTOM_JS_ERROR, 0);
             });
     });
 
     it('Should fail if the loaded page throws an error', function () {
         return runTests('testcafe-fixtures/loaded.test.js', null, { shouldFail: true })
-            .catch(function (err) {
-                expect(err).to.contains(CUSTOM_JS_ERROR);
+            .catch(function (errs) {
+                errorInEachBrowserContains(errs, CUSTOM_JS_ERROR, 0);
             });
     });
 
@@ -59,8 +58,8 @@ describe('Uncaught js errors', function () {
     describe('Regression', function () {
         it('Should include destination URL in the error message', function () {
             return runTests('testcafe-fixtures/no-handler.test.js', null, { shouldFail: true })
-                .catch(function (err) {
-                    expect(err).to.contain('on page "http://localhost:3000/uncaught-js-errors/pages/no-handler.html"');
+                .catch(function (errs) {
+                    errorInEachBrowserContains(errs, 'on page "http://localhost:3000/uncaught-js-errors/pages/no-handler.html"', 0);
                 });
         });
     });

--- a/test/functional/fixtures/upload/test.js
+++ b/test/functional/fixtures/upload/test.js
@@ -12,17 +12,17 @@ describe('Upload', function () {
 
     it('Should fail when uploading a non-existent file', function () {
         return runTests('testcafe-fixtures/upload.test.js', 'Upload a non-existent file - should fail', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).contains('fake.jpg');
+            .catch(function (errs) {
+                expect(errs[0]).contains('fake.jpg');
             });
     });
 
     it('Should fail when uploading multiple files including non-existent files', function () {
         return runTests('testcafe-fixtures/upload.test.js', 'Upload multiple files inc. non-existent - should fail', { shouldFail: true })
-            .catch(function (err) {
-                expect(err).contains('fake1.jpg');
-                expect(err).contains('fake2.jpg');
-                expect(err).not.contains('text1.txt');
+            .catch(function (errs) {
+                expect(errs[0]).contains('fake1.jpg');
+                expect(errs[0]).contains('fake2.jpg');
+                expect(errs[0]).not.contains('text1.txt');
             });
     });
 

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -98,8 +98,17 @@ before(function () {
                 var fixturePath    = path.join(path.dirname(caller()), fixture);
                 var skipJsErrors   = opts && opts.skipJsErrors;
                 var quarantineMode = opts && opts.quarantineMode;
+                var skipOption     = opts && opts.skip;
+                var onlyOption     = opts && opts.only;
 
-                var connections = browsersInfo.map(function (browserInfo) {
+                var actualBrowsers = browsersInfo.filter(function (browserInfo) {
+                    var only = onlyOption ? onlyOption.indexOf(browserInfo.settings.alias) > -1 : true;
+                    var skip = skipOption ? skipOption.indexOf(browserInfo.settings.alias) > -1 : false;
+
+                    return only && !skip;
+                });
+
+                var connections = actualBrowsers.map(function (browserInfo) {
                     return browserInfo.connection;
                 });
 
@@ -121,7 +130,7 @@ before(function () {
                     .run({ skipJsErrors: skipJsErrors, quarantineMode: quarantineMode })
                     .then(function () {
                         var testReport = JSON.parse(report).fixtures[0].tests[0];
-                        var testError  = getTestError(testReport, browsersInfo);
+                        var testError  = getTestError(testReport, actualBrowsers);
                         var shouldFail = opts && opts.shouldFail;
 
                         global.testReport = testReport;


### PR DESCRIPTION
\cc @inikulin, @AlexanderMoskovkin