### PR TITLE
[docs] Revert "[docs] Add "group" metadata to define which tests will be run"

### DIFF
--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -37,8 +37,6 @@ testcafe [options] <browser-list-comma-separated> <file-or-glob ...>
   * [-F \<pattern\>, --fixture-grep \<pattern\>](#-f-pattern---fixture-grep-pattern)
   * [-a \<command\>, --app \<command\>](#-a-command---app-command)
   * [-c \<n\>, --concurrency \<n\>](#-c-n---concurrency-n)
-  * [--test-meta \<key=value\[,key2=value2,...\]\>](#--test-meta-keyvaluekey2value2)
-  * [--fixture-meta \<key=value\[,key2=value2,...\]\>](#--fixture-meta-keyvaluekey2value2)
   * [--debug-on-fail](#--debug-on-fail)
   * [--app-init-delay \<ms\>](#--app-init-delay-ms)
   * [--selector-timeout \<ms\>](#--selector-timeout-ms)
@@ -449,26 +447,6 @@ The following example shows how to run tests in three Chrome instances:
 
 ```sh
 testcafe -c 3 chrome tests/sample-fixture.js
-```
-
-### --test-meta \<key=value\[,key2=value2,...\]\>
-
-TestCafe runs tests whose [metadata](../test-api/test-code-structure.html#specifying-testing-metadata) [matches](https://lodash.com/docs/#isMatch) the specified key-value pair.
-
-For example, the following command runs tests whose metadata have a `device` property with the value `mobile` and a `env` property with the value `production`.
-
-```sh
-testcafe ie my-tests --test-meta device=mobile,env=production
-```
-
-### --fixture-meta \<key=value\[,key2=value2,...\]\>
-
-TestCafe runs tests whose fixture's [metadata](../test-api/test-code-structure.html#specifying-testing-metadata) [matches](https://lodash.com/docs/#isMatch) the specified key-value pair.
-
-For example, the following command runs tests whose fixture's metadata have a `device` property with the value `mobile` and a `env` property with the value `production`.
-
-```sh
-testcafe ie my-tests --fixture-meta device=mobile,env=production
 ```
 
 ### --debug-on-fail

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -87,9 +87,9 @@ Allows you to select which tests should be run.
 filter(callback) → this
 ```
 
-Parameter  | Type                                                                  | Description
----------- | --------------------------------------------------------------------- | ----------------------------------------------------------------
-`callback` | `function(testName, fixtureName, fixturePath, testMeta, fixtureMeta)` | The callback that determines if a particular test should be run.
+Parameter  | Type                                           | Description
+---------- | ---------------------------------------------- | ----------------------------------------------------------------
+`callback` | `function(testName, fixtureName, fixturePath)` | The callback that determines if a particular test should be run.
 
 The callback function is called for each test in the files specified using the [src](#src) method.
 
@@ -97,23 +97,19 @@ Return `true` from the callback to include the current test or `false` to exclud
 
 The callback function accepts the following arguments:
 
-Parameter     | Type                     | Description
-------------- | ------------------------ | ----------------------------------
-`testName`    | String                   | The name of the test.
-`fixtureName` | String                   | The name of the test fixture.
-`fixturePath` | String                   | The path to the test fixture file.
-`testMeta`    | Object\<String, String\> | The test metadata.
-`fixtureMeta` | Object\<String, String\> | The fixture metadata.
+Parameter     | Type   | Description
+------------- | ------ | ----------------------------------
+`testName`    | String | The name of the test.
+`fixtureName` | String | The name of the test fixture.
+`fixturePath` | String | The path to the test fixture file.
 
 **Example**
 
 ```js
-runner.filter((testName, fixtureName, fixturePath, testMeta, fixtureMeta) => {
+runner.filter((testName, fixtureName, fixturePath) => {
     return fixturePath.startsWith('D') &&
         testName.match(someRe) &&
-        fixtureName.match(anotherRe) &&
-        testMeta.mobile === 'true' &&
-        fixtureMeta.env === 'staging';
+        fixtureName.match(anotherRe);
 });
 ```
 


### PR DESCRIPTION
Reverts DevExpress/testcafe#2954

Reasons can be found here: https://github.com/DevExpress/testcafe/pull/2954#issuecomment-433978514

@kirovboris @miherlosev 