### PR TITLE
isIFrameWindowInDOM behavior fixed. sandboxed-jquery client test corrected

### DIFF
--- a/src/client/core/utils/dom.js
+++ b/src/client/core/utils/dom.js
@@ -70,7 +70,7 @@ function insertIFramesContentElements (elements, iFrames) {
                 elementsWithTabIndex = elementsWithTabIndex.sort(sortBy('tabIndex'));
                 results              = results.concat(elementsWithTabIndex);
                 results.push(elements[i]);
-                results              = results.concat(elementsWithoutTabIndexArray);
+                results = results.concat(elementsWithoutTabIndexArray);
             }
             else {
                 if (browserUtils.isWebKit && iFramesElements[arrayUtils.indexOf(iFrames, elements[i])].length)
@@ -361,18 +361,22 @@ export function isIFrameWindowInDOM (win) {
     if (!win.setTimeout)
         return false;
 
-    //NOTE: Cross-domain iframes in Firefox have null in frameElement even if they are in DOM
-    //But Firefox doesn't execute scripts in removed iframes, so we suppose that the iframe is in DOM
-    if (browserUtils.isFirefox && win.top !== win.self && !win.frameElement)
-        return true;
+    var frameElement = null;
 
     try {
-        //NOTE: This raises a cross-domain policy error in WebKit-based browsers.
-        return !!(win.frameElement && win.frameElement.contentDocument);
+        //NOTE: This may raise a cross-domain policy error in some browsers.
+        frameElement = win.frameElement;
     }
     catch (e) {
         return !!win.top;
     }
+
+    // NOTE: in Firefox and WebKit, frameElement is null for cross-domain iframes even if they are in the DOM.
+    // But these browsers don't execute scripts in removed iframes, so we suppose that the iframe is in the DOM.
+    if ((browserUtils.isFirefox || browserUtils.isWebKit) && win.top !== win.self && !frameElement)
+        return true;
+
+    return !!(frameElement && frameElement.contentDocument);
 }
 
 export function isTopWindow (win) {

--- a/test/client/fixtures/core/dom-utils-test.js
+++ b/test/client/fixtures/core/dom-utils-test.js
@@ -35,7 +35,9 @@ asyncTest('isIFrameWindowInDOM', function () {
 
     window.addEventListener('message', onMessage, false);
 
-    var iframe = $('<iframe>').attr('src', window.getCrossDomainPageUrl('../../data/dom-utils/iframe.html'))[0];
+    var iframe = $('<iframe>')[0];
+
+    iframe.src = window.getCrossDomainPageUrl('../../data/dom-utils/iframe.html');
 
     window.QUnitGlobals.waitForIframe(iframe).then(function () {
         iframe.contentWindow.postMessage('isIFrameWindowInDOM', '*');

--- a/test/client/fixtures/core/sandboxed-jquery-test/index-test.js
+++ b/test/client/fixtures/core/sandboxed-jquery-test/index-test.js
@@ -75,7 +75,7 @@ HOW TO FIX - go to sandboxed-jquery and replace the following code:
  }*/
 
 asyncTest('T230756: TD15.1 - _ is not defined on tula.metro-cc.ru', function () {
-    var iframe = $('<iframe>').attr('src', window.getCrossDomainPageUrl('iframe.html'))[0];
+    var iframe = $('<iframe>').attr('src', window.QUnitGlobals.getResourceUrl('iframe.html'))[0];
 
     window.QUnitGlobals.waitForIframe(iframe).then(function () {
         ok(!('$' in iframe.contentWindow));


### PR DESCRIPTION


about the `isIFrameWindowInDOM` test - the functionality was broken for cross-domain iframes.
about the `sandboxed-jquery` test - I've discussed with test creator, here should be same-domain iframe

/cc @helen-dikareva @georgiy-abbasov 