### PR TITLE
Add `paste` option to TypeOptions

### DIFF
--- a/docs/articles/documentation/test-api/actions/action-options.md
+++ b/docs/articles/documentation/test-api/actions/action-options.md
@@ -81,7 +81,8 @@ Provide additional parameters for a typing operation.
     offsetX: Number,
     offsetY: Number,
     caretPos: Number,
-    replace: Boolean
+    replace: Boolean,
+    paste: Boolean
 }
 ```
 
@@ -91,5 +92,6 @@ Parameter                      | Type    | Description                          
 `offsetX`, `offsetY`           | Number  | Mouse pointer coordinates that define a point where the action is performed or started. If an offset is a positive integer, coordinates are calculated relative to the top-left corner of the target element. If an offset is a negative integer, they are calculated relative to the bottom-right corner. | The center of the target element.
 `caretPos`                     | Number  | The initial caret position. A zero-based integer.                                                                                        | The length of the input field content.
 `replace`                      | Boolean | `true` to remove the current text in the target element, and `false` to leave the text as it is.                                                         | `false`
+`paste`                        | Boolean | `true` to insert the entire block of current text in a single keystroke (similar to a copy & paste function), and `false` to insert the current text character by character.                         | `false`
 
 Typing action options are used in the [t.typeText](type-text.md) action.

--- a/src/client/automation/playback/type/index.js
+++ b/src/client/automation/playback/type/index.js
@@ -30,6 +30,7 @@ export default class TypeAutomation {
         this.modifiers = typeOptions.modifiers;
         this.caretPos  = typeOptions.caretPos;
         this.replace   = typeOptions.replace;
+        this.paste     = typeOptions.paste;
         this.offsetX   = typeOptions.offsetX;
         this.offsetY   = typeOptions.offsetY;
 
@@ -200,6 +201,16 @@ export default class TypeAutomation {
 
         this.eventArgs = this._calculateEventArguments();
 
+        if (this.paste) {
+            return this
+                ._typeAllText(elementForTyping)
+                .then(() => {
+                    eventSimulator.keyup(this.eventArgs.element, this.eventArgs.options);
+
+                    this.currentPos = this.text.length;
+                });
+        }
+
         return this
             ._typeChar(elementForTyping)
             .then(() => {
@@ -241,6 +252,11 @@ export default class TypeAutomation {
 
         typeChar(element, currentChar);
 
+        return delay(ACTION_STEP_DELAY);
+    }
+
+    _typeAllText (element) {
+        typeChar(element, this.text);
         return delay(ACTION_STEP_DELAY);
     }
 

--- a/src/test-run/commands/options.js
+++ b/src/test-run/commands/options.js
@@ -112,12 +112,16 @@ export class TypeOptions extends ClickOptions {
         super();
 
         this.replace = false;
+        this.paste   = false;
 
         this._assignFrom(obj, validate);
     }
 
     _getAssignableProperties () {
-        return super._getAssignableProperties().concat([{ name: 'replace', type: booleanOption }]);
+        return super._getAssignableProperties().concat([
+            { name: 'replace', type: booleanOption },
+            { name: 'paste', type: booleanOption }
+        ]);
     }
 }
 

--- a/test/client/fixtures/automation/type-test.js
+++ b/test/client/fixtures/automation/type-test.js
@@ -161,6 +161,37 @@ $(document).ready(function () {
             });
     });
 
+    asyncTest('set option.paste to true to insert all text in one keystroke', function () {
+        var keydownCount    = 0;
+        var keyupCount      = 0;
+        var keypressCount   = 0;
+        var text = 'new text';
+
+        $commonInput[0].value = '';
+
+        $commonInput[0].addEventListener('keydown', function () {
+            keydownCount++;
+        });
+        $commonInput[0].addEventListener('keypress', function () {
+            keydownCount++;
+        });
+        $commonInput[0].addEventListener('keyup', function () {
+            keydownCount++;
+        });
+
+        var type = new TypeAutomation($commonInput[0], text, new TypeOptions({ paste: true, offsetX: 5, offsetY: 5 }));
+
+        type
+            .run()
+            .then(function () {
+                equal($commonInput[0].value, text, 'text entered in one keystroke');
+                equal(keydownCount, 1, 'keydown event raises once');
+                equal(keyupCount, 1, 'keyup event raises once');
+                equal(keypressCount, 1, 'keypress event raises once');
+                start();
+            });
+    });
+
     asyncTest('do not change readonly inputs value', function () {
         var $input1      = $('<input type="text" readonly />').addClass(TEST_ELEMENT_CLASS).appendTo($('body'));
         var $input2      = $('<input type="text" value="value" />').attr('readonly', 'readonly').addClass(TEST_ELEMENT_CLASS).appendTo($('body'));

--- a/test/functional/fixtures/api/es-next/type/testcafe-fixtures/type-test.js
+++ b/test/functional/fixtures/api/es-next/type/testcafe-fixtures/type-test.js
@@ -23,6 +23,10 @@ test('Incorrect action text', async t => {
     await t.typeText('#input', 123);
 });
 
-test('Incorrect action option', async t => {
+test('Incorrect action option (replace)', async t => {
     await t.typeText('#input', 'a', { replace: null });
+});
+
+test('Incorrect action option (paste)', async t => {
+    await t.typeText('#input', 'a', { paste: null });
 });

--- a/test/functional/fixtures/regression/gh-1054/testcafe-fixtures/index.test.js
+++ b/test/functional/fixtures/regression/gh-1054/testcafe-fixtures/index.test.js
@@ -8,7 +8,7 @@ const getFirstValue = ClientFunction(() => window.storedValue);
 
 test('Type text in the input', async t => {
     await t
-        .typeText('input', 'text', { replace: true })
+        .typeText('input', 'text', { replace: true, paste: true })
         .expect(Selector('input').value).eql('text');
 
     await t.expect(await getFirstValue()).eql('t');
@@ -16,7 +16,7 @@ test('Type text in the input', async t => {
 
 test('Type text in the content editable element', async t => {
     await t
-        .typeText('div', 'text', { replace: true })
+        .typeText('div', 'text', { replace: true, paste: true })
         .expect(Selector('div').textContent).eql('text');
 
     await t.expect(await getFirstValue()).eql('t');

--- a/test/server/test-run-command-options-test.js
+++ b/test/server/test-run-command-options-test.js
@@ -125,6 +125,7 @@ describe('Test run command options', function () {
                 caretPos: 20,
                 replace:  true,
                 dummy:    false,
+                paste:    true,
 
                 modifiers: {
                     ctrl:  true,
@@ -138,6 +139,7 @@ describe('Test run command options', function () {
                 offsetY:  null,
                 caretPos: 20,
                 replace:  true,
+                paste:    true,
 
                 modifiers: {
                     ctrl:  true,

--- a/test/server/test-run-commands-test.js
+++ b/test/server/test-run-commands-test.js
@@ -455,6 +455,7 @@ describe('Test run commands', function () {
                     caretPos: 2,
                     dummy:    'yo',
                     replace:  true,
+                    paste:    true,
 
                     modifiers: {
                         ctrl:  true,
@@ -478,6 +479,7 @@ describe('Test run commands', function () {
                     offsetY:  32,
                     caretPos: 2,
                     replace:  true,
+                    paste:    true,
 
                     modifiers: {
                         ctrl:  true,
@@ -506,6 +508,7 @@ describe('Test run commands', function () {
                     offsetY:  null,
                     caretPos: null,
                     replace:  false,
+                    paste:    false,
 
                     modifiers: {
                         ctrl:  false,


### PR DESCRIPTION
There is currently no way to enter a block of text in a single keystroke with the [Test API](http://devexpress.github.io/testcafe/documentation/test-api/actions/action-options.html#typing-action-options).  This will allow optionally inserting a block of text with one keystroke instead of typing each character individually, similar to a copy and paste command.

This could be useful in a number of situations, such as:

* Speeding up test playback where individual keystrokes are not important to the result
* Testing a large block of text entry in a WYSIWYG editor
* Testing form validation and submission on a form with 100+ fields

Documentation and tests have been updated to verify that this does not break or override any existing settings.

The build fails because the master branch is currently failing, but the updates in the PR should have no effect on the mobile testing.
