### PR TITLE
Add the proxy-host setting (closes #1206)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 node_modules
 .idea
-lib
-site
+/lib
+/site
 .sass-cache
 .publish
 ___test-screenshots___

--- a/src/cli/argument-parser.js
+++ b/src/cli/argument-parser.js
@@ -105,7 +105,7 @@ export default class CLIArgumentParser {
             .option('--speed <factor>', 'set the speed of test execution (0.01 ... 1)')
             .option('--ports <port1,port2>', 'specify custom port numbers')
             .option('--hostname <name>', 'specify the hostname')
-            .option('--proxyHost <host>', 'specify proxy host')
+            .option('--proxy-host <host>', 'specify proxy host')
             .option('--qr-code', 'outputs QR-code that repeats URLs used to connect the remote browsers')
 
             // NOTE: these options will be handled by chalk internally

--- a/src/cli/argument-parser.js
+++ b/src/cli/argument-parser.js
@@ -105,6 +105,7 @@ export default class CLIArgumentParser {
             .option('--speed <factor>', 'set the speed of test execution (0.01 ... 1)')
             .option('--ports <port1,port2>', 'specify custom port numbers')
             .option('--hostname <name>', 'specify the hostname')
+            .option('--proxyHost <host>', 'specify proxy host')
             .option('--qr-code', 'outputs QR-code that repeats URLs used to connect the remote browsers')
 
             // NOTE: these options will be handled by chalk internally
@@ -186,6 +187,11 @@ export default class CLIArgumentParser {
         }
     }
 
+    _parseProxyHost () {
+        if (this.opts.proxyHost)
+            assertType(is.string, null, 'Proxy host', this.opts.proxyHost);
+    }
+
     _parseBrowserList () {
         var browsersArg = this.program.args[0] || '';
 
@@ -263,6 +269,7 @@ export default class CLIArgumentParser {
         this._parseAppInitDelay();
         this._parseSpeed();
         this._parsePorts();
+        this._parseProxyHost();
         this._parseBrowserList();
 
         await Promise.all([

--- a/src/cli/argument-parser.js
+++ b/src/cli/argument-parser.js
@@ -105,7 +105,7 @@ export default class CLIArgumentParser {
             .option('--speed <factor>', 'set the speed of test execution (0.01 ... 1)')
             .option('--ports <port1,port2>', 'specify custom port numbers')
             .option('--hostname <name>', 'specify the hostname')
-            .option('--proxy-host <host>', 'specify proxy host')
+            .option('--proxy-host <host>', 'specify the hostname of the proxy server')
             .option('--qr-code', 'outputs QR-code that repeats URLs used to connect the remote browsers')
 
             // NOTE: these options will be handled by chalk internally

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -57,6 +57,7 @@ async function runTests (argParser) {
         .reporter(opts.reporter)
         .filter(argParser.filter)
         .screenshots(opts.screenshots, opts.screenshotsOnFails)
+        .useProxy(opts.proxyHost)
         .startApp(opts.app, opts.appInitDelay);
 
     runner.once('done-bootstrapping', () => log.hideSpinner());

--- a/src/runner/browser-job.js
+++ b/src/runner/browser-job.js
@@ -158,7 +158,7 @@ export default class BrowserJob extends EventEmitter {
             else {
                 testRun.start();
 
-                return this.proxy.openSession(testRun.test.pageUrl, testRun);
+                return this.proxy.openSession(testRun.test.pageUrl, testRun, { url: this.opts.proxyHost });
             }
         }
 

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -29,7 +29,8 @@ export default class Runner extends EventEmitter {
             skipJsErrors:           false,
             quarantineMode:         false,
             reportOutStream:        void 0,
-            selectorTimeout:        DEFAULT_SELECTOR_TIMEOUT
+            selectorTimeout:        DEFAULT_SELECTOR_TIMEOUT,
+            proxyHost:              null
         };
     }
 
@@ -150,6 +151,12 @@ export default class Runner extends EventEmitter {
     startApp (command, initDelay) {
         this.bootstrapper.appCommand   = command;
         this.bootstrapper.appInitDelay = initDelay;
+
+        return this;
+    }
+
+    useProxy (host) {
+        this.opts.proxyHost = host;
 
         return this;
     }

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -171,7 +171,8 @@ module.exports = {
         port1:     3000,
         port2:     3001,
         port3:     3002,
-        port4:     3003
+        port4:     3003,
+        port5:     3004
     },
 
     browsers: []

--- a/test/functional/fixtures/run-options/proxy/pages/index.html
+++ b/test/functional/fixtures/run-options/proxy/pages/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Example</title>
+</head>
+<body>
+</body>
+</html>

--- a/test/functional/fixtures/run-options/proxy/test.js
+++ b/test/functional/fixtures/run-options/proxy/test.js
@@ -1,0 +1,11 @@
+var config = require('../../../config');
+
+describe('[API] Proxy', function () {
+    it('Should send requests to a target server directly when the property is not specified', function () {
+        return runTests('./testcafe-fixtures/proxy-test.js', 'Without proxy', { only: 'chrome' });
+    });
+
+    it('Should send requests to a proxy server when the property is specified', function () {
+        return runTests('./testcafe-fixtures/proxy-test.js', 'With proxy', { only: 'chrome', proxyHost: 'localhost:' + config.site.port5 });
+    });
+});

--- a/test/functional/fixtures/run-options/proxy/testcafe-fixtures/proxy-test.js
+++ b/test/functional/fixtures/run-options/proxy/testcafe-fixtures/proxy-test.js
@@ -1,0 +1,14 @@
+fixture `Proxy`
+    .page `http://localhost:3000/fixtures/run-options/proxy/pages/index.html`;
+
+test('Without proxy', async t => {
+    const pageTitle = await t.eval(() => document.title);
+
+    await t.expect(pageTitle).eql('Example');
+});
+
+test('With proxy', async t => {
+    const pageTitle = await t.eval(() => document.title);
+
+    await t.expect(pageTitle).eql('(Proxy) Example');
+});

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -117,7 +117,7 @@ before(function () {
 
             process.stdout.write('Running tests in browsers: ' + aliases.join(', ') + '\n');
 
-            site.create(config.site.port1, config.site.port2, config.site.port3, config.site.port4, config.site.viewsPath);
+            site.create(config.site.port1, config.site.port2, config.site.port3, config.site.port4, config.site.port5, config.site.viewsPath);
 
             if (!config.useLocalBrowsers) {
                 // NOTE: we need to disable this particular timeout for preventing mocha timeout
@@ -148,6 +148,7 @@ before(function () {
                 var speed              = opts && opts.speed;
                 var appCommand         = opts && opts.appCommand;
                 var appInitDelay       = opts && opts.appInitDelay;
+                var proxyHost          = opts && opts.proxyHost;
 
                 var actualBrowsers = browsersInfo.filter(function (browserInfo) {
                     var only = onlyOption ? onlyOption.indexOf(browserInfo.settings.alias) > -1 : true;
@@ -192,6 +193,7 @@ before(function () {
                     .src(fixturePath)
                     .screenshots(screenshotPath, screenshotsOnFails)
                     .startApp(appCommand, appInitDelay)
+                    .useProxy(proxyHost)
                     .run({
                         skipJsErrors:     skipJsErrors,
                         quarantineMode:   quarantineMode,

--- a/test/functional/site/index.js
+++ b/test/functional/site/index.js
@@ -1,4 +1,5 @@
 var Server                    = require('./server');
+var ProxyServer               = require('./proxy-server');
 var createServerWithBasicAuth = require('./basic-auth-server');
 var createServerWithNtlmAuth  = require('./ntlm-auth-server');
 
@@ -6,12 +7,14 @@ var server1         = null;
 var server2         = null;
 var basicAuthServer = null;
 var ntlmAuthServer  = null;
+var proxyServer     = null;
 
-exports.create = function (port1, port2, port3, port4, viewsPath) {
+exports.create = function (port1, port2, port3, port4, port5, viewsPath) {
     server1         = new Server(port1, viewsPath);
     server2         = new Server(port2, viewsPath);
     basicAuthServer = createServerWithBasicAuth(port3);
     ntlmAuthServer  = createServerWithNtlmAuth(port4);
+    proxyServer     = new ProxyServer(port5);
 };
 
 exports.destroy = function () {
@@ -19,4 +22,5 @@ exports.destroy = function () {
     server2.close();
     basicAuthServer.close();
     ntlmAuthServer.close();
+    proxyServer.close();
 };

--- a/test/functional/site/proxy-server.js
+++ b/test/functional/site/proxy-server.js
@@ -1,0 +1,66 @@
+var http   = require('http');
+var urlLib = require('url');
+
+var ProxyServer = module.exports = function (port) {
+    var server = this;
+
+    this.sockets = [];
+
+    function handler (socket) {
+        server.sockets.push(socket);
+
+        socket.on('close', function () {
+            server.sockets.splice(server.sockets.indexOf(socket), 1);
+        });
+    }
+
+    this.appServer = http
+        .createServer(ProxyServer._onRequest)
+        .listen(port);
+
+    this.appServer.on('connection', handler);
+};
+
+ProxyServer._onRequest = function (req, res) {
+    var options = urlLib.parse(req.url);
+
+    options.method  = req.method;
+    options.headers = req.headers;
+
+    var proxyReq = http.request(options);
+
+    proxyReq.on('response', function (proxyRes) {
+        var response = '';
+
+        proxyRes.on('data', function (chunk) {
+            response += chunk.toString();
+        });
+
+        proxyRes.on('end', function () {
+            var pageTitleRe    = /<title>([\w\s]+)<\/title>/;
+            var pageTitleMatch = response.match(pageTitleRe);
+            var pageTitle      = pageTitleMatch && pageTitleMatch[1];
+
+            response = response.replace(pageTitleRe, '<title>(Proxy) ' + pageTitle + '</title>');
+
+            proxyRes.headers['content-length'] = response.length;
+
+            res.writeHead(proxyRes.statusCode, proxyRes.headers);
+            res.end(response);
+        });
+    });
+
+    req.on('data', function (chunk) {
+        proxyReq.write(chunk, 'binary');
+    });
+
+    req.on('end', function () {
+        proxyReq.end();
+    });
+};
+
+ProxyServer.prototype.close = function () {
+    this.sockets.forEach(function (socket) {
+        socket.destroy();
+    });
+};

--- a/test/functional/site/proxy-server.js
+++ b/test/functional/site/proxy-server.js
@@ -61,4 +61,6 @@ ProxyServer.prototype.close = function () {
     this.sockets.forEach(function (socket) {
         socket.destroy();
     });
+
+    this.appServer.close();
 };

--- a/test/functional/site/proxy-server.js
+++ b/test/functional/site/proxy-server.js
@@ -14,11 +14,9 @@ var ProxyServer = module.exports = function (port) {
         });
     }
 
-    this.appServer = http
-        .createServer(ProxyServer._onRequest)
-        .listen(port);
-
+    this.appServer = http.createServer(ProxyServer._onRequest);
     this.appServer.on('connection', handler);
+    this.appServer.listen(port);
 };
 
 ProxyServer._onRequest = function (req, res) {

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -289,7 +289,7 @@ describe('CLI argument parser', function () {
     });
 
     it('Should parse command line arguments', function () {
-        return parse('-r list -S -q -e --hostname myhost --qr-code --app run-app --speed 0.5 ie test/server/data/file-list/file-1.js')
+        return parse('-r list -S -q -e --hostname myhost --qr-code --app run-app --speed 0.5 ie test/server/data/file-list/file-1.js --proxy-host localhost:2000')
             .then(function (parser) {
                 expect(parser.browsers).eql(['ie']);
                 expect(parser.src).eql([path.resolve(process.cwd(), 'test/server/data/file-list/file-1.js')]);
@@ -302,6 +302,7 @@ describe('CLI argument parser', function () {
                 expect(parser.opts.skipJsErrors).to.be.ok;
                 expect(parser.opts.speed).eql(0.5);
                 expect(parser.opts.qrCode).to.be.ok;
+                expect(parser.opts.proxyHost).eql('localhost:2000');
             });
     });
 });


### PR DESCRIPTION
## Feature summary

### Motivation
In corporate networks, where browser have specified proxy settings for access to WEB, TestCafe cannot establish connection to the remote resources, cause all requests are sent directly to the remote host, bypassing corporate proxy.
TestCafe should provide capability to setup proxy options.

### Cli API
```sh
testcafe chrome test.js --proxy-host localhost:2000
```

### Programming API
```js
runner.useProxy('localhost:2000')
```

/cc @inikulin @helen-dikareva @VasilyStrelyaev 