### PR TITLE
fix 'Should not fail when logger logs and stringifies a response body and it equals null' (close #2718)

### DIFF
--- a/src/api/request-hooks/request-logger.js
+++ b/src/api/request-hooks/request-logger.js
@@ -73,8 +73,11 @@ class RequestLoggerImplementation extends RequestHook {
         if (this.options.logResponseHeaders)
             loggerReq.response.headers = Object.assign({}, event.headers);
 
-        if (this.options.logResponseBody)
-            loggerReq.response.body = this.options.stringifyResponseBody ? event.body.toString() : event.body;
+        if (this.options.logResponseBody) {
+            loggerReq.response.body = this.options.stringifyResponseBody && event.body
+                ? event.body.toString()
+                : event.body;
+        }
     }
 
     _prepareInternalRequestInfo () {

--- a/test/server/request-hooks-test.js
+++ b/test/server/request-hooks-test.js
@@ -184,6 +184,16 @@ describe('RequestLogger', () => {
 
         expect(logger.requests.length).eql(0);
     });
+
+    it('Should not fail when logger logs and stringifies a response body and it equals null (GH-2718)', () => {
+        const logger                  = new RequestLogger('http://example.com/', { logResponseBody: true, stringifyResponseBody: true });
+        const clonedResponseEventMock = Object.assign({}, responseEventMock, { body: null });
+
+        logger.onRequest(requestEventMock);
+        logger.onResponse(clonedResponseEventMock);
+
+        expect(logger.requests[0].response.body).eql(null);
+    });
 });
 
 describe('RequestMock', () => {


### PR DESCRIPTION
@AndreyBelym 