### PR TITLE
Added regression test for GH-599 (closes #599)

### DIFF
--- a/test/server/data/test-suites/regression-gh-599/testfile.js
+++ b/test/server/data/test-suites/regression-gh-599/testfile.js
@@ -1,0 +1,23 @@
+import { APIError } from '../../../../../lib/errors/runtime';
+
+fixture `Test`
+    .page `http://example.com`;
+
+var obj = {
+    method1: () => {
+        throw new APIError('method1');
+    },
+
+    method2: () => {
+        return obj;
+    }
+};
+
+test('test', async () => {
+    await obj
+        .method2()
+        .method1()
+        .method2();
+
+    const actual = true;
+});


### PR DESCRIPTION
\cc @inikulin, @AlexanderMoskovkin
Module `babel-preset-es2015-loose` uses the latest version of `babel-plugin-transform-regenerator` module, so we have the fix already