### PR TITLE
Change `selectText()` to match documentation (fixes #1697)

### DIFF
--- a/test/server/data/test-suites/typescript-defs/test-controller.ts
+++ b/test/server/data/test-suites/typescript-defs/test-controller.ts
@@ -666,11 +666,19 @@ test('Right click button', async t => {
 
 
 test('Select text in input', async t => {
-    await t.selectText('#input', 2, 4);
+    await t
+        .selectText('#input', 2, 4)
+        .selectText('#input', 2)
+        .selectText('#input');
 });
 
 test('Select content in textarea', async t => {
-    await t.selectTextAreaContent('#textarea', 0, 2, 1, 3);
+    await t
+        .selectTextAreaContent('#textarea', 0, 2, 1, 3)
+        .selectTextAreaContent('#textarea', 0, 2, 1)
+        .selectTextAreaContent('#textarea', 0, 2)
+        .selectTextAreaContent('#textarea', 1)
+        .selectTextAreaContent('#textarea');
 });
 
 test('Select editable content', async t => {

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -878,10 +878,10 @@ interface TestController {
      * @param options
      */
     selectTextAreaContent(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-                          startLine: number,
-                          startPos: number,
-                          endLine: number,
-                          endPos: number,
+                          startLine?: number,
+                          startPos?: number,
+                          endLine?: number,
+                          endPos?: number,
                           options?: ActionOptions): TestControllerPromise;
     /**
      * Performs selection within editable content

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -864,8 +864,8 @@ interface TestController {
      * @param options - A set of options that provide additional parameters for the action.
      */
     selectText(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-               startPos: number,
-               endPos: number,
+               startPos?: number,
+               endPos?: number,
                options?: ActionOptions): TestControllerPromise;
     /**
      * Selects `<textarea>` content.


### PR DESCRIPTION
Change `selectText()` required parameters to match documentation.  In the documentation ([see here](https://devexpress.github.io/testcafe/documentation/test-api/actions/select-text.html)), it states that only the first parameter is required which seems to make sense since you wouldn't want to give all three parameters in all situations. 

If the `startPos` and `endPos` are not made optional, then a build error occurs.

fixes #1697 