### PR TITLE
[docs] Fix a bug in a --disable-test-syntax-validation example

### DIFF
--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -669,7 +669,7 @@ export default function runTests () {
 **test.js**
 
 ```js
-import { runTests } from 'external-lib';
+import runTests from './external-lib';
 
 runTests();
 ```


### PR DESCRIPTION
\cc @AlexKamaev 