### PR TITLE
[docs] Move the landing page head to assets

### DIFF
--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -1,26 +1,8 @@
 ---
 layout: landing
-title: TestCafe Landing Page
 permalink: /
 ---
 
-<html>
-<head>
-    <title>TestCafe Landing Page</title>
-    <link rel="stylesheet" href="css/landing-page.css">
-
-    <!-- Enable the gallery-->
-    <script type="text/javascript" src="http://ajax.aspnetcdn.com/ajax/jquery/jquery-2.2.3.min.js"></script>
-    <script type="text/javascript" src="http://cdn3.devexpress.com/jslib/16.1.4/js/dx.all.js"></script>
-    <script src="scripts/gallery.js" type="text/javascript"></script>
-    <link rel="stylesheet" type="text/css" href="http://cdn3.devexpress.com/jslib/16.1.4/css/dx.common.css" />
-    <link rel="stylesheet" type="text/css" href="http://cdn3.devexpress.com/jslib/16.1.4/css/dx.ios7.default.css" />
-    <link href="css/gallery.css" type="text/css" rel="stylesheet">
-
-    <!--GitHub Star button-->
-    <script async defer src="https://buttons.github.io/buttons.js"></script>
-</head>
-<body>
     <form id="main-form" action="#">
     <div class="banner">
         <div class="header">
@@ -32,7 +14,9 @@ permalink: /
         <div class="white-button-container">
         <a href="documentation/getting-started/" class="white-button">Get Started</a>
         </div>
-        <a class="github-button" href="https://github.com/DevExpress/testcafe" data-style="mega" data-count-href="/DevExpress/testcafe/stargazers" data-count-api="/repos/DevExpress/testcafe#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star DevExpress/testcafe on GitHub">Star</a>
+        <div class="star-button">
+            <a class="github-button" href="https://github.com/DevExpress/testcafe" data-style="mega" data-count-href="/DevExpress/testcafe/stargazers" data-count-api="/repos/DevExpress/testcafe#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star DevExpress/testcafe on GitHub"><span style="color:#ffffff">Star</span></a>
+        </div>
     </div>
     <div class="main-content">
         <div class="feature">
@@ -136,5 +120,3 @@ test('My Test', async t => {
         </div>
     </div>
     </form>
-</body>
-</html>


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs 
Part of https://github.com/DevExpress/testcafe-gh-page-assets/issues/13

Landing page doesn't actually need a head - it should be in the layout.