### PR TITLE
[docs] createBrowserConnection is async now

### DIFF
--- a/docs/articles/documentation/using-testcafe/programming-interface/browserconnection.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/browserconnection.md
@@ -15,7 +15,7 @@ Created by the [testCafe.createBrowserConnection](testcafe.md#createbrowserconne
 const createTestCafe   = require('testcafe');
 const testCafe         = await createTestCafe('localhost', 1337, 1338);
 
-const remoteConnection = testcafe.createBrowserConnection();
+const remoteConnection = await testcafe.createBrowserConnection();
 
 // Outputs remoteConnection.url to visit it from the remote browser.
 console.log(remoteConnection.url);

--- a/docs/articles/documentation/using-testcafe/programming-interface/createtestcafe.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/createtestcafe.md
@@ -8,7 +8,7 @@ permalink: /documentation/using-testcafe/programming-interface/createtestcafe.ht
 Creates a [TestCafe](testcafe.md) server instance.
 
 ```text
-async createTestCafe([hostname], [port1], [port2]) → TestCafe
+async createTestCafe([hostname], [port1], [port2]) → Promise<TestCafe>
 ```
 
 Parameter                     | Type   | Description                                                                                                                                                                                                  | Default

--- a/docs/articles/documentation/using-testcafe/programming-interface/createtestcafe.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/createtestcafe.md
@@ -8,7 +8,7 @@ permalink: /documentation/using-testcafe/programming-interface/createtestcafe.ht
 Creates a [TestCafe](testcafe.md) server instance.
 
 ```text
-createTestCafe([hostname], [port1], [port2]) → Promise<TestCafe>
+async createTestCafe([hostname], [port1], [port2]) → TestCafe
 ```
 
 Parameter                     | Type   | Description                                                                                                                                                                                                  | Default

--- a/docs/articles/documentation/using-testcafe/programming-interface/index.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/index.md
@@ -20,7 +20,7 @@ the [remote browser connections](browserconnection.md)
 and the [test runner](runner.md).
 
 ```js
-const remoteConnection = testcafe.createBrowserConnection();
+const remoteConnection = await testcafe.createBrowserConnection();
 const runner           = testcafe.createRunner();
 ```
 

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -141,7 +141,7 @@ runner.browsers({
 const createTestCafe   = require('testcafe');
 const testCafe         = await createTestCafe('localhost', 1337, 1338);
 
-const remoteConnection = testcafe.createBrowserConnection();
+const remoteConnection = await testcafe.createBrowserConnection();
 
 // Outputs remoteConnection.url to visit it from the remote browser.
 console.log(remoteConnection.url);
@@ -233,7 +233,7 @@ You can also build your own reporter. Use a [dedicated Yeoman generator](https:/
 Runs tests according to the current configuration. Returns the number of failed tests.
 
 ```text
-run(options) → Promise<Number>
+async run(options) → Number
 ```
 
 > Important! Make sure to keep the browser tab that is running tests active. Do not minimize the browser window.

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -233,7 +233,7 @@ You can also build your own reporter. Use a [dedicated Yeoman generator](https:/
 Runs tests according to the current configuration. Returns the number of failed tests.
 
 ```text
-async run(options) → Number
+async run(options) → Promise<Number>
 ```
 
 > Important! Make sure to keep the browser tab that is running tests active. Do not minimize the browser window.

--- a/docs/articles/documentation/using-testcafe/programming-interface/testcafe.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/testcafe.md
@@ -27,7 +27,7 @@ const testCafe       = await createTestCafe('localhost', 1337, 1338);
 Creates a [remote browser connection](browserconnection.md).
 
 ```text
-async createBrowserConnection() → BrowserConnection
+async createBrowserConnection() → Promise<BrowserConnection>
 ```
 
 To connect a remote browser, navigate it to [BrowserConnection.url](browserconnection.md#url).

--- a/docs/articles/documentation/using-testcafe/programming-interface/testcafe.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/testcafe.md
@@ -79,5 +79,5 @@ console.log('Tests failed: ' + failed);
 Stops the TestCafe server. Forcibly closes all connections and pending test runs immediately.
 
 ```text
-close()
+async close()
 ```

--- a/docs/articles/documentation/using-testcafe/programming-interface/testcafe.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/testcafe.md
@@ -27,7 +27,7 @@ const testCafe       = await createTestCafe('localhost', 1337, 1338);
 Creates a [remote browser connection](browserconnection.md).
 
 ```text
-createBrowserConnection() → BrowserConnection
+async createBrowserConnection() → BrowserConnection
 ```
 
 To connect a remote browser, navigate it to [BrowserConnection.url](browserconnection.md#url).
@@ -38,7 +38,7 @@ To connect a remote browser, navigate it to [BrowserConnection.url](browserconne
 const createTestCafe   = require('testcafe');
 const testCafe         = await createTestCafe('localhost', 1337, 1338);
 
-const remoteConnection = testcafe.createBrowserConnection();
+const remoteConnection = await testcafe.createBrowserConnection();
 
 // Outputs remoteConnection.url to navigate the remote browser to it.
 console.log(remoteConnection.url);


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs @AndreyBelym 

I've also changed the synopsis for async methods from

`methodName(param1, param2) → Promise<Type>`

to

`async methodName(param1, param2) → Type`

it reads better IMHO