### PR TITLE
[docs] Last corrections

### DIFF
--- a/docs/articles/documentation/test-api/a-z-index.md
+++ b/docs/articles/documentation/test-api/a-z-index.md
@@ -36,7 +36,7 @@ This topic lists test API members in alphabetical order.
     * [prevSibling](selecting-page-elements/selectors.md#prevsibling)
     * [sibling](selecting-page-elements/selectors.md#sibling)
     * [with](selecting-page-elements/selector-options.md#overwriting-options)
-    * [withAttr](selecting-page-elements/selectors.md#withAttr)
+    * [withAttribute](selecting-page-elements/selectors.md#withAttribute)
     * [withText](selecting-page-elements/selectors.md#withtext)
 * [test](test-code-structure.md#tests)
     * [after](test-code-structure.md#initialization-and-clean-up)

--- a/docs/articles/documentation/test-api/a-z-index.md
+++ b/docs/articles/documentation/test-api/a-z-index.md
@@ -36,7 +36,7 @@ This topic lists test API members in alphabetical order.
     * [prevSibling](selecting-page-elements/selectors.md#prevsibling)
     * [sibling](selecting-page-elements/selectors.md#sibling)
     * [with](selecting-page-elements/selector-options.md#overwriting-options)
-    * [withAttribute](selecting-page-elements/selectors.md#withAttribute)
+    * [withAttribute](selecting-page-elements/selectors.md#withattribute)
     * [withText](selecting-page-elements/selectors.md#withtext)
 * [test](test-code-structure.md#tests)
     * [after](test-code-structure.md#initialization-and-clean-up)

--- a/docs/articles/documentation/test-api/selecting-page-elements/selectors.md
+++ b/docs/articles/documentation/test-api/selecting-page-elements/selectors.md
@@ -22,7 +22,7 @@ This topic contains the following sections.
   * [Filter DOM Nodes](#filter-dom-nodes)
       * [nth](#nth)
       * [withText](#withtext)
-      * [withAttr](#withattr)
+      * [withAttribute](#withattribute)
       * [filter](#filter)
   * [Search for Elements in the DOM Hierarchy](#search-for-elements-in-the-dom-hierarchy)
       * [find](#find)
@@ -176,11 +176,11 @@ Method | Type | Description
 `withText(text)` | Selector | Creates a selector that filters a matching set by the specified text.
 `withText(re)` | Selector | Creates a selector that filters a matching set using the specified regular expression.
 
-#### withAttr
+#### withAttribute
 
 Method                              | Type     | Description
 ----------------------------------- | -------- | -----------
-`withAttr(attrName [, attrValue])` | Selector | Creates a selector that filters a matching set by the specified attribute and, optionally, attribute value.
+`withAttribute(attrName [, attrValue])` | Selector | Creates a selector that filters a matching set by the specified attribute and, optionally, attribute value.
 
 This method takes the following parameters.
 

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -334,6 +334,7 @@ Parameter         | Type    | Description                                       
 `selectorTimeout` | Number  | Specifies the amount of time, in milliseconds, within which [selectors](../../test-api/selecting-page-elements/selectors.md) make attempts to obtain a node to be returned. See [Selector Timeout](../../test-api/selecting-page-elements/selectors.md#selector-timeout). | `10000`
 `assertionTimeout` | Number  | Specifies the amount of time, in milliseconds, within which TestCafe makes attempts  to successfully execute an [assertion](../../test-api/assertions/README.md) if [a selector property](../../test-api/selecting-page-elements/selectors.md#define-assertion-actual-value) or a [client function](../../test-api/obtaining-data-from-the-client.md) was passed as an actual value. See [Smart Assertion Query Mechanism](../../test-api/assertions/README.md#smart-assertion-query-mechanism). | `3000`
 `speed`           | Number  | Specifies the speed of test execution. Should be a number between `1` (the fastest) and `0.01` (the slowest). If speed is also specified for an [individual action](../../test-api/actions/action-options.md#basic-action-options), the action speed setting overrides test speed. | `1`
+`debugMode`       | Boolean | Specifies if tests run in the debug mode. If this option is enabled, test execution is paused before the first action or assertion allowing you to invoke the developer tools and debug. | `false`
 
 After all tests are finished, call the [testcafe.close](testcafe.md#close) function to stop the TestCafe server.
 


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs  @helen-dikareva 
1. `withAttr` renamed to `withAttribute`
2, Added the runner's `debugMode` option