### PR TITLE
update chai

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "bin-v8-flags-filter": "^1.1.2",
     "callsite": "^1.0.0",
     "callsite-record": "^4.0.0",
-    "chai": "^3.0.0",
+    "chai": "^4.1.2",
     "chalk": "^1.1.0",
     "chrome-emulated-devices-list": "^0.1.0",
     "chrome-remote-interface": "^0.25.3",

--- a/test/server/create-testcafe-test.js
+++ b/test/server/create-testcafe-test.js
@@ -87,9 +87,8 @@ describe('TestCafe factory function', function () {
             });
     });
 
-    it('Should contain plugin testing, embedding utils and common runtime functions', function () {
-        expect(createTestCafe.pluginTestingUtils).to.be.an.object;
-        expect(createTestCafe.embeddingUtils).to.be.an.object;
+    it('Should contain embedding utils and common runtime functions', function () {
+        expect(createTestCafe.embeddingUtils).to.be.an('object');
         expect(createTestCafe.Role).eql(exportableLib.Role);
         expect(createTestCafe.ClientFunction).eql(exportableLib.ClientFunction);
     });


### PR DESCRIPTION
@AndreyBelym @AlexKamaev 

Fix two issues:
* `npm WARN chai-string@1.5.0 requires a peer of chai@^4.1.2 but none is installed...`
* `to.be.an.object` assertion method works wrong in `chai@3.x`