### PR TITLE
Refactor report errors for the APIv2 (closes #374)

### DIFF
--- a/src/errors/process-test-fn-error.js
+++ b/src/errors/process-test-fn-error.js
@@ -14,7 +14,7 @@ const INTERNAL = 'internal/';
 function isAssertionErrorCallsiteFrame (frame) {
     var filename = frame.getFileName();
 
-    // NOTE: filter node and assertion libraries internals
+    // NOTE: filter out the internals of node.js and assertion libraries
     return filename &&
            filename.indexOf(sep) > -1 &&
            filename.indexOf(INTERNAL) !== 0 &&

--- a/src/errors/test-run/formattable-adapter.js
+++ b/src/errors/test-run/formattable-adapter.js
@@ -52,7 +52,7 @@ export default class TestRunErrorFormattableAdapter {
         return this.TEMPLATES[this.type](this, viewportWidth);
     }
 
-    getCallsiteMarkup (opts) {
+    getCallsiteMarkup () {
         if (!this.callsite)
             return '';
 
@@ -60,12 +60,9 @@ export default class TestRunErrorFormattableAdapter {
         if (typeof this.callsite === 'string')
             return this.callsite;
 
-        opts = opts || {};
-
         try {
             return this.callsite.renderSync({
                 renderer:    renderers.html,
-                codeFrame:   !opts.stackOnly,
                 stackFilter: stackFilter
             });
         }

--- a/src/errors/test-run/templates.js
+++ b/src/errors/test-run/templates.js
@@ -224,6 +224,8 @@ export default {
 
     [TYPE.externalAssertionLibraryError]: err => markup(err, `
         ${escapeHtml(err.errMsg)} ${err.getCallsiteMarkup({ stackOnly: true })}
+
+        ${err.getCallsiteMarkup()}
     `),
 
     [TYPE.regeneratorInFunctionArgumentOfClientFunctionError]: err => markup(err, `

--- a/src/errors/test-run/templates.js
+++ b/src/errors/test-run/templates.js
@@ -223,7 +223,7 @@ export default {
     `),
 
     [TYPE.externalAssertionLibraryError]: err => markup(err, `
-        ${escapeHtml(err.errMsg)} ${err.getCallsiteMarkup({ stackOnly: true })}
+        ${escapeHtml(err.errMsg)}
 
         ${err.getCallsiteMarkup()}
     `),

--- a/test/functional/fixtures/api/es-next/generic-errors/test.js
+++ b/test/functional/fixtures/api/es-next/generic-errors/test.js
@@ -44,7 +44,7 @@ describe('[API] Generic errors', function () {
             return runTests('./testcafe-fixtures/external-assertion-lib-errors-test.js', 'Built-in assertion lib error',
                 { shouldFail: true, only: 'chrome' })
                 .catch(function (errs) {
-                    expect(errs[0]).to.contains("> 11 |    assert.strictEqual(\'answer\', \'42\');");
+                    expect(errs[0]).to.contains("> 13 |    assert.strictEqual(\'answer\', \'42\');");
                     expect(errs[0]).to.contains("AssertionError: 'answer' === '42'");
                 });
         });
@@ -53,7 +53,7 @@ describe('[API] Generic errors', function () {
             return runTests('./testcafe-fixtures/external-assertion-lib-errors-test.js', 'Chai assertion error',
                 { shouldFail: true, only: 'chrome' })
                 .catch(function (errs) {
-                    expect(errs[0]).to.contains("> 15 |    expect(\'answer\').eql(\'42\');");
+                    expect(errs[0]).to.contains("> 17 |    expect(\'answer\').eql(\'42\');");
                     expect(errs[0]).to.contains("AssertionError: expected 'answer' to deeply equal '42'");
                 });
         });

--- a/test/functional/fixtures/api/es-next/generic-errors/test.js
+++ b/test/functional/fixtures/api/es-next/generic-errors/test.js
@@ -44,6 +44,7 @@ describe('[API] Generic errors', function () {
             return runTests('./testcafe-fixtures/external-assertion-lib-errors-test.js', 'Built-in assertion lib error',
                 { shouldFail: true, only: 'chrome' })
                 .catch(function (errs) {
+                    expect(errs[0]).to.contains("> 11 |    assert.strictEqual(\'answer\', \'42\');");
                     expect(errs[0]).to.contains("AssertionError: 'answer' === '42'");
                 });
         });
@@ -52,6 +53,7 @@ describe('[API] Generic errors', function () {
             return runTests('./testcafe-fixtures/external-assertion-lib-errors-test.js', 'Chai assertion error',
                 { shouldFail: true, only: 'chrome' })
                 .catch(function (errs) {
+                    expect(errs[0]).to.contains("> 15 |    expect(\'answer\').eql(\'42\');");
                     expect(errs[0]).to.contains("AssertionError: expected 'answer' to deeply equal '42'");
                 });
         });
@@ -60,6 +62,7 @@ describe('[API] Generic errors', function () {
             return runTests('./testcafe-fixtures/external-assertion-lib-errors-test.js', 'Assertion error in helper',
                 { shouldFail: true, only: 'chrome' })
                 .catch(function (errs) {
+                    expect(errs[0]).to.contains('>  8 |    assert(false);');
                     expect(errs[0]).to.contains('AssertionError: false == true');
                 });
         });

--- a/test/functional/fixtures/api/es-next/generic-errors/testcafe-fixtures/external-assertion-lib-errors-test.js
+++ b/test/functional/fixtures/api/es-next/generic-errors/testcafe-fixtures/external-assertion-lib-errors-test.js
@@ -2,8 +2,8 @@ import assert from 'assert';
 import { expect, config as chaiConfig } from 'chai';
 import { assertionError } from './helpers';
 
-// NOTE: set this flag to check that TestCafe adds a correct callsite to the
-// report when there are chai module files in the top of the error stack.
+// NOTE: set this flag to check that TestCafe adds a correct callsite to
+// the report when there are chai module files on top of the error stack.
 chaiConfig.includeStack = true;
 
 fixture `External assertion library errors`

--- a/test/functional/fixtures/api/es-next/generic-errors/testcafe-fixtures/external-assertion-lib-errors-test.js
+++ b/test/functional/fixtures/api/es-next/generic-errors/testcafe-fixtures/external-assertion-lib-errors-test.js
@@ -1,6 +1,10 @@
 import assert from 'assert';
-import { expect } from 'chai';
+import { expect, config as chaiConfig } from 'chai';
 import { assertionError } from './helpers';
+
+// NOTE: set this flag to check that TestCafe adds a correct callsite to the
+// report when there are chai module files in the top of the error stack.
+chaiConfig.includeStack = true;
 
 fixture `External assertion library errors`
     .page(`http://localhost:3000/api/es-next/generic-errors/pages/index.html`);

--- a/test/server/data/expected-test-run-errors/external-assertion-library-error
+++ b/test/server/data/expected-test-run-errors/external-assertion-library-error
@@ -1,6 +1,18 @@
 Chrome 15.0.874 / Mac OS X 10.8.1
 AssertionError: expected true to deeply equal false
 
+   18 |function func1 () {
+   19 |    record = createCallsiteRecord('func1');
+   20 |}
+   21 |
+   22 |(function func2 () {
+ > 23 |    func1();
+   24 |})();
+   25 |
+   26 |stackTrace.filter.deattach(stackFilter);
+   27 |
+   28 |module.exports = record;
+
    at func2 (testfile.js:23:5)
    at Object.<anonymous> (testfile.js:24:3)
 


### PR DESCRIPTION
* Callsites for assertion errors (filter node_modules and internal callsites)

/cc @inikulin @VasilyStrelyaev 