### PR TITLE
Usage of "browserUtils.isOpera" dropped (closes #497)

### DIFF
--- a/src/client/core/utils/dom.js
+++ b/src/client/core/utils/dom.js
@@ -139,7 +139,7 @@ function getFocusableElements (doc) {
             needPush = true;
         else if (browserUtils.isIE && isIframeElement(el))
             focusableElements.push(el);
-        else if (!browserUtils.isOpera && isAnchorElement(el) && el.hasAttribute('href'))
+        else if (isAnchorElement(el) && el.hasAttribute('href'))
             needPush = el.getAttribute('href') !== '' || !browserUtils.isIE || tabIndex !== null;
 
         var contentEditableAttr = el.getAttribute('contenteditable');
@@ -333,8 +333,7 @@ export function getNextFocusableElement (element, reverse) {
 
     //NOTE: in all browsers except Mozilla and Opera focus sets on one radio set from group only.
     // in Mozilla and Opera focus sets on any radio set.
-    if (isInputElement(element) && element.type === "radio" && element.name !== "" &&
-        !(browserUtils.isFirefox || browserUtils.isOpera))
+    if (isInputElement(element) && element.type === "radio" && element.name !== "" && !browserUtils.isFirefox)
         allFocusable = arrayUtils.filter(allFocusable, item => {
             return !item.name || item === element || item.name !== element.name;
         });

--- a/src/client/runner/automation/get-element.js
+++ b/src/client/runner/automation/get-element.js
@@ -48,7 +48,7 @@ export function fromPoint (x, y, expectedElement) {
     var isSVGElement  = domUtils.isSVGElement(expectedElement);
 
     // NOTE: 'document.elementFromPoint' can't find these types of elements
-    if (isSVGElement && browserUtils.isOpera || isTREFElement)
+    if (isTREFElement)
         return expectedElement;
 
     // NOTE: T299665 - Incorrect click automation for images with an associated map element in Firefox

--- a/test/client/fixtures/runner/automation/tab-emulation-test.js
+++ b/test/client/fixtures/runner/automation/tab-emulation-test.js
@@ -118,7 +118,7 @@ $(document).ready(function () {
         $expectedFocusedElements.push($selectMultiple);
         $expectedFocusedElements.push($radioInput1);
 
-        if (browserUtils.isOpera || browserUtils.isFirefox) {
+        if (browserUtils.isFirefox) {
             $expectedFocusedElements.push($radioInput3);
             $expectedFocusedElements.push($radioInput4);
         }


### PR DESCRIPTION
\cc @AlexanderMoskovkin, @helen-dikareva 