### PR TITLE
Allow decorators to be used in typescript code (#2117)

### DIFF
--- a/src/compiler/test-file/formats/typescript/compiler.js
+++ b/src/compiler/test-file/formats/typescript/compiler.js
@@ -12,6 +12,8 @@ export default class TypeScriptTestFileCompiler extends APIBasedTestFileCompiler
         var ts = require('typescript');
 
         return {
+            experimentalDecorators:  true,
+            emitDecoratorMetadata:   true,
             allowJs:                 true,
             pretty:                  true,
             inlineSourceMap:         true,

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -566,7 +566,8 @@ describe('Compiler', function () {
                         message: 'Cannot prepare tests due to an error.\n\n' +
                                  'Error: TypeScript compilation failed.\n' +
                                  testfile + ' (6, 13): Property \'doSmthg\' does not exist on type \'TestController\'.\n' +
-                                 testfile + ' (9, 6): Argument of type \'123\' is not assignable to parameter of type \'string\'.\n'
+                                 testfile + ' (9, 6): Argument of type \'123\' is not assignable to parameter of type \'string\'.\n' +
+                                 testfile + ' (18, 5): Unable to resolve signature of property decorator when called as an expression.\n'
                     });
                 });
         });

--- a/test/server/data/test-suites/typescript-basic/testfile1.ts
+++ b/test/server/data/test-suites/typescript-basic/testfile1.ts
@@ -23,3 +23,29 @@ fixture(`Fixture${1 + 1}`)
 test('Fixture2Test1', async() => {
     return 'F2T1';
 });
+
+// Decorators
+function foo () {
+    return function (target, propertyKey: string, descriptor: PropertyDescriptor) {
+        Object.assign({}, { msg: `target is ${target}` });
+    };
+}
+
+function sealed(constructor: Function) {
+    Object.seal(constructor);
+    Object.seal(constructor.prototype);
+}
+
+@sealed
+class Greeter {
+    greeting: string;
+
+    constructor(message: string) {
+        this.greeting = message;
+    }
+
+    @foo()
+    greet() {
+        return "Hello, " + this.greeting;
+    }
+}

--- a/test/server/data/test-suites/typescript-compile-errors/testfile.ts
+++ b/test/server/data/test-suites/typescript-compile-errors/testfile.ts
@@ -8,3 +8,21 @@ test('Yo', async t => {
 
 test(123, async() => {
 });
+
+function sealed(constructor: Function) {
+    Object.seal(constructor);
+    Object.seal(constructor.prototype);
+}
+
+class Greeter {
+    @sealed
+    greeting: string;
+
+    constructor(message: string) {
+        this.greeting = message;
+    }
+
+    greet() {
+        return "Hello, " + this.greeting;
+    }
+}


### PR DESCRIPTION
fixes #2117


### Tests results:

#### `gulp test-server`
> 325 passing (20s)
>
> [05:42:04] Finished 'test-server' after 21 s

#### `gulp test-functional-local` 
fails for me with "TypeError: Cannot read property 'path' of null" in `before all` hook

#### `gulp test-client` 
just hangs - "QUnit server listens on http://localhost:2000" displayed message forever

Same happens in `master`so i donth  think this is related to my changes.


Can you please suggest how to properly configure my local environment to be able to run all required tests so this small change could be merged into your app? Or maybe you could ran test in your environment and approve suggested changes. Decorators are quite useful and it would be great to be able to use them to have a clean and nice test scenarios...

P.S.: Im using same patch locally for a few weeks and found no issues with decorators enabled.
