### PR TITLE
Fallback to `textContent` for `<option>` element text selectors in Firefox (fixes #861)

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -23,7 +23,6 @@ var spawn                = require('cross-spawn');
 var serveStatic          = require('serve-static');
 var Promise              = require('pinkie');
 var markdownlint         = require('markdownlint');
-var ghpages              = require('gulp-gh-pages');
 var prompt               = require('gulp-prompt');
 var nodeVer              = require('node-version');
 var functionalTestConfig = require('./test/functional/config');
@@ -472,9 +471,9 @@ gulp.task('preview-website', function () {
     return new Promise(function (resolve) {
         runSequence('build-website-development', 'serve-website', resolve);
     })
-    .then(function () {
-        return opn('http://localhost:8080/testcafe');
-    });
+        .then(function () {
+            return opn('http://localhost:8080/testcafe');
+        });
 });
 
 function testWebsite (isTravis) {
@@ -483,22 +482,22 @@ function testWebsite (isTravis) {
 
         runSequence(buildTask, 'serve-website', resolve);
     })
-    .then(function () {
-        var WebsiteTester = require('./test/website/test.js');
-        var websiteTester = new WebsiteTester();
+        .then(function () {
+            var WebsiteTester = require('./test/website/test.js');
+            var websiteTester = new WebsiteTester();
 
-        return websiteTester.checkLinks();
-    })
-    .then(function (failed) {
-        return new Promise(function (resolve, reject) {
-            websiteServer.close(function () {
-                if (failed)
-                    reject('Broken links found!');
-                else
-                    resolve();
+            return websiteTester.checkLinks();
+        })
+        .then(function (failed) {
+            return new Promise(function (resolve, reject) {
+                websiteServer.close(function () {
+                    if (failed)
+                        reject('Broken links found!');
+                    else
+                        resolve();
+                });
             });
         });
-    });
 }
 
 gulp.task('test-website', function () {
@@ -510,6 +509,11 @@ gulp.task('test-website-travis', function () {
 });
 
 gulp.task('publish-website', ['build-website-production'], function () {
+    // NOTE: it's accidentally stopped being compatible with node 0.10 without
+    // major version bump due to https://github.com/floridoo/gulp-sourcemaps/issues/236,
+    // so we require it here.
+    var ghpages = require('gulp-gh-pages');
+
     return gulp
         .src('site/deploy/**/*')
         .pipe(prompt.confirm({

--- a/src/client/driver/command-executors/client-functions/selector-executor/index.js
+++ b/src/client/driver/command-executors/client-functions/selector-executor/index.js
@@ -48,8 +48,8 @@ function hasText (node, textRe) {
     if (node.nodeType === 1) {
         var text = getInnerText(node);
 
-        // NOTE: In Firefox <option> elements doesn't have `innerText`.
-        // So we fallback to `textContent` in that case (see GH-861).
+        // NOTE: In Firefox, <option> elements don't have `innerText`.
+        // So, we fallback to `textContent` in that case (see GH-861).
         if (domUtils.isOptionElement(node)) {
             var textContent = getTextContent(node);
 

--- a/src/client/driver/command-executors/client-functions/selector-executor/index.js
+++ b/src/client/driver/command-executors/client-functions/selector-executor/index.js
@@ -45,8 +45,21 @@ function visible (el) {
 
 function hasText (node, textRe) {
     // Element
-    if (node.nodeType === 1)
-        return textRe.test(getInnerText(node));
+    if (node.nodeType === 1) {
+        var text            = getInnerText(node);
+        var isOptionElement = typeof node.tagName === 'string' && node.tagName.toLowerCase() === 'option';
+
+        // NOTE: In Firefox <option> elements doesn't have `innerText`.
+        // So we fallback to `textContent` in that case (see GH-861).
+        if (isOptionElement) {
+            var textContent = getTextContent(node);
+
+            if (!text && textContent)
+                text = textContent;
+        }
+
+        return textRe.test(text);
+    }
 
     // Document and DocumentFragment
     if (node.nodeType === 9 || node.nodeType === 11)

--- a/src/client/driver/command-executors/client-functions/selector-executor/index.js
+++ b/src/client/driver/command-executors/client-functions/selector-executor/index.js
@@ -46,12 +46,11 @@ function visible (el) {
 function hasText (node, textRe) {
     // Element
     if (node.nodeType === 1) {
-        var text            = getInnerText(node);
-        var isOptionElement = typeof node.tagName === 'string' && node.tagName.toLowerCase() === 'option';
+        var text = getInnerText(node);
 
         // NOTE: In Firefox <option> elements doesn't have `innerText`.
         // So we fallback to `textContent` in that case (see GH-861).
-        if (isOptionElement) {
+        if (domUtils.isOptionElement(node)) {
             var textContent = getTextContent(node);
 
             if (!text && textContent)

--- a/test/functional/fixtures/api/es-next/selector/test.js
+++ b/test/functional/fixtures/api/es-next/selector/test.js
@@ -117,5 +117,9 @@ describe('[API] Selector', function () {
         it("Should execute successfully if derivative selector doesn't have options (GH-716)", function () {
             return runTests('./testcafe-fixtures/selector-test.js', 'Derivative selector without options', { only: 'chrome' });
         });
+
+        it('Should select <option> element by text in Firefox (GH-861)', function () {
+            return runTests('./testcafe-fixtures/selector-test.js', '<option> text selector', { only: 'firefox' });
+        });
     });
 });

--- a/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
+++ b/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
@@ -450,7 +450,7 @@ test('Derivative selector without options', async () => {
     await derivative();
 });
 
-test('<option> text selector', async t => {
+test('<option> text selector', async () => {
     const selector = Selector('#selectInput > option').with({ text: 'O2' });
     const el       = await selector();
 

--- a/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
+++ b/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
@@ -449,3 +449,10 @@ test('Derivative selector without options', async () => {
 
     await derivative();
 });
+
+test('<option> text selector', async t => {
+    const selector = Selector('#selectInput > option').with({ text: 'O2' });
+    const el       = await selector();
+
+    expect(el.id).eql('option2');
+});


### PR DESCRIPTION
\cc @AndreyBelym @helen-dikareva @VasilyStrelyaev 