### PR TITLE
Add `paste` option to TypeOptions

### DIFF
--- a/src/client/automation/playback/type/index.js
+++ b/src/client/automation/playback/type/index.js
@@ -30,6 +30,7 @@ export default class TypeAutomation {
         this.modifiers = typeOptions.modifiers;
         this.caretPos  = typeOptions.caretPos;
         this.replace   = typeOptions.replace;
+        this.paste     = typeOptions.paste;
         this.offsetX   = typeOptions.offsetX;
         this.offsetY   = typeOptions.offsetY;
 
@@ -200,6 +201,16 @@ export default class TypeAutomation {
 
         this.eventArgs = this._calculateEventArguments();
 
+        if (this.paste) {
+            return this
+                ._typeAllText(elementForTyping)
+                .then(() => {
+                    eventSimulator.keyup(this.eventArgs.element, this.eventArgs.options);
+
+                    this.currentPos = this.text.length;
+                });
+        }
+
         return this
             ._typeChar(elementForTyping)
             .then(() => {
@@ -241,6 +252,11 @@ export default class TypeAutomation {
 
         typeChar(element, currentChar);
 
+        return delay(ACTION_STEP_DELAY);
+    }
+
+    _typeAllText (element) {
+        typeChar(element, this.text);
         return delay(ACTION_STEP_DELAY);
     }
 

--- a/src/test-run/commands/options.js
+++ b/src/test-run/commands/options.js
@@ -112,12 +112,16 @@ export class TypeOptions extends ClickOptions {
         super();
 
         this.replace = false;
+        this.paste   = false;
 
         this._assignFrom(obj, validate);
     }
 
     _getAssignableProperties () {
-        return super._getAssignableProperties().concat([{ name: 'replace', type: booleanOption }]);
+        return super._getAssignableProperties().concat([
+            { name: 'replace', type: booleanOption },
+            { name: 'paste', type: booleanOption }
+        ]);
     }
 }
 

--- a/test/client/fixtures/automation/regression-test.js
+++ b/test/client/fixtures/automation/regression-test.js
@@ -212,6 +212,7 @@ $(document).ready(function () {
         var typeOptions = new TypeOptions({
             caretPos: options.caretPos,
             replace:  options.replace,
+            paste:    options.paste,
             offsetX:  offsets.offsetX,
             offsetY:  offsets.offsetY
         });

--- a/test/client/fixtures/automation/type-test.js
+++ b/test/client/fixtures/automation/type-test.js
@@ -161,6 +161,37 @@ $(document).ready(function () {
             });
     });
 
+    asyncTest('set option.paste to true to insert all text in one keystroke', function () {
+        var keydownCount    = 0;
+        var keyupCount      = 0;
+        var keypressCount   = 0;
+        var text = 'new text';
+
+        $commonInput[0].value = '';
+
+        $commonInput[0].addEventListener('keydown', function () {
+            keydownCount++;
+        });
+        $commonInput[0].addEventListener('keypress', function () {
+            keydownCount++;
+        });
+        $commonInput[0].addEventListener('keyup', function () {
+            keydownCount++;
+        });
+
+        var type = new TypeAutomation($commonInput[0], text, new TypeOptions({ paste: true, offsetX: 5, offsetY: 5 }));
+
+        type
+            .run()
+            .then(function () {
+                equal($commonInput[0].value, text, 'text entered in one keystroke');
+                equal(keydownCount, 1, 'keydown event raises once');
+                equal(keyupCount, 1, 'keyup event raises once');
+                equal(keypressCount, 1, 'keypress event raises once');
+                start();
+            });
+    });
+
     asyncTest('do not change readonly inputs value', function () {
         var $input1      = $('<input type="text" readonly />').addClass(TEST_ELEMENT_CLASS).appendTo($('body'));
         var $input2      = $('<input type="text" value="value" />').attr('readonly', 'readonly').addClass(TEST_ELEMENT_CLASS).appendTo($('body'));

--- a/test/client/fixtures/automation/type-test.js
+++ b/test/client/fixtures/automation/type-test.js
@@ -173,10 +173,10 @@ $(document).ready(function () {
             keydownCount++;
         });
         $commonInput[0].addEventListener('keypress', function () {
-            keydownCount++;
+            keypressCount++;
         });
         $commonInput[0].addEventListener('keyup', function () {
-            keydownCount++;
+            keyupCount++;
         });
 
         var type = new TypeAutomation($commonInput[0], text, new TypeOptions({ paste: true, offsetX: 5, offsetY: 5 }));

--- a/test/functional/fixtures/api/es-next/type/test.js
+++ b/test/functional/fixtures/api/es-next/type/test.js
@@ -8,13 +8,14 @@ describe('[API] t.typeText()', function () {
     });
 
     it('Should validate options', function () {
-        return runTests('./testcafe-fixtures/type-test.js', 'Incorrect action option', {
+        return runTests('./testcafe-fixtures/type-test.js', 'Incorrect action options', {
             shouldFail: true,
             only:       'chrome'
         })
             .catch(function (errs) {
                 expect(errs[0]).to.contains('The "replace" option is expected to be a boolean value, but it was object.');
-                expect(errs[0]).to.contains('> 27 |    await t.typeText(\'#input\', \'a\', { replace: null });');
+                expect(errs[0]).to.contains('The "paste" option is expected to be a boolean value, but it was object.');
+                expect(errs[0]).to.contains('> 27 |    await t.typeText(\'#input\', \'a\', { replace: null, paste: null });');
             });
     });
 

--- a/test/functional/fixtures/api/es-next/type/test.js
+++ b/test/functional/fixtures/api/es-next/type/test.js
@@ -14,7 +14,6 @@ describe('[API] t.typeText()', function () {
         })
             .catch(function (errs) {
                 expect(errs[0]).to.contains('The "replace" option is expected to be a boolean value, but it was object.');
-                expect(errs[0]).to.contains('The "paste" option is expected to be a boolean value, but it was object.');
                 expect(errs[0]).to.contains('> 27 |    await t.typeText(\'#input\', \'a\', { replace: null, paste: null });');
             });
     });

--- a/test/functional/fixtures/api/es-next/type/testcafe-fixtures/type-test.js
+++ b/test/functional/fixtures/api/es-next/type/testcafe-fixtures/type-test.js
@@ -23,10 +23,6 @@ test('Incorrect action text', async t => {
     await t.typeText('#input', 123);
 });
 
-test('Incorrect action option (replace)', async t => {
-    await t.typeText('#input', 'a', { replace: null });
-});
-
-test('Incorrect action option (paste)', async t => {
-    await t.typeText('#input', 'a', { paste: null });
+test('Incorrect action options', async t => {
+    await t.typeText('#input', 'a', { replace: null, paste: null });
 });

--- a/test/functional/fixtures/api/es-next/type/testcafe-fixtures/type-test.js
+++ b/test/functional/fixtures/api/es-next/type/testcafe-fixtures/type-test.js
@@ -23,6 +23,10 @@ test('Incorrect action text', async t => {
     await t.typeText('#input', 123);
 });
 
-test('Incorrect action option', async t => {
+test('Incorrect action option (replace)', async t => {
     await t.typeText('#input', 'a', { replace: null });
+});
+
+test('Incorrect action option (paste)', async t => {
+    await t.typeText('#input', 'a', { paste: null });
 });

--- a/test/functional/fixtures/api/raw/type/pages/index.html
+++ b/test/functional/fixtures/api/raw/type/pages/index.html
@@ -10,13 +10,17 @@
     var keydownRaised = false;
     var keypressRaised = false;
     var inputRaised = false;
+    var keydownCount = 0;
+    var keypressCount = 0;
 
     document.getElementById('input').addEventListener('keydown', function () {
         keydownRaised = true;
+        keydownCount++;
     });
 
     document.getElementById('input').addEventListener('keypress', function () {
         keypressRaised = true;
+        keypressCount++;
     });
 
     document.getElementById('input').addEventListener('input', function () {
@@ -24,8 +28,15 @@
     });
 
     document.getElementById('input').addEventListener('keyup', function () {
-        if (keydownRaised && keypressRaised && inputRaised && this.value === 'a')
+        var containsAllText = this.value.indexOf('block of text to be inserted in one keystroke') > 0;
+        var allRaised = keydownRaised && keypressRaised && inputRaised;
+        var exactlyOneKeystroke = keydownCount === 1 && keypressCount === 1;
+
+        if (allRaised && this.value === 'a') {
             throw new Error('Type in input raised');
+        } else if (allRaised && exactlyOneKeystroke && containsAllText) {
+            throw new Error('Type block in one keystroke raised');
+        }
     });
 </script>
 </body>

--- a/test/functional/fixtures/api/raw/type/test.js
+++ b/test/functional/fixtures/api/raw/type/test.js
@@ -9,6 +9,13 @@ describe('[Raw API] Type action', function () {
             });
     });
 
+    it("Should type all text in one keystroke if using 'paste' option", function () {
+        return runTests('./testcafe-fixtures/type.testcafe', 'Type with paste option', { shouldFail: true })
+            .catch(function (errs) {
+                errorInEachBrowserContains(errs, 'Type block in one keystroke raised', 0);
+            });
+    });
+
     it("Should fail if a 'text' argument does not have string type", function () {
         return runTests('./testcafe-fixtures/type.testcafe', 'Type with numeric text argument', { shouldFail: true })
             .catch(function (errs) {

--- a/test/functional/fixtures/api/raw/type/testcafe-fixtures/type.testcafe
+++ b/test/functional/fixtures/api/raw/type/testcafe-fixtures/type.testcafe
@@ -18,6 +18,19 @@
                     ]
                 },
                 {
+                    "name": "Type with paste option",
+                    "commands": [
+                        {
+                            "type": "type-text",
+                            "selector": "#input",
+                            "text": "block of text to be inserted in one keystroke",
+                            "options": {
+                                "paste": true
+                            }
+                        }
+                    ]
+                },
+                {
                     "name": "Type with empty text argument",
                     "commands": [
                         {

--- a/test/server/test-run-command-options-test.js
+++ b/test/server/test-run-command-options-test.js
@@ -125,6 +125,7 @@ describe('Test run command options', function () {
                 caretPos: 20,
                 replace:  true,
                 dummy:    false,
+                paste:    true,
 
                 modifiers: {
                     ctrl:  true,
@@ -138,6 +139,7 @@ describe('Test run command options', function () {
                 offsetY:  null,
                 caretPos: 20,
                 replace:  true,
+                paste:    true,
 
                 modifiers: {
                     ctrl:  true,

--- a/test/server/test-run-commands-test.js
+++ b/test/server/test-run-commands-test.js
@@ -455,6 +455,7 @@ describe('Test run commands', function () {
                     caretPos: 2,
                     dummy:    'yo',
                     replace:  true,
+                    paste:    true,
 
                     modifiers: {
                         ctrl:  true,
@@ -478,6 +479,7 @@ describe('Test run commands', function () {
                     offsetY:  32,
                     caretPos: 2,
                     replace:  true,
+                    paste:    true,
 
                     modifiers: {
                         ctrl:  true,
@@ -506,6 +508,7 @@ describe('Test run commands', function () {
                     offsetY:  null,
                     caretPos: null,
                     replace:  false,
+                    paste:    false,
 
                     modifiers: {
                         ctrl:  false,


### PR DESCRIPTION
Resolves #1230.

There is currently no way to enter a block of text in a single keystroke with the [Test API](http://devexpress.github.io/testcafe/documentation/test-api/actions/action-options.html#typing-action-options).  This will allow optionally inserting a block of text with one keystroke instead of typing each character individually.

This could be useful in a number of situations, such as:

* Speeding up test playback where individual keystrokes are not important to the result
* Testing a large block of text entry in a WYSIWYG editor
* Testing form validation and submission on a form with 100+ fields

Documentation and tests have been updated.
