### PR TITLE
[docs] Add docs for the --test-meta and --fixture-meta flags

### DIFF
--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -35,6 +35,8 @@ testcafe [options] <browser-list-comma-separated> <file-or-glob ...>
   * [-T \<pattern\>, --test-grep \<pattern\>](#-t-pattern---test-grep-pattern)
   * [-f \<name\>, --fixture \<name\>](#-f-name---fixture-name)
   * [-F \<pattern\>, --fixture-grep \<pattern\>](#-f-pattern---fixture-grep-pattern)
+  * [--test-meta \<key=value\[,key2=value2,...\]\>](#--test-meta-keyvaluekey2value2)
+  * [--fixture-meta \<key=value\[,key2=value2,...\]\>](#--fixture-meta-keyvaluekey2value2)
   * [-a \<command\>, --app \<command\>](#-a-command---app-command)
   * [-c \<n\>, --concurrency \<n\>](#-c-n---concurrency-n)
   * [--debug-on-fail](#--debug-on-fail)
@@ -418,6 +420,26 @@ For example, the following command runs fixtures whose names match `Page.*`. The
 
 ```sh
 testcafe ie my-tests -F "Page.*"
+```
+
+### --test-meta \<key=value\[,key2=value2,...\]\>
+
+TestCafe runs tests whose [metadata](../test-api/test-code-structure.md#specifying-testing-metadata) [matches](https://lodash.com/docs/#isMatch) the specified key-value pair.
+
+For example, the following command runs tests whose metadata has the `device` property set to the `mobile` value and the `env` property set to the `production` value.
+
+```sh
+testcafe chrome my-tests --test-meta device=mobile,env=production
+```
+
+### --fixture-meta \<key=value\[,key2=value2,...\]\>
+
+TestCafe runs tests whose fixture's [metadata](../test-api/test-code-structure.md#specifying-testing-metadata) [matches](https://lodash.com/docs/#isMatch) the specified key-value pair.
+
+For example, the following command runs tests whose fixture's metadata has the `device` property set to the `mobile` value and the `env` property set to the `production` value.
+
+```sh
+testcafe chrome my-tests --fixture-meta device=mobile,env=production
 ```
 
 ### -a \<command\>, --app \<command\>

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -87,9 +87,9 @@ Allows you to select which tests should be run.
 filter(callback) → this
 ```
 
-Parameter  | Type                                           | Description
----------- | ---------------------------------------------- | ----------------------------------------------------------------
-`callback` | `function(testName, fixtureName, fixturePath)` | The callback that determines if a particular test should be run.
+Parameter  | Type                                                                  | Description
+---------- | --------------------------------------------------------------------- | ----------------------------------------------------------------
+`callback` | `function(testName, fixtureName, fixturePath, testMeta, fixtureMeta)` | The callback that determines if a particular test should be run.
 
 The callback function is called for each test in the files specified using the [src](#src) method.
 
@@ -97,19 +97,23 @@ Return `true` from the callback to include the current test or `false` to exclud
 
 The callback function accepts the following arguments:
 
-Parameter     | Type   | Description
-------------- | ------ | ----------------------------------
-`testName`    | String | The name of the test.
-`fixtureName` | String | The name of the test fixture.
-`fixturePath` | String | The path to the test fixture file.
+Parameter     | Type                     | Description
+------------- | ------------------------ | ----------------------------------
+`testName`    | String                   | The name of the test.
+`fixtureName` | String                   | The name of the test fixture.
+`fixturePath` | String                   | The path to the test fixture file.
+`testMeta`    | Object\<String, String\> | The test metadata.
+`fixtureMeta` | Object\<String, String\> | The fixture metadata.
 
 **Example**
 
 ```js
-runner.filter((testName, fixtureName, fixturePath) => {
+runner.filter((testName, fixtureName, fixturePath, testMeta, fixtureMeta) => {
     return fixturePath.startsWith('D') &&
         testName.match(someRe) &&
-        fixtureName.match(anotherRe);
+        fixtureName.match(anotherRe) &&
+        testMeta.mobile === 'true' &&
+        fixtureMeta.env === 'staging';
 });
 ```
 


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs 

Pull requesting user's content from https://github.com/DevExpress/testcafe/pull/2954 to the right branch (with my minor changes).