### PR TITLE
Edit a warning message displayed when a user tries to debug in headless mode

### DIFF
--- a/src/notifications/warning-message.js
+++ b/src/notifications/warning-message.js
@@ -10,5 +10,5 @@ export default {
     resizeError:                             'Was unable to resize the window due to an error.\n\n{errMessage}',
     maximizeError:                           'Was unable to maximize the window due to an error.\n\n{errMessage}',
     requestMockCORSValidationFailed:         '{RequestHook}: CORS validation failed for a request specified as {requestFilterRule}',
-    debugInHeadlessError:                    'It is not allowed to debug in Headless mode'
+    debugInHeadlessError:                    'You cannot debug in headless mode.'
 };

--- a/test/functional/fixtures/regression/gh-2846/test.js
+++ b/test/functional/fixtures/regression/gh-2846/test.js
@@ -6,7 +6,7 @@ if (config.useHeadlessBrowsers) {
         it('Should add warning on t.debug', function () {
             return runTests('./testcafe-fixtures/index.js')
                 .then(() => {
-                    expect(testReport.warnings).eql(['It is not allowed to debug in Headless mode']);
+                    expect(testReport.warnings).eql(['You cannot debug in headless mode.']);
                 });
         });
     });


### PR DESCRIPTION
\cc @AlexKamaev @AndreyBelym 