### PR TITLE
[docs] Added a contribution guide, code of conduct and issue template (closes #703)

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,15 +6,15 @@
 
 
 
-### How would you reproduce this behavior (if this is a bug)?
-
-
-
 ### What is the expected behavior?
 
 
 
-### Provide the test code and the tested page URL (if applicable)
+### How would you reproduce the current behavior (if this is a bug)?
+
+
+
+#### Provide the test code and the tested page URL (if applicable)
 
 Tested page URL:
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,31 @@
+### Are you requesting a feature or reporting a bug?
+
+
+
+### What is the current behavior?
+
+
+
+### How would you reproduce this behavior (if this is a bug)?
+
+
+
+### What is the expected behavior?
+
+
+
+### Provide the test code and the tested page URL (if applicable)
+
+Tested page URL:
+
+Test code
+
+```js
+
+```
+
+### Specify your
+
+* operating system:
+* testcafe version:
+* node.js version:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at ivann@devexpress.com. All
+reported by contacting the project team at ifaaan@gmail.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at ivann@devexpress.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to TestCafe
+
+Everyone is welcome to contribute to our project and we truly appreciate your help.
+TestCafe would not be possible without active support from the community.
+
+These guidelines help you contribute easily and painlessly.
+
+* [Code of Conduct](#code-of-conduct)
+* [General Discussion](#general-discussion)
+* [Reporting a Problem](#reporting-a-problem)
+* [Code Contribution](#code-contribution)
+
+## Code of Conduct
+
+TestCafe has adopted a [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
+By participating in the project you agree to abide by its terms.
+
+## General Discussion
+
+If you have a question about TestCafe or want to share your opinion,
+welcome to our [discussion board](https://testcafe-discuss.devexpress.com/).
+
+## Reporting a Problem
+
+Something went wrong with TestCafe? File an issue in our [GitHub repository](https://github.com/DevExpress/testcafe/issues).
+But first please search through the existing issues to see if the problem has already been reported or addressed.
+
+When you create a new issue, a template text is automatically added to its body. To help us understand your
+problem, be sure to fill in all sections in this template.
+
+## Code Contribution
+
+Please follow these steps when submitting your code.
+
+1. Search the [list of issues](https://github.com/DevExpress/testcafe/issues) to see if
+  there is an issue for the bug you are going to fix or the feature you are going to implement. If you don't find any, please create one.
+
+2. If you are going to address an existing issue, check the comment thread to make sure that nobody is working on it at the moment.
+
+3. Leave a comment saying that you are willing to fix this issue and if possible provide details on how you are going to do this.
+
+4. Core team members may need to discuss the details of the proposed fix with you. As soon as you get the green light from them,
+  leave a comment saying that you are currently working on this issue.
+
+5. Fork TestCafe and create a branch in your fork. Name this branch with an issue number, e.g. `gh852`, `gh853`.
+  
+    > If you are going to update documentation, do this in a separate branch, e.g. `gh852-docs`.
+
+6. Commit your changes into the branch.
+
+7. Add regression tests to the appropriate sections if you are fixing a bug. You can find these sections by searching for `Regression` in code.
+
+    Add unit and/or functional tests if you are developing new functionality.
+
+8. Fetch upstream changes and rebase your branch onto `master`.
+
+9. Run tests before submitting a pull request to ensure that everything works properly.
+
+    ```sh
+    gulp test-server
+    gulp test-functional-local
+    gulp test-client
+    ```
+
+10. Push changes to your fork.
+
+11. Submit a pull request. If you are also updating documentation, submit a separate pull request for these changes.
+
+    The pull request name should describe what has been done and contain
+    the [closes](https://github.com/blog/1506-closing-issues-via-pull-requests) directive
+    with an appropriate issue number.
+
+    Documentation pull requests should have the `[docs]` prefix in their title.
+    This ensures that documentation tests are triggered against these pull requests.


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs 

Not checked yet so just take a look.

fixes #703 