### PR TITLE
Implemented 'path:' prefix for browser paths (closes #468, closes #466)

### DIFF
--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -34,9 +34,9 @@ describe('CLI argument parser', function () {
 
     describe('Browser list', function () {
         it('Should be parsed as array of aliases or paths', function () {
-            return parse('/Applications/Firefox.app,ie,chrome,ff,')
+            return parse('path:"/Applications/Firefox.app",ie,chrome,ff,')
                 .then(function (parser) {
-                    expect(parser.browsers).eql(['/Applications/Firefox.app', 'ie', 'chrome', 'ff']);
+                    expect(parser.browsers).eql(['path:/Applications/Firefox.app', 'ie', 'chrome', 'ff']);
                 });
         });
 
@@ -59,6 +59,16 @@ describe('CLI argument parser', function () {
                     var parser      = results[1];
 
                     expect(parser.browsers).eql(['ie', 'chrome'].concat(allAliasses));
+                });
+        });
+
+        it('Should split browsers correctly if paths have commas and quotes', function () {
+            return parse('path:"/Apps,Libs/\'Firefox.app",ie,chrome,ff,path:\'/Apps,Libs/"Chrome.app\'')
+                .then(function (parser) {
+                    expect(parser.browsers).eql([
+                        'path:/Apps,Libs/\'Firefox.app', 'ie', 'chrome', 'ff',
+                        'path:/Apps,Libs/"Chrome.app'
+                    ]);
                 });
         });
     });

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -84,6 +84,22 @@ describe('Runner', function () {
                 });
         });
 
+
+        it('Should raise an error if an unprefixed path is provided', function () {
+            return runner
+                .browsers('/Applications/Firefox.app')
+                .reporter('list')
+                .src('test/server/data/test-suites/basic/testfile2.js')
+                .run()
+                .then(function () {
+                    throw new Error('Promise rejection expected');
+                })
+                .catch(function (err) {
+                    expect(err.message).eql('Unable to find the browser. "/Applications/Firefox.app" is not a ' +
+                                            'browser alias or path to an executable file.');
+                });
+        });
+
         it('Should raise an error if browser was not set', function () {
             return runner
                 .reporter('list')


### PR DESCRIPTION
\cc @inikulin. @AlexanderMoskovkin, @VasilyStrelyaev (changed error message, test names)