### PR TITLE
Fix potential NPE in getElementFromPoint

### DIFF
--- a/src/client/core/utils/position.js
+++ b/src/client/core/utils/position.js
@@ -229,7 +229,7 @@ export function getElementFromPoint (x, y) {
     if (el === null)
         el = func.call(document, x - 1, y - 1);
 
-    while (el && el.shadowRoot) {
+    while (el && el.shadowRoot && el.shadowRoot.elementFromPoint) {
         var shadowEl = el.shadowRoot.elementFromPoint(x, y);
 
         if (!shadowEl)


### PR DESCRIPTION
`elementFromPoint` part of DocumentOrShadowRoot interface is not fully supported by all browsers. If you are using a polyfill for ShadowDOM, it is likely that 'elementFromPoint' will not be available. Adding a check to ensure that it doesn't result in NPE.
https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/elementFromPoint