### PR TITLE
Fix the "Cannot redefine property" error (closes #1996).

### DIFF
--- a/src/client/automation/index.js
+++ b/src/client/automation/index.js
@@ -48,9 +48,7 @@ exports.cursor                       = cursor;
 exports.get = require;
 
 hammerhead.nativeMethods.objectDefineProperty.call(window, window, '%testCafeAutomation%', {
-    enumerable:   false,
     configurable: true,
-    writable:     false,
     value:        exports
 });
 

--- a/src/client/automation/index.js
+++ b/src/client/automation/index.js
@@ -49,7 +49,7 @@ exports.get = require;
 
 hammerhead.nativeMethods.objectDefineProperty.call(window, window, '%testCafeAutomation%', {
     enumerable:   false,
-    configurable: false,
+    configurable: true,
     writable:     false,
     value:        exports
 });

--- a/src/client/core/index.js
+++ b/src/client/core/index.js
@@ -58,7 +58,7 @@ exports.get = require;
 
 hammerhead.nativeMethods.objectDefineProperty.call(window, window, '%testCafeCore%', {
     enumerable:   false,
-    configurable: false,
+    configurable: true,
     writable:     false,
     value:        exports
 });

--- a/src/client/core/index.js
+++ b/src/client/core/index.js
@@ -57,9 +57,7 @@ exports.selectorAttributeFilter = selectorAttributeFilter;
 exports.get = require;
 
 hammerhead.nativeMethods.objectDefineProperty.call(window, window, '%testCafeCore%', {
-    enumerable:   false,
     configurable: true,
-    writable:     false,
     value:        exports
 });
 

--- a/src/client/driver/command-executors/client-functions/selector-executor/filter.js
+++ b/src/client/driver/command-executors/client-functions/selector-executor/filter.js
@@ -59,5 +59,6 @@ hammerhead.nativeMethods.objectDefineProperty.call(window, window, '%testCafeSel
         }
 
         return getNodeByIndex(filtered, options.index || 0);
-    }
+    },
+    configurable: true
 });

--- a/src/client/driver/index.js
+++ b/src/client/driver/index.js
@@ -6,30 +6,22 @@ import embeddingUtils from './embedding-utils';
 
 
 hammerhead.nativeMethods.objectDefineProperty.call(window, window, '%testCafeDriver%', {
-    enumerable:   false,
     configurable: true,
-    writable:     false,
     value:        Driver
 });
 
 hammerhead.nativeMethods.objectDefineProperty.call(window, window, '%testCafeIframeDriver%', {
-    enumerable:   false,
     configurable: true,
-    writable:     false,
     value:        IframeDriver
 });
 
 hammerhead.nativeMethods.objectDefineProperty.call(window, window, '%ScriptExecutionBarrier%', {
-    enumerable:   false,
     configurable: true,
-    writable:     false,
     value:        ScriptExecutionBarrier
 });
 
 hammerhead.nativeMethods.objectDefineProperty.call(window, window, '%testCafeEmbeddingUtils%', {
-    enumerable:   false,
     configurable: true,
-    writable:     false,
     value:        embeddingUtils
 });
 

--- a/src/client/driver/index.js
+++ b/src/client/driver/index.js
@@ -7,28 +7,28 @@ import embeddingUtils from './embedding-utils';
 
 hammerhead.nativeMethods.objectDefineProperty.call(window, window, '%testCafeDriver%', {
     enumerable:   false,
-    configurable: false,
+    configurable: true,
     writable:     false,
     value:        Driver
 });
 
 hammerhead.nativeMethods.objectDefineProperty.call(window, window, '%testCafeIframeDriver%', {
     enumerable:   false,
-    configurable: false,
+    configurable: true,
     writable:     false,
     value:        IframeDriver
 });
 
 hammerhead.nativeMethods.objectDefineProperty.call(window, window, '%ScriptExecutionBarrier%', {
     enumerable:   false,
-    configurable: false,
+    configurable: true,
     writable:     false,
     value:        ScriptExecutionBarrier
 });
 
 hammerhead.nativeMethods.objectDefineProperty.call(window, window, '%testCafeEmbeddingUtils%', {
     enumerable:   false,
-    configurable: false,
+    configurable: true,
     writable:     false,
     value:        embeddingUtils
 });

--- a/src/client/test-run/iframe.js.mustache
+++ b/src/client/test-run/iframe.js.mustache
@@ -8,4 +8,11 @@
     });
 
     driver.start();
+
+    Object.defineProperty(window, '%testCafeDriverInstance%', {
+        enumerable:   false,
+        configurable: true,
+        writable:     false,
+        value:        driver
+    });
 })();

--- a/src/client/test-run/iframe.js.mustache
+++ b/src/client/test-run/iframe.js.mustache
@@ -10,9 +10,7 @@
     driver.start();
 
     Object.defineProperty(window, '%testCafeDriverInstance%', {
-        enumerable:   false,
         configurable: true,
-        writable:     false,
         value:        driver
     });
 })();

--- a/src/client/test-run/index.js.mustache
+++ b/src/client/test-run/index.js.mustache
@@ -29,9 +29,7 @@
     );
 
     Object.defineProperty(window, '%testCafeDriverInstance%', {
-        enumerable:   false,
         configurable: true,
-        writable:     false,
         value:        driver
     });
 

--- a/src/client/test-run/index.js.mustache
+++ b/src/client/test-run/index.js.mustache
@@ -30,7 +30,7 @@
 
     Object.defineProperty(window, '%testCafeDriverInstance%', {
         enumerable:   false,
-        configurable: false,
+        configurable: true,
         writable:     false,
         value:        driver
     });

--- a/src/client/ui/index.js
+++ b/src/client/ui/index.js
@@ -60,7 +60,7 @@ exports.show = function (showTopRoot) {
 
 hammerhead.nativeMethods.objectDefineProperty.call(window, window, '%testCafeUI%', {
     enumerable:   false,
-    configurable: false,
+    configurable: true,
     writable:     false,
     value:        exports
 });

--- a/src/client/ui/index.js
+++ b/src/client/ui/index.js
@@ -59,9 +59,7 @@ exports.show = function (showTopRoot) {
 };
 
 hammerhead.nativeMethods.objectDefineProperty.call(window, window, '%testCafeUI%', {
-    enumerable:   false,
     configurable: true,
-    writable:     false,
     value:        exports
 });
 

--- a/test/functional/fixtures/regression/gh-1999/pages/index.html
+++ b/test/functional/fixtures/regression/gh-1999/pages/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>gh-1999</title>
+</head>
+<body>
+    <iframe id="iframe" src="javascript:'<html><body>Empty</body></html>'"></iframe>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-1999/test.js
+++ b/test/functional/fixtures/regression/gh-1999/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-1999)', function () {
+    it("Shouldn't raise an error if an iframe has html in src", function () {
+        return runTests('testcafe-fixtures/index.js', null, { only: 'chrome' });
+    });
+});

--- a/test/functional/fixtures/regression/gh-1999/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-1999/testcafe-fixtures/index.js
@@ -1,0 +1,8 @@
+fixture `GH-1999 - Shouldn't raise an error if an iframe has html in src`
+    .page `http://localhost:3000/fixtures/regression/gh-1999/pages/index.html`;
+
+test('Click in iframe', async t => {
+    await t
+        .switchToIframe('#iframe')
+        .click('body');
+});


### PR DESCRIPTION
Additionally Define the "testcafeDriverInstance" client global var in iframes.

/cc @AndreyBelym @miherlosev 