### PR TITLE
Allow specifying browser arguments (closes #905)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,4 @@ build: off
 # NOTE: We should prerun Firefox to avoid "Refresh Firefox" notification in the tests window.
 test_script:
 - cmd: >-
-    start /D "C:\Program Files (x86)\Mozilla Firefox" firefox.exe -new-window https://google.com
-
     npm test

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "source-map-support": "^0.4.0",
     "stack-chain": "^1.3.6",
     "strip-bom": "^2.0.0",
-    "testcafe-browser-tools": "1.1.2",
+    "testcafe-browser-tools": "1.1.5",
     "testcafe-hammerhead": "10.1.5",
     "testcafe-legacy-api": "^2.0.0",
     "testcafe-reporter-json": "^2.0.0",

--- a/src/browser/provider/built-in/locally-installed.js
+++ b/src/browser/provider/built-in/locally-installed.js
@@ -5,7 +5,13 @@ export default {
     isMultiBrowser: true,
 
     async openBrowser (browserId, pageUrl, browserName) {
-        var openParameters = await browserTools.getBrowserInfo(browserName);
+        var args  = browserName.split(' ');
+        var alias = args.shift();
+
+        var openParameters = await browserTools.getBrowserInfo(alias);
+
+        if (args.length)
+            openParameters.cmd += (openParameters.cmd ? ' ' : '') + args.join(' ');
 
         await browserTools.open(openParameters, pageUrl);
     },
@@ -27,7 +33,7 @@ export default {
     async isValidBrowserName (browserName) {
         var browserNames = await this.getBrowserList();
 
-        browserName = browserName.toLowerCase();
+        browserName = browserName.toLowerCase().split(' ')[0];
 
         return browserNames.indexOf(browserName) > -1;
     }

--- a/src/browser/provider/built-in/path.js
+++ b/src/browser/provider/built-in/path.js
@@ -1,8 +1,24 @@
 import browserTools from 'testcafe-browser-tools';
+import { splitQuotedText } from '../../../utils/string';
 
 
 export default {
     isMultiBrowser: true,
+
+    async _handleString (str) {
+        var args = splitQuotedText(str, ' ', '`"\'');
+        var path = args.shift();
+
+        var params = await browserTools.getBrowserInfo(path);
+
+        if (!params)
+            return null;
+
+        if (args.length)
+            params.cmd += (params.cmd ? ' ' : '') + args.join(' ');
+
+        return params;
+    },
 
     async _handleJSON (str) {
         var params = null;
@@ -29,7 +45,7 @@ export default {
     },
 
     async openBrowser (browserId, pageUrl, browserName) {
-        var openParameters = await browserTools.getBrowserInfo(browserName) || await this._handleJSON(browserName);
+        var openParameters = await this._handleString(browserName) || await this._handleJSON(browserName);
 
         if (!openParameters)
             throw new Error('The specified browser name is not valid!');

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -39,3 +39,37 @@ export function wordWrap (str, indent, width) {
 
     return indentString(wrappedMsg + curStr, ' ', indent);
 }
+
+export function splitQuotedText (str, splitChar, quotes = '"\'') {
+    var currentPart = '';
+    var parts       = [];
+    var quoteChar   = null;
+
+    for (var i = 0; i < str.length; i++) {
+        var currentChar = str[i];
+
+        if (currentChar === splitChar) {
+            if (quoteChar)
+                currentPart += currentChar;
+            else {
+                parts.push(currentPart);
+                currentPart = '';
+            }
+        }
+        else if (quotes.indexOf(currentChar) > -1) {
+            if (quoteChar === currentChar)
+                quoteChar = null;
+            else if (!quoteChar)
+                quoteChar = currentChar;
+            else
+                currentPart += currentChar;
+        }
+        else
+            currentPart += currentChar;
+    }
+
+    if (currentPart)
+        parts.push(currentPart);
+
+    return parts;
+}

--- a/test/server/browser-provider-test.js
+++ b/test/server/browser-provider-test.js
@@ -1,0 +1,79 @@
+var expect               = require('chai').expect;
+var Promise              = require('pinkie');
+var testcafeBrowserTools = require('testcafe-browser-tools');
+var browserProviderPool  = require('../../lib/browser/provider/pool');
+
+describe('Browser provider', function () {
+    var processedBrowserInfo                 = null;
+    var originalBrowserToolsGetBrowserInfo   = null;
+    var originalBrowserToolsOpen             = null;
+    var originalBrowserToolsGetInstallations = null;
+
+    function getBrowserInfo (arg) {
+        return browserProviderPool
+            .getBrowserInfo(arg)
+            .then(function (browserInfo) {
+                return browserInfo.provider.openBrowser('id', 'test-url', browserInfo.browserName);
+            })
+            .catch(function (error) {
+                expect(error.message).to.contain('STOP');
+                return processedBrowserInfo;
+            });
+    }
+
+    before(function () {
+        originalBrowserToolsGetBrowserInfo   = testcafeBrowserTools.getBrowserInfo;
+        originalBrowserToolsOpen             = testcafeBrowserTools.open;
+        originalBrowserToolsGetInstallations = testcafeBrowserTools.getInstallations;
+
+        testcafeBrowserTools.getBrowserInfo = function (path) {
+            return {
+                path: path,
+                cmd:  '--internal-arg'
+            };
+        };
+
+        testcafeBrowserTools.open = function (browserInfo) {
+            processedBrowserInfo = browserInfo;
+
+            throw new Error('STOP');
+        };
+
+        testcafeBrowserTools.getInstallations = function () {
+            return new Promise(function (resolve) {
+                resolve({ chrome: {} });
+            });
+        };
+    });
+
+    after(function () {
+        testcafeBrowserTools.getBrowserInfo   = originalBrowserToolsGetBrowserInfo;
+        testcafeBrowserTools.open             = originalBrowserToolsOpen;
+        testcafeBrowserTools.getInstallations = originalBrowserToolsGetInstallations;
+    });
+
+    it('Should parse browser parameters with arguments', function () {
+        return getBrowserInfo('path:/usr/bin/chrome --arg1 --arg2')
+            .then(function (browserInfo) {
+                expect(browserInfo.path).to.be.equal('/usr/bin/chrome');
+                expect(browserInfo.cmd).to.be.equal('--internal-arg --arg1 --arg2');
+            });
+    });
+
+    it('Should parse browser parameters with arguments if there are spaces in a file path', function () {
+        return getBrowserInfo('path:`/opt/Google Chrome/chrome` --arg1 --arg2')
+            .then(function (browserInfo) {
+                expect(browserInfo.path).to.be.equal('/opt/Google Chrome/chrome');
+                expect(browserInfo.cmd).to.be.equal('--internal-arg --arg1 --arg2');
+            });
+    });
+
+    it('Should parse alias with arguments', function () {
+        return getBrowserInfo('chrome --arg1 --arg2')
+            .then(function (browserInfo) {
+                expect(browserInfo.path).to.be.equal('chrome');
+                expect(browserInfo.cmd).to.be.equal('--internal-arg --arg1 --arg2');
+            });
+    });
+});
+

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -12,7 +12,7 @@ describe('CLI argument parser', function () {
     function parse (args, cwd) {
         var parser = new CliArgumentParser(cwd);
 
-        args = ['node', 'index.js'].concat(args.split(/\s+/));
+        args = ['node', 'index.js'].concat(typeof args === 'string' ? args.split(/\s+/) : args);
 
         return parser.parse(args)
             .then(function () {
@@ -59,6 +59,16 @@ describe('CLI argument parser', function () {
                     expect(parser.browsers).eql([
                         'path:/Apps,Libs/\'Firefox.app', 'ie', 'chrome', 'firefox',
                         'path:/Apps,Libs/"Chrome.app'
+                    ]);
+                });
+        });
+
+        it('Should split browsers correctly if providers have arguments', function () {
+            return parse(['path:"/Apps/Firefox.app --arg1",chrome --arg2'])
+                .then(function (parser) {
+                    expect(parser.browsers).eql([
+                        'path:/Apps/Firefox.app --arg1',
+                        'chrome --arg2'
                     ]);
                 });
         });


### PR DESCRIPTION
\cc @inikulin @AlexanderMoskovkin 
### Feature summary
Allow to pass command line arguments for a browser starting through CLI. Example:

```
testcafe 'path:/usr/bin/chrome-browser --start-fullscreen' test.js 

testcafe 'path:`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe` --start-fullscreen' test.js

testcafe 'chrome --start-fullscreen' test.js
``` 