### PR TITLE
Add test for caretRangeFromPoint and caretPositionFromPoint usage (closes #1385)

### DIFF
--- a/test/functional/fixtures/regression/gh-1385/pages/index.html
+++ b/test/functional/fixtures/regression/gh-1385/pages/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>gh-1385</title>
+</head>
+<body>
+
+<div id='div' contenteditable="true">content</div>
+
+<script>
+    document.getElementById('div').addEventListener('mousedown', function (e) {
+        var x = e.clientX;
+        var y = e.clientY;
+
+        window.elementFromPointId = document.elementFromPoint(x, y).id;
+
+        if (document.caretPositionFromPoint)
+            window.caretPositionFromPointData = document.caretPositionFromPoint(x, y).offsetNode.data;
+
+        if (document.caretRangeFromPoint)
+            window.caretRangeFromPointData = document.caretRangeFromPoint(x, y).startContainer.data;
+    });
+</script>
+
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-1385/test.js
+++ b/test/functional/fixtures/regression/gh-1385/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-1385)', function () {
+    it('Should be able to get elements under cursor via "...fromPoint" functions', function () {
+        return runTests('testcafe-fixtures/index-test.js', 'Check "...fromPoint" functions');
+    });
+});

--- a/test/functional/fixtures/regression/gh-1385/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/regression/gh-1385/testcafe-fixtures/index-test.js
@@ -1,0 +1,30 @@
+fixture `gh-1385`
+    .page `http://localhost:3000/fixtures/regression/gh-1385/pages/index.html`;
+
+test('Check "...fromPoint" functions', async t => {
+    await t.click('#div');
+
+    const {
+              caretPositionFromPointSupported,
+              caretRangeFromPointSupported,
+              elementFromPointId,
+              caretPositionFromPointData,
+              caretRangeFromPointData
+          } = await t.eval(() => {
+        return {
+            caretPositionFromPointSupported: !!document.caretPositionFromPoint,
+            caretRangeFromPointSupported:    !!document.caretRangeFromPoint,
+            elementFromPointId:              window.elementFromPointId,
+            caretPositionFromPointData:      window.caretPositionFromPointData,
+            caretRangeFromPointData:         window.caretRangeFromPointData
+        };
+    });
+
+    await t.expect(elementFromPointId).eql('div');
+
+    if (caretPositionFromPointSupported)
+        await t.expect(caretPositionFromPointData).eql('content');
+
+    if (caretRangeFromPointSupported)
+        await t.expect(caretRangeFromPointData).eql('content');
+});

--- a/test/functional/fixtures/regression/gh-1385/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/regression/gh-1385/testcafe-fixtures/index-test.js
@@ -1,16 +1,10 @@
+import { ClientFunction } from 'testcafe';
+
 fixture `gh-1385`
     .page `http://localhost:3000/fixtures/regression/gh-1385/pages/index.html`;
 
 test('Check "...fromPoint" functions', async t => {
-    await t.click('#div');
-
-    const {
-              caretPositionFromPointSupported,
-              caretRangeFromPointSupported,
-              elementFromPointId,
-              caretPositionFromPointData,
-              caretRangeFromPointData
-          } = await t.eval(() => {
+    const getDataFromClient = ClientFunction(() => {
         return {
             caretPositionFromPointSupported: !!document.caretPositionFromPoint,
             caretRangeFromPointSupported:    !!document.caretRangeFromPoint,
@@ -19,6 +13,16 @@ test('Check "...fromPoint" functions', async t => {
             caretRangeFromPointData:         window.caretRangeFromPointData
         };
     });
+
+    await t.click('#div');
+
+    const {
+              caretPositionFromPointSupported,
+              caretRangeFromPointSupported,
+              elementFromPointId,
+              caretPositionFromPointData,
+              caretRangeFromPointData
+          } = await getDataFromClient();
 
     await t.expect(elementFromPointId).eql('div');
 


### PR DESCRIPTION
It was fixed in `testcafe-hammerhead` but it's impossible to create a complete test there, so I've added a functional test

/cc @helen-dikareva @georgiy-abbasov 