### PR TITLE
[docs] Add testing for invalid hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 .idea
 lib
-website
+site
 .sass-cache
 .publish

--- a/docs/articles/documentation/getting-started/index.md
+++ b/docs/articles/documentation/getting-started/index.md
@@ -13,7 +13,7 @@ This guide provides step-by-step instructions on how to create a functional web 
 * [Viewing the Test Results](#viewing-the-test-results)
 * [Writing Test Code](#writing-test-code)
   * [Performing Actions on the Page](#performing-actions-on-the-page)
-  * [Observing the Page State](#observing-the-page-state)
+  * [Observing Page State](#observing-page-state)
   * [Assertions](#assertions)
 
 ## Installing TestCafe
@@ -41,7 +41,7 @@ fixture `Getting Started`
     .page('http://testcafe.devexpress.com/example');
 ```
 
-Then create the [test](/test-api/test-code-structure.md#tests) function where you will further place test code.
+Then create the [test](../test-api/test-code-structure.md#tests) function where you will further place test code.
 
 ```js
 fixture `Getting Started`
@@ -99,7 +99,7 @@ To wait for actions to be complete, use the `await` keyword when calling these a
 
 TestCafe allows you to observe the page state.
 For this purpose, it offers special kinds of functions that will execute your code on the client: [Selector](../test-api/executing-client-code/index.md#selector-functions) used to get direct access to DOM elements
-and [ClientFunction](test-api/executing-client-code/index.md#client-functions) used to obtain arbitrary data from the client side.
+and [ClientFunction](../test-api/executing-client-code/index.md#client-functions) used to obtain arbitrary data from the client side.
 You call these functions as regular async functions, that is you can obtain their results and use parameters to pass data to them.
 
 For example, clicking the Submit button on the sample web page opens a "Thank you" page.
@@ -129,7 +129,7 @@ test('Test1', async t => {
 });
 ```
 
-For more information, see [Executing Client Code](../test-api/executing-client-code.md).
+For more information, see [Executing Client Code](../test-api/executing-client-code/index.md).
 
 ### Assertions
 

--- a/docs/articles/documentation/test-api/actions.md
+++ b/docs/articles/documentation/test-api/actions.md
@@ -1,0 +1,6 @@
+---
+layout: docs
+title: Actions
+permalink: /documentation/test-api/actions.html
+---
+# Stub

--- a/docs/articles/documentation/test-api/executing-client-code/index.md
+++ b/docs/articles/documentation/test-api/executing-client-code/index.md
@@ -1,0 +1,10 @@
+---
+layout: docs
+title: Executing Client Code
+permalink: /documentation/test-api/executing-client-code/
+---
+# Stub
+
+## selector functions
+
+## client functions

--- a/docs/articles/documentation/test-api/index.md
+++ b/docs/articles/documentation/test-api/index.md
@@ -1,0 +1,6 @@
+---
+layout: docs
+title: Test API
+permalink: /documentation/test-api/
+---
+# Stub

--- a/docs/articles/documentation/test-api/test-code-structure.md
+++ b/docs/articles/documentation/test-api/test-code-structure.md
@@ -1,0 +1,14 @@
+---
+layout: docs
+title: Test Code Structure
+permalink: /documentation/test-api/test-code-structure.html
+---
+# Stub
+
+## fixtures
+
+## specifying the start webpage
+
+## tests
+
+## test-controller

--- a/docs/articles/documentation/using-testcafe/programming-interface/browserconnection.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/browserconnection.md
@@ -7,7 +7,7 @@ permalink: /documentation/using-testcafe/programming-interface/browserconnection
 
 Connection to a remote browser.
 
-Created by the [testCafe.createBrowserConnection](testcafe.md#createBrowserConnection) function.
+Created by the [testCafe.createBrowserConnection](testcafe.md#createbrowserconnection) function.
 
 **Example**
 

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -7,7 +7,7 @@ permalink: /documentation/using-testcafe/programming-interface/runner.html
 
 An object that configures and launches test runs.
 
-Created by the [testCafe.createRunner](testcafe.md#createRunner) function.
+Created by the [testCafe.createRunner](testcafe.md#createrunner) function.
 
 **Example**
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "connect": "^3.4.0",
     "cross-spawn-async": "^2.1.6",
     "del": "^2.2.0",
+    "dom-walk": "^0.1.1",
     "error-stack-parser": "^1.3.3",
     "eslint-plugin-babel": "^3.1.0",
     "eslint-plugin-hammerhead": "0.0.5",

--- a/test/website/test.js
+++ b/test/website/test.js
@@ -1,0 +1,140 @@
+const blc     = require('broken-link-checker');
+const http    = require('http');
+const https   = require('https');
+const util    = require('gulp-util');
+const url     = require('url');
+const parse5  = require('parse5');
+const Promise = require('pinkie');
+const walk    = require('dom-walk');
+
+
+class WebsiteTester {
+    constructor () {
+        this.parsedDocs    = {};
+        this.checkedHashes = {};
+    }
+
+    _hasHash (tree, hash) {
+        const attrMatches = attr => (attr.name === 'name' || attr.name === 'id') && attr.value === hash;
+        const hasId       = node => node.attrs && node.attrs.some(attrMatches);
+
+        return walk(tree, hasId);
+    }
+
+    _parsePage (pageUrl) {
+        if (this.parsedDocs[pageUrl])
+            return Promise.resolve(this.parsedDocs[pageUrl]);
+
+        return new Promise(resolve => {
+            const protocol = url.parse(pageUrl).protocol === 'http:' ? http : https;
+
+            protocol.get(pageUrl, resolve);
+        })
+        .then(response => {
+            return new Promise(resolve => {
+                let data = '';
+
+                response.on('data', chunk => data += chunk);
+                response.on('end', () => resolve(data));
+            });
+        })
+        .then(body => {
+            const parser   = new parse5.Parser();
+            const document = parser.parse(body);
+
+            this.parsedDocs[pageUrl] = document;
+            return document;
+        });
+    }
+
+    _isHashValid (link) {
+        const parsedLink   = url.parse(link);
+        const hashlessLink = link.substring(0, link.indexOf('#'));
+
+        if (this.checkedHashes[link])
+            return Promise.resolve(this.checkedHashes[link]);
+
+        return this._parsePage(hashlessLink)
+            .then(tree => {
+                const hash = parsedLink.hash.substr(1);
+                let res    = this._hasHash(tree, hash);
+
+                // NOTE: GitHub renders headers in md documents with ids that
+                // start with 'user-content-'.
+                if (!res && parsedLink.host === 'github.com')
+                    res = this._hasHash(tree, 'user-content-' + hash);
+
+                this.checkedHashes[link] = res;
+                return res;
+            });
+    }
+
+    _outputBrokenLinks (pageUrl, links) {
+        if (links.length) {
+            util.log('URL: ' + pageUrl);
+            util.log(util.colors.red('Broken links:'));
+
+            links.forEach(link => util.log(util.colors.red(link)));
+
+            util.log();
+        }
+    }
+
+    // NOTE: Echoes the link if it is broken;
+    // otherwise, resolves to null.
+    _getBrokenLink (result) {
+        return Promise.resolve()
+            .then(() => {
+                if (result.broken)
+                    return result.url.resolved || result.url.original;
+
+                const link       = result.url.resolved;
+                const parsedLink = url.parse(link);
+
+                if (parsedLink.hash) {
+                    return this._isHashValid(link)
+                        .then(isValid => isValid ? null : link);
+                }
+
+                return null;
+            });
+    }
+
+    checkLinks () {
+        return new Promise(resolve => {
+            const pageTests = [];
+            let linkTests   = [];
+
+            const siteChecker = new blc.SiteChecker({ excludeLinksToSamePage: false }, {
+                link: result => linkTests.push(this._getBrokenLink(result)),
+                page: (error, pageUrl) => {
+                    pageTests.push(Promise
+                        .all(linkTests)
+                        .then(res => {
+                            const brokenLinks = res.filter(value => !!value);
+
+                            this._outputBrokenLinks(pageUrl, brokenLinks);
+                            return brokenLinks.length;
+                        }));
+                },
+                html: (tree, robots, response, pageUrl) => {
+                    linkTests = [];
+                    this.parsedDocs[pageUrl] = tree;
+                },
+                end: () => {
+                    Promise
+                        .all(pageTests)
+                        .then(res => {
+                            const brokenLinksCount = res.reduce((acc, value) => acc + value);
+
+                            resolve(!!brokenLinksCount);
+                        });
+                }
+            });
+
+            siteChecker.enqueue('http://localhost:8080/testcafe');
+        });
+    }
+}
+
+module.exports = WebsiteTester;


### PR DESCRIPTION
/cc @DevExpress/testcafe-docs 
Added a thing that, when checking for broken links, parses the referenced documents to check that an element with a particular name/id exists.
Is it too crappy?