### PR TITLE
Refactor report errors for the APIv2 (part of #374)

### DIFF
--- a/src/errors/test-run/templates.js
+++ b/src/errors/test-run/templates.js
@@ -7,10 +7,10 @@ function markup (err, msgMarkup) {
     var prefix = `<span class="user-agent">${err.userAgent}</span>\n`;
 
     if (err.testRunState === TEST_RUN_STATE.inBeforeEach)
-        prefix += `<strong>- Error in <code>beforeEach</code> hook -</strong>\n`;
+        prefix += `<span class="subtitle">Error in <code>beforeEach</code> hook</span>`;
 
     else if (err.testRunState === TEST_RUN_STATE.inAfterEach)
-        prefix += `<strong>- Error in <code>afterEach</code> hook -</strong>\n`;
+        prefix += `<span class="subtitle">Error in <code>afterEach</code> hook</span>`;
 
     msgMarkup = prefix + dedent(msgMarkup);
 
@@ -78,7 +78,7 @@ export default {
     `),
 
     [TYPE.actionOptionsTypeError]: err => markup(err, `
-        Action options is expected to be an object, null or undefined but it was <code>${err.actualType}</code>.
+        Action options is expected to be an object, <code>null</code> or <code>undefined</code> but it was <code>${err.actualType}</code>.
 
         ${err.getCallsiteMarkup()}
     `),
@@ -108,7 +108,7 @@ export default {
     `),
 
     [TYPE.actionStringArrayElementError]: err => markup(err, `
-        Elements of the <code>${err.argumentName}</code> argument are expected to be non-empty strings, but the element at index ${err.elementIndex} was ${err.actualValue}.
+        Elements of the <code>${err.argumentName}</code> argument are expected to be non-empty strings, but the element at index <code>${err.elementIndex}</code> was ${err.actualValue}.
 
         ${err.getCallsiteMarkup()}
     `),

--- a/src/reporter/plugin-host.js
+++ b/src/reporter/plugin-host.js
@@ -43,6 +43,8 @@ export default class ReporterPluginHost {
             'span step-name':  str => `"${str}"`,
             'span user-agent': str => this.chalk.gray(str),
 
+            'span subtitle': str => `- ${this.chalk.bold(str)} -\n`,
+
             'div screenshot-info': identity,
             'a screenshot-path':   str => this.chalk.underline(str),
 


### PR DESCRIPTION
* Add decorator for error subtitles
* Wrap null, undefined number, etc. with \<code\> in messages

/cc @inikulin 