### PR TITLE
[docs] Replace a long tweet with a shorter one

### DIFF
--- a/docs/tweets/tweets.json
+++ b/docs/tweets/tweets.json
@@ -1,6 +1,6 @@
 [
     {
-        "url": "https://twitter.com/martin_hotell/status/971339016888029184"
+        "url": "https://twitter.com/martin_hotell/status/958079928574119941"
     },
     {
         "url": "https://twitter.com/pantvivek28/status/973799993705410560"


### PR DESCRIPTION
\cc @kirovboris 

The previous tweet was rendered too high to fit the designated area on the landing page.
