### PR TITLE
CoffeeScript support (close #1556)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "chalk": "^1.1.0",
     "chrome-emulated-devices-list": "^0.1.0",
     "chrome-remote-interface": "^0.25.3",
+    "coffeescript": "^2.3.1",
     "commander": "^2.8.1",
     "debug": "^2.2.0",
     "dedent": "^0.4.0",

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -6,6 +6,7 @@ import { Compiler as LegacyTestFileCompiler } from 'testcafe-legacy-api';
 import hammerhead from 'testcafe-hammerhead';
 import EsNextTestFileCompiler from './test-file/formats/es-next/compiler';
 import TypeScriptTestFileCompiler from './test-file/formats/typescript/compiler';
+import CoffeeScriptTestFileCompiler from './test-file/formats/coffeescript/compiler';
 import RawTestFileCompiler from './test-file/formats/raw';
 import { readFile } from '../utils/promisified-functions';
 import { GeneralError } from '../errors/runtime';
@@ -18,6 +19,7 @@ var testFileCompilers = [
     new LegacyTestFileCompiler(hammerhead.processScript),
     new EsNextTestFileCompiler(),
     new TypeScriptTestFileCompiler(),
+    new CoffeeScriptTestFileCompiler(),
     new RawTestFileCompiler()
 ];
 

--- a/src/compiler/test-file/formats/coffeescript/compiler.js
+++ b/src/compiler/test-file/formats/coffeescript/compiler.js
@@ -1,4 +1,5 @@
 import CoffeeScript from 'coffeescript';
+import loadBabelLibs from '../../../load-babel-libs';
 import ESNextTestFileCompiler from '../es-next/compiler.js';
 
 const FIXTURE_RE = /(^|;|\s+)fixture\s*(\.|\(|'|")/;
@@ -13,17 +14,20 @@ export default class CoffeeScriptTestFileCompiler extends ESNextTestFileCompiler
         if (this.cache[filename])
             return this.cache[filename];
 
-        var compiled = CoffeeScript.compile(code, {
+        var transpiled = CoffeeScript.compile(code, {
+            filename,
             sourceMap: true,
             inlineMap: true,
-            filename,
-            header:    false,
-            transpile: ESNextTestFileCompiler.getBabelOptions(filename, code)
+            header:    false
         });
 
-        this.cache[filename] = compiled.js;
+        var { babel }    = loadBabelLibs();
+        var babelOptions = ESNextTestFileCompiler.getBabelOptions(filename, code);
+        var compiled     = babel.transform(transpiled.js, babelOptions);
 
-        return compiled.js;
+        this.cache[filename] = compiled.code;
+
+        return compiled.code;
     }
 
     _getRequireCompilers () {

--- a/src/compiler/test-file/formats/coffeescript/compiler.js
+++ b/src/compiler/test-file/formats/coffeescript/compiler.js
@@ -16,6 +16,7 @@ export default class CoffeeScriptTestFileCompiler extends ESNextTestFileCompiler
 
         var transpiled = CoffeeScript.compile(code, {
             filename,
+            bare:      true,
             sourceMap: true,
             inlineMap: true,
             header:    false

--- a/src/compiler/test-file/formats/coffeescript/compiler.js
+++ b/src/compiler/test-file/formats/coffeescript/compiler.js
@@ -1,0 +1,36 @@
+import CoffeeScript from 'coffeescript';
+import ESNextTestFileCompiler from '../es-next/compiler.js';
+
+const FIXTURE_RE = /(^|;|\s+)fixture\s*(\.|\(|'|")/;
+const TEST_RE    = /(^|;|\s+)test\s*/;
+
+export default class CoffeeScriptTestFileCompiler extends ESNextTestFileCompiler {
+    _hasTests (code) {
+        return FIXTURE_RE.test(code) && TEST_RE.test(code);
+    }
+
+    _compileCode (code, filename) {
+        if (this.cache[filename])
+            return this.cache[filename];
+
+        var compiled = CoffeeScript.compile(code, {
+            sourceMap: true,
+            inlineMap: true,
+            filename,
+            header:    false,
+            transpile: ESNextTestFileCompiler.getBabelOptions(filename, code)
+        });
+
+        this.cache[filename] = compiled.js;
+
+        return compiled.js;
+    }
+
+    _getRequireCompilers () {
+        return { '.coffee': (code, filename) => this._compileCode(code, filename) };
+    }
+
+    getSupportedExtension () {
+        return '.coffee';
+    }
+}

--- a/src/compiler/test-file/formats/coffeescript/get-test-list.js
+++ b/src/compiler/test-file/formats/coffeescript/get-test-list.js
@@ -11,6 +11,7 @@ export class CoffeeScriptTestFileParser extends EsNextTestFileParser {
         babelOptions.ast = true;
 
         code = CoffeeScript.compile(code, {
+            bare:      true,
             sourceMap: false,
             inlineMap: false,
             header:    false

--- a/src/compiler/test-file/formats/coffeescript/get-test-list.js
+++ b/src/compiler/test-file/formats/coffeescript/get-test-list.js
@@ -1,0 +1,28 @@
+import CoffeeScript from 'coffeescript';
+import { transform } from 'babel-core';
+import ESNextTestFileCompiler from '../es-next/compiler.js';
+import { EsNextTestFileParser } from '../es-next/get-test-list';
+
+export class CoffeeScriptTestFileParser extends EsNextTestFileParser {
+    parse (code) {
+        const babelOptions = ESNextTestFileCompiler.getBabelOptions(null, code);
+
+        delete babelOptions.filename;
+        babelOptions.ast = true;
+
+        code = CoffeeScript.compile(code, {
+            sourceMap: false,
+            inlineMap: false,
+            header:    false
+        });
+
+        const ast = transform(code, babelOptions).ast;
+
+        return this.analyze(ast.program.body);
+    }
+}
+
+const parser = new CoffeeScriptTestFileParser();
+
+export const getCoffeeScriptTestList         = parser.getTestList.bind(parser);
+export const getCoffeeScriptTestListFromCode = parser.getTestListFromCode.bind(parser);

--- a/src/compiler/test-file/formats/es-next/get-test-list.js
+++ b/src/compiler/test-file/formats/es-next/get-test-list.js
@@ -13,6 +13,7 @@ const TOKEN_TYPE = {
     ArrowFunctionExpression:  'ArrowFunctionExpression',
     FunctionExpression:       'FunctionExpression',
     ExpressionStatement:      'ExpressionStatement',
+    ReturnStatement:          'ReturnStatement',
     FunctionDeclaration:      'FunctionDeclaration',
     VariableDeclaration:      'VariableDeclaration'
 };

--- a/src/compiler/test-file/formats/es-next/get-test-list.js
+++ b/src/compiler/test-file/formats/es-next/get-test-list.js
@@ -17,7 +17,7 @@ const TOKEN_TYPE = {
     VariableDeclaration:      'VariableDeclaration'
 };
 
-class EsNextTestFileParser extends TestFileParserBase {
+export class EsNextTestFileParser extends TestFileParserBase {
     constructor () {
         super(TOKEN_TYPE);
     }

--- a/src/compiler/test-file/test-file-parser-base.js
+++ b/src/compiler/test-file/test-file-parser-base.js
@@ -122,6 +122,9 @@ export class TestFileParserBase {
             case tokenType.PropertyAccessExpression:
             case tokenType.TaggedTemplateExpression:
                 return this.analyzeFnCall(token);
+
+            case tokenType.ReturnStatement:
+                return token.argument ? this.analyzeToken(token.argument) : null;
         }
 
         return null;

--- a/src/compiler/test-file/test-file-parser-base.js
+++ b/src/compiler/test-file/test-file-parser-base.js
@@ -112,8 +112,11 @@ export class TestFileParserBase {
 
                 return this.getFunctionBody(token).map(this.analyzeToken, this);
 
-            case tokenType.VariableDeclaration:
-                return this.analyzeToken(this.getRValue(token));
+            case tokenType.VariableDeclaration: {
+                const variableValue = this.getRValue(token); // Skip variable declarations like `var foo;`
+
+                return variableValue ? this.analyzeToken(variableValue) : null;
+            }
 
             case tokenType.CallExpression:
             case tokenType.PropertyAccessExpression:

--- a/src/embedding-utils.js
+++ b/src/embedding-utils.js
@@ -6,13 +6,16 @@ import COMMAND_TYPE from './test-run/commands/type';
 import Assignable from './utils/assignable';
 import { getTestList, getTestListFromCode } from './compiler/test-file/formats/es-next/get-test-list';
 import { getTypeScriptTestList, getTypeScriptTestListFromCode } from './compiler/test-file/formats/typescript/get-test-list';
+import { getCoffeeScriptTestList, getCoffeeScriptTestListFromCode } from './compiler/test-file/formats/coffeescript/get-test-list';
 import { initSelector } from './test-run/commands/validations/initializers';
 
 export default {
     getTestList,
     getTypeScriptTestList,
+    getCoffeeScriptTestList,
     getTestListFromCode,
     getTypeScriptTestListFromCode,
+    getCoffeeScriptTestListFromCode,
     TestRunErrorFormattableAdapter,
     TestRun,
     testRunErrors,

--- a/test/functional/fixtures/api/coffeescript/smoke/test.js
+++ b/test/functional/fixtures/api/coffeescript/smoke/test.js
@@ -1,0 +1,15 @@
+var expect = require('chai').expect;
+
+describe('[CoffeeScript] Smoke tests', function () {
+    it('Should run non-trivial tests', function () {
+        return runTests('./testcafe-fixtures/non-trivial-test.coffee', null, { selectorTimeout: 5000 });
+    });
+
+    it('Should produce correct callsites on error', function () {
+        return runTests('./testcafe-fixtures/callsite-test.coffee', null, { shouldFail: true })
+            .catch(function (errs) {
+                expect(errs[0]).contains('The specified selector does not match any element in the DOM tree.');
+                expect(errs[0]).contains('> 5 |doSmthg = (selector, t) -> await t.click selector');
+            });
+    });
+});

--- a/test/functional/fixtures/api/coffeescript/smoke/testcafe-fixtures/callsite-test.coffee
+++ b/test/functional/fixtures/api/coffeescript/smoke/testcafe-fixtures/callsite-test.coffee
@@ -1,0 +1,8 @@
+import 'testcafe'
+
+fixture 'CoffeeScript callsites'
+
+doSmthg = (selector, t) -> await t.click selector
+
+test 'Test', (t) =>
+    await doSmthg '#heyheyhey', t

--- a/test/functional/fixtures/api/coffeescript/smoke/testcafe-fixtures/non-trivial-test.coffee
+++ b/test/functional/fixtures/api/coffeescript/smoke/testcafe-fixtures/non-trivial-test.coffee
@@ -1,0 +1,59 @@
+import { Selector, Role, t } from 'testcafe'
+
+iframeElement = Selector '#element-in-iframe'
+pageElement = Selector '#element-on-page'
+showAlertBtn = Selector '#show-alert'
+
+initConfiguration = ->
+    await t
+        .setNativeDialogHandler => on
+        .click showAlertBtn
+
+    history = await t.getNativeDialogHistory()
+
+    await t
+        .expect(history[0].text).eql 'Hey!'
+        .switchToIframe '#iframe'
+        .expect(iframeElement.exists).ok()
+        .setTestSpeed 0.95
+        .setPageLoadTimeout 95
+
+    t.ctx['someVal'] = 'ctxVal'
+    t.fixtureCtx['someVal'] = 'fixtureCtxVal'
+
+role1 = Role 'http://localhost:3000/fixtures/api/es-next/roles/pages/index.html', =>
+    await t
+        .setNativeDialogHandler => on
+
+    await t
+        .expect(pageElement.exists).ok()
+        .expect(t.ctx['someVal']).notOk()
+        .expect(t.fixtureCtx['someVal']).notOk()
+
+    await t.click showAlertBtn
+
+role2 = Role 'http://localhost:3000/fixtures/api/es-next/roles/pages/index.html', =>
+
+fixture 'CoffeeScript smoke tests'
+    .page 'http://localhost:3000/fixtures/api/es-next/roles/pages/index.html'
+
+test 'Clear configuration', =>
+    await initConfiguration()
+    await t.useRole role1
+
+test 'Restore configuration', =>
+    await initConfiguration()
+
+    await t
+        .useRole role2
+        .expect(iframeElement.exists).ok()
+        .expect(t.ctx['someVal']).eql 'ctxVal'
+        .expect(t.fixtureCtx['someVal']).eql 'fixtureCtxVal'
+
+    await t
+        .switchToMainWindow()
+        .click showAlertBtn
+
+    history = await t.getNativeDialogHistory()
+
+    await t.expect(history[0].text).eql 'Hey!'

--- a/test/server/data/test-suites/coffeescript-basic/dep1.coffee
+++ b/test/server/data/test-suites/coffeescript-basic/dep1.coffee
@@ -1,0 +1,2 @@
+export default ->
+    'Hey from dep1'

--- a/test/server/data/test-suites/coffeescript-basic/dep2.coffee
+++ b/test/server/data/test-suites/coffeescript-basic/dep2.coffee
@@ -1,0 +1,4 @@
+import dep1Fn from './dep1'
+
+export default ->
+    "#{await dep1Fn()} and dep2"

--- a/test/server/data/test-suites/coffeescript-basic/testfile1.coffee
+++ b/test/server/data/test-suites/coffeescript-basic/testfile1.coffee
@@ -1,0 +1,21 @@
+import 'testcafe'
+import dep1Fn from './dep1'
+
+fixture 'Fixture1'
+
+test 'Fixture1Test1', =>
+    res = await dep1Fn()
+    "F1T1: #{res}"
+
+test2Name = 'Fixture1Test2'
+
+test test2Name, =>
+    'F1T2'
+
+fixture "Fixture#{1 + 1}"
+    .page 'http://example.org'
+    .beforeEach => 'yo'
+    .afterEach => 'yo'
+
+test 'Fixture2Test1', =>
+    'F2T1'

--- a/test/server/data/test-suites/coffeescript-basic/testfile2.coffee
+++ b/test/server/data/test-suites/coffeescript-basic/testfile2.coffee
@@ -1,0 +1,13 @@
+import 'testcafe'
+import dep2Fn from './dep2'
+
+fixture 'Fixture3'
+    .page 'https://example.com'
+    .afterEach => 'yo'
+    .beforeEach => 'yo'
+
+fixture3Name = 'Fixture3Test1'
+
+test fixture3Name, =>
+    res = await dep2Fn()
+    "F3T1: #{res}"

--- a/test/server/data/test-suites/coffeescript-parser-smoke/testfile1.coffee
+++ b/test/server/data/test-suites/coffeescript-parser-smoke/testfile1.coffee
@@ -1,0 +1,15 @@
+getPageUrl = (index) ->
+	"http://page/#{index}"
+
+fixture('fixture 1').page getFixtureName(1)
+
+doSmthg = (selector, t) ->
+	await t.click selector
+
+test 'test 1', (t) =>
+	await doSmthg '#my-el', t
+
+((fixtureName, testName) ->
+	fixture(fixtureName).page 'http://myPage'
+	test testName, (t) =>
+) 'fixture 2', 'test 2'

--- a/test/server/data/test-suites/coffeescript-parser-smoke/testfile2.coffee
+++ b/test/server/data/test-suites/coffeescript-parser-smoke/testfile2.coffee
@@ -1,0 +1,5 @@
+fixture('fixture 1').page 'https://page'
+
+test.before((t) =>
+	await t.wait 1
+) 'test 1'

--- a/test/server/parse-fixture-test.js
+++ b/test/server/parse-fixture-test.js
@@ -1,13 +1,15 @@
-var expect                        = require('chai').expect;
-var fs                            = require('fs');
-var path                          = require('path');
-var assign                        = require('lodash').assign;
-var getTestList                   = require('../../lib/embedding-utils').getTestList;
-var getTypeScriptTestList         = require('../../lib/embedding-utils').getTypeScriptTestList;
-var getTestListFromCode           = require('../../lib/embedding-utils').getTestListFromCode;
-var getTypeScriptTestListFromCode = require('../../lib/embedding-utils').getTypeScriptTestListFromCode;
-var Promise                       = require('pinkie');
-var parserBase                    = require('../../lib/compiler/test-file/test-file-parser-base');
+var expect                          = require('chai').expect;
+var fs                              = require('fs');
+var path                            = require('path');
+var assign                          = require('lodash').assign;
+var getTestList                     = require('../../lib/embedding-utils').getTestList;
+var getTypeScriptTestList           = require('../../lib/embedding-utils').getTypeScriptTestList;
+var getCoffeeScriptTestList         = require('../../lib/embedding-utils').getCoffeeScriptTestList;
+var getTestListFromCode             = require('../../lib/embedding-utils').getTestListFromCode;
+var getTypeScriptTestListFromCode   = require('../../lib/embedding-utils').getTypeScriptTestListFromCode;
+var getCoffeeScriptTestListFromCode = require('../../lib/embedding-utils').getCoffeeScriptTestListFromCode;
+var Promise                         = require('pinkie');
+var parserBase                      = require('../../lib/compiler/test-file/test-file-parser-base');
 
 var Test    = parserBase.Test;
 var Fixture = function (name, start, end, loc, tests) {
@@ -50,6 +52,10 @@ function testJSFilesParser (dir, expectedStructure) {
 
 function testTypeScriptFilesParser (dir, expectedStructure) {
     return testFixtureParser(dir, expectedStructure, getTypeScriptTestList, getTypeScriptTestListFromCode);
+}
+
+function testCoffeeScriptFilesParser (dir, expectedStructure) {
+    return testFixtureParser(dir, expectedStructure, getCoffeeScriptTestList, getCoffeeScriptTestListFromCode);
 }
 
 describe('Should get structure of files (esnext and typescript common cases)', function () {
@@ -200,8 +206,7 @@ describe('Should get structure of files (esnext and typescript common cases)', f
     });
 });
 
-
-describe('Should get structure of typescript files', function () {
+describe('Should get structure of TypeScript files', function () {
     it('Smoke test', () => {
         var expectedStructure = [
             [
@@ -228,6 +233,36 @@ describe('Should get structure of typescript files', function () {
         ];
 
         return testTypeScriptFilesParser('./data/test-suites/typescript-parser-smoke', expectedStructure);
+    });
+});
+
+describe('Should get structure of CoffeeScript files', function () {
+    it('Smoke test', () => {
+        var expectedStructure = [
+            [
+                new Fixture('fixture 1', 94, 138, new Loc(7, 0, 7, 44),
+                    [
+                        new Test('test 1', 221, 291, new Loc(13, 0, 15, 2))
+                    ]
+                ),
+
+                new Fixture('<computed name>(line: 18)', 331, 373, new Loc(18, 2, 18, 44),
+                    [
+                        new Test('<computed name>(line: 19)', 384, 409, new Loc(19, 9, 19, 34))
+                    ]
+                )
+            ],
+
+            [
+                new Fixture('fixture 1', 0, 41, new Loc(1, 0, 1, 41),
+                    [
+                        new Test('test 1', 44, 110, new Loc(3, 0, 5, 12))
+                    ]
+                )
+            ]
+        ];
+
+        return testCoffeeScriptFilesParser('./data/test-suites/coffeescript-parser-smoke', expectedStructure);
     });
 });
 


### PR DESCRIPTION
Closes #1556. Adds support for CoffeeScript test files, similar to the existing TypeScript support.