### PR TITLE
[docs] Add a TestCafe Studio top-level link

### DIFF
--- a/docs/nav/top-menu-items.yml
+++ b/docs/nav/top-menu-items.yml
@@ -6,8 +6,8 @@
   external: true
 - text: FAQ
   url: /faq/
-- text: Publications
-  url: /publications/
+# - text: Publications
+#   url: /publications/
 - text: Release Notes
   url: /blog/
 - text: Issues
@@ -15,4 +15,7 @@
   external: true
 - text: Q&amp;A
   url: https://stackoverflow.com/questions/tagged/testcafe
+  external: true
+- text: TestCafe Studio
+  url: https://testcafe-studio.devexpress.com
   external: true

--- a/docs/nav/top-menu-items.yml
+++ b/docs/nav/top-menu-items.yml
@@ -19,3 +19,4 @@
 - text: TestCafe Studio
   url: https://testcafe-studio.devexpress.com
   external: true
+  id: studio-link


### PR DESCRIPTION
\cc @kirovboris 

Per @Nuarat 's request, added a `TestCafe Studio` link to the top menu instead of `Publications`