### PR TITLE
Fix origExt is not a function while using TypeScript node modules

### DIFF
--- a/src/compiler/test-file/api-based.js
+++ b/src/compiler/test-file/api-based.js
@@ -72,7 +72,7 @@ export default class APIBasedTestFileCompilerBase extends TestFileCompilerBase {
                 // NOTE: remove global API so that it will be unavailable for the dependencies
                 this._removeGlobalAPI();
 
-                if (APIBasedTestFileCompilerBase._isNodeModulesDep(filename))
+                if (APIBasedTestFileCompilerBase._isNodeModulesDep(filename) && origExt)
                     origExt(mod, filename);
 
                 else {


### PR DESCRIPTION
While importing a node module that has only a `index.ts` file I am experiencing the following error:
```
TypeError: origExt is not a function
    at Object.origExt [as .ts] (/home/bbuhler/Dokumente/test-pts/node_modules/testcafe/src/compiler/test-file/api-based.js:76:21)
    at Object.<anonymous> (/home/bbuhler/Dokumente/test-pts/tests/test.ts:4:1)
    at Function._compile [as _execAsModule] (/home/bbuhler/Dokumente/test-pts/node_modules/testcafe/src/compiler/test-file/api-based.js:50:13)
    at TypeScriptTestFileCompiler._execAsModule [as compile] (/home/bbuhler/Dokumente/test-pts/node_modules/testcafe/src/compiler/test-file/api-based.js:144:42)
    at compile (/home/bbuhler/Dokumente/test-pts/node_modules/testcafe/src/compiler/index.js:48:42)
```

TypeScript seems not be registered as a require extension.

I found out that treating it as a non node module is solving the error, so I added `origExt` to the condition to validate it's existence before execution.

Though I don't know if that is the best solution in the overall context, but at least it was unblocking me in my use case.