### PR TITLE
remove deprecated Buffer constructor usage

### DIFF
--- a/src/screenshots/crop.js
+++ b/src/screenshots/crop.js
@@ -45,7 +45,7 @@ function markSeedToId (markSeed) {
 }
 
 export default async function (screenshotPath, markSeed, clientAreaDimensions, cropDimensions) {
-    var mark = new Buffer(markSeed);
+    var mark = Buffer.from(markSeed);
 
     var srcImage  = await readPng(screenshotPath);
 

--- a/src/screenshots/generate-mark.js
+++ b/src/screenshots/generate-mark.js
@@ -17,7 +17,7 @@ export default function () {
     // It happens on Retina displays, because they have more than 1 physical pixel in a CSS pixel.
     // So increase mark size by prepending transparent pixels before the actual mark.
     var imageData       = times(MARK_BYTES_PER_PIXEL * MARK_LENGTH * (MARK_HEIGHT - 1), constant(0)).concat(markSeed);
-    var imageDataBuffer = new Buffer(imageData);
+    var imageDataBuffer = Buffer.from(imageData);
     var pngImage        = new PNG({ width: MARK_LENGTH, height: MARK_HEIGHT });
 
     imageDataBuffer.copy(pngImage.data);


### PR DESCRIPTION
@AndreyBelym 

The message `(node:3052) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.` is displayed during functional tests.

[appveyor test log](https://ci.appveyor.com/project/testcafe-build-bot/testcafe/build/%232986)
