### PR TITLE
Use V8 flag filters only in CLI. Helps avoid confusion when bin/testcafe.js is used for debugging from IDE

### DIFF
--- a/bin/testcafe-with-v8-flag-filter.js
+++ b/bin/testcafe-with-v8-flag-filter.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var path          = require('path');
+var v8FlagsFilter = require('bin-v8-flags-filter');
+
+v8FlagsFilter(path.join(__dirname, '../lib/cli'));

--- a/bin/testcafe.js
+++ b/bin/testcafe.js
@@ -2,7 +2,4 @@
 
 'use strict';
 
-var path          = require('path');
-var v8FlagsFilter = require('bin-v8-flags-filter');
-
-v8FlagsFilter(path.join(__dirname, '../lib/cli'));
+require('../lib/cli');

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "main": "lib/index",
   "bin": {
-    "testcafe": "./bin/testcafe.js"
+    "testcafe": "./bin/testcafe-with-v8-flag-filter.js"
   },
   "files": [
     "lib",


### PR DESCRIPTION
\cc @helen-dikareva @churkin @VasilyStrelyaev 