### PR TITLE
Allow Multiple Reporters (closes #1412)

### DIFF
--- a/src/cli/argument-parser.js
+++ b/src/cli/argument-parser.js
@@ -87,7 +87,7 @@ export default class CLIArgumentParser {
             .description(CLIArgumentParser._getDescription())
 
             .option('-b, --list-browsers [provider]', 'output the aliases for local browsers or browsers available through the specified browser provider')
-            .option('-r, --reporter <name[:outFile][,...]>', 'specify reporter types to use and corresponding output files')
+            .option('-r, --reporters <name[:outputFile][,...]>', 'specify the reporters and optionally files where reports are saved')
             .option('-s, --screenshots <path>', 'enable screenshot capturing and specify the path to save the screenshots to')
             .option('-S, --screenshots-on-fails', 'take a screenshot whenever a test fails')
             .option('-q, --quarantine-mode', 'enable the quarantine mode')

--- a/src/cli/argument-parser.js
+++ b/src/cli/argument-parser.js
@@ -87,7 +87,7 @@ export default class CLIArgumentParser {
             .description(CLIArgumentParser._getDescription())
 
             .option('-b, --list-browsers [provider]', 'output the aliases for local browsers or browsers available through the specified browser provider')
-            .option('-r, --reporters <name[:outFile][,...]>', 'specify reporter types to use and corresponding output files')
+            .option('-r, --reporter <name[:outFile][,...]>', 'specify reporter types to use and corresponding output files')
             .option('-s, --screenshots <path>', 'enable screenshot capturing and specify the path to save the screenshots to')
             .option('-S, --screenshots-on-fails', 'take a screenshot whenever a test fails')
             .option('-q, --quarantine-mode', 'enable the quarantine mode')

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import resolveCwd from 'resolve-cwd';
+import fs from 'fs';
 import browserProviderPool from '../browser/provider/pool';
 import { GeneralError, APIError } from '../errors/runtime';
 import MESSAGE from '../errors/runtime/message';
@@ -52,13 +53,20 @@ async function runTests (argParser) {
     var browsers       = argParser.browsers.concat(remoteBrowsers);
     var runner         = testCafe.createRunner();
     var failed         = 0;
+    var reporters      = argParser.opts.reporters.map(r => {
+        return {
+            name:      r.name,
+            outStream: r.outFile ? fs.createWriteStream(r.outFile) : void 0
+        };
+    });
+
+    reporters.forEach(r => runner.reporter(r.name, r.outStream));
 
     runner
         .useProxy(externalProxyHost)
         .src(argParser.src)
         .browsers(browsers)
         .concurrency(concurrency)
-        .reporter(opts.reporter)
         .filter(argParser.filter)
         .screenshots(opts.screenshots, opts.screenshotsOnFails)
         .startApp(opts.app, opts.appInitDelay);

--- a/src/errors/runtime/message.js
+++ b/src/errors/runtime/message.js
@@ -8,6 +8,7 @@ export default {
     testSourcesNotSet:                     'No test file specified.',
     noTestsToRun:                          'No tests to run. Either the test files contain no tests or the filter function is too restrictive.',
     cantFindReporterForAlias:              'The provided "{name}" reporter does not exist. Check that you have specified the report format correctly.',
+    multipleStdoutReporters:               'Multiple reporters attempting to write to stdout: "{reporters}"',
     optionValueIsNotValidRegExp:           'The "{optionName}" option value is not a valid regular expression.',
     testedAppFailedWithError:              'Tested app failed with an error:\n\n{errMessage}',
     invalidSpeedValue:                     'Speed should be a number between 0.01 and 1.',

--- a/src/errors/runtime/message.js
+++ b/src/errors/runtime/message.js
@@ -8,7 +8,7 @@ export default {
     testSourcesNotSet:                     'No test file specified.',
     noTestsToRun:                          'No tests to run. Either the test files contain no tests or the filter function is too restrictive.',
     cantFindReporterForAlias:              'The provided "{name}" reporter does not exist. Check that you have specified the report format correctly.',
-    multipleStdoutReporters:               'Multiple reporters attempting to write to stdout: "{reporters}"',
+    multipleStdoutReporters:               'Multiple reporters attempting to write to stdout: "{reporters}". Only one reporter can write to stdout.',
     optionValueIsNotValidRegExp:           'The "{optionName}" option value is not a valid regular expression.',
     testedAppFailedWithError:              'Tested app failed with an error:\n\n{errMessage}',
     invalidSpeedValue:                     'Speed should be a number between 0.01 and 1.',

--- a/src/runner/bootstrapper.js
+++ b/src/runner/bootstrapper.js
@@ -92,23 +92,23 @@ export default class Bootstrapper {
         var stdoutReporters = filter(this.reporters, r => isUndefined(r.outStream) || r.outStream === process.stdout);
 
         if (stdoutReporters.length > 1)
-            throw new GeneralError(MESSAGE.multipleStdoutReporters, stdoutReporters.map(r => r.reporter).join(', '));
+            throw new GeneralError(MESSAGE.multipleStdoutReporters, stdoutReporters.map(r => r.name).join(', '));
         else if (stdoutReporters.length === 0) {
             this.reporters.push({
-                reporter:  'spec',
+                name:      'spec',
                 outStream: process.stdout
             });
         }
 
-        return this.reporters.map(({ reporter, outStream }) => {
-            let pluginFactory = reporter;
+        return this.reporters.map(({ name, outStream }) => {
+            let pluginFactory = name;
 
             if (typeof pluginFactory !== 'function') {
                 try {
-                    pluginFactory = require('testcafe-reporter-' + reporter);
+                    pluginFactory = require('testcafe-reporter-' + name);
                 }
                 catch (err) {
-                    throw new GeneralError(MESSAGE.cantFindReporterForAlias, reporter);
+                    throw new GeneralError(MESSAGE.cantFindReporterForAlias, name);
                 }
             }
 

--- a/src/runner/bootstrapper.js
+++ b/src/runner/bootstrapper.js
@@ -108,7 +108,7 @@ export default class Bootstrapper {
                     pluginFactory = require('testcafe-reporter-' + reporter);
                 }
                 catch (err) {
-                    throw new GeneralError(MESSAGE.cantFindReporterForAlias, this.reporter);
+                    throw new GeneralError(MESSAGE.cantFindReporterForAlias, reporter);
                 }
             }
 

--- a/src/runner/bootstrapper.js
+++ b/src/runner/bootstrapper.js
@@ -93,7 +93,8 @@ export default class Bootstrapper {
 
         if (stdoutReporters.length > 1)
             throw new GeneralError(MESSAGE.multipleStdoutReporters, stdoutReporters.map(r => r.name).join(', '));
-        else if (stdoutReporters.length === 0) {
+
+        if (!this.reporters.length) {
             this.reporters.push({
                 name:      'spec',
                 outStream: process.stdout

--- a/src/runner/bootstrapper.js
+++ b/src/runner/bootstrapper.js
@@ -103,7 +103,7 @@ export default class Bootstrapper {
         return this.reporters.map(({ reporter, outStream }) => {
             let pluginFactory = reporter;
 
-            if (typeof reporter !== 'function') {
+            if (typeof pluginFactory !== 'function') {
                 try {
                     pluginFactory = require('testcafe-reporter-' + reporter);
                 }

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -148,9 +148,9 @@ export default class Runner extends EventEmitter {
         return this;
     }
 
-    reporter (reporter, outStream) {
+    reporter (name, outStream) {
         this.bootstrapper.reporters.push({
-            reporter,
+            name,
             outStream
         });
 

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -94,7 +94,7 @@ export default class Runner extends EventEmitter {
         var completed         = false;
         var task              = new Task(tests, browserSet.browserConnectionGroups, this.proxy, this.opts);
         var reporters         = reporterPlugins.map(reporter => new Reporter(reporter.plugin, task, reporter.outStream));
-        var completionPromise = this._getTaskResult(task, browserSet, reporter, testedApp);
+        var completionPromise = this._getTaskResult(task, browserSet, reporters[0], testedApp);
 
         var setCompleted = () => {
             completed = true;

--- a/test/functional/fixtures/reporter/pages/index.html
+++ b/test/functional/fixtures/reporter/pages/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Reporter</title>
+</head>
+<body>
+</body>
+</html>

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -1,0 +1,48 @@
+var expect = require('chai').expect;
+
+describe('Reporter', function () {
+    it('Should support several different reporters for a test run', function () {
+        var data1   = '';
+        var data2   = '';
+        var stream1 = {
+            write: function (data) {
+                data1 += data;
+            },
+
+            end: function (data) {
+                data1 += data;
+            }
+        };
+        var stream2 = {
+            write: function (data) {
+                data2 += data;
+            },
+
+            end: function (data) {
+                data2 += data;
+            }
+        };
+
+        return runTests('testcafe-fixtures/index-test.js', 'Simple test', {
+            only:      ['chrome'],
+            reporters: [
+                {
+                    reporter:  'json',
+                    outStream: stream1
+                },
+                {
+                    reporter:  'list',
+                    outStream: stream2
+                }
+            ]
+        })
+            .then(function () {
+                expect(data1).to.contains('Chrome');
+                expect(data1).to.contains('Reporter');
+                expect(data1).to.contains('Simple test');
+                expect(data2).to.contains('Chrome');
+                expect(data2).to.contains('Reporter');
+                expect(data2).to.contains('Simple test');
+            });
+    });
+});

--- a/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
@@ -1,0 +1,7 @@
+fixture `Reporter`
+    .page `http://localhost:3000/fixtures/reporter/pages/index.html`;
+
+
+test('Simple test', async t => {
+    await t.wait(1);
+});

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -305,12 +305,25 @@ describe('CLI argument parser', function () {
             });
     });
 
+    it('Should parse reporters and their output file paths and ensure they exist', function () {
+        var cwd      = process.cwd();
+        var filePath = path.join(tmp.dirSync().name, 'my/reports/report.json');
+
+        return parse('-r list,json:' + filePath)
+            .then(function (parser) {
+                expect(parser.opts.reporters[0].name).eql('list');
+                expect(parser.opts.reporters[0].outFile).to.be.undefined;
+                expect(parser.opts.reporters[1].name).eql('json');
+                expect(parser.opts.reporters[1].outFile).eql(path.resolve(cwd, filePath));
+            });
+    });
+
     it('Should parse command line arguments', function () {
         return parse('-r list -S -q -e --hostname myhost --proxy localhost:1234 --qr-code --app run-app --speed 0.5 ie test/server/data/file-list/file-1.js')
             .then(function (parser) {
                 expect(parser.browsers).eql(['ie']);
                 expect(parser.src).eql([path.resolve(process.cwd(), 'test/server/data/file-list/file-1.js')]);
-                expect(parser.opts.reporter).eql('list');
+                expect(parser.opts.reporters[0].name).eql('list');
                 expect(parser.opts.hostname).eql('myhost');
                 expect(parser.opts.app).eql('run-app');
                 expect(parser.opts.screenshots).to.be.undefined;

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -159,11 +159,11 @@ describe('Runner', function () {
         });
 
         it('Should fallback to the default reporter if reporter was not set', function () {
-            runner._runTask = function (reporterPlugin) {
-                expect(reporterPlugin.reportFixtureStart).to.be.a('function');
-                expect(reporterPlugin.reportTestDone).to.be.a('function');
-                expect(reporterPlugin.reportTaskStart).to.be.a('function');
-                expect(reporterPlugin.reportTaskDone).to.be.a('function');
+            runner._runTask = function (reporterPlugins) {
+                expect(reporterPlugins[0].reportFixtureStart).to.be.a('function');
+                expect(reporterPlugins[0].reportTestDone).to.be.a('function');
+                expect(reporterPlugins[0].reportTaskStart).to.be.a('function');
+                expect(reporterPlugins[0].reportTaskDone).to.be.a('function');
 
                 return Promise.resolve({});
             };

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -159,11 +159,11 @@ describe('Runner', function () {
         });
 
         it('Should fallback to the default reporter if reporter was not set', function () {
-            runner._runTask = function (reporterPlugins) {
-                expect(reporterPlugins[0].reportFixtureStart).to.be.a('function');
-                expect(reporterPlugins[0].reportTestDone).to.be.a('function');
-                expect(reporterPlugins[0].reportTaskStart).to.be.a('function');
-                expect(reporterPlugins[0].reportTaskDone).to.be.a('function');
+            runner._runTask = function ([reporter]) {
+                expect(reporter.plugin.reportFixtureStart).to.be.a('function');
+                expect(reporter.plugin.reportTestDone).to.be.a('function');
+                expect(reporter.plugin.reportTaskStart).to.be.a('function');
+                expect(reporter.plugin.reportTaskDone).to.be.a('function');
 
                 return Promise.resolve({});
             };

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -159,11 +159,13 @@ describe('Runner', function () {
         });
 
         it('Should fallback to the default reporter if reporter was not set', function () {
-            runner._runTask = function ([reporter]) {
-                expect(reporter.plugin.reportFixtureStart).to.be.a('function');
-                expect(reporter.plugin.reportTestDone).to.be.a('function');
-                expect(reporter.plugin.reportTaskStart).to.be.a('function');
-                expect(reporter.plugin.reportTaskDone).to.be.a('function');
+            runner._runTask = function (reporters) {
+                var reporterPlugin = reporters[0].plugin;
+
+                expect(reporterPlugin.reportFixtureStart).to.be.a('function');
+                expect(reporterPlugin.reportTestDone).to.be.a('function');
+                expect(reporterPlugin.reportTaskStart).to.be.a('function');
+                expect(reporterPlugin.reportTaskDone).to.be.a('function');
 
                 return Promise.resolve({});
             };

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -158,6 +158,22 @@ describe('Runner', function () {
                 });
         });
 
+        it('Should raise an error if several reporters are going to write to the stdout', function () {
+            return runner
+                .browsers(connection)
+                .reporter('json')
+                .reporter('xunit')
+                .src('test/server/data/test-suites/basic/testfile2.js')
+                .run()
+                .then(function () {
+                    throw new Error('Promise rejection expected');
+                })
+                .catch(function (err) {
+                    expect(err.message).eql('Multiple reporters attempting to write to stdout: "json, xunit". ' +
+                                            'Only one reporter can write to stdout.');
+                });
+        });
+
         it('Should fallback to the default reporter if reporter was not set', function () {
             runner._runTask = function (reporters) {
                 var reporterPlugin = reporters[0].plugin;
@@ -172,6 +188,42 @@ describe('Runner', function () {
 
             return runner
                 .browsers(connection)
+                .src('test/server/data/test-suites/basic/testfile2.js')
+                .run();
+        });
+
+        it('Should fallback to the default reporter if reporter with "outStream=process.stdout" was not set', function () {
+            runner._runTask = function (reporters) {
+                expect(reporters.length).to.be.eql(2);
+
+                var reporterPlugin1 = reporters[0].plugin;
+
+                expect(reporterPlugin1.reportFixtureStart).to.be.a('function');
+                expect(reporterPlugin1.reportTestDone).to.be.a('function');
+                expect(reporterPlugin1.reportTaskStart).to.be.a('function');
+                expect(reporterPlugin1.reportTaskDone).to.be.a('function');
+
+                var reporterPlugin2 = reporters[0].plugin;
+
+                expect(reporterPlugin2.reportFixtureStart).to.be.a('function');
+                expect(reporterPlugin2.reportTestDone).to.be.a('function');
+                expect(reporterPlugin2.reportTaskStart).to.be.a('function');
+                expect(reporterPlugin2.reportTaskDone).to.be.a('function');
+
+                return Promise.resolve({});
+            };
+
+            var outStreamMock = {
+                write: function () {
+                },
+
+                end: function () {
+                }
+            };
+
+            return runner
+                .browsers(connection)
+                .reporter('json', outStreamMock)
                 .src('test/server/data/test-suites/basic/testfile2.js')
                 .run();
         });

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -191,42 +191,6 @@ describe('Runner', function () {
                 .src('test/server/data/test-suites/basic/testfile2.js')
                 .run();
         });
-
-        it('Should fallback to the default reporter if reporter with "outStream=process.stdout" was not set', function () {
-            runner._runTask = function (reporters) {
-                expect(reporters.length).to.be.eql(2);
-
-                var reporterPlugin1 = reporters[0].plugin;
-
-                expect(reporterPlugin1.reportFixtureStart).to.be.a('function');
-                expect(reporterPlugin1.reportTestDone).to.be.a('function');
-                expect(reporterPlugin1.reportTaskStart).to.be.a('function');
-                expect(reporterPlugin1.reportTaskDone).to.be.a('function');
-
-                var reporterPlugin2 = reporters[0].plugin;
-
-                expect(reporterPlugin2.reportFixtureStart).to.be.a('function');
-                expect(reporterPlugin2.reportTestDone).to.be.a('function');
-                expect(reporterPlugin2.reportTaskStart).to.be.a('function');
-                expect(reporterPlugin2.reportTaskDone).to.be.a('function');
-
-                return Promise.resolve({});
-            };
-
-            var outStreamMock = {
-                write: function () {
-                },
-
-                end: function () {
-                }
-            };
-
-            return runner
-                .browsers(connection)
-                .reporter('json', outStreamMock)
-                .src('test/server/data/test-suites/basic/testfile2.js')
-                .run();
-        });
     });
 
     describe('.src()', function () {


### PR DESCRIPTION
When using the TestCafé runner programmatically, calling `.reporter()` multiple times only uses the last reporter.

This PR allows calling `.reporter()` multiple times, however throws an error if multiple reporters are configured to use stdout.

This allows usage such that test runs can output json to a `.json` file, verbose output to a log file, and minimal output to the TTY (for example).

Also potentially serves as groundwork for #1412.

**NOTE**: I wasn't able to figure out how to run the tests, so those are not implemented.