### PR TITLE
Implement `Selector` (part7, closes #574)

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
       "connect",
       "cross-spawn-async",
       "del",
+      "dom-walk",
       "error-stack-parser",
       "eslint-plugin-hammerhead",
       "express",

--- a/src/api/test-controller.js
+++ b/src/api/test-controller.js
@@ -1,8 +1,10 @@
 import Promise from 'pinkie';
-import { identity } from 'lodash';
+import { identity, assign } from 'lodash';
 import { MissingAwaitError } from '../errors/test-run';
 import getCallsite from '../errors/get-callsite';
 import ClientFunctionFactory from '../client-functions/client-function-factory';
+import SelectorFactory from '../client-functions/selector-factory';
+
 
 import {
     ClickCommand,
@@ -214,6 +216,15 @@ export default class TestController {
         var clientFn = factory.getFunction({ boundTestRun: this.testRun });
 
         return clientFn();
+    }
+
+    _select$ (fn, scopeVars, options) {
+        options = assign({}, options, { boundTestRun: this.testRun });
+
+        var factory  = new SelectorFactory(fn, scopeVars, { instantiation: 'select', execution: 'select' });
+        var selector = factory.getFunction(options);
+
+        return selector();
     }
 }
 

--- a/src/client/driver/command-executors/client-functions/selector-executor.js
+++ b/src/client/driver/command-executors/client-functions/selector-executor.js
@@ -20,13 +20,19 @@ function visible (el) {
 }
 
 export default class SelectorExecutor extends ClientFunctionExecutor {
-    constructor (command, timeout, createNotFoundError, createIsInvisibleError) {
+    constructor (command, globalTimeout, startTime, createNotFoundError, createIsInvisibleError) {
         super(command);
 
 
         this.createNotFoundError    = createNotFoundError;
         this.createIsInvisibleError = createIsInvisibleError;
-        this.timeout                = typeof command.timeout === 'number' ? command.timeout : timeout;
+        this.timeout                = typeof command.timeout === 'number' ? command.timeout : globalTimeout;
+
+        if (startTime) {
+            var elapsed = new Date() - startTime;
+
+            this.timeout = Math.max(this.timeout - elapsed, 0);
+        }
     }
 
     _createReplicator () {

--- a/src/client/driver/command-executors/execute-action.js
+++ b/src/client/driver/command-executors/execute-action.js
@@ -92,9 +92,7 @@ function ensureCommandElements (command, timeout) {
     var ensureElement = (selectorCommand, createNotFoundError, createIsInvisibleError) => {
         ensureElementPromise = ensureElementPromise
             .then(() => {
-                var elapsed          = new Date() - startTime;
-                var adjustedTimeout  = Math.max(timeout - elapsed, 0);
-                var selectorExecutor = new SelectorExecutor(selectorCommand, adjustedTimeout, createNotFoundError, createIsInvisibleError);
+                var selectorExecutor = new SelectorExecutor(selectorCommand, timeout, startTime, createNotFoundError, createIsInvisibleError);
 
                 return selectorExecutor.getResult();
             })

--- a/test/functional/fixtures/api/es-next/select/pages/index.html
+++ b/test/functional/fixtures/api/es-next/select/pages/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<div id="answer">42</div>
+<div id="invisible" style="display: none;"></div>
+</body>
+</html>

--- a/test/functional/fixtures/api/es-next/select/test.js
+++ b/test/functional/fixtures/api/es-next/select/test.js
@@ -20,7 +20,7 @@ describe('[API] t.select', function () {
                     'select is expected to be initialized with a function, CSS selector string, ' +
                     'another Selector, node snapshot or a Promise returned by a Selector, but "number" was passed.'
                 );
-                expect(errs[0]).contains("> 23 |    await t.select(42);");
+                expect(errs[0]).contains('> 23 |    await t.select(42);');
             });
     });
 

--- a/test/functional/fixtures/api/es-next/select/test.js
+++ b/test/functional/fixtures/api/es-next/select/test.js
@@ -1,0 +1,34 @@
+var expect = require('chai').expect;
+
+describe('[API] t.select', function () {
+    it('Should execute an anonymous selector', function () {
+        return runTests('./testcafe-fixtures/select-test.js', 'Select element');
+    });
+
+    it('Should execute an anonymous selector with scope vars', function () {
+        return runTests('./testcafe-fixtures/select-test.js', 'Select with scope vars');
+    });
+
+    it('Should execute an anonymous selector with options', function () {
+        return runTests('./testcafe-fixtures/select-test.js', 'Select with options');
+    });
+
+    it('Should have the correct callsite if an error occurs on instantiation', function () {
+        return runTests('./testcafe-fixtures/select-test.js', 'Error on instantiation', { shouldFail: true })
+            .catch(function (errs) {
+                expect(errs[0]).contains(
+                    'select is expected to be initialized with a function, CSS selector string, ' +
+                    'another Selector, node snapshot or a Promise returned by a Selector, but "number" was passed.'
+                );
+                expect(errs[0]).contains("> 23 |    await t.select(42);");
+            });
+    });
+
+    it('Should have the correct callsite if an error occurs during execution', function () {
+        return runTests('./testcafe-fixtures/select-test.js', 'Error during execution', { shouldFail: true })
+            .catch(function (errs) {
+                expect(errs[0]).contains('An error occurred in select code:  Error: yo');
+                expect(errs[0]).contains('> 27 |    await t.select(() => {');
+            });
+    });
+});

--- a/test/functional/fixtures/api/es-next/select/testcafe-fixtures/select-test.js
+++ b/test/functional/fixtures/api/es-next/select/testcafe-fixtures/select-test.js
@@ -1,0 +1,36 @@
+// NOTE: to preserve callsites, add new tests AFTER the existing ones
+import { expect } from 'chai';
+import { Selector } from 'testcafe';
+
+fixture `t.select`
+    .page `http://localhost:3000/api/es-next/select/pages/index.html`;
+
+
+test('Select element', async t => {
+    const el = await t.select('#answer');
+
+    expect(el.innerText).eql('42');
+});
+
+test('Select with scope vars', async t => {
+    const getById = Selector(id => document.getElementById(id));
+    const el      = await t.select(() => getById('answer'), { getById });
+
+    expect(el.innerText).eql('42');
+});
+
+test('Error on instantiation', async t => {
+    await t.select(42);
+});
+
+test('Error during execution', async t => {
+    await t.select(() => {
+        throw new Error('yo');
+    });
+});
+
+test('Select with options', async t => {
+    const el = await t.select('#invisible', null, { visibilityCheck: true });
+
+    expect(el).to.be.null;
+});

--- a/test/functional/fixtures/api/es-next/selector/pages/index.html
+++ b/test/functional/fixtures/api/es-next/selector/pages/index.html
@@ -39,6 +39,8 @@
 <input type="button" id="makeVisible">
 <div id="invisibleElement" style="display: none; width:500px; height: 500px;"></div>
 
+<input type="button" id="newPage">
+
 <script>
     document.querySelector('#createElement').addEventListener('click', function () {
         var div = document.createElement('div');
@@ -56,6 +58,12 @@
         window.setTimeout(function () {
             div.style.display = 'block';
         }, 500);
+    });
+
+    document.querySelector('#newPage').addEventListener('click', function () {
+        window.setTimeout(function () {
+            document.location = 'http://localhost:3000/api/es-next/selector/pages/new-page-element.html';
+        }, 1000);
     });
 
     document.addEventListener("DOMContentLoaded", function () {

--- a/test/functional/fixtures/api/es-next/selector/pages/new-page-element.html
+++ b/test/functional/fixtures/api/es-next/selector/pages/new-page-element.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<div id="newPageElement"></div>
+</body>
+</html>

--- a/test/functional/fixtures/api/es-next/selector/test.js
+++ b/test/functional/fixtures/api/es-next/selector/test.js
@@ -61,6 +61,10 @@ describe('[API] Selector', function () {
         return runTests('./testcafe-fixtures/selector-test.js', 'Snapshot `hasClass` method');
     });
 
+    it('Should wait for element to appear on new page', function () {
+        return runTests('./testcafe-fixtures/selector-test.js', 'Element on new page');
+    });
+
     describe('Errors', function () {
         it('Should handle errors in Selector code', function () {
             return runTests('./testcafe-fixtures/selector-test.js', 'Error in code', { shouldFail: true })

--- a/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
+++ b/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
@@ -303,3 +303,13 @@ test('Snapshot `hasClass` method', async () => {
     expect(el.hasClass('svg2')).to.be.true;
     expect(el.hasClass('cool')).to.be.false;
 });
+
+test('Element on new page', async t => {
+    const getNewElement = Selector('#newPageElement').with({ timeout: 5000 });
+
+    await t.click('#newPage');
+
+    const el = await getNewElement();
+
+    expect(el.tagName).eql('div');
+});


### PR DESCRIPTION
In this final part:
- Cross-page behavior
- `t.select`

\cc @helen-dikareva @AlexanderMoskovkin @VasilyStrelyaev 