### PR TITLE
Fix `ReferenceError: selector is not defined` if selector promise is passed to `t.select` (fixes #716). Fix linting and related errors. Bump version.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,1 @@
-test/server/data/test-suites/**/*.js
+test/server/data/**/*.js

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -6,7 +6,6 @@ var filter               = require('gulp-filter');
 var git                  = require('gulp-git');
 var globby               = require('globby');
 var qunitHarness         = require('gulp-qunit-harness');
-var merge                = require('merge-stream');
 var mocha                = require('gulp-mocha');
 var mustache             = require('gulp-mustache');
 var rename               = require('gulp-rename');
@@ -157,7 +156,7 @@ gulp.task('lint', function () {
 
     var eslint = require('gulp-eslint');
 
-    gulp
+    return gulp
         .src([
             'src/**/*.js',
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "testcafe",
   "license": "MIT",
-  "version": "0.2.1-alpha",
+  "version": "0.2.2-alpha",
   "main": "lib/index",
   "bin": {
     "testcafe": "./bin/testcafe.js"

--- a/src/browser/provider/built-in/saucelabs.js
+++ b/src/browser/provider/built-in/saucelabs.js
@@ -52,7 +52,7 @@ function unfoldTreeNode (node, level = Infinity) {
                            flatten(node.list.map(child => unfoldTreeNode(child, level - 1))) :
                            [node.list ? node.list : []];
 
-    return unfoldedChildren.map(child =>[node.name].concat(child));
+    return unfoldedChildren.map(child => [node.name].concat(child));
 }
 
 async function getAssetData (assetNameParts, unfoldingLevel = Infinity) {
@@ -87,7 +87,7 @@ function formatAutomationApiData (automationApi, automationApiData) {
         formattedData.browserName    = automationApiData[6];
         formattedData.browserVersion = automationApiData[7];
 
-        if (formattedData.browserName == 'MS Edge')
+        if (formattedData.browserName === 'MS Edge')
             formattedData.browserName = 'MicrosoftEdge';
 
         if (MAC_OS_MAP[formattedData.os])
@@ -97,9 +97,7 @@ function formatAutomationApiData (automationApi, automationApiData) {
         formattedData.os  = automationApiData[5];
         formattedData.api = find(automationApiData, item => item && item.api).api;
 
-        var isAndroidJellyBean = formattedData.platformGroup === 'Android' &&
-                                 (parseFloat(formattedData.os) >= 4.4);
-
+        var isAndroidJellyBean   = formattedData.platformGroup === 'Android' && parseFloat(formattedData.os) >= 4.4;
         var isUnsupportedAndroid = isAndroidJellyBean ? isSelendroid(formattedData) : isAppium(formattedData);
 
         if (isUnsupportedAndroid)

--- a/src/client-functions/client-function-builder.js
+++ b/src/client-functions/client-function-builder.js
@@ -18,7 +18,8 @@ export default class ClientFunctionBuilder {
             execution:     callsiteNames.execution || DEFAULT_EXECUTION_CALLSITE_NAME
         };
 
-        options = isNullOrUndefined(options) ? {} : options;
+        if (isNullOrUndefined(options))
+            options = {};
 
         this._validateOptions(options);
 
@@ -124,8 +125,11 @@ export default class ClientFunctionBuilder {
     _validateOptions (options) {
         var optionsType = typeof options;
 
-        if (optionsType !== 'object')
-            throw new APIError(this.callsiteNames.instantiation, MESSAGE.optionsArgumentIsNotAnObject, optionsType);
+        if (isNullOrUndefined(options) || optionsType !== 'object') {
+            var actualVal = options === null ? 'null' : optionsType;
+
+            throw new APIError(this.callsiteNames.instantiation, MESSAGE.optionsArgumentIsNotAnObject, actualVal);
+        }
 
         if (!isNullOrUndefined(options.boundTestRun)) {
             // NOTE: we can't use strict `t instanceof TestController`

--- a/src/client-functions/selector-builder.js
+++ b/src/client-functions/selector-builder.js
@@ -20,8 +20,8 @@ export default class SelectorBuilder extends ClientFunctionBuilder {
         if (builder) {
             fn = builder.fn;
 
-            if (typeof options === 'object')
-                options = assign({}, builder.options, options, { originSelectorBuilder: builder });
+            if (options === void 0 || typeof options === 'object')
+                options = assign({}, builder.options, options, { sourceSelectorBuilder: builder });
         }
 
         super(fn, options, callsiteNames);
@@ -51,14 +51,14 @@ export default class SelectorBuilder extends ClientFunctionBuilder {
 
     _getCompiledFnCode () {
         // OPTIMIZATION: if selector was produced from another selector and
-        // it has same dependencies as origin selector, then we can
+        // it has same dependencies as source selector, then we can
         // avoid recompilation and just re-use already compiled code.
-        var hasSameDependenciesAsOriginSelector = this.options.originSelectorBuilder &&
-                                                  this.options.originSelectorBuilder.options.dependencies ===
+        var hasSameDependenciesAsSourceSelector = this.options.sourceSelectorBuilder &&
+                                                  this.options.sourceSelectorBuilder.options.dependencies ===
                                                   this.options.dependencies;
 
-        if (hasSameDependenciesAsOriginSelector)
-            return this.options.originSelectorBuilder.compiledFnCode;
+        if (hasSameDependenciesAsSourceSelector)
+            return this.options.sourceSelectorBuilder.compiledFnCode;
 
         var code = typeof this.fn === 'string' ?
                    `(function(){return document.querySelectorAll('${this.fn.replace(/'/g, "\\'")}');});` :

--- a/src/client/core/index.js
+++ b/src/client/core/index.js
@@ -56,4 +56,6 @@ Object.defineProperty(window, '%testCafeCore%', {
     value:        exports
 });
 
+// NOTE: initTestCafeCore defined in wrapper template
+/* global initTestCafeCore */
 hammerhead.on(hammerhead.EVENTS.evalIframeScript, e => initTestCafeCore(e.iframe.contentWindow, true));

--- a/src/client/driver/iframe-driver.js
+++ b/src/client/driver/iframe-driver.js
@@ -1,5 +1,4 @@
 import { eventSandbox } from './deps/hammerhead';
-import { delay } from './deps/testcafe-core';
 import { IframeStatusBar } from './deps/testcafe-ui';
 import Driver from './driver';
 import ContextStorage from './storage';

--- a/test/functional/fixtures/api/es-next/selector/test.js
+++ b/test/functional/fixtures/api/es-next/selector/test.js
@@ -112,4 +112,10 @@ describe('[API] Selector', function () {
             });
         });
     });
+
+    describe('Regression', function () {
+        it("Should execute successfully if derivative selector doesn't have options (GH-716)", function () {
+            return runTests('./testcafe-fixtures/selector-test.js', 'Derivative selector without options', { only: 'chrome' });
+        });
+    });
 });

--- a/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
+++ b/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
@@ -428,3 +428,9 @@ test('Compound filter', async t => {
 
     expect(id).eql('el2');
 });
+
+test('Derivative selector without options', async () => {
+    var derivative = Selector(getElementById('textInput'));
+
+    await derivative();
+});


### PR DESCRIPTION
\cc @AlexanderMoskovkin @AndreyBelym 