### PR TITLE
Refactor TestController. Implement t.eval() (#241)

### DIFF
--- a/src/api/common/index.js
+++ b/src/api/common/index.js
@@ -1,4 +1,11 @@
 import Role from './role';
-import Hybrid from './hybrid';
+import createHybridFunction from './hybrid';
 
-export default { Role, Hybrid };
+export default {
+    Role,
+
+    Hybrid (fn, dependencies) {
+        return createHybridFunction(fn, dependencies);
+    }
+};
+

--- a/src/test-run/commands/type.js
+++ b/src/test-run/commands/type.js
@@ -15,6 +15,6 @@ export default {
     selectTextAreaContent: 'select-text-area-content',
     selectEditableContent: 'select-editable-content',
     pressKey:              'press-key',
-    execHybridFn:          'execHybridFn',
+    execHybridFn:          'exec-hybrid-fn',
     testDone:              'test-done'
 };

--- a/test/functional/fixtures/api/es-next/eval/pages/index.html
+++ b/test/functional/fixtures/api/es-next/eval/pages/index.html
@@ -5,6 +5,6 @@
     <title>Title</title>
 </head>
 <body>
-
+<div id="answer">42</div>
 </body>
 </html>

--- a/test/functional/fixtures/api/es-next/eval/test.js
+++ b/test/functional/fixtures/api/es-next/eval/test.js
@@ -2,7 +2,7 @@ var expect         = require('chai').expect;
 var parseUserAgent = require('useragent').parse;
 
 describe('[API] t.eval', function () {
-    it('Should execute anonymous hybrid function', function () {
+    it('Should execute an anonymous hybrid function', function () {
         function assertUA (errs, alias, expected) {
             var ua = parseUserAgent(errs[alias][0]).toString();
 
@@ -17,11 +17,11 @@ describe('[API] t.eval', function () {
             });
     });
 
-    it('Should execute anonymous hybrid function with dependencies', function () {
+    it('Should execute an anonymous hybrid function with dependencies', function () {
         return runTests('./testcafe-fixtures/eval-test.js', 'Eval with dependencies');
     });
 
-    it('Should have correct callsite if error occurs on instantiation', function () {
+    it('Should have the correct callsite if an error occurs on instantiation', function () {
         return runTests('./testcafe-fixtures/eval-test.js', 'Error on instantiation', { shouldFail: true })
             .catch(function (errs) {
                 expect(errs[0]).contains('Client code is expected to be specified as a function, but "string" was passed.');
@@ -29,7 +29,7 @@ describe('[API] t.eval', function () {
             });
     });
 
-    it('Should have correct callsite if error occurs during execution', function () {
+    it('Should have the correct callsite if an error occurs during execution', function () {
         return runTests('./testcafe-fixtures/eval-test.js', 'Error during execution', { shouldFail: true })
             .catch(function (errs) {
                 expect(errs[0]).contains('An error occurred in code executed on the client:  Error: Hi there!');

--- a/test/functional/fixtures/api/es-next/eval/test.js
+++ b/test/functional/fixtures/api/es-next/eval/test.js
@@ -1,0 +1,39 @@
+var expect         = require('chai').expect;
+var parseUserAgent = require('useragent').parse;
+
+describe('[API] t.eval', function () {
+    it('Should execute anonymous hybrid function', function () {
+        function assertUA (errs, alias, expected) {
+            var ua = parseUserAgent(errs[alias][0]).toString();
+
+            expect(ua.indexOf(expected)).eql(0);
+        }
+
+        return runTests('./testcafe-fixtures/eval-test.js', 'Get UA', { shouldFail: true })
+            .catch(function (errs) {
+                assertUA(errs, 'chrome', 'Chrome');
+                assertUA(errs, 'ff', 'Firefox');
+                assertUA(errs, 'ie', 'IE');
+            });
+    });
+
+    it('Should execute anonymous hybrid function with dependencies', function () {
+        return runTests('./testcafe-fixtures/eval-test.js', 'Eval with dependencies');
+    });
+
+    it('Should have correct callsite if error occurs on instantiation', function () {
+        return runTests('./testcafe-fixtures/eval-test.js', 'Error on instantiation', { shouldFail: true })
+            .catch(function (errs) {
+                expect(errs[0]).contains('Client code is expected to be specified as a function, but "string" was passed.');
+                expect(errs[0]).contains("> 21 |    await t.eval('42');");
+            });
+    });
+
+    it('Should have correct callsite if error occurs during execution', function () {
+        return runTests('./testcafe-fixtures/eval-test.js', 'Error during execution', { shouldFail: true })
+            .catch(function (errs) {
+                expect(errs[0]).contains('An error occurred in code executed on the client:  Error: Hi there!');
+                expect(errs[0]).contains('> 25 |    await t.eval(() => {');
+            });
+    });
+});

--- a/test/functional/fixtures/api/es-next/eval/testcafe-fixtures/eval-test.js
+++ b/test/functional/fixtures/api/es-next/eval/testcafe-fixtures/eval-test.js
@@ -1,0 +1,28 @@
+// NOTE: to preserve callsites, add new tests AFTER the existing ones
+import { Hybrid } from 'testcafe';
+import { expect } from 'chai';
+
+fixture `t.eval`
+    .page `http://localhost:3000/api/es-next/eval/pages/index.html`;
+
+const getById = Hybrid(id => document.getElementById(id));
+
+test('Get UA', async t => {
+    throw await t.eval(() => navigator.userAgent);
+});
+
+test('Eval with dependencies', async t => {
+    const answer = await t.eval(() => getById('answer').textContent, { getById });
+
+    expect(answer).eql('42');
+});
+
+test('Error on instantiation', async t => {
+    await t.eval('42');
+});
+
+test('Error during execution', async t => {
+    await t.eval(() => {
+        throw new Error('Hi there!');
+    });
+});

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -7,8 +7,7 @@ var stackParser = require('error-stack-parser');
 var stripAnsi   = require('strip-ansi');
 var sortBy      = require('lodash').sortBy;
 var Compiler    = require('../../lib/compiler');
-var Role        = require('../../lib/api/common/role');
-var Hybrid      = require('../../lib/api/common/hybrid');
+var commonAPI   = require('../../lib/api/common');
 var NODE_VER    = require('../../lib/utils/node-version');
 
 describe('Compiler', function () {
@@ -155,8 +154,7 @@ describe('Compiler', function () {
                 return compiled.tests[0].fn(testRunMock);
             })
             .then(function (commons) {
-                expect(commons.Role).eql(Role);
-                expect(commons.Hybrid).eql(Hybrid);
+                expect(commons).eql(commonAPI);
             });
     });
 

--- a/test/server/create-testcafe-test.js
+++ b/test/server/create-testcafe-test.js
@@ -2,8 +2,7 @@ var expect         = require('chai').expect;
 var url            = require('url');
 var net            = require('net');
 var createTestCafe = require('../../lib/');
-var Role           = require('../../lib/api/common/role');
-var Hybrid         = require('../../lib/api/common/hybrid');
+var commonAPI      = require('../../lib/api/common');
 var Promise        = require('pinkie');
 
 
@@ -87,7 +86,7 @@ describe('TestCafe factory function', function () {
     it('Should contain plugin testing, embedding utils and common runtime functions', function () {
         expect(createTestCafe.pluginTestingUtils).to.be.an.object;
         expect(createTestCafe.embeddingUtils).to.be.an.object;
-        expect(createTestCafe.Role).eql(Role);
-        expect(createTestCafe.Hybrid).eql(Hybrid);
+        expect(createTestCafe.Role).eql(commonAPI.Role);
+        expect(createTestCafe.Hybrid).eql(commonAPI.Hybrid);
     });
 });


### PR DESCRIPTION
\cc @AlexanderMoskovkin @helen-dikareva @AndreyBelym 
Note that I've changed the way we define API methods to avoid code duplication.
@VasilyStrelyaev pls, check strings