### PR TITLE
fix 'Should not raise an error if during a long running request the "clear" method will be called' (close #2688)

### DIFF
--- a/src/api/request-hooks/request-logger.js
+++ b/src/api/request-hooks/request-logger.js
@@ -62,6 +62,8 @@ class RequestLoggerImplementation extends RequestHook {
     onResponse (event) {
         const loggerReq = this._internalRequests[event.requestId];
 
+        // NOTE: If the 'clear' method is called during a long running request,
+        // we should not save a response part - this part has been already removed.
         if (!loggerReq)
             return;
 

--- a/src/api/request-hooks/request-logger.js
+++ b/src/api/request-hooks/request-logger.js
@@ -63,7 +63,7 @@ class RequestLoggerImplementation extends RequestHook {
         const loggerReq = this._internalRequests[event.requestId];
 
         if (!loggerReq)
-            throw new TypeError(`Cannot find a recorded request with id=${event.id}. This is an internal TestCafe problem. Please contact the TestCafe team and provide an example to reproduce the problem.`);
+            return;
 
         loggerReq.response            = {};
         loggerReq.response.statusCode = event.statusCode;

--- a/src/api/request-hooks/request-logger.js
+++ b/src/api/request-hooks/request-logger.js
@@ -63,7 +63,7 @@ class RequestLoggerImplementation extends RequestHook {
         const loggerReq = this._internalRequests[event.requestId];
 
         // NOTE: If the 'clear' method is called during a long running request,
-        // we should not save a response part - this part has been already removed.
+        // we should not save a response part - request part has been already removed.
         if (!loggerReq)
             return;
 

--- a/test/server/request-hooks-test.js
+++ b/test/server/request-hooks-test.js
@@ -174,6 +174,16 @@ describe('RequestLogger', () => {
                 expect(data[2]).eql(false);
             });
     });
+
+    it('Should not raise an error if during a long running request the ".clear" method will be called (GH-2688)', () => {
+        const logger = new RequestLogger();
+
+        logger.onRequest(requestEventMock);
+        logger.clear();
+        logger.onResponse(responseEventMock);
+
+        expect(logger.requests.length).eql(0);
+    });
 });
 
 describe('RequestMock', () => {


### PR DESCRIPTION
@AndreyBelym