### PR TITLE
[docs] Readme - add links to blog and twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,16 @@
 
 TestCafe is a pure node.js solution for testing web apps. It takes care of all the stages: starting browsers, running tests, gathering test results and generating reports. TestCafe doesn’t need browser plugins - it works in all popular modern browsers out-of-the-box.
 
-* [Build status](#build-status)
+* [Build Status](#build-status)
 * [Features](#features)
 * [Getting Started](#getting-started)
 * [Documentation](#documentation)
 * [Contributing](#contributing)
+* [Stay in Touch](#stay-in-touch)
 * [License](#license)
 * [Author](#author)
 
-## Build status
+## Build Status
 
 Tests             | Status
 ----------------- | ----------
@@ -306,6 +307,11 @@ Please use our [issues page](https://github.com/DevExpress/testcafe/issues) to r
 For general purpose questions and discussions, use the [discussion board](https://testcafe-discuss.devexpress.com/).
 
 For more information on how to help us improve TestCafe, please see the [CONTRIBUTING.md](CONTRIBUTING.md) file.
+
+## Stay in Touch
+
+* [Blog](https://devexpress.github.io/testcafe/blog/)
+* [Twitter](https://twitter.com/dxtestcafe)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <h1 align="center">
-    <a href="http://devexpress.github.io/testcafe">
+    <a href="https://devexpress.github.io/testcafe">
         <img src="https://raw.github.com/DevExpress/testcafe/master/media/logo.png" alt="testcafe" />
     </a>
 </h1>
 <p align="center">
-<a href="http://devexpress.github.io/testcafe">http://devexpress.github.io/testcafe</a>
+<a href="https://devexpress.github.io/testcafe">https://devexpress.github.io/testcafe</a>
 </p>
 <p align="center">
 <i>Automated browser testing for the modern web development stack.</i>
@@ -61,14 +61,14 @@ When testing is finished, TestCafe aggregates test results from different browse
 
 You can write TestCafe tests in ES2016 using the latest JavaScript features like `async/await`.
 
-[Test API](http://devexpress.github.io/testcafe/documentation/test-api/index.html) consists of over two dozen methods that can emulate all actions one could possibly do with a webpage.
+[Test API](https://devexpress.github.io/testcafe/documentation/test-api/index.html) consists of over two dozen methods that can emulate all actions one could possibly do with a webpage.
 Chained syntax allows for code that is easy to write and read.
 
 ```js
 import { expect } from 'chai';
 
 fixture `Example page`
-    .page('http://devexpress.github.io/testcafe/example');
+    .page('https://devexpress.github.io/testcafe/example');
 
 test('Emulate user actions and perform a verification', async t => {
     await t
@@ -85,7 +85,7 @@ To debug your test code, start a debugging session in an IDE that supports sourc
 
 ### Direct Access to Page Elements
 
-TestCafe allows you to access webpage elements using standard CSS selectors or [custom selectors](http://devexpress.github.io/testcafe/documentation/test-api/selecting-page-elements/selectors.html) that run client JavaScript code.
+TestCafe allows you to access webpage elements using standard CSS selectors or [custom selectors](https://devexpress.github.io/testcafe/documentation/test-api/selecting-page-elements/selectors.html) that run client JavaScript code.
 You can call a custom selector as a regular function within your test.
 It will execute your code on the client and pass the returned value back to the test.
 This allows you to determine the state of each element on the tested page or select a proper element to perform an action on.
@@ -96,7 +96,7 @@ import { Selector } from 'testcafe';
 const getElementById = Selector(id => document.querySelector(`#${id}`));
 
 fixture `Example page`
-    .page('http://devexpress.github.io/testcafe/example');
+    .page('https://devexpress.github.io/testcafe/example');
 
 test('Type the developer name, obtain the header text and check it', async t => {
     await t
@@ -122,14 +122,14 @@ Write tests without boilerplate code.
 TestCafe automatically generates full-detailed reports that provide a test run summary and comprehensive information about errors.
 Automatic page screenshots, fancy call sites and call stacks free of TestCafe internals allow you to easily detect error causes.
 
-Use one of [built-in reporters](http://devexpress.github.io/testcafe/documentation/using-testcafe/common-concepts/reporters.html) to output test results or [create your own one](http://devexpress.github.io/testcafe/documentation/extending-testcafe/custom-reporter-plugin/) to produce custom reports.
+Use one of [built-in reporters](https://devexpress.github.io/testcafe/documentation/using-testcafe/common-concepts/reporters.html) to output test results or [create your own one](https://devexpress.github.io/testcafe/documentation/extending-testcafe/custom-reporter-plugin/) to produce custom reports.
 
 ![Spec Report](docs/articles/images/spec-report.png)
 
 ### Straightforward Continuous Integration
 
 TestCafe is easy to set up on popular Continuous Integration platforms as it allows you to test against various browsers: local, remote or cloud (e.g., [Sauce Labs](https://saucelabs.com/)).
-You can also create a custom [browser provider](http://devexpress.github.io/testcafe/documentation/extending-testcafe/browser-provider-plugin/index.html) to add support for a browser or a cloud platform of your choice.
+You can also create a custom [browser provider](https://devexpress.github.io/testcafe/documentation/extending-testcafe/browser-provider-plugin/index.html) to add support for a browser or a cloud platform of your choice.
 
 ## Getting Started
 
@@ -141,30 +141,30 @@ Ensure that [Node.js](https://nodejs.org/) and [npm](https://www.npmjs.com/) are
 npm install -g testcafe
 ```
 
-For more information, see [Installing TestCafe](http://devexpress.github.io/testcafe/documentation/using-testcafe/installing-testcafe.html).
+For more information, see [Installing TestCafe](https://devexpress.github.io/testcafe/documentation/using-testcafe/installing-testcafe.html).
 
 ### Creating a Test
 
 To create a test, create a new .js file anywhere on your computer.
-This file must have a special structure: tests must be organized into fixtures. Thus, begin by declaring a fixture using the [fixture](http://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.md#fixtures) function.
+This file must have a special structure: tests must be organized into fixtures. Thus, begin by declaring a fixture using the [fixture](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.md#fixtures) function.
 
 ```js
 fixture `Getting Started`
 ```
 
-In this tutorial, you will create a test for the [http://devexpress.github.io/testcafe/example](http://devexpress.github.io/testcafe/example) sample page.
-Specify this page as a start page for the fixture by using the [page](http://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.md#specifying-the-start-webpage) function.
+In this tutorial, you will create a test for the [https://devexpress.github.io/testcafe/example](https://devexpress.github.io/testcafe/example) sample page.
+Specify this page as a start page for the fixture by using the [page](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.md#specifying-the-start-webpage) function.
 
 ```js
 fixture `Getting Started`
-    .page('http://devexpress.github.io/testcafe/example');
+    .page('https://devexpress.github.io/testcafe/example');
 ```
 
-Then, create the [test](http://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.md#tests) function where you will place test code.
+Then, create the [test](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.md#tests) function where you will place test code.
 
 ```js
 fixture `Getting Started`
-    .page('http://devexpress.github.io/testcafe/example');
+    .page('https://devexpress.github.io/testcafe/example');
 
 test('My first test', async t => {
     // Test code
@@ -173,7 +173,7 @@ test('My first test', async t => {
 
 ### Running the Test
 
-You can simply run the test from a command shell by calling a single command where you specify the [target browser](http://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.md#browser-list) and [file path](http://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.md#file-pathglob-pattern).
+You can simply run the test from a command shell by calling a single command where you specify the [target browser](https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.md#browser-list) and [file path](https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.md#file-pathglob-pattern).
 
 ```bash
 testcafe safari test1.js
@@ -185,7 +185,7 @@ TestCafe will automatically open the chosen browser and start test execution wit
 > Inactive tabs and minimized browser windows switch to a lower resource consumption mode
 > where tests are not guaranteed to execute correctly.
 
-For more information on how to configure the test run, see [Command Line Interface](http://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.md).
+For more information on how to configure the test run, see [Command Line Interface](https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.md).
 
 ### Viewing the Test Results
 
@@ -193,21 +193,21 @@ While the test is running, TestCafe is gathering information about the test run 
 
 ![Test Report](docs/articles/images/report.png)
 
-For more information, see [Reporters](http://devexpress.github.io/testcafe/documentation/using-testcafe/common-concepts/reporters.md).
+For more information, see [Reporters](https://devexpress.github.io/testcafe/documentation/using-testcafe/common-concepts/reporters.md).
 
 ### Writing Test Code
 
 #### Performing Actions on the Page
 
 Every test should be capable of interacting with page content. To perform user actions, TestCafe provides
-a number of [actions](http://devexpress.github.io/testcafe/documentation/test-api/actions/index.md): `click`, `hover`, `typeText`, `setFilesToUpload`, etc.
+a number of [actions](https://devexpress.github.io/testcafe/documentation/test-api/actions/index.md): `click`, `hover`, `typeText`, `setFilesToUpload`, etc.
 They can be called in a chain.
 
 The following fixture contains a simple test that types a developer name into a text editor and then clicks the Submit button.
 
 ```js
 fixture `Getting Started`
-    .page('http://devexpress.github.io/testcafe/example');
+    .page('https://devexpress.github.io/testcafe/example');
 
 test('My first test', async t => {
     await t
@@ -216,7 +216,7 @@ test('My first test', async t => {
 });
 ```
 
-All test actions are implemented as async functions of the [test controller object](http://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.md#test-controller) `t`.
+All test actions are implemented as async functions of the [test controller object](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.md#test-controller) `t`.
 This object is used to access test run API.
 To wait for actions to complete, use the `await` keyword when calling these actions or action chains.
 
@@ -224,8 +224,8 @@ To wait for actions to complete, use the `await` keyword when calling these acti
 
 TestCafe allows you to observe the page state.
 For this purpose, it offers special kinds of functions that will execute your code on the client:
-[Selector](http://devexpress.github.io/testcafe/documentation/test-api/selecting-page-elements/selectors.md) used to get direct access to DOM elements
-and [ClientFunction](http://devexpress.github.io/testcafe/documentation/test-api/obtaining-data-from-the-client.md) used to obtain arbitrary data from the client side.
+[Selector](https://devexpress.github.io/testcafe/documentation/test-api/selecting-page-elements/selectors.md) used to get direct access to DOM elements
+and [ClientFunction](https://devexpress.github.io/testcafe/documentation/test-api/obtaining-data-from-the-client.md) used to obtain arbitrary data from the client side.
 You call these functions as regular async functions, that is you can obtain their results and use parameters to pass data to them.
 
 For example, clicking the Submit button on the sample web page opens a "Thank you" page.
@@ -240,7 +240,7 @@ import { Selector } from 'testcafe';
 const getElementById = Selector(id => document.getElementById(id));
 
 fixture `Getting Started`
-    .page('http://devexpress.github.io/testcafe/example');
+    .page('https://devexpress.github.io/testcafe/example');
 
 test('My first test', async t => {
     await t
@@ -255,7 +255,7 @@ test('My first test', async t => {
 });
 ```
 
-For more information, see [Selecting Page Elements](http://devexpress.github.io/testcafe/documentation/test-api/selecting-page-elements/index.md).
+For more information, see [Selecting Page Elements](https://devexpress.github.io/testcafe/documentation/test-api/selecting-page-elements/index.md).
 
 #### Assertions
 
@@ -278,7 +278,7 @@ import { Selector } from 'testcafe';
 const getElementById = Selector(id => document.getElementById(id));
 
 fixture `Getting Started`
-    .page('http://devexpress.github.io/testcafe/example');
+    .page('https://devexpress.github.io/testcafe/example');
 
 test('My first test', async t => {
     await t
@@ -295,10 +295,10 @@ test('My first test', async t => {
 
 ## Documentation
 
-* [Test API](http://devexpress.github.io/testcafe/documentation/test-api/)
-* [Using TestCafe](http://devexpress.github.io/testcafe/documentation/using-testcafe/)
-* [Extending TestCafe](http://devexpress.github.io/testcafe/documentation/extending-testcafe/)
-* [Recipes](http://devexpress.github.io/testcafe/documentation/recipes/)
+* [Test API](https://devexpress.github.io/testcafe/documentation/test-api/)
+* [Using TestCafe](https://devexpress.github.io/testcafe/documentation/using-testcafe/)
+* [Extending TestCafe](https://devexpress.github.io/testcafe/documentation/extending-testcafe/)
+* [Recipes](https://devexpress.github.io/testcafe/documentation/recipes/)
 
 ## Contributing
 


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs 

**A question:** should we also change all the links from this Readme to GitHub Pages from `http` to `https` or it doesn't matter?