### PR TITLE
prevent calling toString() on a null object

### DIFF
--- a/src/api/request-hooks/request-logger.js
+++ b/src/api/request-hooks/request-logger.js
@@ -71,7 +71,7 @@ class RequestLoggerImplementation extends RequestHook {
         if (this.options.logResponseHeaders)
             loggerReq.response.headers = Object.assign({}, event.headers);
 
-        if (this.options.logResponseBody)
+        if (this.options.logResponseBody && event.body)
             loggerReq.response.body = this.options.stringifyResponseBody ? event.body.toString() : event.body;
     }
 


### PR DESCRIPTION
Prevent the below TypeError when trying to parse the response body
```
TypeError: Cannot read property 'toString' of null
    at RequestLoggerImplementation.onResponse (/private/app/node_modules/testcafe/lib/api/request-hooks/request-logger.js:131:117)
    at SessionController.callRequestEventCallback (/private/app/node_modules/testcafe-hammerhead/lib/session/index.js:239:63)
    at PassThrough.<anonymous> (/private/app/node_modules/testcafe-hammerhead/lib/request-pipeline/index.js:334:21)
    at PassThrough.emit (events.js:185:15)
    at PassThrough.emit (domain.js:440:23)
    at finishMaybe (_stream_writable.js:636:14)
    at endWritable (_stream_writable.js:644:3)
    at PassThrough.Writable.end (_stream_writable.js:586:5)
    at IncomingMessage.onend (_stream_readable.js:607:10)
    at Object.onceWrapper (events.js:272:13)
    at IncomingMessage.emit (events.js:185:15)
    at IncomingMessage.emit (domain.js:440:23)
    at endReadableNT (_stream_readable.js:1106:12)
    at process._tickCallback (internal/process/next_tick.js:178:19)
```