### PR TITLE
Update the warning message about debugging in headless mode

### DIFF
--- a/src/notifications/warning-message.js
+++ b/src/notifications/warning-message.js
@@ -10,5 +10,5 @@ export default {
     resizeError:                             'Was unable to resize the window due to an error.\n\n{errMessage}',
     maximizeError:                           'Was unable to maximize the window due to an error.\n\n{errMessage}',
     requestMockCORSValidationFailed:         '{RequestHook}: CORS validation failed for a request specified as {requestFilterRule}',
-    debugInHeadlessError:                    'It is not allowed to debug in Headless mode'
+    debugInHeadlessError:                    'You cannot debug in headless mode.'
 };


### PR DESCRIPTION
I guess you cannot debug in headless mode not because it's not allowed but because it's impossible.