### PR TITLE
fix mocha timeout in debug mode

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -274,9 +274,7 @@ gulp.task('test-server', ['build'], function () {
     return gulp
         .src('test/server/*-test.js', { read: false })
         .pipe(mocha({
-            ui:       'bdd',
-            reporter: 'spec',
-            timeout:  typeof v8debug === 'undefined' ? 2000 : Infinity // NOTE: disable timeouts in debug
+            timeout: typeof v8debug !== 'undefined' || !!process.debugPort ? Infinity : 2000 // NOTE: disable timeouts in debug
         }));
 });
 


### PR DESCRIPTION
@AlexanderMoskovkin @AndreyBelym 

Changes
* Fix timeout for mocha debug mode. In new nodejs versions (6.x and later) `v8debug` global object was removed (https://github.com/nodejs/node/pull/6599).
* remove mocha config properties with default values: `ui`, `reporter`.