### PR TITLE
Fix server compiler test after babylon@6.11.6 update

### DIFF
--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -279,7 +279,7 @@ describe('Compiler', function () {
                         stackTop: testfile,
 
                         message: 'Cannot prepare tests due to an error.\n\n' +
-                                 'SyntaxError: ' + dep + ': Unexpected token (1:7)'
+                                 'SyntaxError: ' + dep + ': Unexpected token, expected { (1:7)'
                     });
                 });
         });
@@ -338,7 +338,7 @@ describe('Compiler', function () {
                         stackTop: null,
 
                         message: 'Cannot prepare tests due to an error.\n\n' +
-                                 'SyntaxError: ' + testfile + ': Unexpected token (1:7)'
+                                 'SyntaxError: ' + testfile + ': Unexpected token, expected { (1:7)'
                     });
                 });
         });


### PR DESCRIPTION
We have failed server tests after [changes in babylon](https://github.com/babel/babylon/pull/150). It was released in [v6.11.5](https://github.com/babel/babylon/blob/c300230a59ff80f524be609c12bc158cada1ead5/CHANGELOG.md#v6115-2016-10-12) several hours ago

/cc @inikulin 