### PR TITLE
fix `Update babel-preset-env target to node 6`

### DIFF
--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,7 +1,10 @@
 {
   "compact": false,
   "presets": [
-    ["env", { "loose": true }],
+    ["env", {
+      "targets": { "node": "6" },
+      "loose": true
+    }],
     "babel-preset-stage-2"
   ],
   "plugins": [

--- a/src/api/exportable-lib/index.js
+++ b/src/api/exportable-lib/index.js
@@ -19,13 +19,13 @@ function RequestLogger (requestFilterRuleInit, logOptions) {
 }
 
 function ClientFunction (fn, options) {
-    var builder = new ClientFunctionBuilder(fn, options, { instantiation: 'ClientFunction' });
+    const builder = new ClientFunctionBuilder(fn, options, { instantiation: 'ClientFunction' });
 
     return builder.getFunction();
 }
 
 function Selector (fn, options) {
-    var builder = new SelectorBuilder(fn, options, { instantiation: 'Selector' });
+    const builder = new SelectorBuilder(fn, options, { instantiation: 'Selector' });
 
     return builder.getFunction();
 }

--- a/src/api/exportable-lib/index.js
+++ b/src/api/exportable-lib/index.js
@@ -18,22 +18,26 @@ function RequestLogger (requestFilterRuleInit, logOptions) {
     return createRequestLogger(requestFilterRuleInit, logOptions);
 }
 
+function ClientFunction (fn, options) {
+    var builder = new ClientFunctionBuilder(fn, options, { instantiation: 'ClientFunction' });
+
+    return builder.getFunction();
+}
+
+function Selector (fn, options) {
+    var builder = new SelectorBuilder(fn, options, { instantiation: 'Selector' });
+
+    return builder.getFunction();
+}
+
 Role.anonymous = createAnonymousRole;
 
 export default {
     Role,
 
-    ClientFunction (fn, options) {
-        var builder = new ClientFunctionBuilder(fn, options, { instantiation: 'ClientFunction' });
+    ClientFunction,
 
-        return builder.getFunction();
-    },
-
-    Selector (fn, options) {
-        var builder = new SelectorBuilder(fn, options, { instantiation: 'Selector' });
-
-        return builder.getFunction();
-    },
+    Selector,
 
     RequestLogger,
 
@@ -43,4 +47,3 @@ export default {
 
     t: testControllerProxy
 };
-

--- a/src/errors/stack-cleaning-hook.js
+++ b/src/errors/stack-cleaning-hook.js
@@ -5,6 +5,7 @@ import createStackFilter from './create-stack-filter';
 const ORIGINAL_STACK_TRACE_LIMIT = Error.stackTraceLimit;
 const STACK_TRACE_LIMIT          = 200;
 const TOP_ANONYMOUS_FRAME_RE     = /\s+at\s<anonymous>$/;
+const GENERATOR_NEXT_FRAME_RE    = /\s+at\sgenerator.next\s\(<anonymous>\)$/im;
 
 
 export default {
@@ -43,6 +44,7 @@ export default {
 
     cleanError (error) {
         error.stack = error.stack.replace(TOP_ANONYMOUS_FRAME_RE, '');
+        error.stack = error.stack.replace(GENERATOR_NEXT_FRAME_RE, '');
 
         let frames = this._getFrames(error);
 

--- a/src/utils/delegated-api.js
+++ b/src/utils/delegated-api.js
@@ -2,7 +2,7 @@ const API_IMPLEMENTATION_METHOD_RE = /^_(\S+)\$(getter|setter)?$/;
 
 export function getDelegatedAPIList (src) {
     return Object
-        .keys(src)
+        .getOwnPropertyNames(src)
         .map(prop => {
             var match = prop.match(API_IMPLEMENTATION_METHOD_RE);
 


### PR DESCRIPTION
### Todo
- [x] ~~`"error-stack-parser": "^1.3.6"` >> `"error-stack-parser": "^2.0.2"`?~~
- [x] ~~add `propertyIsEnumerable` in `getOwnPropertyNames(src).map(...)`?~~
- [x] ~~remove "babel-preset-stage-2" preset?~~
- [x] ~~any other "error stack entries" cases for cleaning?~~
- [x] rewrite both `var builder = new ClientFunctionBuilder`, `var builder = new SelectorBuilder` as `const`?
- [ ] add `new Selector` case in tests?

https://github.com/DevExpress/testcafe-hammerhead/issues/1651

### Changes
1. Update node version to 6 (src/.babelrc)
2. Clean `Generator.next` error stack entries (Fix "Compiler > Error" tests)
3. Rewrite src/api/exportable-lib/index.js (Fix `new ClientFunction` tests, etc)

### Notes:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions#Method_definitions_are_not_constructable

>  All method definitions are not constructors and will throw a TypeError if you try to instantiate them.
> ```js
> var obj = { 
>   method() {}
> };
> new obj.method; // TypeError: obj.method is not a constructor
> 
> var obj = { 
>   * g() {} 
> };
> new obj.g; // TypeError: obj.g is not a constructor (changed in ES2016)
> ```