### PR TITLE
Fix selector text filter for `document` nodes in MSEdge 14 (closes #875)

### DIFF
--- a/src/client/driver/command-executors/client-functions/selector-executor/index.js
+++ b/src/client/driver/command-executors/client-functions/selector-executor/index.js
@@ -60,17 +60,39 @@ function hasText (node, textRe) {
         return textRe.test(text);
     }
 
-    // Document and DocumentFragment
-    if (node.nodeType === 9 || node.nodeType === 11)
-        return !!filterNodeCollectionByText(node.childNodes, textRe).length;
+    // Document
+    if (node.nodeType === 9) {
+        // NOTE: latest version of Edge doesn't have `innerText` for `document`,
+        // `html` and `body`. So we check their children instead.
+        var head = node.querySelector('head');
+        var body = node.querySelector('body');
+
+        return hasChildrenWithText(head, textRe) || hasChildrenWithText(body, textRe);
+    }
+
+    // DocumentFragment
+    if (node.nodeType === 11)
+        return hasChildrenWithText(node, textRe);
 
     return textRe.test(getTextContent(node));
 }
 
+function hasChildrenWithText (node, textRe) {
+    var cnCount = node.childNodes.length;
+
+    for (var i = 0; i < cnCount; i++) {
+        if (hasText(node.childNodes[i], textRe))
+            return true;
+    }
+
+    return false;
+}
+
 function filterNodeCollectionByText (collection, textRe) {
+    var count    = collection.length;
     var filtered = [];
 
-    for (var i = 0; i < collection.length; i++) {
+    for (var i = 0; i < count; i++) {
         if (hasText(collection[i], textRe))
             filtered.push(collection[i]);
     }


### PR DESCRIPTION
\cc @AlexanderMoskovkin @helen-dikareva 