### PR TITLE
Add the capability to get browser console messages (closes #1738)

### DIFF
--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -24,7 +24,7 @@ import {
     SwitchToMainWindowCommand,
     SetNativeDialogHandlerCommand,
     GetNativeDialogHistoryCommand,
-    GetConsoleMessagesCommand,
+    GetBrowserConsoleMessagesCommand,
     SetTestSpeedCommand,
     SetPageLoadTimeoutCommand,
     UseRoleCommand
@@ -240,10 +240,10 @@ export default class TestController {
         return this.testRun.executeCommand(new GetNativeDialogHistoryCommand(), callsite);
     }
 
-    _getConsoleMessages$ () {
-        var callsite = getCallsiteForMethod('getConsoleMessages');
+    _getBrowserConsoleMessages$ () {
+        var callsite = getCallsiteForMethod('getBrowserConsoleMessages');
 
-        return this.testRun.executeCommand(new GetConsoleMessagesCommand(), callsite);
+        return this.testRun.executeCommand(new GetBrowserConsoleMessagesCommand(), callsite);
     }
 
     _expect$ (actual) {

--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -24,6 +24,7 @@ import {
     SwitchToMainWindowCommand,
     SetNativeDialogHandlerCommand,
     GetNativeDialogHistoryCommand,
+    GetConsoleMessagesCommand,
     SetTestSpeedCommand,
     SetPageLoadTimeoutCommand,
     UseRoleCommand
@@ -237,6 +238,12 @@ export default class TestController {
         var callsite = getCallsiteForMethod('getNativeDialogHistory');
 
         return this.testRun.executeCommand(new GetNativeDialogHistoryCommand(), callsite);
+    }
+
+    _getConsoleMessages$ () {
+        var callsite = getCallsiteForMethod('getConsoleMessages');
+
+        return this.testRun.executeCommand(new GetConsoleMessagesCommand(), callsite);
     }
 
     _expect$ (actual) {

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -362,7 +362,7 @@ export default class Driver {
         }));
     }
 
-    _onGetConsoleMessagesCommand () {
+    _onGetBrowserConsoleMessagesCommand () {
         this._onReady(new DriverStatus({
             isCommandResult: true,
             result:          this.consoleMessages
@@ -531,8 +531,8 @@ export default class Driver {
         else if (command.type === COMMAND_TYPE.getNativeDialogHistory)
             this._onGetNativeDialogHistoryCommand(command);
 
-        else if (command.type === COMMAND_TYPE.getConsoleMessages)
-            this._onGetConsoleMessagesCommand(command);
+        else if (command.type === COMMAND_TYPE.getBrowserConsoleMessages)
+            this._onGetBrowserConsoleMessagesCommand(command);
 
         else if (command.type === COMMAND_TYPE.setTestSpeed)
             this._onSetTestSpeedCommand(command);

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -206,12 +206,8 @@ export default class Driver {
     }
 
     _addConsoleMessagesToStatus (status) {
-        var messages = this.consoleMessages;
-
-        if (messages) {
-            status.consoleMessages = messages;
-            this.consoleMessages   = null;
-        }
+        status.consoleMessages = this.consoleMessages;
+        this.consoleMessages   = null;
     }
 
     _sendStatus (status) {

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -27,6 +27,8 @@ import {
     CurrentIframeNotFoundError,
     CurrentIframeIsInvisibleError
 } from '../../errors/test-run';
+
+import BrowserConsoleMessages from '../../test-run/browser-console-messages';
 import NativeDialogTracker from './native-dialog-tracker';
 
 import { SetNativeDialogHandlerMessage, TYPE as MESSAGE_TYPE } from './driver-link/messages';
@@ -127,11 +129,11 @@ export default class Driver {
     }
 
     get consoleMessages () {
-        return this.contextStorage.getItem(CONSOLE_MESSAGES);
+        return new BrowserConsoleMessages(this.contextStorage.getItem(CONSOLE_MESSAGES));
     }
 
     set consoleMessages (messages) {
-        return this.contextStorage.setItem(CONSOLE_MESSAGES, messages);
+        return this.contextStorage.setItem(CONSOLE_MESSAGES, messages ? messages.getCopy() : null);
     }
 
     // Error handling
@@ -167,15 +169,6 @@ export default class Driver {
     }
 
     // Console messages
-    static _getDefaultConsoleMessages () {
-        return {
-            log:   [],
-            info:  [],
-            error: [],
-            warn:  []
-        };
-    }
-
     _onConsoleMessage (e) {
         const meth = e.meth;
 
@@ -189,9 +182,9 @@ export default class Driver {
             return arg.toString();
         });
 
-        const messages = this.consoleMessages || Driver._getDefaultConsoleMessages();
+        const messages = this.consoleMessages;
 
-        messages[meth].push(Array.prototype.slice.call(args).join(' '));
+        messages.addMessage(meth, Array.prototype.slice.call(args).join(' '));
 
         this.consoleMessages = messages;
     }

--- a/src/client/driver/status.js
+++ b/src/client/driver/status.js
@@ -12,6 +12,7 @@ export default class DriverStatus extends Assignable {
         this.pageError       = null;
         this.resent          = false;
         this.result          = null;
+        this.consoleMessages = null;
 
         this._assignFrom(obj, true);
     }
@@ -21,7 +22,8 @@ export default class DriverStatus extends Assignable {
             { name: 'isCommandResult' },
             { name: 'executionError' },
             { name: 'pageError' },
-            { name: 'result' }
+            { name: 'result' },
+            { name: 'consoleMessages' }
         ];
     }
 }

--- a/src/test-run/bookmark.js
+++ b/src/test-run/bookmark.js
@@ -28,6 +28,7 @@ export default class TestRunBookmark {
         this.pageLoadTimeout = testRun.pageLoadTimeout;
         this.ctx             = testRun.ctx;
         this.fixtureCtx      = testRun.fixtureCtx;
+        this.consoleMessages = testRun.consoleMessages;
     }
 
     async init () {
@@ -94,8 +95,9 @@ export default class TestRunBookmark {
 
         this.testRun.phase = TEST_RUN_PHASE.inBookmarkRestore;
 
-        this.testRun.ctx        = this.ctx;
-        this.testRun.fixtureCtx = this.fixtureCtx;
+        this.testRun.ctx             = this.ctx;
+        this.testRun.fixtureCtx      = this.fixtureCtx;
+        this.testRun.consoleMessages = this.consoleMessages;
 
         try {
             await this._restoreSpeed();

--- a/src/test-run/browser-console-messages.js
+++ b/src/test-run/browser-console-messages.js
@@ -1,0 +1,46 @@
+// -------------------------------------------------------------
+// WARNING: this file is used by both the client and the server.
+// Do not use any browser or node-specific API!
+// -------------------------------------------------------------
+import { assignIn } from 'lodash';
+import Assignable from '../utils/assignable';
+
+
+export default class BrowserConsoleMessages extends Assignable {
+    constructor (obj) {
+        super();
+
+        this.log   = [];
+        this.info  = [];
+        this.warn  = [];
+        this.error = [];
+
+        this._assignFrom(obj);
+    }
+
+    _getAssignableProperties () {
+        return [
+            { name: 'log' },
+            { name: 'info' },
+            { name: 'warn' },
+            { name: 'error' }
+        ];
+    }
+
+    concat (consoleMessages) {
+        this.log   = this.log.concat(consoleMessages.log);
+        this.info  = this.info.concat(consoleMessages.info);
+        this.warn  = this.warn.concat(consoleMessages.warn);
+        this.error = this.error.concat(consoleMessages.error);
+    }
+
+    addMessage (type, msg) {
+        this[type].push(msg);
+    }
+
+    getCopy () {
+        const { log, info, warn, error } = this;
+
+        return assignIn({}, { log, info, warn, error });
+    }
+}

--- a/src/test-run/commands/actions.js
+++ b/src/test-run/commands/actions.js
@@ -418,6 +418,12 @@ export class GetNativeDialogHistoryCommand {
     }
 }
 
+export class GetConsoleMessagesCommand {
+    constructor () {
+        this.type = TYPE.getConsoleMessages;
+    }
+}
+
 export class SetTestSpeedCommand extends Assignable {
     constructor (obj) {
         super(obj);

--- a/src/test-run/commands/actions.js
+++ b/src/test-run/commands/actions.js
@@ -418,9 +418,9 @@ export class GetNativeDialogHistoryCommand {
     }
 }
 
-export class GetConsoleMessagesCommand {
+export class GetBrowserConsoleMessagesCommand {
     constructor () {
-        this.type = TYPE.getConsoleMessages;
+        this.type = TYPE.getBrowserConsoleMessages;
     }
 }
 

--- a/src/test-run/commands/type.js
+++ b/src/test-run/commands/type.js
@@ -34,6 +34,7 @@ export default {
     switchToMainWindow:         'switch-to-main-window',
     setNativeDialogHandler:     'set-native-dialog-handler',
     getNativeDialogHistory:     'get-native-dialog-history',
+    getConsoleMessages:         'get-console-messages',
     setTestSpeed:               'set-test-speed',
     setPageLoadTimeout:         'set-page-load-timeout',
     debug:                      'debug',

--- a/src/test-run/commands/type.js
+++ b/src/test-run/commands/type.js
@@ -34,7 +34,7 @@ export default {
     switchToMainWindow:         'switch-to-main-window',
     setNativeDialogHandler:     'set-native-dialog-handler',
     getNativeDialogHistory:     'get-native-dialog-history',
-    getConsoleMessages:         'get-console-messages',
+    getBrowserConsoleMessages:  'get-browser-console-messages',
     setTestSpeed:               'set-test-speed',
     setPageLoadTimeout:         'set-page-load-timeout',
     debug:                      'debug',

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -352,8 +352,7 @@ export default class TestRun extends Session {
 
         var currentTaskRejectedByError = pageError && this._handlePageErrorStatus(pageError);
 
-        if (driverStatus.consoleMessages)
-            this.consoleMessages.concat(driverStatus.consoleMessages);
+        this.consoleMessages.concat(driverStatus.consoleMessages);
 
         if (!currentTaskRejectedByError && driverStatus.isCommandResult) {
             if (this.currentDriverTask.command.type === COMMAND_TYPE.testDone) {

--- a/test/functional/fixtures/api/es-next/console/pages/empty.html
+++ b/test/functional/fixtures/api/es-next/console/pages/empty.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Console messages (empty page)</title>
+</head>
+<body>
+</body>
+</html>

--- a/test/functional/fixtures/api/es-next/console/pages/index.html
+++ b/test/functional/fixtures/api/es-next/console/pages/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Console messages</title>
+</head>
+<body>
+<button id="trigger-messages">Trigger Messages</button>
+
+<a id="reload" href="./empty.html">Reload</a>
+
+<script>
+    var counter = 1;
+
+    function triggerMessages () {
+        console.log('log' + counter);
+        console.warn('warn' + counter);
+        console.error('error' + counter);
+        console.info('info' + counter);
+
+        counter++;
+    }
+
+    triggerMessages();
+    document.querySelector('#trigger-messages').addEventListener('click', triggerMessages);
+</script>
+</body>
+</html>

--- a/test/functional/fixtures/api/es-next/console/test.js
+++ b/test/functional/fixtures/api/es-next/console/test.js
@@ -1,0 +1,9 @@
+describe('[API] t.getConsoleMessages()', function () {
+    it('Should return messages from the console', function () {
+        return runTests('./testcafe-fixtures/console-test.js', 't.getConsoleMessages');
+    });
+
+    it('Should format messages if several args were passed', function () {
+        return runTests('./testcafe-fixtures/console-test.js', 'messages formatting');
+    });
+});

--- a/test/functional/fixtures/api/es-next/console/test.js
+++ b/test/functional/fixtures/api/es-next/console/test.js
@@ -1,6 +1,6 @@
-describe('[API] t.getConsoleMessages()', function () {
+describe('[API] t.getBrowserConsoleMessages()', function () {
     it('Should return messages from the console', function () {
-        return runTests('./testcafe-fixtures/console-test.js', 't.getConsoleMessages');
+        return runTests('./testcafe-fixtures/console-test.js', 't.getBrowserConsoleMessages');
     });
 
     it('Should format messages if several args were passed', function () {

--- a/test/functional/fixtures/api/es-next/console/testcafe-fixtures/console-test.js
+++ b/test/functional/fixtures/api/es-next/console/testcafe-fixtures/console-test.js
@@ -17,6 +17,10 @@ test
         // Check the driver keeps the messages between page reloads
         .click('#reload');
 
+    // Changes in the getBrowserConsoleMessages result object should
+    // not affect the console messages state in the test run.
+    messages.log.push('unexpected');
+
     messages = await t.getBrowserConsoleMessages();
 
     await t

--- a/test/functional/fixtures/api/es-next/console/testcafe-fixtures/console-test.js
+++ b/test/functional/fixtures/api/es-next/console/testcafe-fixtures/console-test.js
@@ -1,0 +1,39 @@
+fixture `Double Click`;
+
+
+test
+    .page `http://localhost:3000/fixtures/api/es-next/console/pages/index.html`
+('t.getConsoleMessages', async t => {
+    let messages = await t.getConsoleMessages();
+
+    await t
+        .expect(messages.error).eql(['error1'])
+        .expect(messages.warn).eql(['warn1'])
+        .expect(messages.log).eql(['log1'])
+        .expect(messages.info).eql(['info1'])
+
+        .click('#trigger-messages')
+
+        // Check the driver keeps the messages between page reloads
+        .click('#reload');
+
+    messages = await t.getConsoleMessages();
+
+    await t
+        .expect(messages.error).eql(['error1', 'error2'])
+        .expect(messages.warn).eql(['warn1', 'warn2'])
+        .expect(messages.log).eql(['log1', 'log2'])
+        .expect(messages.info).eql(['info1', 'info2']);
+});
+
+test
+    .page `http://localhost:3000/fixtures/api/es-next/console/pages/empty.html`
+('messages formatting', async t => {
+    /* eslint-disable no-console */
+    await t.eval(() => console.log('a', 1, null, void 0, ['b', 2], { c: 3 }));
+    /* eslint-enable no-console */
+
+    const { log } = await t.getConsoleMessages();
+
+    await t.expect(log[0]).eql('a 1 null undefined b,2 [object Object]');
+});

--- a/test/functional/fixtures/api/es-next/console/testcafe-fixtures/console-test.js
+++ b/test/functional/fixtures/api/es-next/console/testcafe-fixtures/console-test.js
@@ -3,8 +3,8 @@ fixture `Double Click`;
 
 test
     .page `http://localhost:3000/fixtures/api/es-next/console/pages/index.html`
-('t.getConsoleMessages', async t => {
-    let messages = await t.getConsoleMessages();
+('t.getBrowserConsoleMessages', async t => {
+    let messages = await t.getBrowserConsoleMessages();
 
     await t
         .expect(messages.error).eql(['error1'])
@@ -17,7 +17,7 @@ test
         // Check the driver keeps the messages between page reloads
         .click('#reload');
 
-    messages = await t.getConsoleMessages();
+    messages = await t.getBrowserConsoleMessages();
 
     await t
         .expect(messages.error).eql(['error1', 'error2'])
@@ -33,7 +33,7 @@ test
     await t.eval(() => console.log('a', 1, null, void 0, ['b', 2], { c: 3 }));
     /* eslint-enable no-console */
 
-    const { log } = await t.getConsoleMessages();
+    const { log } = await t.getBrowserConsoleMessages();
 
     await t.expect(log[0]).eql('a 1 null undefined b,2 [object Object]');
 });

--- a/test/functional/fixtures/api/es-next/console/testcafe-fixtures/console-test.js
+++ b/test/functional/fixtures/api/es-next/console/testcafe-fixtures/console-test.js
@@ -1,4 +1,4 @@
-fixture `Double Click`;
+fixture `getBrowserConsoleMessages`;
 
 
 test

--- a/test/functional/fixtures/api/es-next/roles/test.js
+++ b/test/functional/fixtures/api/es-next/roles/test.js
@@ -23,7 +23,7 @@ describe('[API] t.useRole()', function () {
         return runTests('./testcafe-fixtures/configuration-test.js', 'Clear configuration', TEST_WITH_IFRAME_FAILED_RUN_OPTIONS)
             .catch(function (errs) {
                 expect(errs[0]).contains('- Error in Role initializer - A native alert dialog was invoked');
-                expect(errs[0]).contains('> 32 |    await t.click(showAlertBtn);');
+                expect(errs[0]).contains('> 34 |    await t.click(showAlertBtn);');
             });
     });
 

--- a/test/server/data/test-suites/typescript-defs/test-controller.ts
+++ b/test/server/data/test-suites/typescript-defs/test-controller.ts
@@ -772,9 +772,13 @@ test('t.getBrowserConsoleMessages', async t => {
 
 test('messages formatting', async t => {
     // Several arguments
-    await t.eval(() => console.log('a', 1, null, void 0, ['b', 2], {c: 3}))
+    await t.eval(() => console.log('a', 1, null, void 0, ['b', 2], {c: 3}));
 
-    let {log} = await t.getBrowserConsoleMessages();
+    const messages = await t.getBrowserConsoleMessages();
 
-    await t.expect(log[0]).eql('a 1 null undefined b,2 [object Object]');
+    await t
+        .expect(messages.log[0]).eql('a 1 null undefined b,2 [object Object]')
+        .expect(messages.info.length).eql(0)
+        .expect(messages.warn.length).eql(0)
+        .expect(messages.error.length).eql(0);
 });

--- a/test/server/data/test-suites/typescript-defs/test-controller.ts
+++ b/test/server/data/test-suites/typescript-defs/test-controller.ts
@@ -747,8 +747,8 @@ test('Chaining callsites', async t => {
         .click('#btn3');
 });
 
-test('t.getConsoleMessages', async t => {
-    let messages = await t.getConsoleMessages();
+test('t.getBrowserConsoleMessages', async t => {
+    let messages = await t.getBrowserConsoleMessages();
 
     await t
         .expect(messages.error).eql(['error1'])
@@ -761,7 +761,7 @@ test('t.getConsoleMessages', async t => {
         // Check the driver keeps the messages between page reloads
         .click('#reload');
 
-    messages = await t.getConsoleMessages();
+    messages = await t.getBrowserConsoleMessages();
 
     await t
         .expect(messages.error).eql(['error1', 'error2'])
@@ -774,7 +774,7 @@ test('messages formatting', async t => {
     // Several arguments
     await t.eval(() => console.log('a', 1, null, void 0, ['b', 2], {c: 3}))
 
-    let {log} = await t.getConsoleMessages();
+    let {log} = await t.getBrowserConsoleMessages();
 
     await t.expect(log[0]).eql('a 1 null undefined b,2 [object Object]');
 });

--- a/test/server/data/test-suites/typescript-defs/test-controller.ts
+++ b/test/server/data/test-suites/typescript-defs/test-controller.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../../ts-defs/index.d.ts" />
-import {Selector, ClientFunction} from 'testcafe';
-import {expect} from 'chai';
+import { Selector, ClientFunction } from 'testcafe';
+import { expect } from 'chai';
 
 fixture(`TestController`)
     .page(`http://localhost:3000/fixtures/api/es-next/assertions/pages/index.html`);

--- a/test/server/data/test-suites/typescript-defs/test-controller.ts
+++ b/test/server/data/test-suites/typescript-defs/test-controller.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../../ts-defs/index.d.ts" />
-import { Selector, ClientFunction } from 'testcafe';
-import { expect } from 'chai';
+import {Selector, ClientFunction} from 'testcafe';
+import {expect} from 'chai';
 
 fixture(`TestController`)
     .page(`http://localhost:3000/fixtures/api/es-next/assertions/pages/index.html`);
@@ -704,7 +704,7 @@ test('Take a screenshot in quarantine mode', async t => {
 
 
 test('Type text in input', async t => {
-    await t.typeText('#input', 'a', { replace: true });
+    await t.typeText('#input', 'a', {replace: true});
 });
 
 
@@ -745,4 +745,36 @@ test('Chaining callsites', async t => {
         .click('#btn2')
         .click('#error')
         .click('#btn3');
+});
+
+test('t.getConsoleMessages', async t => {
+    let messages = await t.getConsoleMessages();
+
+    await t
+        .expect(messages.error).eql(['error1'])
+        .expect(messages.warn).eql(['warn1'])
+        .expect(messages.log).eql(['log1'])
+        .expect(messages.info).eql(['info1'])
+
+        .click('#trigger-messages')
+
+        // Check the driver keeps the messages between page reloads
+        .click('#reload');
+
+    messages = await t.getConsoleMessages();
+
+    await t
+        .expect(messages.error).eql(['error1', 'error2'])
+        .expect(messages.warn).eql(['warn1', 'warn2'])
+        .expect(messages.log).eql(['log1', 'log2'])
+        .expect(messages.info).eql(['info1', 'info2']);
+});
+
+test('messages formatting', async t => {
+    // Several arguments
+    await t.eval(() => console.log('a', 1, null, void 0, ['b', 2], {c: 3}))
+
+    let {log} = await t.getConsoleMessages();
+
+    await t.expect(log[0]).eql('a 1 null undefined b,2 [object Object]');
 });

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -799,21 +799,21 @@ interface NativeDialogHistoryItem {
     url: string;
 }
 
-interface ConsoleMessagesCollection {
+interface BrowserConsoleMessages {
     /**
-     * TODO:
+     * Messages output to the browser console by the console.log() method.
      */
     log: string[],
     /**
-     * TODO:
+     * Warning messages output to the browser console by the console.warn() method.
      */
     warn: string[],
     /**
-     * TODO:
+     * Error messages output to the browser console by the console.error() method.
      */
     error: string[],
     /**
-     * TODO:
+     * Information messages output to the browser console by the console.info() method.
      */
     info: string[]
 }
@@ -1024,9 +1024,9 @@ interface TestController {
      */
     getNativeDialogHistory(): Promise<NativeDialogHistoryItem[]>;
     /**
-     * TODO: Returns a collection of browser console messages.
+     * Returns an object that contains messages output to the browser console.
      */
-    getConsoleMessages(): Promise<ConsoleMessagesCollection>;
+    getBrowserConsoleMessages(): Promise<BrowserConsoleMessages>;
     /**
      * Starts an assertion chain and specifies assertion actual value.
      *

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -799,6 +799,25 @@ interface NativeDialogHistoryItem {
     url: string;
 }
 
+interface ConsoleMessagesCollection {
+    /**
+     * TODO:
+     */
+    log: string[],
+    /**
+     * TODO:
+     */
+    warn: string[],
+    /**
+     * TODO:
+     */
+    error: string[],
+    /**
+     * TODO:
+     */
+    info: string[]
+}
+
 interface TestController {
     /**
      * Dictionary that is shared between test hook functions and test code.
@@ -1004,6 +1023,10 @@ interface TestController {
      * corresponds to a certain native dialog that appears in the main window or in an `<iframe>`.
      */
     getNativeDialogHistory(): Promise<NativeDialogHistoryItem[]>;
+    /**
+     * TODO: Returns a collection of browser console messages.
+     */
+    getConsoleMessages(): Promise<ConsoleMessagesCollection>;
     /**
      * Starts an assertion chain and specifies assertion actual value.
      *


### PR DESCRIPTION
## Feature summary

### API
```js
const consoleMessages = await t.getBrowserConsoleMessages();

// returns arrays of messages in the browser console for...
// ...console.log()
const logs = consoleMessages.log;         // -> ['some log message 1', 'some log message 2']
// ...console.error()
const errors = consoleMessages.error;   // -> ['some error message'] 
// ...console.warn()
const warnings = consoleMessages.warn;   // -> ['some warning message'] 
// ...console.info()
const info = consoleMessages.info;   // -> ['some info message'] 
```

Some browsers can write messages to the console with a little bit different formatting. We just call `toString()` for arguments that were passed to the console methods (see an example in the [test](https://github.com/DevExpress/testcafe/compare/master...AlexanderMoskovkin:gh-1738?expand=1#diff-de9a031b2f8d42f2b6046cefbe1a9a7eR779))

### Real-World Use Case
Check your react application doesn't have prop type errors:

```js
// check-prop-types.js
import { t } from 'testcafe';

export default async function () {
    const { error } = await t.getBrowserConsoleMessages();
        
    await t.expect(error[0]).notOk();
}

// test.js
import { Selector } from 'testcafe';
import checkPropTypes from './check-prop-types';

fixture `react example`
    .page `http://localhost:8080/`  // https://github.com/mzabriskie/react-example
    .afterEach(() => checkPropTypes());

test('test', async t => {
    await t
        .typeText(Selector('.form-control'), 'devexpress')
        .click(Selector('button').withText('Go'))
        .click(Selector('h4').withText('Organizations'));
});
```