### PR TITLE
Update testcafe-legacy-api. Downgrade MSEdge version for functional tests (workaround for #872)

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "^1.0.0",
     "testcafe-hammerhead": "^9.2.1",
-    "testcafe-legacy-api": "^1.2.0",
+    "testcafe-legacy-api": "^2.0.0",
     "testcafe-reporter-json": "^2.0.0",
     "testcafe-reporter-list": "^2.0.0",
     "testcafe-reporter-minimal": "^2.0.0",

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -41,7 +41,8 @@ testingEnvironments[testingEnvironmentNames.saucelabsOSXDesktopAndMSEdgeBrowsers
         {
             platform:    'Windows 10',
             browserName: 'microsoftedge',
-            alias:       'edge'
+            alias:       'edge',
+            version:     '13.10586'
         }
     ]
 };


### PR DESCRIPTION
Updating `testcafe-legacy-api` is related with https://github.com/DevExpress/testcafe/pull/869 and https://github.com/DevExpress/testcafe-legacy-api/pull/20

/cc @inikulin 