### PR TITLE
[docs] Fix an example in 'Using Selectors' with innerText

### DIFF
--- a/docs/articles/documentation/test-api/selecting-page-elements/selectors/using-selectors.md
+++ b/docs/articles/documentation/test-api/selecting-page-elements/selectors/using-selectors.md
@@ -162,9 +162,9 @@ test('Assertion with Selector', async t => {
     const developerNameInput = Selector('#developer-name');
 
     await t
-        .expect(developerNameInput.innerText).eql('')
+        .expect(developerNameInput.value).eql('')
         .typeText(developerNameInput, 'Peter')
-        .expect(developerNameInput.innerText).eql('Peter');
+        .expect(developerNameInput.value).eql('Peter');
 });
 ```
 


### PR DESCRIPTION
\cc @AndreyBelym @kirovboris 

closes #2962 