### PR TITLE
[docs] Change screenshot path pattern command line syntax to single quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,7 @@ You specify a screenshot path pattern when you run tests. Each time TestCafe tak
 The following example shows how to specify a screenshot path pattern through the command line:
 
 ```sh
-testcafe all test.js -s screenshots -p "${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png"
+testcafe all test.js -s screenshots -p '${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png'
 ```
 
 When you use a programming API, pass the screenshot path pattern to the [runner.screenshots method](https://devexpress.github.io/testcafe/documentation/using-testcafe/programming-interface/runner.html#screenshots).

--- a/docs/articles/blog/2018-08-02-testcafe-v0-21-0-released.md
+++ b/docs/articles/blog/2018-08-02-testcafe-v0-21-0-released.md
@@ -64,7 +64,7 @@ You specify a screenshot path pattern when you run tests. Each time TestCafe tak
 The following example shows how to specify a screenshot path pattern through the command line:
 
 ```sh
-testcafe all test.js -s screenshots -p "${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png"
+testcafe all test.js -s screenshots -p '${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png'
 ```
 
 When you use a programming API, pass the screenshot path pattern to the [runner.screenshots method](https://devexpress.github.io/testcafe/documentation/using-testcafe/programming-interface/runner.html#screenshots).

--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -330,7 +330,13 @@ Placeholder | Description
 `${OS_VERSION}` | The operation system's version.
 
 ```sh
-testcafe all tests/sample-fixture.js -s screenshots -p "${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png"
+testcafe all tests/sample-fixture.js -s screenshots -p '${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png'
+```
+
+In Windows `cmd.exe` shell, use double quotes because single quotes do not escape spaces.
+
+```sh
+testcafe all tests/sample-fixture.js -s screenshots -p "${DATE} ${TIME}/test ${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png"
 ```
 
 ### -q, --quarantine-mode


### PR DESCRIPTION
\cc @AndreyBelym @kirovboris 

closes #2952 