### PR TITLE
Rename selector `textFilter` property to `text` (closes #765)

### DIFF
--- a/src/client-functions/selector-builder.js
+++ b/src/client-functions/selector-builder.js
@@ -111,15 +111,15 @@ export default class SelectorBuilder extends ClientFunctionBuilder {
 
     getFunctionDependencies () {
         var dependencies = super.getFunctionDependencies();
-        var textFilter   = this.options.textFilter;
+        var text         = this.options.text;
 
-        if (typeof textFilter === 'string')
-            textFilter = new RegExp(escapeRe(textFilter));
+        if (typeof text === 'string')
+            text = new RegExp(escapeRe(text));
 
         return assign({}, dependencies, {
             __filterOptions$: {
-                index:      this.options.index || 0,
-                textFilter: textFilter
+                index: this.options.index || 0,
+                text:  text
             }
         });
     }
@@ -154,11 +154,11 @@ export default class SelectorBuilder extends ClientFunctionBuilder {
                 throw new APIError(this.callsiteNames.instantiation, MESSAGE.optionValueIsNotABoolean, 'visibilityCheck', visibilityCheckOptionType);
         }
 
-        if (!isNullOrUndefined(options.textFilter)) {
-            var textFilterType = typeof options.textFilter;
+        if (!isNullOrUndefined(options.text)) {
+            var textType = typeof options.text;
 
-            if (textFilterType !== 'string' && !isRegExp(options.textFilter))
-                throw new APIError(this.callsiteNames.instantiation, MESSAGE.optionValueIsNotAStringOrRegExp, 'textFilter', textFilterType);
+            if (textType !== 'string' && !isRegExp(options.text))
+                throw new APIError(this.callsiteNames.instantiation, MESSAGE.optionValueIsNotAStringOrRegExp, 'text', textType);
         }
 
         this._validateNonNegativeNumberOption('timeout', options.timeout);

--- a/src/client/driver/command-executors/client-functions/selector-executor/index.js
+++ b/src/client/driver/command-executors/client-functions/selector-executor/index.js
@@ -74,15 +74,15 @@ Object.defineProperty(window, '%testCafeSelectorFilter%', {
             return node;
 
         if (node instanceof Node) {
-            if (options.textFilter)
-                return hasText(node, options.textFilter) ? node : null;
+            if (options.text)
+                return hasText(node, options.text) ? node : null;
 
             return node;
         }
 
         if (node instanceof HTMLCollection || node instanceof NodeList || isArrayOfNodes(node)) {
-            if (options.textFilter)
-                node = filterNodeCollectionByText(node, options.textFilter);
+            if (options.text)
+                node = filterNodeCollectionByText(node, options.text);
 
             return node[options.index];
         }

--- a/test/functional/fixtures/api/es-next/selector/test.js
+++ b/test/functional/fixtures/api/es-next/selector/test.js
@@ -69,8 +69,8 @@ describe('[API] Selector', function () {
         return runTests('./testcafe-fixtures/selector-test.js', 'Selector "index" option');
     });
 
-    it('Should filter results with "textFilter" options', function () {
-        return runTests('./testcafe-fixtures/selector-test.js', 'Selector "textFilter" option');
+    it('Should filter results with "text" options', function () {
+        return runTests('./testcafe-fixtures/selector-test.js', 'Selector "text" option');
     });
 
     it('Should filter results using compound filter', function () {

--- a/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
+++ b/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
@@ -339,37 +339,37 @@ test('Selector "index" option', async () => {
     expect(el.id).eql('el1');
 });
 
-test('Selector "textFilter" option', async () => {
+test('Selector "text" option', async () => {
     // String selector and string filter
-    let selector = Selector('div', { textFilter: 'element 4.' });
+    let selector = Selector('div', { text: 'element 4.' });
 
     let el = await selector();
 
     expect(el.id).eql('el4');
 
     // String selector and regexp filter
-    selector = Selector('div', { textFilter: /This is element \d+/ });
+    selector = Selector('div', { text: /This is element \d+/ });
 
     el = await selector();
 
     expect(el.id).eql('el1');
 
     // Function selector and string filter
-    selector = Selector(() => document.querySelectorAll('.idxEl'), { textFilter: 'element 4.' });
+    selector = Selector(() => document.querySelectorAll('.idxEl'), { text: 'element 4.' });
 
     el = await selector();
 
     expect(el.id).eql('el4');
 
     // Function selector and regexp filter
-    selector = Selector(() => document.querySelectorAll('.idxEl'), { textFilter: /This is element \d+/ });
+    selector = Selector(() => document.querySelectorAll('.idxEl'), { text: /This is element \d+/ });
 
     el = await selector();
 
     expect(el.id).eql('el1');
 
     // Should filter element if text filter specified
-    selector = Selector(id => document.getElementById(id), { textFilter: 'element 4.' });
+    selector = Selector(id => document.getElementById(id), { text: 'element 4.' });
 
     el = await selector('el1');
 
@@ -380,39 +380,39 @@ test('Selector "textFilter" option', async () => {
     expect(el.id).eql('el4');
 
     // Should filter document if text filter specified
-    selector = Selector(() => document, { textFilter: 'Lorem ipsum dolor sit amet, consectetur' });
+    selector = Selector(() => document, { text: 'Lorem ipsum dolor sit amet, consectetur' });
 
     el = await selector();
 
     expect(el).to.be.null;
 
-    el = await selector.with({ textFilter: 'Hey?! (yo)' })();
+    el = await selector.with({ text: 'Hey?! (yo)' })();
 
     expect(el.nodeType).eql(9);
 
     // Should text node if text filter specified
-    selector = Selector(() => document.getElementById('el2').childNodes[0], { textFilter: 'Lorem ipsum dolor sit amet, consectetur' });
+    selector = Selector(() => document.getElementById('el2').childNodes[0], { text: 'Lorem ipsum dolor sit amet, consectetur' });
 
     el = await selector();
 
     expect(el).to.be.null;
 
-    el = await selector.with({ textFilter: 'Hey?! (yo)' })();
+    el = await selector.with({ text: 'Hey?! (yo)' })();
 
     expect(el.nodeType).eql(3);
 });
 
 test('Compound filter', async t => {
     const selector = Selector('div', {
-        textFilter: 'Hey?! (yo)',
-        index:      1
+        text:  'Hey?! (yo)',
+        index: 1
     });
 
     let el = await selector();
 
     expect(el.id).eql('el3');
 
-    el = await selector.with({ textFilter: /This is element \d+/ })();
+    el = await selector.with({ text: /This is element \d+/ })();
 
     expect(el.id).eql('el4');
 

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -863,13 +863,13 @@ describe('Compiler', function () {
                         stackTop: testfile,
 
                         message: 'Cannot prepare tests due to an error.\n\n' +
-                                 '"textFilter" option is expected to be a string or a regular expression, but it was object.',
+                                 '"text" option is expected to be a string or a regular expression, but it was object.',
 
                         callsite: "   1 |import { Selector } from 'testcafe';\n" +
                                   '   2 |\n' +
                                   '   3 |fixture `Test`;\n' +
                                   '   4 |\n' +
-                                  ' > 5 |Selector(() => {}, { textFilter: {} });\n' +
+                                  ' > 5 |Selector(() => {}, { text: {} });\n' +
                                   '   6 |\n' +
                                   "   7 |test('yo', () => {\n" +
                                   '   8 |});'

--- a/test/server/data/test-suites/selector-text-filter-is-not-regexp-or-string/testfile.js
+++ b/test/server/data/test-suites/selector-text-filter-is-not-regexp-or-string/testfile.js
@@ -2,7 +2,7 @@ import { Selector } from 'testcafe';
 
 fixture `Test`;
 
-Selector(() => {}, { textFilter: {} });
+Selector(() => {}, { text: {} });
 
 test('yo', () => {
 });


### PR DESCRIPTION
\cc @VasilyStrelyaev @AlexanderMoskovkin 