### PR TITLE
Avoid HTML5 Drag'n'Drop if a browser doesn't support it (closes #1522)

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "stack-chain": "^1.3.6",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "1.2.1",
-    "testcafe-hammerhead": "10.8.1",
+    "testcafe-hammerhead": "10.9.0",
     "testcafe-legacy-api": "3.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/src/client/automation/playback/move/index.js
+++ b/src/client/automation/playback/move/index.js
@@ -425,7 +425,7 @@ export default class MoveAutomation {
 
                 var draggable = findDraggableElement(this.dragElement);
 
-                if (draggable) {
+                if (draggable && browserUtils.hasDataTransfer) {
                     this.dragAndDropState.enabled      = true;
                     this.dragElement                   = draggable;
                     this.dragAndDropState.element      = this.dragElement;


### PR DESCRIPTION
\cc @AlexanderMoskovkin 