### PR TITLE
[docs] Fix doc's typo.

### DIFF
--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -286,13 +286,13 @@ testcafe all tests/sample-fixture.js -s screenshots
 
 The captured screenshots are organized into subdirectories within the base directory. The following path patterns are used to define a relative path and name for screenshots the [Take Screenshot](../test-api/actions/take-screenshot.md) actions take:
 
-* `${DATE}_${TIME}\test-${TEST_INDEX}\${USERAGENT}\{$FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is disabled;
-* `${DATE}_${TIME}\test-${TEST_INDEX}\run-${QUARANTINE_ATTEMPT}\${USERAGENT}\{$FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is enabled.
+* `${DATE}_${TIME}\test-${TEST_INDEX}\${USERAGENT}\${FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is disabled;
+* `${DATE}_${TIME}\test-${TEST_INDEX}\run-${QUARANTINE_ATTEMPT}\${USERAGENT}\${FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is enabled.
 
 If TestCafe takes screenshots when a test fails (see [--screenshots-on-fails](#-s---screenshots-on-fails) option), the following path patterns are used:
 
-* `${DATE}_${TIME}\test-${TEST_INDEX}\${USERAGENT}\errors\{$FILE_INDEX}.png`;
-* `${DATE}_${TIME}\test-${TEST_INDEX}\run-${QUARANTINE_ATTEMPT}\${USERAGENT}\errors\{$FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is enabled.
+* `${DATE}_${TIME}\test-${TEST_INDEX}\${USERAGENT}\errors\${FILE_INDEX}.png`;
+* `${DATE}_${TIME}\test-${TEST_INDEX}\run-${QUARANTINE_ATTEMPT}\${USERAGENT}\errors\${FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is enabled.
 
 You can also use the [--screenshot-path-pattern](#-p---screenshot-path-pattern) option to specify a custom pattern.
 


### PR DESCRIPTION
I found document's typos about `FILE_INDEX `.
Please merge and fix them.