### PR TITLE
Always use escaped strings for templates (fixes #814)

### DIFF
--- a/src/client/test-run/iframe.js.mustache
+++ b/src/client/test-run/iframe.js.mustache
@@ -1,6 +1,6 @@
 (function () {
 var IframeDriver = window['%testCafeIframeDriver%'];
-var driver = new IframeDriver({ testRun: '{{{testRunId}}}' }, { selectorTimeout: {{{selectorTimeout}}}, dialogHandler: {{{dialogHandler}}} });
+var driver = new IframeDriver({ testRun: {{{testRunId}}} }, { selectorTimeout: {{{selectorTimeout}}}, dialogHandler: {{{dialogHandler}}} });
 
 driver.start();
 })();

--- a/src/client/test-run/index.js.mustache
+++ b/src/client/test-run/index.js.mustache
@@ -2,16 +2,16 @@
     if (window !== window.top)
         return;
 
-    var testRunId           = '{{{testRunId}}}';
-    var browserId           = '{{{browserId}}}';
+    var testRunId           = {{{testRunId}}};
+    var browserId           = {{{browserId}}};
     var selectorTimeout     = {{{selectorTimeout}}};
-    var browserHeartbeatUrl = '{{{browserHeartbeatUrl}}}';
-    var browserStatusUrl    = '{{{browserStatusUrl}}}';
+    var browserHeartbeatUrl = {{{browserHeartbeatUrl}}};
+    var browserStatusUrl    = {{{browserStatusUrl}}};
     var skipJsErrors        = {{{skipJsErrors}}};
     var dialogHandler       = {{{dialogHandler}}};
-    var userAgent           = '{{{userAgent}}}';
-    var fixtureName         = '{{{fixtureName}}}';
-    var testName            = '{{{testName}}}';
+    var userAgent           = {{{userAgent}}};
+    var fixtureName         = {{{fixtureName}}};
+    var testName            = {{{testName}}};
 
     var ClientDriver = window['%testCafeDriver%'];
     var driver       = new ClientDriver(

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -71,13 +71,13 @@ export default class TestRun extends Session {
     // Hammerhead payload
     _getPayloadScript () {
         return Mustache.render(TEST_RUN_TEMPLATE, {
-            testRunId:           this.id,
-            browserId:           this.browserConnection.id,
-            browserHeartbeatUrl: this.browserConnection.heartbeatUrl,
-            browserStatusUrl:    this.browserConnection.statusUrl,
-            userAgent:           this.browserConnection.userAgent,
-            testName:            this.test.name.replace(/'/g, "\\'"),
-            fixtureName:         this.test.fixture.name.replace(/'/g, "\\'"),
+            testRunId:           JSON.stringify(this.id),
+            browserId:           JSON.stringify(this.browserConnection.id),
+            browserHeartbeatUrl: JSON.stringify(this.browserConnection.heartbeatUrl),
+            browserStatusUrl:    JSON.stringify(this.browserConnection.statusUrl),
+            userAgent:           JSON.stringify(this.browserConnection.userAgent),
+            testName:            JSON.stringify(this.test.name),
+            fixtureName:         JSON.stringify(this.test.fixture.name),
             selectorTimeout:     this.opts.selectorTimeout,
             skipJsErrors:        this.opts.skipJsErrors,
             dialogHandler:       JSON.stringify(this.dialogHandler)
@@ -86,7 +86,7 @@ export default class TestRun extends Session {
 
     _getIframePayloadScript () {
         return Mustache.render(IFRAME_TEST_RUN_TEMPLATE, {
-            testRunId:       this.id,
+            testRunId:       JSON.stringify(this.id),
             selectorTimeout: this.opts.selectorTimeout,
             dialogHandler:   JSON.stringify(this.dialogHandler)
         });

--- a/test/functional/fixtures/regression/gh-754/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/regression/gh-754/testcafe-fixtures/index-test.js
@@ -1,5 +1,4 @@
 fixture `fixture'with'several'singlequotes`;
 
-test(`test'name'with'several'singlequotes`, async t => {
-    await t.wait(100);
+test(`test'name'with'several'singlequotes`, () => {
 });


### PR DESCRIPTION
\cc @kirovboris @AlexanderMoskovkin 