### PR TITLE
[docs] Edit the main menu in light of the new support page

### DIFF
--- a/docs/nav/top-menu-items.yml
+++ b/docs/nav/top-menu-items.yml
@@ -6,16 +6,10 @@
   external: true
 - text: FAQ
   url: /faq/
-# - text: Publications
-#   url: /publications/
 - text: Release Notes
   url: /blog/
-- text: Issues
-  url: https://github.com/DevExpress/testcafe/issues
-  external: true
-- text: Q&amp;A
-  url: https://stackoverflow.com/questions/tagged/testcafe
-  external: true
+- text: Support
+  url: /support/
 - text: TestCafe Studio
   url: https://testcafe-studio.devexpress.com
   external: true


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs 

Edited the main menu: removed `Issues` and `Q&A`; added `Support`. Need to confirm we leave `FAQ`. 

Main PR: https://github.com/DevExpress/testcafe-gh-page-assets/pull/68