### PR TITLE
Add origin argument to selector fitler methods (closes #1065)

### DIFF
--- a/src/client-functions/selector-builder/add-api.js
+++ b/src/client-functions/selector-builder/add-api.js
@@ -15,7 +15,7 @@ import {
 const SNAPSHOT_PROPERTIES = NODE_SNAPSHOT_PROPERTIES.concat(ELEMENT_SNAPSHOT_PROPERTIES);
 
 
-var filterNodes = (new ClientFunctionBuilder((nodes, filter, querySelectorRoot) => {
+var filterNodes = (new ClientFunctionBuilder((nodes, filter, querySelectorRoot, originNode) => {
     if (typeof filter === 'number')
         return [nodes[filter]];
 
@@ -37,7 +37,7 @@ var filterNodes = (new ClientFunctionBuilder((nodes, filter, querySelectorRoot) 
 
     if (typeof filter === 'function') {
         for (var j = 0; j < nodes.length; j++) {
-            if (filter(nodes[j], j))
+            if (filter(nodes[j], j, originNode))
                 result.push(nodes[j]);
         }
     }
@@ -236,7 +236,7 @@ function addFilterMethods (obj, getSelector, SelectorBuilder) {
             if (!nodes.length)
                 return null;
 
-            return filterNodes(nodes, filter, document);
+            return filterNodes(nodes, filter, document, void 0);
             /* eslint-enable no-undef */
         };
 
@@ -276,7 +276,7 @@ function addHierachicalSelectors (obj, getSelector, SelectorBuilder) {
 
                 visitNode(node);
 
-                return filterNodes(results, filter, null);
+                return filterNodes(results, filter, null, node);
             });
             /* eslint-enable no-undef */
         };
@@ -296,10 +296,10 @@ function addHierachicalSelectors (obj, getSelector, SelectorBuilder) {
             return expandSelectorResults(selector, node => {
                 var parents = [];
 
-                for (node = node.parentNode; node; node = node.parentNode)
-                    parents.push(node);
+                for (var parent = node.parentNode; parent; parent = parent.parentNode)
+                    parents.push(parent);
 
-                return filter !== void 0 ? filterNodes(parents, filter, document) : parents;
+                return filter !== void 0 ? filterNodes(parents, filter, document, node) : parents;
             });
             /* eslint-enable no-undef */
         };
@@ -327,7 +327,7 @@ function addHierachicalSelectors (obj, getSelector, SelectorBuilder) {
                         childElements.push(child);
                 }
 
-                return filter !== void 0 ? filterNodes(childElements, filter, node) : childElements;
+                return filter !== void 0 ? filterNodes(childElements, filter, node, node) : childElements;
             });
             /* eslint-enable no-undef */
         };
@@ -360,7 +360,7 @@ function addHierachicalSelectors (obj, getSelector, SelectorBuilder) {
                         siblings.push(child);
                 }
 
-                return filter !== void 0 ? filterNodes(siblings, filter, parent) : siblings;
+                return filter !== void 0 ? filterNodes(siblings, filter, parent, node) : siblings;
             });
             /* eslint-enable no-undef */
         };

--- a/test/functional/fixtures/api/es-next/selector/test.js
+++ b/test/functional/fixtures/api/es-next/selector/test.js
@@ -121,6 +121,10 @@ describe('[API] Selector', function () {
         return runTests('./testcafe-fixtures/selector-test.js', 'Selector filter dependencies and index argument', { only: 'chrome' });
     });
 
+    it('Should provide filter origin argument', function () {
+        return runTests('./testcafe-fixtures/selector-test.js', 'Selector filter origin node argument', { only: 'chrome' });
+    });
+
     describe('Errors', function () {
         it('Should handle errors in Selector code', function () {
             return runTests('./testcafe-fixtures/selector-test.js', 'Error in code', { shouldFail: true })

--- a/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
+++ b/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
@@ -862,3 +862,23 @@ test('Selector filter dependencies and index argument', async t => {
         .expect(Selector('.find-parent').child((node, i) => isOne(i), { isOne }).id).eql('find-child3')
         .expect(Selector('#find-child1').sibling(firstNode, { isOne }).id).eql('find-child4');
 });
+
+test('Selector filter origin node argument', async t => {
+    await t
+        .expect(Selector('#p2').find((el, idx, ancestor) => {
+            return ancestor.id === 'p2' && el.id === 'childDiv';
+        }).id).eql('childDiv')
+
+        .expect(Selector('#p0').child((el, idx, parent) => {
+            return parent.id === 'p0' && el.id === 'childDiv';
+        }).id).eql('childDiv')
+
+        .expect(Selector('#childDiv').parent((el, idx, child) => {
+            return child.id === 'childDiv' && el.id === 'p1';
+        }).id).eql('p1')
+
+        .expect(Selector('#el2').sibling((el, idx, refSibling) => {
+            return refSibling.id === 'el2' && el.id === 'el3';
+        }).id).eql('el3');
+
+});


### PR DESCRIPTION
## Feature summary

Filter methods for `.find`, `.child`, '.parent`, '.sibling` now accepts third `origin` argument. Origin is the element in the left hand side selector matching set by which derivative node is produced, e.g.:
```js
Selector('.someClass').find((el, idx, originNode) => ...});
```
here `originNode` will be an element of `someClass` in which `el` was found. 
Another example:
```js
Selector('.someChild').parent((el, idx, originNode) => ... });
```
here `originNode` will be an element of `someClass` whose parent is `el`

\cc @VasilyStrelyaev @AlexanderMoskovkin @helen-dikareva 