### PR TITLE
Check for e.isFakeIEEvent has been deleted from page-unload-barrier (closes #608)

### DIFF
--- a/src/client/core/page-unload-barrier.js
+++ b/src/client/core/page-unload-barrier.js
@@ -39,10 +39,7 @@ function handleSubmit () {
         overrideFormSubmit(forms[i]);
 }
 
-function onBeforeUnload (e) {
-    if (e.isFakeIEBeforeUnloadEvent)
-        return;
-
+function onBeforeUnload () {
     if (!browserUtils.isIE) {
         unloading = true;
         return;

--- a/test/functional/fixtures/regression/gh-608/pages/index.html
+++ b/test/functional/fixtures/regression/gh-608/pages/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Title</title>
+</head>
+<body>
+<a id="fakeLink" href="javascript:void(0)">fake link</a>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-608/test.js
+++ b/test/functional/fixtures/regression/gh-608/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-608)', function () {
+    it("Shouldn't wait for page unload if a link with javascript that doesn't lead to unload is clicked", function () {
+        return runTests('testcafe-fixtures/index-test.js', 'click on a fake link');
+    });
+});

--- a/test/functional/fixtures/regression/gh-608/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/regression/gh-608/testcafe-fixtures/index-test.js
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+import { ClientFunction } from 'testcafe';
+
+
+fixture `GH-608`
+    .page `http://localhost:3000/fixtures/regression/gh-608/pages/index.html`;
+
+
+const getDate = ClientFunction(() => Date.now());
+
+
+test('click on a fake link', async t => {
+    const maxActionDelay = 5000;
+
+    const startTime = await getDate();
+
+    await t.click('#fakeLink');
+
+    const stopTime = await getDate();
+
+    expect(stopTime - startTime).to.be.below(maxActionDelay);
+});


### PR DESCRIPTION
\cc @AlexanderMoskovkin, @inikulin