### PR TITLE
Implement builds of Docker images (closes #1141)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*
+!bin
+!docker
+!lib
+!package.json

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text=auto
+*.sh text eol=lf
 *.js text eol=lf
 *.css text eol=lf
 *.html text eol=lf

--- a/.publishrc
+++ b/.publishrc
@@ -9,5 +9,6 @@
   },
   "confirm": true,
   "publishTag": "alpha",
-  "prePublishScript": "gulp test-server"
+  "prePublishScript": "gulp test-server",
+  "postPublishScript": "gulp docker-publish"
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:latest
+
+RUN apk --no-cache add nodejs chromium firefox-esr xvfb dbus eudev ttf-freefont fluxbox
+
+COPY . /opt/testcafe
+
+RUN cd /opt/testcafe; \
+ npm install --production && \
+ npm cache clean && \
+ rm -rf /tmp/* && \
+ chmod +x /opt/testcafe/docker/testcafe-docker.sh && \
+ adduser -D user
+
+USER user
+EXPOSE 1337 1338
+ENTRYPOINT ["/opt/testcafe/docker/testcafe-docker.sh"]
+
+

--- a/docker/testcafe-docker.sh
+++ b/docker/testcafe-docker.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+XVFB_SCREEN_WIDTH=${SCREEN_WIDTH-1280}
+XVFB_SCREEN_HEIGHT=${SCREEN_HEIGHT-720}
+
+dbus-daemon --session --fork
+Xvfb :1 -screen 0 "${XVFB_SCREEN_WIDTH}x${XVFB_SCREEN_HEIGHT}x24" >/dev/null 2>&1 &
+export DISPLAY=:1.0
+fluxbox >/dev/null 2>&1 &
+node /opt/testcafe/bin/testcafe.js "$@"


### PR DESCRIPTION
\cc @inikulin @AlexanderMoskovkin 
Hub for our images: https://hub.docker.com/r/testcafe/testcafe/

Container comes with Chromium and Firefox preinstalled with Xvfb, so it allows headless testing out-of-the-box.

## Build How-To For Windows
Get the [Docker Toolbox](https://github.com/docker/toolbox/releases) and install it.
Open Docker Quickstart Terminal and navigate to the TestCafe repository.
Do `gulp docker-build` or `gulp docker-publish`. If you are planning to publish the image, do `docker login` with TestCafe credentials before running `gulp docker-publish`.
Image will be published with the dist tag specified in the `.publishrc`.
## How To Use Example
`docker pull testcafe/testcafe:alpha`
`docker run -v ${TEST_FOLDER}:/tests -it testcafe/testcafe:alpha 'chromium --no-sandbox,firefox' /tests/test.js`, e. g.
`docker run -v //c/Users/belym.andrey/tests:/tests -it testcafe/testcafe:alpha 'chromium --no-sandbox,firefox' /tests/test.js`

Actually, IMHO we need a recipe for that because there is a lot of caveats with docker, especially on Windows. https://docs.docker.com/engine/tutorials/dockervolumes/#/mount-a-host-directory-as-a-data-volume 