### PR TITLE
Customize the proxy protocol

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,14 +36,15 @@ async function getValidPort (port) {
 }
 
 // API
-async function createTestCafe (hostname, port1, port2) {
-    [hostname, port1, port2] = await Promise.all([
+async function createTestCafe (hostname, port1, port2, protocol) {
+    [hostname, port1, port2, protocol] = await Promise.all([
         getValidHostname(hostname),
         getValidPort(port1),
-        getValidPort(port2)
+        getValidPort(port2),
+        protocol
     ]);
 
-    var testcafe = new TestCafe(hostname, port1, port2);
+    var testcafe = new TestCafe(hostname, port1, port2, protocol);
 
     setupExitHook(cb => testcafe.close().then(cb));
 

--- a/src/testcafe.js
+++ b/src/testcafe.js
@@ -18,9 +18,9 @@ const FAVICON           = read('./client/ui/favicon.ico', true);
 
 
 export default class TestCafe {
-    constructor (hostname, port1, port2) {
+    constructor (hostname, port1, port2, protocol) {
         this.closed                   = false;
-        this.proxy                    = new Proxy(hostname, port1, port2);
+        this.proxy                    = new Proxy(hostname, port1, port2, protocol);
         this.browserConnectionGateway = new BrowserConnectionGateway(this.proxy);
         this.runners                  = [];
 

--- a/test/server/create-testcafe-test.js
+++ b/test/server/create-testcafe-test.js
@@ -10,8 +10,8 @@ describe('TestCafe factory function', function () {
     var testCafe = null;
     var server   = null;
 
-    function getTestCafe (hostname, port1, port2) {
-        return createTestCafe(hostname, port1, port2)
+    function getTestCafe (hostname, port1, port2, protocol) {
+        return createTestCafe(hostname, port1, port2, protocol)
             .then(function (tc) {
                 testCafe = tc;
             });
@@ -54,6 +54,21 @@ describe('TestCafe factory function', function () {
                 var port  = parseInt(bcUrl.port, 10);
 
                 expect(bcUrl.hostname).eql('localhost');
+                expect(port).eql(1338);
+            });
+    });
+
+    it('Should accept custom ports, hostname and protocol', function () {
+        return getTestCafe('localhost', 1338, 1339, 'https')
+            .then(function () {
+                return testCafe.createBrowserConnection();
+            })
+            .then(function (bc) {
+                var bcUrl = url.parse(bc.url);
+                var port  = parseInt(bcUrl.port, 10);
+
+                expect(bcUrl.hostname).eql('localhost');
+                expect(bcUrl.protocol).eql('https:');
                 expect(port).eql(1338);
             });
     });


### PR DESCRIPTION
* Related Issue:  #1985 

* Purpose:
When the load balance on AWS is used to handle SSL, not testcafe server handles SSL, I would like to customize the protocol of testcafe runner as `https`, instead of `http`.  Another [PR](https://github.com/DevExpress/testcafe-hammerhead/pull/1431) is created on testcafe-hammerhead to pass protocol data to customize the proxy protocol.


