### PR TITLE
Fix unstable iframe-switching test in safari

### DIFF
--- a/test/functional/fixtures/api/es-next/iframe-switching/pages/iframe.html
+++ b/test/functional/fixtures/api/es-next/iframe-switching/pages/iframe.html
@@ -41,7 +41,7 @@
 
     document.getElementById('too-long-loading-page-link').addEventListener('click', function () {
         window.setTimeout(function () {
-            document.location = 'iframe.html?delay=11000';
+            document.location = 'second.html?delay=14000';
         }, 1000);
     });
 </script>

--- a/test/functional/fixtures/api/es-next/iframe-switching/pages/index.html
+++ b/test/functional/fixtures/api/es-next/iframe-switching/pages/index.html
@@ -12,8 +12,8 @@
 
 <h2>Same-domain iframes</h2>
 
-<iframe id="iframe" src="iframe.html" width="500px" height="200px"></iframe>
-<iframe name="long" id="slowly-loading-iframe" src="iframe.html?delay=1000" height="200px"></iframe>
+<iframe id="iframe" src="iframe.html" width="500px" height="300px"></iframe>
+<iframe name="long" id="slowly-loading-iframe" src="iframe.html?delay=1000" height="300px"></iframe>
 
 <script>
     document.addEventListener('DOMContentLoaded', function () {
@@ -26,7 +26,7 @@
         tooSlowlyLoadingIframe.id           = 'too-slowly-loading-iframe';
         tooSlowlyLoadingIframe.src          = "iframe.html?delay=10000";
         tooSlowlyLoadingIframe.style.width  = "500px";
-        tooSlowlyLoadingIframe.style.height = "200px";
+        tooSlowlyLoadingIframe.style.height = "300px";
 
         document.body.insertBefore(tooSlowlyLoadingIframe, document.getElementById('slowly-loading-iframe'));
     });

--- a/test/functional/fixtures/api/es-next/iframe-switching/test.js
+++ b/test/functional/fixtures/api/es-next/iframe-switching/test.js
@@ -106,7 +106,7 @@ describe('[API] t.switchToIframe(), t.switchToMainWindow()', function () {
             })
                 .catch(function (errs) {
                     expect(errs[0]).to.contains('Content of the iframe in which the test is currently operating did not load.');
-                    expect(errs[0]).to.contains("> 200 |        .click('#btn');");
+                    expect(errs[0]).to.contains("> 200 |        .click('#second-page-btn');");
                 });
         });
     });

--- a/test/functional/fixtures/api/es-next/iframe-switching/testcafe-fixtures/iframe-switching-test.js
+++ b/test/functional/fixtures/api/es-next/iframe-switching/testcafe-fixtures/iframe-switching-test.js
@@ -196,6 +196,6 @@ test('Click in an iframe that is not loaded', async t => {
     await t
         .switchToIframe('#iframe')
         .click('#too-long-loading-page-link')
-        .wait(1500)
-        .click('#btn');
+        .wait(3000)
+        .click('#second-page-btn');
 });


### PR DESCRIPTION
For this test: https://travis-ci.org/testcafe-build-bot/testcafe/jobs/166387072#L1797

It seems the problem occurs because the `beforeUnload` event is raised a little bit later than we are expecting in the test.