### PR TITLE
Fix TypeScript compilation performance (closes #1591)

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -270,13 +270,7 @@ gulp.task('images', ['clean'], function () {
         .pipe(gulp.dest('lib'));
 });
 
-gulp.task('ts-definitions', ['clean'], function () {
-    return gulp
-        .src('src/**/*.d.ts')
-        .pipe(gulp.dest('lib'));
-});
-
-gulp.task('fast-build', ['server-scripts', 'client-scripts', 'styles', 'images', 'templates', 'ts-definitions']);
+gulp.task('fast-build', ['server-scripts', 'client-scripts', 'styles', 'images', 'templates']);
 gulp.task('build', ['lint', 'fast-build']);
 
 // Test

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -270,7 +270,13 @@ gulp.task('images', ['clean'], function () {
         .pipe(gulp.dest('lib'));
 });
 
-gulp.task('fast-build', ['server-scripts', 'client-scripts', 'styles', 'images', 'templates']);
+gulp.task('ts-definitions', ['clean'], function () {
+    return gulp
+        .src('src/**/*.d.ts')
+        .pipe(gulp.dest('lib'));
+});
+
+gulp.task('fast-build', ['server-scripts', 'client-scripts', 'styles', 'images', 'templates', 'ts-definitions']);
 gulp.task('build', ['lint', 'fast-build']);
 
 // Test

--- a/src/compiler/test-file/formats/typescript.js
+++ b/src/compiler/test-file/formats/typescript.js
@@ -71,9 +71,9 @@ export default class TypeScriptTestFileCompiler extends APIBasedTestFileCompiler
         if (diagnostics.length)
             TypeScriptTestFileCompiler._reportErrors(diagnostics);
 
-        // NOTE: First argument of emit() is a source file for compilation. If it's undefined, all files in <program> will be compiled.
-        // <program> contains the file specified in createProgram() plus all its dependencies. This mode is a lot faster than
-        // compiling files one-by-one, and used in tsc CLI compiler.
+        // NOTE: The first argument of emit() is a source file to be compiled. If it's undefined, all files in
+        // <program> will be compiled. <program> contains a file specified in createProgram() plus all its dependencies.
+        // This mode is much faster than compiling files one-by-one, and it is used in the tsc CLI compiler.
         program.emit(void 0, (outputName, result, writeBOM, onError, sources) => {
             var sourcePath = TypeScriptTestFileCompiler._normalizeFilename(sources[0].path);
 

--- a/src/compiler/test-file/formats/typescript.js
+++ b/src/compiler/test-file/formats/typescript.js
@@ -4,7 +4,7 @@ import APIBasedTestFileCompilerBase from '../api-based';
 import ESNextTestFileCompiler from './es-next';
 
 
-const RENAMED_DEPENDENCIES_MAP = new Map ([['testcafe', APIBasedTestFileCompilerBase.EXPORTABLE_LIB_PATH]]);
+const RENAMED_DEPENDENCIES_MAP = new Map([['testcafe', APIBasedTestFileCompilerBase.EXPORTABLE_LIB_PATH]]);
 
 export default class TypeScriptTestFileCompiler extends APIBasedTestFileCompilerBase {
     static _getTypescriptOptions () {
@@ -61,7 +61,9 @@ export default class TypeScriptTestFileCompiler extends APIBasedTestFileCompiler
         var opts        = TypeScriptTestFileCompiler._getTypescriptOptions();
         var program     = ts.createProgram([filename], opts);
 
-        program.getSourceFiles().forEach(sourceFile => sourceFile.renamedDependencies = RENAMED_DEPENDENCIES_MAP);
+        program.getSourceFiles().forEach(sourceFile => {
+            sourceFile.renamedDependencies = RENAMED_DEPENDENCIES_MAP;
+        });
 
         var diagnostics = ts.getPreEmitDiagnostics(program);
 

--- a/src/compiler/test-file/formats/typescript.js
+++ b/src/compiler/test-file/formats/typescript.js
@@ -12,15 +12,16 @@ export default class TypeScriptTestFileCompiler extends APIBasedTestFileCompiler
         var ts = require('typescript');
 
         return {
-            allowJs:         true,
-            pretty:          true,
-            inlineSourceMap: true,
-            noImplicitAny:   false,
-            module:          ts.ModuleKind.CommonJS,
-            target:          'ES6',
-            lib:             ['lib.es6.d.ts'],
-            baseUrl:         __dirname,
-            paths:           { testcafe: ['../../../../ts-defs/index.d.ts'] }
+            allowJs:                 true,
+            pretty:                  true,
+            inlineSourceMap:         true,
+            noImplicitAny:           false,
+            module:                  ts.ModuleKind.CommonJS,
+            target:                  2 /* ES6 */,
+            lib:                     ['lib.es6.d.ts'],
+            baseUrl:                 __dirname,
+            paths:                   { testcafe: ['../../../../ts-defs/index.d.ts'] },
+            suppressOutputPathCheck: true
         };
     }
 
@@ -58,8 +59,8 @@ export default class TypeScriptTestFileCompiler extends APIBasedTestFileCompiler
         if (this.cache[filename])
             return this.cache[filename];
 
-        var opts        = TypeScriptTestFileCompiler._getTypescriptOptions();
-        var program     = ts.createProgram([filename], opts);
+        var opts    = TypeScriptTestFileCompiler._getTypescriptOptions();
+        var program = ts.createProgram([filename], opts);
 
         program.getSourceFiles().forEach(sourceFile => {
             sourceFile.renamedDependencies = RENAMED_DEPENDENCIES_MAP;


### PR DESCRIPTION
\cc @AlexanderMoskovkin 
Tested on https://github.com/caseyWebb/testcafe-slow-typescript-example. I'm going to run it on Travis CI for demonstration, and will post a link after it will be done.