### PR TITLE
[docs] Add a note that concurrency testing is not supported in Edge

### DIFF
--- a/docs/articles/documentation/using-testcafe/common-concepts/concurrent-test-execution.md
+++ b/docs/articles/documentation/using-testcafe/common-concepts/concurrent-test-execution.md
@@ -21,6 +21,8 @@ These instances constitute the pool of browsers against which tests run concurre
 To enable concurrency, use the [-c or --concurrency](../command-line-interface.md#-c-n---concurrency-n)
 command line option or the [runner.concurrency](../programming-interface/runner.md#concurrency) method of the programming interface.
 
+> Important! Concurrent test execution is not supported in Microsoft Edge.
+
 The following command invokes three Chrome instances and runs tests concurrently.
 
 ```sh


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs 

fixes #1664   