### PR TITLE
[docs] Running portable browsers with parameters on *nix systems

### DIFF
--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -134,13 +134,15 @@ testcafe "saucelabs:Chrome@52.0:Windows 8.1" tests/sample-fixture.js
 
 ### Starting browser with arguments
 
-If you need to pass arguments for the specified browser, write them right after browser alias. Surround the browser call and its arguments with quotation marks. On Windows, use double quotation marks.
+If you need to pass arguments for the specified browser, write them right after browser alias. Surround the browser call and its arguments with quotation marks.
+
+On Windows `cmd.exe`, the default command prompt, use double quotation marks.
 
 ```sh
 testcafe "chrome --start-fullscreen" tests/sample-fixture.js
 ```
 
-On `*nix` systems, prefer single quotation marks.
+On `Unix` shells like `bash`, `zsh`, `csh` (on macOS, Linux, Windows Subsystem for Linux) and Windows PowerShell, prefer single quotation marks.
 
 ```sh
 testcafe 'chrome --start-fullscreen' tests/sample-fixture.js
@@ -148,16 +150,16 @@ testcafe 'chrome --start-fullscreen' tests/sample-fixture.js
 
 You can also specify arguments for portable browsers. If a path to a browser contains spaces, the path should be surrounded with backticks:
 
-On Windows:
-
-```sh
-testcafe "path:`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe` --start-fullscreen" tests/sample-fixture.js
-```
-
-On `*nix`:
+For Unix shells and Windows PowerShell:
 
 ```sh
 testcafe 'path:`/Users/TestCafe/Apps/Google Chrome.app` --start-fullscreen' tests/sample-fixture.js
+```
+
+For `cmd.exe`:
+
+```sh
+testcafe "path:`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe` --start-fullscreen" tests/sample-fixture.js
 ```
 
 You can specify arguments for local browsers only.

--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -134,16 +134,30 @@ testcafe "saucelabs:Chrome@52.0:Windows 8.1" tests/sample-fixture.js
 
 ### Starting browser with arguments
 
-If you need to pass arguments for the specified browser, write them right after browser alias. Surround the browser call and its arguments with quotation marks:
+If you need to pass arguments for the specified browser, write them right after browser alias. Surround the browser call and its arguments with quotation marks. On Windows, use double quotation marks.
 
 ```sh
 testcafe "chrome --start-fullscreen" tests/sample-fixture.js
 ```
 
+On `*nix` systems, prefer single quotation marks.
+
+```sh
+testcafe 'chrome --start-fullscreen' tests/sample-fixture.js
+```
+
 You can also specify arguments for portable browsers. If a path to a browser contains spaces, the path should be surrounded with backticks:
+
+On Windows:
 
 ```sh
 testcafe "path:`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe` --start-fullscreen" tests/sample-fixture.js
+```
+
+On `*nix`:
+
+```sh
+testcafe 'path:`/Users/TestCafe/Apps/Google Chrome.app` --start-fullscreen' tests/sample-fixture.js
 ```
 
 You can specify arguments for local browsers only.


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs @AndreyBelym  

The docs part for https://github.com/DevExpress/testcafe/issues/1640