### PR TITLE
[docs] Add Firefox profile command to user-profiles docs

### DIFF
--- a/docs/articles/documentation/using-testcafe/common-concepts/browsers/user-profiles.md
+++ b/docs/articles/documentation/using-testcafe/common-concepts/browsers/user-profiles.md
@@ -13,6 +13,12 @@ However, if you need to start a browser with the current user profile, you can d
 testcafe firefox:userProfile tests/test.js
 ```
 
+In some versions of Firefox, you may need to run the following:
+
+```sh
+testcafe "firefox -P userProfile" tests/test.js
+```
+
 ```js
 runner
     .src('tests/fixture1.js')


### PR DESCRIPTION
In the [`User Profile`](http://devexpress.github.io/testcafe/documentation/using-testcafe/common-concepts/browsers/user-profiles.html) section of the docs, the command to open Firefox with a specific user profile was not working.

This PR updates the docs to reflect the proper command: `testcafe "firefox -P userProfile" tests/test.js`
