### PR TITLE
add typescript defs for new features (close #2428)

### DIFF
--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -1,14 +1,14 @@
-var expect            = require('chai').expect;
-var resolve           = require('path').resolve;
-var readFile          = require('fs').readFileSync;
-var Promise           = require('pinkie');
-var renderers         = require('callsite-record').renderers;
-var ERR_TYPE          = require('../../lib/errors/test-run/type');
-var exportableLib     = require('../../lib/api/exportable-lib');
-var NODE_VER          = require('../../lib/utils/node-version');
-var createStackFilter = require('../../lib/errors/create-stack-filter.js');
-var assertError       = require('./helpers/assert-error').assertError;
-var compile           = require('./helpers/compile');
+const expect            = require('chai').expect;
+const path              = require('path');
+const fs                = require('fs');
+const Promise           = require('pinkie');
+const renderers         = require('callsite-record').renderers;
+const ERR_TYPE          = require('../../lib/errors/test-run/type');
+const exportableLib     = require('../../lib/api/exportable-lib');
+const NODE_VER          = require('../../lib/utils/node-version');
+const createStackFilter = require('../../lib/errors/create-stack-filter.js');
+const assertError       = require('./helpers/assert-error').assertError;
+const compile           = require('./helpers/compile');
 
 describe('Compiler', function () {
     var testRunMock = { id: 'yo' };
@@ -16,8 +16,8 @@ describe('Compiler', function () {
     this.timeout(20000);
 
     // FIXME: Babel errors always contain POSIX-format file paths.
-    function posixResolve (path) {
-        return resolve(path).replace(new RegExp('\\\\', 'g'), '/');
+    function posixResolve (pathname) {
+        return path.resolve(pathname).replace(new RegExp('\\\\', 'g'), '/');
     }
 
     it('Should compile mixed content', function () {
@@ -49,8 +49,8 @@ describe('Compiler', function () {
 
             return compile(sources)
                 .then(function (compiled) {
-                    var testfile1 = resolve('test/server/data/test-suites/basic/testfile1.js');
-                    var testfile2 = resolve('test/server/data/test-suites/basic/testfile2.js');
+                    var testfile1 = path.resolve('test/server/data/test-suites/basic/testfile1.js');
+                    var testfile2 = path.resolve('test/server/data/test-suites/basic/testfile2.js');
                     var tests     = compiled.tests;
                     var fixtures  = compiled.fixtures;
 
@@ -142,8 +142,8 @@ describe('Compiler', function () {
 
             return compile(sources)
                 .then(function (compiled) {
-                    var testfile1 = resolve('test/server/data/test-suites/typescript-basic/testfile1.ts');
-                    var testfile2 = resolve('test/server/data/test-suites/typescript-basic/testfile2.ts');
+                    var testfile1 = path.resolve('test/server/data/test-suites/typescript-basic/testfile1.ts');
+                    var testfile2 = path.resolve('test/server/data/test-suites/typescript-basic/testfile2.ts');
                     var tests     = compiled.tests;
                     var fixtures  = compiled.fixtures;
 
@@ -199,13 +199,12 @@ describe('Compiler', function () {
         });
 
         it('Should provide API definitions', function () {
-            var src = [
-                'test/server/data/test-suites/typescript-defs/structure.ts',
-                'test/server/data/test-suites/typescript-defs/selectors.ts',
-                'test/server/data/test-suites/typescript-defs/client-functions.ts',
-                'test/server/data/test-suites/typescript-defs/roles.ts',
-                'test/server/data/test-suites/typescript-defs/test-controller.ts'
-            ];
+            const typescriptDefsFolder = 'test/server/data/test-suites/typescript-defs/';
+            const src                  = [];
+
+            fs.readdirSync(typescriptDefsFolder).forEach(file => {
+                src.push(path.join(typescriptDefsFolder, file));
+            });
 
             return compile(src).then(function (compiled) {
                 expect(compiled.tests.length).gt(0);
@@ -232,7 +231,7 @@ describe('Compiler', function () {
 
             return compile(sources)
                 .then(function (compiled) {
-                    var testfile = resolve('test/server/data/test-suites/raw/test.testcafe');
+                    var testfile = path.resolve('test/server/data/test-suites/raw/test.testcafe');
                     var tests    = compiled.tests;
                     var fixtures = compiled.fixtures;
 
@@ -259,8 +258,8 @@ describe('Compiler', function () {
         });
 
         it('Should raise an error if it cannot parse a raw file', function () {
-            var testfile1 = resolve('test/server/data/test-suites/raw/invalid.testcafe');
-            var testfile2 = resolve('test/server/data/test-suites/raw/invalid2.testcafe');
+            var testfile1 = path.resolve('test/server/data/test-suites/raw/invalid.testcafe');
+            var testfile2 = path.resolve('test/server/data/test-suites/raw/invalid2.testcafe');
 
             return compile(testfile1)
                 .then(function () {
@@ -345,14 +344,14 @@ describe('Compiler', function () {
         function getExpected (testDir) {
             if (NODE_VER < 4) {
                 try {
-                    return readFile(testDir + '/expected-node10.js').toString();
+                    return fs.readFileSync(testDir + '/expected-node10.js').toString();
                 }
                 catch (err) {
                     // NOTE: ignore error - we don't have version-specific data
                 }
             }
 
-            return readFile(testDir + '/expected.js').toString();
+            return fs.readFileSync(testDir + '/expected.js').toString();
         }
 
         function testClientFnCompilation (testName) {
@@ -405,12 +404,12 @@ describe('Compiler', function () {
                 })
                 .catch(function (err) {
                     expect(err.message).eql('Cannot find a test source file at "' +
-                                            resolve('does/not/exists.js') + '".');
+                                            path.resolve('does/not/exists.js') + '".');
                 });
         });
 
         it('Should raise an error if test dependency has a syntax error', function () {
-            var testfile = resolve('test/server/data/test-suites/syntax-error-in-dep/testfile.js');
+            var testfile = path.resolve('test/server/data/test-suites/syntax-error-in-dep/testfile.js');
             var dep      = posixResolve('test/server/data/test-suites/syntax-error-in-dep/dep.js');
 
             return compile(testfile)
@@ -428,8 +427,8 @@ describe('Compiler', function () {
         });
 
         it("Should raise an error if dependency can't require a module", function () {
-            var testfile = resolve('test/server/data/test-suites/require-error-in-dep/testfile.js');
-            var dep      = resolve('test/server/data/test-suites/require-error-in-dep/dep.js');
+            var testfile = path.resolve('test/server/data/test-suites/require-error-in-dep/testfile.js');
+            var dep      = path.resolve('test/server/data/test-suites/require-error-in-dep/dep.js');
 
             return compile(testfile)
                 .then(function () {
@@ -449,8 +448,8 @@ describe('Compiler', function () {
         });
 
         it('Should raise an error if dependency throws runtime error', function () {
-            var testfile = resolve('test/server/data/test-suites/runtime-error-in-dep/testfile.js');
-            var dep      = resolve('test/server/data/test-suites/runtime-error-in-dep/dep.js');
+            var testfile = path.resolve('test/server/data/test-suites/runtime-error-in-dep/testfile.js');
+            var dep      = path.resolve('test/server/data/test-suites/runtime-error-in-dep/dep.js');
 
             return compile(testfile)
                 .then(function () {
@@ -470,7 +469,7 @@ describe('Compiler', function () {
         });
 
         it("Should raise an error if test file can't require a module", function () {
-            var testfile = resolve('test/server/data/test-suites/require-error-in-testfile/testfile.js');
+            var testfile = path.resolve('test/server/data/test-suites/require-error-in-testfile/testfile.js');
 
             return compile(testfile)
                 .then(function () {
@@ -487,7 +486,7 @@ describe('Compiler', function () {
         });
 
         it('Should raise an error if test file throws runtime error', function () {
-            var testfile = resolve('test/server/data/test-suites/runtime-error-in-testfile/testfile.js');
+            var testfile = path.resolve('test/server/data/test-suites/runtime-error-in-testfile/testfile.js');
 
             return compile(testfile)
                 .then(function () {

--- a/test/server/data/test-suites/typescript-defs/meta.ts
+++ b/test/server/data/test-suites/typescript-defs/meta.ts
@@ -1,0 +1,12 @@
+/// <reference path="../../../../../ts-defs/index.d.ts" />
+import { ClientFunction } from 'testcafe';
+
+fixture ('Fixture with metadata')
+    .meta('fixtureID', 'f-0001')
+    .meta({ author: 'John', creationDate: '05/03/2018' });
+
+test
+    .meta('testID', 't-0005')
+    .meta({ severity: 'critical', testedAPIVersion: '1.0' })
+    ('MyTest', async t => { /* ... */});
+

--- a/test/server/data/test-suites/typescript-defs/request-hooks.ts
+++ b/test/server/data/test-suites/typescript-defs/request-hooks.ts
@@ -1,0 +1,41 @@
+/// <reference path="../../../../../ts-defs/index.d.ts" />
+import {ClientFunction, RequestLogger, RequestMock, RequestHook} from 'testcafe';
+
+class CustomRequestHook extends RequestHook {
+    constructor() {
+        super();
+    }
+
+    onRequest(event) {
+
+    }
+
+    onResponse(event) {
+
+    }
+}
+
+const customHook = new CustomRequestHook();
+const logger     = RequestLogger('example.com', {logRequestBody: true});
+
+const mock = RequestMock()
+    .onRequestTo(/example.com/)
+    .respond()
+    .onRequestTo({url: 'https://example.com'})
+    .respond(null, 204)
+    .onRequestTo('https://example.com')
+    .respond(null, 200, {'x-frame-options': 'deny'});
+
+fixture `Request Hooks`
+    .requestHooks(mock, logger, customHook);
+
+test
+    .requestHooks(logger)
+    ('Request hook', async t => {
+        await t
+            .addRequestHooks(mock)
+            .removeRequestHooks(mock)
+            .expect(logger.contains(t => t.request.statusCode === 200)).ok()
+            .expect(logger.count(t => t.request.statusCode === 200)).eql(1)
+            .expect(logger.requests[0].request.body === 'test').ok();
+    });

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -1563,12 +1563,12 @@ declare module 'testcafe' {
     export function ClientFunction(fn: Function, options?: ClientFunctionOptions): ClientFunction;
 
     /**
-     * Creates a RequestMock
+     * Creates a request mock
      */
     export function RequestMock(): RequestMock;
 
     /**
-     * Creates a RequestLogger
+     * Creates a request logger
      */
     export function RequestLogger(filter?: string | RegExp | object | ((req, res) => boolean), options?: RequestLoggerOptions): RequestLogger;
 

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -934,11 +934,11 @@ interface Request {
      */
     userAgent: string;
     /**
-     * Request part of the logged request
+     * The request part of the logged request
      */
     request: RequestData;
     /**
-     * Response part of the logged request
+     * The response part of the logged request
      */
     response: ResponseData;
 }
@@ -1268,7 +1268,7 @@ interface TestController {
      */
     useRole(role: Role): TestControllerPromise;
     /**
-     * Attach the hooks during a test run
+     * Attaches the hooks during a test run
      *
      * @param hook - The set of RequestHook subclasses
      */
@@ -1572,10 +1572,10 @@ declare module 'testcafe' {
      */
     export function RequestLogger(filter?: string | RegExp | object | ((req, res) => boolean), options?: RequestLoggerOptions): RequestLogger;
 
-    /** The RequestHook class used to create a custom HTTP Request Hook **/
+    /** The RequestHook class used to create a custom HTTP request hook **/
     export class RequestHook {
         /**
-         * Creates a Request Hook
+         * Creates a request hook
          * @param requestFilterRules - determines which requests the hook handles
          * @param responseEventConfigureOpts - defines whether to pass the response headers and body to the onResponse method
          * @returns {RequestHook}
@@ -1647,7 +1647,7 @@ interface FixtureFn {
     /**
      * Specifies a webpage at which all tests in a fixture start.
      *
-     * @param url - The URL of the webpage at this tests start.
+     * @param url - The URL of the webpage where tests start.
      * To test webpages in local directories, you can use the `file://` scheme or relative paths.
      */
     page(url: string | TemplateStringsArray): this;
@@ -1694,14 +1694,14 @@ interface FixtureFn {
      */
     only: this;
     /**
-     * Specifies the additional information for all tests in the fixture that can be used in reports
+     * Specifies the additional information for all tests in the fixture. This information can be used in reports.
      *
      * @param key - The name of the metadata entry
      * @param value - The value of the metadata entry
      */
     meta(key: string, value: string): this;
     /**
-     * Specifies the additional information for all tests in the fixture that can be used in reports
+     * Specifies the additional information for all tests in the fixture. This information can be used in reports.
      *
      * @param data - Key-value pairs
      */
@@ -1709,7 +1709,7 @@ interface FixtureFn {
     /**
      * Attaches hooks to all tests in the fixture
      *
-     * @param hook - The set of RequestHook subclasses
+     * @param hook - The set of the RequestHook subclasses
      */
     requestHooks(...hook: object[]): this;
 }
@@ -1759,14 +1759,14 @@ interface TestFn {
      */
     only: this;
     /**
-     * Specifies the additional information for the test that can be used in reports
+     * Specifies the additional information for the test. This information can be used in reports.
      *
      * @param key - The name of the metadata entry
      * @param value - The value of the metadata entry
      */
     meta(key: string, value: string): this;
     /**
-     * Specifies the additional information for the test that can be used in reports
+     * Specifies the additional information for the test. This information can be used in reports.
      *
      * @param data - Key-value pairs
      */
@@ -1774,7 +1774,7 @@ interface TestFn {
     /**
      * Attaches hooks to the test
      *
-     * @param hook - The set of RequestHook subclasses
+     * @param hook - The set of the RequestHook subclasses
      */
     requestHooks(...hook: object[]): this;
 }


### PR DESCRIPTION
@AndreyBelym @MargaritaLoseva 

Changes:
* change var to const in header of `test/server/compiler-test.js`
* `resolve` -> `path.resolve`
* rewrite `Should provide API definitions` using `fs.readDirSync`
* add typescript definitions for `meta` and `Request Hook` features.