### PR TITLE
Update `testcafe-legacy-api`

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "1.4.6",
     "testcafe-hammerhead": "12.1.6",
-    "testcafe-legacy-api": "3.1.3",
+    "testcafe-legacy-api": "3.1.4",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",
     "testcafe-reporter-minimal": "^2.1.0",


### PR DESCRIPTION
The legacy tests is fixed by this version of the `testcafe-legacy-api`.