### PR TITLE
Use single browser for about:blank regression tests. Escape string selector code (fixes #822).

### DIFF
--- a/src/client-functions/selector-builder.js
+++ b/src/client-functions/selector-builder.js
@@ -61,7 +61,7 @@ export default class SelectorBuilder extends ClientFunctionBuilder {
             return this.options.sourceSelectorBuilder.compiledFnCode;
 
         var code = typeof this.fn === 'string' ?
-                   `(function(){return document.querySelectorAll('${this.fn.replace(/'/g, "\\'")}');});` :
+                   `(function(){return document.querySelectorAll(${JSON.stringify(this.fn)});});` :
                    super._getCompiledFnCode();
 
 

--- a/test/functional/fixtures/regression/gh-754/test.js
+++ b/test/functional/fixtures/regression/gh-754/test.js
@@ -1,5 +1,5 @@
 describe('[Regression](GH-754) Should run tests if fixture name or test name contains several singlequotes', function () {
     it('gh-754', function () {
-        return runTests('testcafe-fixtures/index-test.js');
+        return runTests('testcafe-fixtures/index-test.js', '', { only: 'chrome' });
     });
 });

--- a/test/functional/fixtures/regression/gh-814/test.js
+++ b/test/functional/fixtures/regression/gh-814/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-814) Should run tests if fixture name or test name contains new line symbols', function () {
+    it('gh-814', function () {
+        return runTests('testcafe-fixtures/index-test.js', '', { only: 'chrome' });
+    });
+});

--- a/test/functional/fixtures/regression/gh-814/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/regression/gh-814/testcafe-fixtures/index-test.js
@@ -1,0 +1,4 @@
+fixture `fixture\n\r`;
+
+test(`\ntest\n`, () => {
+});

--- a/test/functional/fixtures/regression/gh-822/pages/index.html
+++ b/test/functional/fixtures/regression/gh-822/pages/index.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>GH-754</title>
+    <title>GH-822</title>
 </head>
 <body>
+<div id="5-2">1</div>
 </body>
 </html>

--- a/test/functional/fixtures/regression/gh-822/test.js
+++ b/test/functional/fixtures/regression/gh-822/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-822) Should execute selectors with escapable symbols', function () {
+    it('gh-822', function () {
+        return runTests('testcafe-fixtures/index-test.js', '', { only: 'chrome' });
+    });
+});

--- a/test/functional/fixtures/regression/gh-822/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/regression/gh-822/testcafe-fixtures/index-test.js
@@ -4,7 +4,7 @@ import { Selector } from 'testcafe';
 fixture `gh822`
     .page `http://localhost:3000/fixtures/regression/gh-822/pages/index.html`;
 
-test('Selectors with escapable symbols', async t => {
+test('Selectors with escapable symbols', async () => {
     const div = await Selector('#\\35 -2')();
 
     expect(div.innerText).eql('1');

--- a/test/functional/fixtures/regression/gh-822/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/regression/gh-822/testcafe-fixtures/index-test.js
@@ -1,0 +1,11 @@
+import { expect } from 'chai';
+import { Selector } from 'testcafe';
+
+fixture `gh822`
+    .page `http://localhost:3000/fixtures/regression/gh-822/pages/index.html`;
+
+test('Selectors with escapable symbols', async t => {
+    const div = await Selector('#\\35 -2')();
+
+    expect(div.innerText).eql('1');
+});


### PR DESCRIPTION
\cc @helen-dikareva @AndreyBelym 