### PR TITLE
Use `chrome-canary` alias for Chrome Canary (closes #1711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * SelectText and SelectTextAreaContent TypeScript definitions now match the documentation ([#1697](https://github.com/DevExpress/testcafe/issues/1697))
 * TestCafe now finds browsers installed for the current user on Windows ([#1688](https://github.com/DevExpress/testcafe/issues/1688))
 * TestCafe can now resize MS Edge 15 window ([#1517](https://github.com/DevExpress/testcafe/issues/1517))
+* Detected Google Chrome Canary has the dedicated `chrome-canary` alias now ([#1711](https://github.com/DevExpress/testcafe/issues/1711)) 
 * Test no longer hangs when `takeScreenshot` is called in headless Chrome Canary on Windows ([#1685](https://github.com/DevExpress/testcafe/issues/1685))
 * Tests now fail if the `uncaughtRejection` exception is raised ([#1473](https://github.com/DevExpress/testcafe/issues/1473))
 * TypeScript tests now run on macOS with no errors ([#1696](https://github.com/DevExpress/testcafe/issues/1696))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.17.1 (2017-8-16)
+## v0.17.1 (2017-8-17)
 
 ### Bug Fixes
 
@@ -8,7 +8,7 @@
 * SelectText and SelectTextAreaContent TypeScript definitions now match the documentation ([#1697](https://github.com/DevExpress/testcafe/issues/1697))
 * TestCafe now finds browsers installed for the current user on Windows ([#1688](https://github.com/DevExpress/testcafe/issues/1688))
 * TestCafe can now resize MS Edge 15 window ([#1517](https://github.com/DevExpress/testcafe/issues/1517))
-* Detected Google Chrome Canary has the dedicated `chrome-canary` alias now ([#1711](https://github.com/DevExpress/testcafe/issues/1711)) 
+* Google Chrome Canary has a dedicated `chrome-canary` alias now ([#1711](https://github.com/DevExpress/testcafe/issues/1711)) 
 * Test no longer hangs when `takeScreenshot` is called in headless Chrome Canary on Windows ([#1685](https://github.com/DevExpress/testcafe/issues/1685))
 * Tests now fail if the `uncaughtRejection` exception is raised ([#1473](https://github.com/DevExpress/testcafe/issues/1473))
 * TypeScript tests now run on macOS with no errors ([#1696](https://github.com/DevExpress/testcafe/issues/1696))

--- a/docs/articles/documentation/using-testcafe/common-concepts/browser-support.md
+++ b/docs/articles/documentation/using-testcafe/common-concepts/browser-support.md
@@ -21,7 +21,7 @@ permalink: /documentation/using-testcafe/common-concepts/browser-support.html
 While TestCafe is designed to support most modern browsers, there are a limited number
 of *officially supported* browsers against which TestCafe is actively tested.
 
-* Google Chrome
+* Google Chrome (Stable, Beta, Dev and Canary)
 * Internet Explorer (9+)
 * Microsoft Edge
 * Mozilla Firefox
@@ -38,15 +38,16 @@ You can use a short name - *browser alias* - to identify these browsers when lau
 
 The following table lists browsers that can be detected automatically.
 
-Browser           | Browser Alias
------------------ | -------------------
-Chromium          | `chromium`
-Google Chrome     | `chrome`
-Internet Explorer | `ie`
-Microsoft Edge    | `edge`
-Mozilla Firefox   | `firefox`
-Opera             | `opera`
-Safari            | `safari`
+Browser                                      | Browser Alias
+---------------------------------------------| -------------------
+Chromium                                     | `chromium`
+Google Chrome (Stable, Beta, Dev channel)    | `chrome`
+Google Chrome Canary                         | `chrome-canary`
+Internet Explorer                            | `ie`
+Microsoft Edge                               | `edge`
+Mozilla Firefox                              | `firefox`
+Opera                                        | `opera`
+Safari                                       | `safari`
 
 The list of all the available browsers can be obtained by calling the `testcafe` command
 with the [--list-browsers](../command-line-interface.md#-b---list-browsers) flag.

--- a/docs/articles/documentation/using-testcafe/common-concepts/browser-support.md
+++ b/docs/articles/documentation/using-testcafe/common-concepts/browser-support.md
@@ -21,7 +21,7 @@ permalink: /documentation/using-testcafe/common-concepts/browser-support.html
 While TestCafe is designed to support most modern browsers, there are a limited number
 of *officially supported* browsers against which TestCafe is actively tested.
 
-* Google Chrome: regular Update Channels (Stable, Beta, Dev) and Canary
+* Google Chrome: Stable, Beta, Dev and Canary
 * Internet Explorer (9+)
 * Microsoft Edge
 * Mozilla Firefox
@@ -38,16 +38,16 @@ You can use a short name - *browser alias* - to identify these browsers when lau
 
 The following table lists browsers that can be detected automatically.
 
-Browser                                      | Browser Alias
----------------------------------------------| -------------------
-Chromium                                     | `chromium`
-Google Chrome (Regular Channels)             | `chrome`
-Google Chrome Canary                         | `chrome-canary`
-Internet Explorer                            | `ie`
-Microsoft Edge                               | `edge`
-Mozilla Firefox                              | `firefox`
-Opera                                        | `opera`
-Safari                                       | `safari`
+Browser              | Browser Alias
+---------------------| -------------------
+Chromium             | `chromium`
+Google Chrome        | `chrome`
+Google Chrome Canary | `chrome-canary`
+Internet Explorer    | `ie`
+Microsoft Edge       | `edge`
+Mozilla Firefox      | `firefox`
+Opera                | `opera`
+Safari               | `safari`
 
 The list of all the available browsers can be obtained by calling the `testcafe` command
 with the [--list-browsers](../command-line-interface.md#-b---list-browsers) flag.

--- a/docs/articles/documentation/using-testcafe/common-concepts/browser-support.md
+++ b/docs/articles/documentation/using-testcafe/common-concepts/browser-support.md
@@ -21,7 +21,7 @@ permalink: /documentation/using-testcafe/common-concepts/browser-support.html
 While TestCafe is designed to support most modern browsers, there are a limited number
 of *officially supported* browsers against which TestCafe is actively tested.
 
-* Google Chrome (Stable, Beta, Dev and Canary)
+* Google Chrome: regular Update Channels (Stable, Beta, Dev) and Canary
 * Internet Explorer (9+)
 * Microsoft Edge
 * Mozilla Firefox
@@ -41,7 +41,7 @@ The following table lists browsers that can be detected automatically.
 Browser                                      | Browser Alias
 ---------------------------------------------| -------------------
 Chromium                                     | `chromium`
-Google Chrome (Stable, Beta, Dev channel)    | `chrome`
+Google Chrome (Regular Channels)             | `chrome`
 Google Chrome Canary                         | `chrome-canary`
 Internet Explorer                            | `ie`
 Microsoft Edge                               | `edge`

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "source-map-support": "^0.4.0",
     "stack-chain": "^1.3.6",
     "strip-bom": "^2.0.0",
-    "testcafe-browser-tools": "1.4.0",
+    "testcafe-browser-tools": "1.4.1",
     "testcafe-hammerhead": "11.1.1",
     "testcafe-legacy-api": "3.1.1",
     "testcafe-reporter-json": "^2.1.0",


### PR DESCRIPTION
\cc @AlexanderMoskovkin @VasilyStrelyaev 