### PR TITLE
[docs] Work around a bug in the broken link checker

### DIFF
--- a/.travis-docs.yml
+++ b/.travis-docs.yml
@@ -1,7 +1,7 @@
 language: node_js
 matrix:
  include:
-  - node_js: "5"
+  - node_js: "stable"
     env: GULP_TASK="test-docs"
  fast_finish: true
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -401,7 +401,7 @@ gulp.task('test-website', ['serve-website'], function (cb) {
     var fail        = false;
     var brokenLinks = [];
 
-    var siteChecker = new blc.SiteChecker({}, {
+    var siteChecker = new blc.SiteChecker({ excludeLinksToSamePage: false }, {
         link: function (result) {
             if (result.broken) {
                 brokenLinks.push(result.url.resolved ? result.url.resolved : result.url.original);

--- a/docs/articles/documentation/extending-testcafe/custom-reporter/helper-methods.md
+++ b/docs/articles/documentation/extending-testcafe/custom-reporter/helper-methods.md
@@ -5,7 +5,7 @@ permalink: /documentation/extending-testcafe/custom-reporter-plugin/helper-metho
 ---
 # Helper Methods
 
-The helper methods are used while [implementing a reporter](creating-reporter-plugin.md#implementing-reporter)
+The helper methods are used while [implementing a reporter](index.md#implementing-reporter)
 to format a report output. TestCafe mixins these methods to the reporter.
 
 To access the helper methods, use `this`.


### PR DESCRIPTION
The broken link checker seems to wrongly mark links as "leading to the same page".
That's why it's missing some broken links unless the `excludeLinksToSamePage` option is disabled.
\cc @DevExpress/testcafe-docs 