### PR TITLE
add --force flag for npm cache clean command

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ COPY . /opt/testcafe
 
 RUN cd /opt/testcafe; \
  npm install --production && \
- npm cache clean && \
+ npm cache clean --force && \
  rm -rf /tmp/* && \
  chmod +x /opt/testcafe/docker/testcafe-docker.sh && \
  adduser -D user


### PR DESCRIPTION
@AlexanderMoskovkin  @AndreyBelym 
For fresh npm version (I have `5.6.0`) need to specify `--force` flag for `npm cache clean` command.
See https://docs.npmjs.com/cli/cache#details.