### PR TITLE
[docs] Describe the --disable-test-syntax-validation option

### DIFF
--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -53,6 +53,7 @@ testcafe [options] <browser-list-comma-separated> <file-or-glob ...>
   * [--dev](#--dev)
   * [--qr-code](#--qr-code)
   * [--sf, --stop-on-first-fail](#--sf---stop-on-first-fail)
+  * [--disable-test-syntax-validation](#--disable-test-syntax-validation)
   * [--color](#--color)
   * [--no-color](#--no-color)
 
@@ -642,6 +643,41 @@ Stops an entire test run if any test fails. This allows you not to wait for all 
 
 ```sh
 testcafe chrome my-tests --sf
+```
+
+### --disable-test-syntax-validation
+
+Disables checks for `test` and `fixture` directives in test files. Use this flag to run dynamically loaded tests.
+
+TestCafe requires test files to have the [fixture](../test-api/test-code-structure.md#fixtures) and [test](../test-api/test-code-structure.md#tests) directives. Otherwise, an error is thrown.
+
+However, when you import tests from external libraries or generate them dynamically, the `.js` file provided to TestCafe may not contain any tests.
+
+**external-lib.js**
+
+```js
+export default function runTests () {
+    fixture `External tests`
+        .page `http:///example.com`;
+
+    test('My Test', async t => {
+        // ...
+    });
+}
+```
+
+**test.js**
+
+```js
+import { runTests } from 'external-lib';
+
+runTests();
+```
+
+In this instance, specify the `--disable-test-syntax-validation` flag to bypass checks for test syntax.
+
+```sh
+testcafe safari test.js --disable-test-syntax-validation
 ```
 
 ### --color

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -422,6 +422,7 @@ Parameter         | Type    | Description                                       
 `pageLoadTimeout` | Number  | Specifies the time (in milliseconds) passed after the `DOMContentLoaded` event, within which TestCafe waits for the `window.load` event to fire. After the timeout passes or the `window.load` event is raised (whichever happens first), TestCafe starts the test. You can set this timeout to `0` to skip waiting for `window.load`. | `3000`
 `speed`           | Number  | Specifies the test execution speed. Should be a number between `1` (the fastest) and `0.01` (the slowest). If speed is also specified for an [individual action](../../test-api/actions/action-options.md#basic-action-options), the action speed setting overrides test speed. | `1`
 `stopOnFirstFail`    | Boolean | Defines whether to stop an entire test run if any test fails. This allows you not to wait for all the tests included in the test task to finish and allows focusing on the first error. | `false`
+`disableTestSyntaxValidation` | Boolean | Defines whether to disable checks for [test](../../test-api/test-code-structure.md#tests) and [fixture](../../test-api/test-code-structure.md#fixtures) directives in test files. Use this option to run dynamically loaded tests. See details in the [--disable-test-syntax-validation](../command-line-interface.md#--disable-test-syntax-validation) command line option description. | `false`
 
 After all tests are finished, call the [testcafe.close](testcafe.md#close) function to stop the TestCafe server.
 


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs @AlexKamaev 