### PR TITLE
update hammerhead and remove unnecessary util methods

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -8,7 +8,7 @@
     "gitTag": true
   },
   "confirm": true,
-  "publishTag": "latest",
+  "publishTag": "dev",
   "prePublishScript": "gulp test-server",
   "postPublishScript": "gulp docker-publish"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "0.18.7-dev20180111",
+  "version": "0.18.7-dev20180112",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "0.18.6",
+  "version": "0.18.7-dev20180111",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"
@@ -102,7 +102,7 @@
     "stack-chain": "^1.3.6",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "1.4.6",
-    "testcafe-hammerhead": "12.1.6",
+    "testcafe-hammerhead": "12.1.7",
     "testcafe-legacy-api": "3.1.4",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/src/api/test-run-tracker.js
+++ b/src/api/test-run-tracker.js
@@ -4,19 +4,6 @@ import BabelPromise from 'babel-runtime/core-js/promise';
 const TRACKING_MARK_RE = /^\$\$testcafe_test_run\$\$(\S+)\$\$$/;
 const STACK_CAPACITY   = 5000;
 
-// Utils
-// NOTE: testRunId may contain '-' which is not allowed in function names.
-// But it's guaranteed that it will never contain '$'
-// (see: https://github.com/dylang/shortid#charactersstring)
-// So we use '$' to encode '-'.
-function encodeTestRunId (testRunId) {
-    return testRunId.replace(/-/g, '$');
-}
-
-function decodeTestRunId (testRunId) {
-    return testRunId.replace(/\$/g, '-');
-}
-
 // Tracker
 export default {
     enabled: false,
@@ -74,7 +61,7 @@ export default {
 
     addTrackingMarkerToFunction (testRunId, fn) {
         var markerFactoryBody = `
-            return function $$testcafe_test_run$$${encodeTestRunId(testRunId)}$$ () {
+            return function $$testcafe_test_run$$${testRunId}$$ () {
                 switch (arguments.length) {
                     case 0: return fn.call(this);
                     case 1: return fn.call(this, arguments[0]);
@@ -102,7 +89,7 @@ export default {
             var match  = fnName && fnName.match(TRACKING_MARK_RE);
 
             if (match)
-                return decodeTestRunId(match[1]);
+                return match[1];
         }
 
         return null;

--- a/test/server/test-run-tracker-test.js
+++ b/test/server/test-run-tracker-test.js
@@ -9,7 +9,7 @@ describe('Test run tracker', function () {
     function runTest (testName) {
         var src         = 'test/server/data/test-run-tracking/' + testName;
         var compiler    = new Compiler([src]);
-        var testRunMock = { id: 'dB_J4h-H' };
+        var testRunMock = { id: 'dB_J4h0H' };
         var expected    = fill(Array(3), testRunMock.id);
 
         return compiler.getTests()


### PR DESCRIPTION
@AlexanderMoskovkin @AndreyBelym @helen-dikareva 

Now, `testRunId` does not contain the '-' symbol.