### PR TITLE
Resolve page-unload-barrier waiting after a timeout (workaround for #437, #664)

### DIFF
--- a/src/client/core/page-unload-barrier.js
+++ b/src/client/core/page-unload-barrier.js
@@ -102,8 +102,8 @@ export function wait (timeout) {
             });
     });
 
-    // NOTE: sometimes the page is not really unloading after the beforeunload event
-    // appeared (see issues #664, #437). To avoid test hanging we resolve unload
+    // NOTE: sometimes the page isn't actually unloaded after the beforeunload event
+    // fires (see issues #664, #437). To avoid test hanging, we resolve the unload
     // barrier waiting promise in MAX_UNLOADING_TIMEOUT. We can improve this logic when
     // the https://github.com/DevExpress/testcafe-hammerhead/issues/667 issue is fixed.
     var watchdog = delay(MAX_UNLOADING_TIMEOUT)

--- a/src/client/core/page-unload-barrier.js
+++ b/src/client/core/page-unload-barrier.js
@@ -10,6 +10,7 @@ var nativeMethods = hammerhead.nativeMethods;
 const DEFAULT_BARRIER_TIMEOUT       = 500;
 const WAIT_FOR_UNLOAD_TIMEOUT       = 3000;
 const SHORT_WAIT_FOR_UNLOAD_TIMEOUT = 30;
+const MAX_UNLOADING_TIMEOUT         = 15 * 1000;
 
 
 var waitingForUnload          = null;
@@ -87,9 +88,9 @@ export function init () {
     handleBeforeUnload();
 }
 
-export function wait () {
-    return new Promise(resolve => {
-        delay(DEFAULT_BARRIER_TIMEOUT)
+export function wait (timeout) {
+    var waitForUnloadingPromise = new Promise(resolve => {
+        delay(timeout === void 0 ? DEFAULT_BARRIER_TIMEOUT : timeout)
             .then(() => {
                 if (unloading)
                     return;
@@ -100,4 +101,15 @@ export function wait () {
                     waitingPromiseResolvers.push(resolve);
             });
     });
+
+    // NOTE: sometimes the page is not really unloading after the beforeunload event
+    // appeared (see testcafe issues #664, #437). To avoid test hanging we resolve unload
+    // barrier waiting promise in MAX_UNLOADING_TIMEOUT. We can improve this logic when
+    // the https://github.com/DevExpress/testcafe-hammerhead/issues/667 issue is fixed.
+    var watchdog = delay(MAX_UNLOADING_TIMEOUT)
+        .then(() => {
+            unloading = false;
+        });
+
+    return Promise.race([waitForUnloadingPromise, watchdog]);
 }

--- a/src/client/core/page-unload-barrier.js
+++ b/src/client/core/page-unload-barrier.js
@@ -103,7 +103,7 @@ export function wait (timeout) {
     });
 
     // NOTE: sometimes the page is not really unloading after the beforeunload event
-    // appeared (see testcafe issues #664, #437). To avoid test hanging we resolve unload
+    // appeared (see issues #664, #437). To avoid test hanging we resolve unload
     // barrier waiting promise in MAX_UNLOADING_TIMEOUT. We can improve this logic when
     // the https://github.com/DevExpress/testcafe-hammerhead/issues/667 issue is fixed.
     var watchdog = delay(MAX_UNLOADING_TIMEOUT)

--- a/test/functional/fixtures/regression/gh-664/pages/index.html
+++ b/test/functional/fixtures/regression/gh-664/pages/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>GH-664</title>
+</head>
+<body>
+<a id="link">Perform cancelled redirect</a>
+
+<script>
+    document.getElementById('link').addEventListener('click', function () {
+        window.location = 'http://example.com';
+
+        window.setTimeout(function () {
+            window.location = window.location.href + '#hash';
+        }, 200);
+    });
+</script>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-664/test.js
+++ b/test/functional/fixtures/regression/gh-664/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-664)', function () {
+    it('Should not hang if page redirect was cancelled', function () {
+        return runTests('testcafe-fixtures/index-test.js', '', { only: 'chrome' });
+    });
+});

--- a/test/functional/fixtures/regression/gh-664/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/regression/gh-664/testcafe-fixtures/index-test.js
@@ -1,0 +1,6 @@
+fixture `GH-664`
+    .page `http://localhost:3000/fixtures/regression/gh-664/pages/index.html`;
+
+test('Perform cancelled redirect', async t => {
+    await t.click('#link');
+});


### PR DESCRIPTION
/cc @inikulin @helen-dikareva @georgiy-abbasov @VasilyStrelyaev 

We fix the situation when the `beforeunload` event is raised but the page is not unloading (it occurs if it was click on a download link or in the situation described in #664).
So, with this fix we resumes the test if the page is not unloaded after 15 seconds after the `beforeunload` event.
In usual case it can be delay between `beforeunload` and `unload` events if the server responses with some timeout (it can be hard work on the server or a query to a database or smthg else).

We were planning to use the [hammerhead feature](https://github.com/DevExpress/testcafe-hammerhead/issues/667) to fix this, but it takes to much time to implement it. So I think we should add this temporary fix as a workaround for now to have not this problems in the release version