### PR TITLE
Add the `skipLibCheck` option to TypeScript compiler settings (closes #1537)

### DIFF
--- a/src/compiler/test-file/formats/typescript/compiler.js
+++ b/src/compiler/test-file/formats/typescript/compiler.js
@@ -21,7 +21,8 @@ export default class TypeScriptTestFileCompiler extends APIBasedTestFileCompiler
             lib:                     ['lib.es6.d.ts'],
             baseUrl:                 __dirname,
             paths:                   { testcafe: ['../../../../../ts-defs/index.d.ts'] },
-            suppressOutputPathCheck: true
+            suppressOutputPathCheck: true,
+            skipLibCheck:            true
         };
     }
 


### PR DESCRIPTION
See details here: https://github.com/DevExpress/testcafe/issues/1537#issuecomment-321242185
/cc @AndreyBelym 