### PR TITLE
fix absolute paths for source maps (fix bug for #2546)

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -263,7 +263,7 @@ gulp.step('server-scripts', () => {
         .pipe(sourcemaps.init())
         .pipe(gulpBabel())
         .pipe(sourcemaps.mapSources(sourcePath => {
-            const libPath = path.join('src/', sourcePath);
+            const libPath = path.join('src', sourcePath);
 
             return path.relative(sourcePath, libPath);
         }))

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -13,8 +13,8 @@ const rename               = require('gulp-rename');
 const webmake              = require('gulp-webmake');
 const uglify               = require('gulp-uglify');
 const ll                   = require('gulp-ll-next');
-const clone              = require('gulp-clone');
-const mergeStreams       = require('merge-stream');
+const clone                = require('gulp-clone');
+const mergeStreams         = require('merge-stream');
 const del                  = require('del');
 const fs                   = require('fs');
 const path                 = require('path');
@@ -145,7 +145,7 @@ const PUBLISH_TAG = JSON.parse(fs.readFileSync(path.join(__dirname, '.publishrc'
 
 let websiteServer = null;
 
-gulp.task('audit', function () {
+gulp.task('audit', () => {
     return npmAuditor()
         .then(result => {
             process.stdout.write(result.report);
@@ -156,13 +156,13 @@ gulp.task('audit', function () {
         });
 });
 
-gulp.task('clean', function () {
+gulp.task('clean', () => {
     return del('lib');
 });
 
 
 // Lint
-gulp.task('lint', function () {
+gulp.task('lint', () => {
     const eslint = require('gulp-eslint');
 
     return gulp
@@ -179,13 +179,13 @@ gulp.task('lint', function () {
 });
 
 // License checker
-gulp.task('check-licenses', function () {
+gulp.task('check-licenses', () => {
     return checkLicenses();
 });
 
 // Build
 
-gulp.step('client-scripts-bundle', function () {
+gulp.step('client-scripts-bundle', () => {
     return gulp
         .src([
             'src/client/core/index.js',
@@ -196,7 +196,7 @@ gulp.step('client-scripts-bundle', function () {
         ], { base: 'src' })
         .pipe(webmake({
             sourceMap: false,
-            transform: function (filename, code) {
+            transform: (filename, code) => {
                 const transformed = babel.transform(code, {
                     sourceMap: false,
                     ast:       false,
@@ -217,7 +217,7 @@ gulp.step('client-scripts-bundle', function () {
         .pipe(gulp.dest('lib'));
 });
 
-gulp.step('client-scripts-templates-render', function () {
+gulp.step('client-scripts-templates-render', () => {
     const scripts = gulp
         .src([
             'src/client/core/index.js.wrapper.mustache',
@@ -254,7 +254,7 @@ gulp.step('client-scripts-templates-render', function () {
 
 gulp.step('client-scripts', gulp.series('client-scripts-bundle', 'client-scripts-templates-render'));
 
-gulp.step('server-scripts', function () {
+gulp.step('server-scripts', () => {
     return gulp
         .src([
             'src/**/*.js',
@@ -262,7 +262,7 @@ gulp.step('server-scripts', function () {
         ])
         .pipe(sourcemaps.init())
         .pipe(gulpBabel())
-        .pipe(sourcemaps.mapSources(function (sourcePath) {
+        .pipe(sourcemaps.mapSources(sourcePath => {
             const libPath = path.join('src/', sourcePath);
 
             return path.relative(sourcePath, libPath);
@@ -271,14 +271,14 @@ gulp.step('server-scripts', function () {
         .pipe(gulp.dest('lib'));
 });
 
-gulp.step('styles', function () {
+gulp.step('styles', () => {
     return gulp
         .src('src/**/*.less')
         .pipe(less())
         .pipe(gulp.dest('lib'));
 });
 
-gulp.step('templates', function () {
+gulp.step('templates', () => {
     return gulp
         .src([
             'src/**/*.mustache',
@@ -287,7 +287,7 @@ gulp.step('templates', function () {
         .pipe(gulp.dest('lib'));
 });
 
-gulp.step('images', function () {
+gulp.step('images', () => {
     return gulp
         .src([
             'src/**/*.png',
@@ -304,7 +304,7 @@ gulp.task('fast-build', gulp.series('clean', 'package-content'));
 gulp.task('build', DEV_MODE ? gulp.registry().get('fast-build') : gulp.parallel('lint', 'fast-build'));
 
 // Test
-gulp.step('test-server-run', function () {
+gulp.step('test-server-run', () => {
     return gulp
         .src('test/server/*-test.js', { read: false })
         .pipe(mocha({
@@ -326,11 +326,11 @@ function testClient (tests, settings, envSettings, cliMode) {
     if (!cliMode)
         return runTests(envSettings);
 
-    return listBrowsers().then(function (browsers) {
+    return listBrowsers().then(browsers => {
         const browserNames   = Object.keys(browsers);
         const targetBrowsers = [];
 
-        browserNames.forEach(function (browserName) {
+        browserNames.forEach(browserName => {
             if (CLIENT_TEST_LOCAL_BROWSERS_ALIASES.includes(browserName))
                 targetBrowsers.push({ browserInfo: browsers[browserName], browserName: browserName });
         });
@@ -339,25 +339,25 @@ function testClient (tests, settings, envSettings, cliMode) {
     });
 }
 
-gulp.step('test-client-run', function () {
+gulp.step('test-client-run', () => {
     return testClient('test/client/fixtures/**/*-test.js', CLIENT_TESTS_SETTINGS);
 });
 
 gulp.task('test-client', gulp.series('build', 'test-client-run'));
 
-gulp.step('test-client-local-run', function () {
+gulp.step('test-client-local-run', () => {
     return testClient('test/client/fixtures/**/*-test.js', CLIENT_TESTS_LOCAL_SETTINGS, {}, true);
 });
 
 gulp.task('test-client-local', gulp.series('build', 'test-client-local-run'));
 
-gulp.step('test-client-legacy-run', function () {
+gulp.step('test-client-legacy-run', () => {
     return testClient('test/client/legacy-fixtures/**/*-test.js', CLIENT_TESTS_LEGACY_SETTINGS);
 });
 
 gulp.task('test-client-legacy', gulp.series('build', 'test-client-legacy-run'));
 
-gulp.step('test-client-travis-run', function () {
+gulp.step('test-client-travis-run', () => {
     const saucelabsSettings = CLIENT_TESTS_SAUCELABS_SETTINGS;
 
     saucelabsSettings.browsers = CLIENT_TESTS_DESKTOP_BROWSERS;
@@ -367,7 +367,7 @@ gulp.step('test-client-travis-run', function () {
 
 gulp.task('test-client-travis', gulp.series('build', 'test-client-travis-run'));
 
-gulp.step('test-client-travis-mobile-run', function () {
+gulp.step('test-client-travis-mobile-run', () => {
     const saucelabsSettings = CLIENT_TESTS_SAUCELABS_SETTINGS;
 
     saucelabsSettings.browsers = CLIENT_TESTS_MOBILE_BROWSERS;
@@ -377,7 +377,7 @@ gulp.step('test-client-travis-mobile-run', function () {
 
 gulp.task('test-client-travis-mobile', gulp.series('build', 'test-client-travis-mobile-run'));
 
-gulp.step('test-client-legacy-travis-run', function () {
+gulp.step('test-client-legacy-travis-run', () => {
     const saucelabsSettings = CLIENT_TESTS_SAUCELABS_SETTINGS;
 
     saucelabsSettings.browsers = CLIENT_TESTS_DESKTOP_BROWSERS;
@@ -387,7 +387,7 @@ gulp.step('test-client-legacy-travis-run', function () {
 
 gulp.task('test-client-legacy-travis', gulp.series('build', 'test-client-legacy-travis-run'));
 
-gulp.step('test-client-legacy-travis-mobile-run', function () {
+gulp.step('test-client-legacy-travis-mobile-run', () => {
     const saucelabsSettings = CLIENT_TESTS_SAUCELABS_SETTINGS;
 
     saucelabsSettings.browsers = CLIENT_TESTS_MOBILE_BROWSERS;
@@ -398,7 +398,7 @@ gulp.step('test-client-legacy-travis-mobile-run', function () {
 gulp.task('test-client-legacy-travis-mobile', gulp.series('build', 'test-client-legacy-travis-mobile-run'));
 
 //Documentation
-gulp.task('generate-docs-readme', function (done) {
+gulp.task('generate-docs-readme', done => {
     function generateItem (name, url, level) {
         return ' '.repeat(level * 2) + '* [' + name + '](articles' + url + ')\n';
     }
@@ -406,7 +406,7 @@ gulp.task('generate-docs-readme', function (done) {
     function generateDirectory (tocItems, level) {
         let res = '';
 
-        tocItems.forEach(function (item) {
+        tocItems.forEach(item => {
             res += generateItem(item.name ? item.name : item.url, item.url, level);
 
             if (item.content)
@@ -434,10 +434,10 @@ gulp.task('generate-docs-readme', function (done) {
     done();
 });
 
-gulp.task('lint-docs', function () {
+gulp.task('lint-docs', () => {
     function lintFiles (files, config) {
-        return new Promise(function (resolve, reject) {
-            markdownlint({ files: files, config: config }, function (err, result) {
+        return new Promise((resolve, reject) => {
+            markdownlint({ files: files, config: config }, (err, result) => {
                 const lintErr = err || result && result.toString();
 
                 if (lintErr)
@@ -453,19 +453,19 @@ gulp.task('lint-docs', function () {
         '!docs/articles/faq/**/*.md',
         '!docs/articles/documentation/recipes/**/*.md',
         'examples/**/*.md'
-    ]).then(function (files) {
+    ]).then(files => {
         return lintFiles(files, require('./.md-lint/docs.json'));
     });
 
     const lintFaq = globby([
         'docs/articles/faq/**/*.md'
-    ]).then(function (files) {
+    ]).then(files => {
         return lintFiles(files, require('./.md-lint/faq.json'));
     });
 
     const lintRecipes = globby([
         'docs/articles/documentation/recipes/**/*.md'
-    ]).then(function (files) {
+    ]).then(files => {
         return lintFiles(files, require('./.md-lint/recipes.json'));
     });
 
@@ -475,39 +475,39 @@ gulp.task('lint-docs', function () {
     return Promise.all([lintDocsAndExamples, lintReadme, lintChangelog, lintRecipes, lintFaq]);
 });
 
-gulp.task('clean-website', function () {
+gulp.task('clean-website', () => {
     return del('site');
 });
 
-gulp.step('fetch-assets-repo', function (cb) {
+gulp.step('fetch-assets-repo', cb => {
     git.clone('https://github.com/DevExpress/testcafe-gh-page-assets.git', { args: 'site' }, cb);
 });
 
-gulp.step('put-in-articles', function () {
+gulp.step('put-in-articles', () => {
     return gulp
         .src(['docs/articles/**/*', '!docs/articles/blog/**/*'])
         .pipe(gulp.dest('site/src'));
 });
 
-gulp.step('put-in-posts', function () {
+gulp.step('put-in-posts', () => {
     return gulp
         .src('docs/articles/blog/**/*')
         .pipe(gulp.dest('site/src/_posts'));
 });
 
-gulp.step('put-in-navigation', function () {
+gulp.step('put-in-navigation', () => {
     return gulp
         .src('docs/nav/**/*')
         .pipe(gulp.dest('site/src/_data'));
 });
 
-gulp.step('put-in-publications', function () {
+gulp.step('put-in-publications', () => {
     return gulp
         .src('docs/publications/**/*')
         .pipe(gulp.dest('site/src/_data'));
 });
 
-gulp.step('put-in-tweets', function () {
+gulp.step('put-in-tweets', () => {
     return gulp
         .src('docs/tweets/**/*')
         .pipe(gulp.dest('site/src/_data'));
@@ -539,52 +539,52 @@ function buildWebsite (mode, cb) {
 //   - In production mode, public comment threads are displayed.
 // * Google Analytics is enabled in production mode only.
 
-gulp.step('build-website-production-run', function (cb) {
+gulp.step('build-website-production-run', cb => {
     buildWebsite('production', cb);
 });
 
 gulp.task('build-website-production', gulp.series('prepare-website', 'build-website-production-run'));
 
-gulp.step('build-website-development-run', function (cb) {
+gulp.step('build-website-development-run', cb => {
     buildWebsite('development', cb);
 });
 
 gulp.task('build-website-development', gulp.series('prepare-website', 'build-website-development-run'));
 
-gulp.step('build-website-testing-run', function (cb) {
+gulp.step('build-website-testing-run', cb => {
     buildWebsite('testing', cb);
 });
 
 gulp.task('build-website-testing', gulp.series('prepare-website', 'build-website-testing-run'));
 
-gulp.step('build-website-run', function (cb) {
+gulp.step('build-website-run', cb => {
     buildWebsite('', cb);
 });
 
 gulp.task('build-website', gulp.series('prepare-website', 'build-website-run'));
 
-gulp.task('serve-website', function (cb) {
+gulp.task('serve-website', cb => {
     const app = connect()
         .use('/testcafe', serveStatic('site/deploy'));
 
     websiteServer = app.listen(8080, cb);
 });
 
-gulp.step('preview-website-open', function () {
+gulp.step('preview-website-open', () => {
     return opn('http://localhost:8080/testcafe');
 });
 
 gulp.task('preview-website', gulp.series('build-website-development', 'serve-website', 'preview-website-open'));
 
-gulp.step('test-website-run', function () {
+gulp.step('test-website-run', () => {
     const WebsiteTester = require('./test/website/test.js');
     const websiteTester = new WebsiteTester();
 
     return websiteTester
         .checkLinks()
-        .then(function (failed) {
-            return new Promise(function (resolve, reject) {
-                websiteServer.close(function () {
+        .then(failed => {
+            return new Promise((resolve, reject) => {
+                websiteServer.close(() => {
                     if (failed)
                         reject('Broken links found!');
                     else
@@ -598,10 +598,10 @@ gulp.task('test-website', gulp.series('build-website-testing', 'serve-website', 
 
 gulp.task('test-website-travis', gulp.series('build-website', 'serve-website', 'test-website-run'));
 
-gulp.step('website-publish-run', function () {
+gulp.step('website-publish-run', () => {
     return gulp
         .src('site/deploy/**/*')
-        .pipe(rename(function (filePath) {
+        .pipe(rename(filePath => {
             filePath.dirname = filePath.dirname.toLowerCase();
 
             return filePath;
@@ -631,49 +631,49 @@ function testFunctional (fixturesDir, testingEnvironmentName, browserProviderNam
         }));
 }
 
-gulp.step('test-functional-travis-desktop-osx-and-ms-edge-run', function () {
+gulp.step('test-functional-travis-desktop-osx-and-ms-edge-run', () => {
     return testFunctional('test/functional/fixtures', functionalTestConfig.testingEnvironmentNames.osXDesktopAndMSEdgeBrowsers, functionalTestConfig.browserProviderNames.browserstack);
 });
 
 gulp.task('test-functional-travis-desktop-osx-and-ms-edge', gulp.series('build', 'test-functional-travis-desktop-osx-and-ms-edge-run'));
 
-gulp.step('test-functional-travis-mobile-run', function () {
+gulp.step('test-functional-travis-mobile-run', () => {
     return testFunctional('test/functional/fixtures', functionalTestConfig.testingEnvironmentNames.mobileBrowsers, functionalTestConfig.browserProviderNames.browserstack);
 });
 
 gulp.task('test-functional-travis-mobile', gulp.series('build', 'test-functional-travis-mobile-run'));
 
-gulp.step('test-functional-local-run', function () {
+gulp.step('test-functional-local-run', () => {
     return testFunctional('test/functional/fixtures', functionalTestConfig.testingEnvironmentNames.localBrowsers);
 });
 
 gulp.task('test-functional-local', gulp.series('build', 'test-functional-local-run'));
 
-gulp.step('test-functional-local-ie-run', function () {
+gulp.step('test-functional-local-ie-run', () => {
     return testFunctional('test/functional/fixtures', functionalTestConfig.testingEnvironmentNames.localBrowsersIE);
 });
 
 gulp.task('test-functional-local-ie', gulp.series('build', 'test-functional-local-ie-run'));
 
-gulp.step('test-functional-local-chrome-firefox-run', function () {
+gulp.step('test-functional-local-chrome-firefox-run', () => {
     return testFunctional('test/functional/fixtures', functionalTestConfig.testingEnvironmentNames.localBrowsersChromeFirefox);
 });
 
 gulp.task('test-functional-local-chrome-firefox', gulp.series('build', 'test-functional-local-chrome-firefox-run'));
 
-gulp.step('test-functional-local-headless-run', function () {
+gulp.step('test-functional-local-headless-run', () => {
     return testFunctional('test/functional/fixtures', functionalTestConfig.testingEnvironmentNames.localHeadlessBrowsers);
 });
 
 gulp.task('test-functional-local-headless', gulp.series('build', 'test-functional-local-headless-run'));
 
-gulp.step('test-functional-local-legacy-run', function () {
+gulp.step('test-functional-local-legacy-run', () => {
     return testFunctional('test/functional/legacy-fixtures', functionalTestConfig.testingEnvironmentNames.legacy);
 });
 
 gulp.task('test-functional-local-legacy', gulp.series('build', 'test-functional-local-legacy-run'));
 
-gulp.step('test-functional-travis-old-browsers-run', function () {
+gulp.step('test-functional-travis-old-browsers-run', () => {
     return testFunctional('test/functional/fixtures', functionalTestConfig.testingEnvironmentNames.oldBrowsers, functionalTestConfig.browserProviderNames.sauceLabs);
 });
 
@@ -684,13 +684,13 @@ function getDockerEnv (machineName) {
         .execSync('docker-machine env --shell bash ' + machineName)
         .toString()
         .split('\n')
-        .map(function (line) {
+        .map(line => {
             return line.match(/export\s*(.*)="(.*)"$/);
         })
-        .filter(function (match) {
+        .filter(match => {
             return !!match;
         })
-        .reduce(function (env, match) {
+        .reduce((env, match) => {
             env[match[1]] = match[2];
             return env;
         }, {});
@@ -729,7 +729,7 @@ function startDocker () {
     assignIn(process.env, dockerEnv);
 }
 
-gulp.task('docker-build', function (done) {
+gulp.task('docker-build', done => {
     if (!process.env['DOCKER_HOST']) {
         try {
             startDocker();
@@ -753,7 +753,7 @@ gulp.task('docker-build', function (done) {
     done();
 });
 
-gulp.step('docker-publish-run', function (done) {
+gulp.step('docker-publish-run', done => {
     childProcess.execSync('docker push testcafe/testcafe:' + PUBLISH_TAG, { stdio: 'inherit', env: process.env });
 
     done();

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -262,8 +262,8 @@ gulp.step('server-scripts', function () {
         ])
         .pipe(sourcemaps.init())
         .pipe(gulpBabel())
-        .pipe(sourcemaps.mapSources(function (sourcePath, file) {
-            return file.path;
+        .pipe(sourcemaps.mapSources(function (sourcePath) {
+            return path.basename(sourcePath);
         }))
         .pipe(sourcemaps.write())
         .pipe(gulp.dest('lib'));

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -263,7 +263,7 @@ gulp.step('server-scripts', function () {
         .pipe(sourcemaps.init())
         .pipe(gulpBabel())
         .pipe(sourcemaps.mapSources(function (sourcePath) {
-            const libPath = 'src/' + sourcePath;
+            const libPath = path.join('src/', sourcePath);
 
             return path.relative(sourcePath, libPath);
         }))

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -263,7 +263,9 @@ gulp.step('server-scripts', function () {
         .pipe(sourcemaps.init())
         .pipe(gulpBabel())
         .pipe(sourcemaps.mapSources(function (sourcePath) {
-            return path.basename(sourcePath);
+            const libPath = 'src/' + sourcePath;
+
+            return path.relative(sourcePath, libPath);
         }))
         .pipe(sourcemaps.write())
         .pipe(gulp.dest('lib'));


### PR DESCRIPTION
Initialially in the source maps was absolute path of the source-file, because source map resolver could not process relative path correcly (in path we need 'src' but not 'lib'). But absolute path leads to incorrect root folder name, so the right way to use relative path, even with incorrect src folder name.

`[incorrect_root_path]\src\testcafe.js` => `[correct_root_path]\`**lib**`\testcafe.js`

UPD. fixed in normal way `[correct_root_path]\src\testcafe.js`