### PR TITLE
[docs] Update website 11/7/2018

### DIFF
--- a/blog/testcafe-v0-23-1-released.html
+++ b/blog/testcafe-v0-23-1-released.html
@@ -13,15 +13,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   
-  <title>Release Notes | TestCafe</title>
+  <title>TestCafe v0.23.1 Released | TestCafe</title>
 
-  <meta name="description" content="">
+  <meta name="description" content="TestCafe v0.23.1 ReleasedSelect tests and fixtures to run by their metadata and run dynamically loaded tests.">
   <meta name="viewport" content="width=device-width">
 
   <meta property="og:image" content="https://raw.githubusercontent.com/DevExpress/testcafe-gh-page-assets/master/src/images/testcafe-ogp-icon.png">
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="http://devexpress.github.io/testcafe/blog/" />
-  <meta property="og:title" content="Release Notes | TestCafe" />
+  <meta property="og:url" content="http://devexpress.github.io/testcafe/blog/testcafe-v0-23-1-released.html" />
+  <meta property="og:title" content="TestCafe v0.23.1 Released | TestCafe" />
 
   
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.0.0/styles/docco.min.css">
@@ -29,7 +29,7 @@
   
   <link rel="shortcut icon" href="/testcafe/favicon.ico">
   <link rel="stylesheet" href="/testcafe/css/main.css">
-  <link rel="canonical" href="http://devexpress.github.io/testcafe/blog/">
+  <link rel="canonical" href="http://devexpress.github.io/testcafe/blog/testcafe-v0-23-1-released.html">
   <link rel="alternate" type="application/rss+xml" title="TestCafe" href="http://devexpress.github.io/testcafe/feed.xml">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto">
@@ -392,295 +392,72 @@
 
 
       <div class="container">
+    <main>
     <div class="post">
-    <div class="blog-title">
-        TestCafe Release Notes
-    </div>
-    <div class="post-list">
-    
-        <div class="post-preview">
-            <div class="post-date">
-                NOV  7, 2018
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-23-1-released.html">TestCafe v0.23.1 Released</a></div>
-            <div class="post-extract">
-                
-                <p>
+        <div class="post-date">
+            NOV  7, 2018
+        </div>
+        <article class="post-content">
+            <h1>TestCafe v0.23.1 Released</h1>
 <p>Select tests and fixtures to run by their metadata and run dynamically loaded tests.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-23-1-released.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                OCT 25, 2018
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-23-0-released.html">TestCafe v0.23.0 Released</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>Stop a test run after the first test fail, view JavaScript errors&#39; stack trace in test run reports and let TestCafe restart browsers when they stop responding.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-23-0-released.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                SEP  3, 2018
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-22-0-released.html">TestCafe v0.22.0 Released</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>Write tests in CoffeeScript, view failed selector methods in test run reports and detect server-side errors and unhandled promise rejections.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-22-0-released.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                AUG  2, 2018
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-21-0-released.html">TestCafe v0.21.0 Released</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>Test web pages served over HTTPS, construct screenshot paths with patterns and use more info in custom reporters.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-21-0-released.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                MAY 15, 2018
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-20-0-released.html">TestCafe v0.20.0 Released</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>Intercepting HTTP requests, specifying resources accessed by bypassing a proxy server, specifying testing metadata, deprecated passing a regular promise to assertions.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-20-0-released.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                MAR  1, 2018
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-19-0-released.html">TestCafe v0.19.0 Released - Rapid Test Development Tool, Screenshots of Page Elements, etc</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>Welcome TestCafe Live, a tool for rapid test development. We have also added a couple of new features like taking screenshots of individual page elements and filtering visible and hidden elements in the selector chain.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-19-0-released.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                OCT 10, 2017
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-18-0-released.html">TestCafe v0.18.0 Released - Angular Selectors, Using Multiple Reporters, etc</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>With this release, we have prepared a bunch of useful things. We have put finishing touches on Angular selectors to let you address page elements on Angular websites using the component tree. We have also made it possible to output reports to multiple channels (like console + file). Read on to learn about more things we have for you.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-18-0-released.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                SEP 29, 2017
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-18-0-alpha1-released.html">TestCafe v0.18.0-alpha1 Released - Testing in headless Firefox</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>This early release supports headless mode in Firefox v56.0 which was launched on September 28th.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-18-0-alpha1-released.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                AUG  2, 2017
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-17-0-released.html">TestCafe v0.17.0 Released</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>With this release, we have prepared a bunch of new features. Two big news are the Electron browser provider and concurrent test execution.</p>
 
-<p>Read on to learn more.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-17-0-released.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                JUN 13, 2017
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-16-0-released.html">TestCafe v0.16.0 Released</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>TypeScript support, seamless testing in headless Chrome and device emulator, and numerous bug fixes.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-16-0-released.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                APR 26, 2017
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-15-0-released.html">TestCafe v0.15.0 Released</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>Plugins for React and Vue.js, TestCafe Docker image, support for Internet access proxies and lots of bug fixes.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-15-0-released.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                MAR 28, 2017
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-14-0-released.html">TestCafe v0.14.0 Released</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>Authentication via user roles, client-side debugging and numerous bug fixes.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-14-0-released.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                FEB 16, 2017
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-13-0-released.html">TestCafe v0.13.0 Released</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>IDE plugins, fixture hooks, speed setting for actions, a couple of API enhancements and lots of bug fixes.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-13-0-released.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                JAN 19, 2017
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-12-0-released.html">TestCafe v0.12.0 Released</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>HTTP authentication support, a CI-friendly way to start and stop the tested app and lots of API enhancements.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-12-0-released.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                DEC  8, 2016
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-11-0-released.html">TestCafe v0.11.0 Released</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>Redesigned selector system, built-in assertions and lots of bug fixes! 🚀🚀🚀</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-11-0-released.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                NOV  8, 2016
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/testcafe-v0-10-0-released.html">TestCafe v0.10.0 Released</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>First of all, we would like to thank everyone who&#39;s reading this for your interest and support for TestCafe.
-And we especially appreciate those of you who reached us to say thank you, offer help or share feedback.
-Let&#39;s keep building a better testing framework together!</p>
+<!--more-->
+<h2><a class="anchor" id="enhancements"></a>Enhancements <a class="permalink" href="#enhancements">#</a></h2><h3><a class="anchor" id="select-tests-and-fixtures-to-run-by-their-metadata-2527-by-nickcis"></a>⚙ Select Tests and Fixtures to Run by Their Metadata (<a href="https://github.com/DevExpress/testcafe/issues/2527">#2527</a>) by <a href="https://github.com/NickCis">@NickCis</a> <a class="permalink" href="#select-tests-and-fixtures-to-run-by-their-metadata-2527-by-nickcis">#</a></h3>
+<p>You can now run only those tests or fixtures whose <a href="https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#specifying-testing-metadata">metadata</a> contains a specific set of values.</p>
 
-<p>So, here is our first minor update and that&#39;s what it includes.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/testcafe-v0-10-0-released.html">Read More</a>
-                </p>
-            </div>
+<p>Use the <a href="https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#--test-meta-keyvaluekey2value2">--test-meta</a> flag to specify values to look for in test metadata.</p>
+<div class="highlight"><pre><code class="language-sh" data-lang="sh">testcafe chrome my-tests --test-meta <span class="nv">device</span><span class="o">=</span>mobile,env<span class="o">=</span>production
+</code></pre></div>
+<p>To select fixtures by their metadata, use the <a href="https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#--fixture-meta-keyvaluekey2value2">--fixture-meta</a> flag.</p>
+<div class="highlight"><pre><code class="language-sh" data-lang="sh">testcafe chrome my-tests --fixture-meta <span class="nv">subsystem</span><span class="o">=</span>payments,type<span class="o">=</span>regression
+</code></pre></div>
+<p>In the API, test and fixture metadata is now passed to the <a href="https://devexpress.github.io/testcafe/documentation/using-testcafe/programming-interface/runner.html#filter">runner.filter</a> method in the <code>testMeta</code> and <code>fixtureMeta</code> parameters. Use this metadata to decide whether to run the current test.</p>
+<div class="highlight"><pre><code class="language-js" data-lang="js"><span class="nx">runner</span><span class="p">.</span><span class="nx">filter</span><span class="p">((</span><span class="nx">testName</span><span class="p">,</span> <span class="nx">fixtureName</span><span class="p">,</span> <span class="nx">fixturePath</span><span class="p">,</span> <span class="nx">testMeta</span><span class="p">,</span> <span class="nx">fixtureMeta</span><span class="p">)</span> <span class="o">=&gt;</span> <span class="p">{</span>
+    <span class="k">return</span> <span class="nx">testMeta</span><span class="p">.</span><span class="nx">mobile</span> <span class="o">===</span> <span class="s1">'true'</span> <span class="o">&amp;&amp;</span>
+        <span class="nx">fixtureMeta</span><span class="p">.</span><span class="nx">env</span> <span class="o">===</span> <span class="s1">'staging'</span><span class="p">;</span>
+<span class="p">});</span>
+</code></pre></div><h3><a class="anchor" id="run-dynamically-loaded-tests-2074"></a>⚙ Run Dynamically Loaded Tests (<a href="https://github.com/DevExpress/testcafe/issues/2074">#2074</a>) <a class="permalink" href="#run-dynamically-loaded-tests-2074">#</a></h3>
+<p>You can now run tests imported from external libraries or generated dynamically even if the <code>.js</code> file you provide to TestCafe does not contain any tests.</p>
+
+<p>Previously, this was not possible because TestCafe required test files to contain the <a href="https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#fixtures">fixture</a> and <a href="https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#tests">test</a> directives. Now you can bypass this check. To do this, provide the <a href="https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#--disable-test-syntax-validation">--disable-test-syntax-validation</a> command line flag.</p>
+<div class="highlight"><pre><code class="language-sh" data-lang="sh">testcafe safari test.js --disable-test-syntax-validation
+</code></pre></div>
+<p>In the API, use the <a href="https://devexpress.github.io/testcafe/documentation/using-testcafe/programming-interface/runner.html#run">disableTestSyntaxValidation</a> option.</p>
+<div class="highlight"><pre><code class="language-js" data-lang="js"><span class="nx">runner</span><span class="p">.</span><span class="nx">run</span><span class="p">({</span> <span class="na">disableTestSyntaxValidation</span><span class="p">:</span> <span class="kc">true</span> <span class="p">})</span>
+</code></pre></div><h2><a class="anchor" id="bug-fixes"></a>Bug Fixes <a class="permalink" href="#bug-fixes">#</a></h2>
+<ul>
+<li>Touch events are now simulated with correct touch properties (<code>touches</code>, <code>targetTouches</code>, <code>changedTouches</code>) (<a href="https://github.com/DevExpress/testcafe/issues/2856">#2856</a>)</li>
+<li>Google Chrome now closes correctly on macOS after tests are finished (<a href="https://github.com/DevExpress/testcafe/issues/2860">#2860</a>)</li>
+<li>Internal attribute and node changes no longer provoke <code>MutationObserver</code> notifications (<a href="https://github.com/DevExpress/testcafe-hammerhead/issues/1769">testcafe-hammerhead/#1769</a>)</li>
+<li>The <code>ECONNABORTED</code> error is no longer raised (<a href="https://github.com/DevExpress/testcafe-hammerhead/issues/1744">testcafe-hammerhead/#1744</a>)</li>
+<li>Websites that use <code>Location.ancestorOrigins</code> are now proxied correctly (<a href="https://github.com/DevExpress/testcafe-hammerhead/issues/1342">testcafe-hammerhead/#1342</a>)</li>
+</ul>
+
+        </article>
+        <div id="back-to-posts-link">
+            <p><a href="./">Back to Post List</a></p>
         </div>
-    
-        <div class="post-preview">
-            <div class="post-date">
-                OCT 17, 2016
-            </div>
-            <div class="post-title"><a href="/testcafe/blog/introducing-testcafe-open-source-testing-framework.html">Introducing TestCafe Testing Framework</a></div>
-            <div class="post-extract">
-                
-                <p>
-<p>We are happy to announce that DevExpress has released the core library of TestCafe – our automated in-browser
-testing tool – as an open-source framework for node.js. Now everyone in the open-source community can benefit
-from the technologies we developed for the commercial version.</p>
-</p>
-                <p class="read-more">
-                    <a href="/testcafe/blog/introducing-testcafe-open-source-testing-framework.html">Read More</a>
-                </p>
-            </div>
-        </div>
-    
+        <!-- <div id="disqus_thread"></div> -->
     </div>
-</div>    
+</main>
 
+<!-- 
+<script>
+    var disqus_config = function () {
+        this.page.url = 'http://devexpress.github.io/testcafe/blog/testcafe-v0-23-1-released.html';
+        this.page.identifier = '/blog/testcafe-v0-23-1-released';
+    };
+    (function() {
+        var d = document, s = d.createElement('script');
+        
+        s.src = '//testcafe-blog.disqus.com/embed.js';
+        
+        s.setAttribute('data-timestamp', +new Date());
+        (d.head || d.body).appendChild(s);
+    })();
+</script>
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
+ -->
 </div>
 
       <div class="push"></div>

--- a/css/support-page.mobile.css
+++ b/css/support-page.mobile.css
@@ -13,7 +13,7 @@ html body .page-content-wrapper .site-header .site-header-content .site-nav #sea
       font-size: 36px; }
   .support .banner .support-search {
     margin: 0 auto;
-    max-width: none; 
+    max-width: none;
     padding-bottom: 48px; }
     .support .banner .support-search .algolia-autocomplete #support-search-input {
       width: calc(100% - 30px);

--- a/documentation/using-testcafe/command-line-interface.html
+++ b/documentation/using-testcafe/command-line-interface.html
@@ -726,6 +726,8 @@
 <li><a href="#-t-pattern---test-grep-pattern">-T &lt;pattern&gt;, --test-grep &lt;pattern&gt;</a></li>
 <li><a href="#-f-name---fixture-name">-f &lt;name&gt;, --fixture &lt;name&gt;</a></li>
 <li><a href="#-f-pattern---fixture-grep-pattern">-F &lt;pattern&gt;, --fixture-grep &lt;pattern&gt;</a></li>
+<li><a href="#--test-meta-keyvaluekey2value2">--test-meta &lt;key=value[,key2=value2,...]&gt;</a></li>
+<li><a href="#--fixture-meta-keyvaluekey2value2">--fixture-meta &lt;key=value[,key2=value2,...]&gt;</a></li>
 <li><a href="#-a-command---app-command">-a &lt;command&gt;, --app &lt;command&gt;</a></li>
 <li><a href="#-c-n---concurrency-n">-c &lt;n&gt;, --concurrency &lt;n&gt;</a></li>
 <li><a href="#--debug-on-fail">--debug-on-fail</a></li>
@@ -742,6 +744,7 @@
 <li><a href="#--dev">--dev</a></li>
 <li><a href="#--qr-code">--qr-code</a></li>
 <li><a href="#--sf---stop-on-first-fail">--sf, --stop-on-first-fail</a></li>
+<li><a href="#--disable-test-syntax-validation">--disable-test-syntax-validation</a></li>
 <li><a href="#--color">--color</a></li>
 <li><a href="#--no-color">--no-color</a></li>
 </ul></li>
@@ -992,6 +995,16 @@ it is paused within this hook before the first action.</p>
 
 <p>For example, the following command runs fixtures whose names match <code>Page.*</code>. These can be <code>Page1</code>, <code>Page2</code>, etc.</p>
 <div class="highlight"><pre><code class="language-sh" data-lang="sh">testcafe ie my-tests -F <span class="s2">"Page.*"</span>
+</code></pre></div><h3><a class="anchor" id="--test-meta-keyvaluekey2value2"></a>--test-meta &lt;key=value[,key2=value2,...]&gt; <a class="permalink" href="#--test-meta-keyvaluekey2value2">#</a></h3>
+<p>TestCafe runs tests whose <a href="../test-api/test-code-structure.html#specifying-testing-metadata">metadata</a> <a href="https://lodash.com/docs/#isMatch">matches</a> the specified key-value pair.</p>
+
+<p>For example, the following command runs tests whose metadata has the <code>device</code> property set to the <code>mobile</code> value and the <code>env</code> property set to the <code>production</code> value.</p>
+<div class="highlight"><pre><code class="language-sh" data-lang="sh">testcafe chrome my-tests --test-meta <span class="nv">device</span><span class="o">=</span>mobile,env<span class="o">=</span>production
+</code></pre></div><h3><a class="anchor" id="--fixture-meta-keyvaluekey2value2"></a>--fixture-meta &lt;key=value[,key2=value2,...]&gt; <a class="permalink" href="#--fixture-meta-keyvaluekey2value2">#</a></h3>
+<p>TestCafe runs tests whose fixture&#39;s <a href="../test-api/test-code-structure.html#specifying-testing-metadata">metadata</a> <a href="https://lodash.com/docs/#isMatch">matches</a> the specified key-value pair.</p>
+
+<p>For example, the following command runs tests whose fixture&#39;s metadata has the <code>device</code> property set to the <code>mobile</code> value and the <code>env</code> property set to the <code>production</code> value.</p>
+<div class="highlight"><pre><code class="language-sh" data-lang="sh">testcafe chrome my-tests --fixture-meta <span class="nv">device</span><span class="o">=</span>mobile,env<span class="o">=</span>production
 </code></pre></div><h3><a class="anchor" id="-a-command---app-command"></a>-a &lt;command&gt;, --app &lt;command&gt; <a class="permalink" href="#-a-command---app-command">#</a></h3>
 <p>Executes the specified shell command before running tests. Use it to launch or deploy the application you are going to test.</p>
 
@@ -1109,6 +1122,30 @@ See <a href="common-concepts/connect-to-the-testcafe-server-over-https.html">Con
 </code></pre></div><h3><a class="anchor" id="--sf---stop-on-first-fail"></a>--sf, --stop-on-first-fail <a class="permalink" href="#--sf---stop-on-first-fail">#</a></h3>
 <p>Stops an entire test run if any test fails. This allows you not to wait for all the tests included in the test task to finish and allows focusing on the first error.</p>
 <div class="highlight"><pre><code class="language-sh" data-lang="sh">testcafe chrome my-tests --sf
+</code></pre></div><h3><a class="anchor" id="--disable-test-syntax-validation"></a>--disable-test-syntax-validation <a class="permalink" href="#--disable-test-syntax-validation">#</a></h3>
+<p>Disables checks for <code>test</code> and <code>fixture</code> directives in test files. Use this flag to run dynamically loaded tests.</p>
+
+<p>TestCafe requires test files to have the <a href="../test-api/test-code-structure.html#fixtures">fixture</a> and <a href="../test-api/test-code-structure.html#tests">test</a> directives. Otherwise, an error is thrown.</p>
+
+<p>However, when you import tests from external libraries or generate them dynamically, the <code>.js</code> file provided to TestCafe may not contain any tests.</p>
+
+<p><strong>external-lib.js</strong></p>
+<div class="highlight"><pre><code class="language-js" data-lang="js"><span class="kr">export</span> <span class="k">default</span> <span class="kd">function</span> <span class="nx">runTests</span> <span class="p">()</span> <span class="p">{</span>
+    <span class="nx">fixture</span> <span class="err">`</span><span class="nx">External</span> <span class="nx">tests</span><span class="err">`</span>
+        <span class="p">.</span><span class="nx">page</span> <span class="err">`</span><span class="nx">http</span><span class="err">:</span><span class="c1">///example.com`;</span>
+
+    <span class="nx">test</span><span class="p">(</span><span class="s1">'My Test'</span><span class="p">,</span> <span class="nx">async</span> <span class="nx">t</span> <span class="o">=&gt;</span> <span class="p">{</span>
+        <span class="c1">// ...</span>
+    <span class="p">});</span>
+<span class="p">}</span>
+</code></pre></div>
+<p><strong>test.js</strong></p>
+<div class="highlight"><pre><code class="language-js" data-lang="js"><span class="kr">import</span> <span class="nx">runTests</span> <span class="nx">from</span> <span class="s1">'./external-lib'</span><span class="p">;</span>
+
+<span class="nx">runTests</span><span class="p">();</span>
+</code></pre></div>
+<p>In this instance, specify the <code>--disable-test-syntax-validation</code> flag to bypass checks for test syntax.</p>
+<div class="highlight"><pre><code class="language-sh" data-lang="sh">testcafe safari test.js --disable-test-syntax-validation
 </code></pre></div><h3><a class="anchor" id="--color"></a>--color <a class="permalink" href="#--color">#</a></h3>
 <p>Enables colors in the command line.</p>
 <h3><a class="anchor" id="--no-color"></a>--no-color <a class="permalink" href="#--no-color">#</a></h3>

--- a/documentation/using-testcafe/programming-interface/runner.html
+++ b/documentation/using-testcafe/programming-interface/runner.html
@@ -777,7 +777,7 @@
 </tr>
 </thead><tbody><tr>
 <td><code>callback</code></td>
-<td><code>function(testName, fixtureName, fixturePath)</code></td>
+<td><code>function(testName, fixtureName, fixturePath, testMeta, fixtureMeta)</code></td>
 <td>The callback that determines if a particular test should be run.</td>
 </tr>
 </tbody></table></div>
@@ -806,12 +806,24 @@
 <td>String</td>
 <td>The path to the test fixture file.</td>
 </tr>
+<tr>
+<td><code>testMeta</code></td>
+<td>Object&lt;String, String&gt;</td>
+<td>The test metadata.</td>
+</tr>
+<tr>
+<td><code>fixtureMeta</code></td>
+<td>Object&lt;String, String&gt;</td>
+<td>The fixture metadata.</td>
+</tr>
 </tbody></table></div>
 <p><strong>Example</strong></p>
-<div class="highlight"><pre><code class="language-js" data-lang="js"><span class="nx">runner</span><span class="p">.</span><span class="nx">filter</span><span class="p">((</span><span class="nx">testName</span><span class="p">,</span> <span class="nx">fixtureName</span><span class="p">,</span> <span class="nx">fixturePath</span><span class="p">)</span> <span class="o">=&gt;</span> <span class="p">{</span>
+<div class="highlight"><pre><code class="language-js" data-lang="js"><span class="nx">runner</span><span class="p">.</span><span class="nx">filter</span><span class="p">((</span><span class="nx">testName</span><span class="p">,</span> <span class="nx">fixtureName</span><span class="p">,</span> <span class="nx">fixturePath</span><span class="p">,</span> <span class="nx">testMeta</span><span class="p">,</span> <span class="nx">fixtureMeta</span><span class="p">)</span> <span class="o">=&gt;</span> <span class="p">{</span>
     <span class="k">return</span> <span class="nx">fixturePath</span><span class="p">.</span><span class="nx">startsWith</span><span class="p">(</span><span class="s1">'D'</span><span class="p">)</span> <span class="o">&amp;&amp;</span>
         <span class="nx">testName</span><span class="p">.</span><span class="nx">match</span><span class="p">(</span><span class="nx">someRe</span><span class="p">)</span> <span class="o">&amp;&amp;</span>
-        <span class="nx">fixtureName</span><span class="p">.</span><span class="nx">match</span><span class="p">(</span><span class="nx">anotherRe</span><span class="p">);</span>
+        <span class="nx">fixtureName</span><span class="p">.</span><span class="nx">match</span><span class="p">(</span><span class="nx">anotherRe</span><span class="p">)</span> <span class="o">&amp;&amp;</span>
+        <span class="nx">testMeta</span><span class="p">.</span><span class="nx">mobile</span> <span class="o">===</span> <span class="s1">'true'</span> <span class="o">&amp;&amp;</span>
+        <span class="nx">fixtureMeta</span><span class="p">.</span><span class="nx">env</span> <span class="o">===</span> <span class="s1">'staging'</span><span class="p">;</span>
 <span class="p">});</span>
 </code></pre></div><h3><a class="anchor" id="browsers"></a>browsers <a class="permalink" href="#browsers">#</a></h3>
 <p>Configures the test runner to run tests in the specified browsers.</p>
@@ -1142,6 +1154,12 @@ where tests are not guaranteed to execute correctly.</p>
 <td><code>stopOnFirstFail</code></td>
 <td>Boolean</td>
 <td>Defines whether to stop an entire test run if any test fails. This allows you not to wait for all the tests included in the test task to finish and allows focusing on the first error.</td>
+<td><code>false</code></td>
+</tr>
+<tr>
+<td><code>disableTestSyntaxValidation</code></td>
+<td>Boolean</td>
+<td>Defines whether to disable checks for <a href="../../test-api/test-code-structure.html#tests">test</a> and <a href="../../test-api/test-code-structure.html#fixtures">fixture</a> directives in test files. Use this option to run dynamically loaded tests. See details in the <a href="../command-line-interface.html#--disable-test-syntax-validation">--disable-test-syntax-validation</a> command line option description.</td>
 <td><code>false</code></td>
 </tr>
 </tbody></table></div>

--- a/feed.xml
+++ b/feed.xml
@@ -5,9 +5,53 @@
     <description></description>
     <link>http://devexpress.github.io/testcafe/</link>
     <atom:link href="http://devexpress.github.io/testcafe/feed.xml" rel="self" type="application/rss+xml"/>
-    <pubDate>Tue, 06 Nov 2018 14:09:04 +0300</pubDate>
-    <lastBuildDate>Tue, 06 Nov 2018 14:09:04 +0300</lastBuildDate>
+    <pubDate>Wed, 07 Nov 2018 19:07:22 +0300</pubDate>
+    <lastBuildDate>Wed, 07 Nov 2018 19:07:22 +0300</lastBuildDate>
     <generator>Jekyll v3.8.4</generator>
+    
+      <item>
+        <title>TestCafe v0.23.1 Released</title>
+        <description>&lt;h1&gt;TestCafe v0.23.1 Released&lt;/h1&gt;
+&lt;p&gt;Select tests and fixtures to run by their metadata and run dynamically loaded tests.&lt;/p&gt;
+
+&lt;!--more--&gt;
+&lt;h2&gt;&lt;a class=&quot;anchor&quot; id=&quot;enhancements&quot;&gt;&lt;/a&gt;Enhancements &lt;a class=&quot;permalink&quot; href=&quot;#enhancements&quot;&gt;#&lt;/a&gt;&lt;/h2&gt;&lt;h3&gt;&lt;a class=&quot;anchor&quot; id=&quot;select-tests-and-fixtures-to-run-by-their-metadata-2527-by-nickcis&quot;&gt;&lt;/a&gt;⚙ Select Tests and Fixtures to Run by Their Metadata (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/2527&quot;&gt;#2527&lt;/a&gt;) by &lt;a href=&quot;https://github.com/NickCis&quot;&gt;@NickCis&lt;/a&gt; &lt;a class=&quot;permalink&quot; href=&quot;#select-tests-and-fixtures-to-run-by-their-metadata-2527-by-nickcis&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
+&lt;p&gt;You can now run only those tests or fixtures whose &lt;a href=&quot;https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#specifying-testing-metadata&quot;&gt;metadata&lt;/a&gt; contains a specific set of values.&lt;/p&gt;
+
+&lt;p&gt;Use the &lt;a href=&quot;https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#--test-meta-keyvaluekey2value2&quot;&gt;--test-meta&lt;/a&gt; flag to specify values to look for in test metadata.&lt;/p&gt;
+&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-sh&quot; data-lang=&quot;sh&quot;&gt;testcafe chrome my-tests --test-meta &lt;span class=&quot;nv&quot;&gt;device&lt;/span&gt;&lt;span class=&quot;o&quot;&gt;=&lt;/span&gt;mobile,env&lt;span class=&quot;o&quot;&gt;=&lt;/span&gt;production
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+&lt;p&gt;To select fixtures by their metadata, use the &lt;a href=&quot;https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#--fixture-meta-keyvaluekey2value2&quot;&gt;--fixture-meta&lt;/a&gt; flag.&lt;/p&gt;
+&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-sh&quot; data-lang=&quot;sh&quot;&gt;testcafe chrome my-tests --fixture-meta &lt;span class=&quot;nv&quot;&gt;subsystem&lt;/span&gt;&lt;span class=&quot;o&quot;&gt;=&lt;/span&gt;payments,type&lt;span class=&quot;o&quot;&gt;=&lt;/span&gt;regression
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+&lt;p&gt;In the API, test and fixture metadata is now passed to the &lt;a href=&quot;https://devexpress.github.io/testcafe/documentation/using-testcafe/programming-interface/runner.html#filter&quot;&gt;runner.filter&lt;/a&gt; method in the &lt;code&gt;testMeta&lt;/code&gt; and &lt;code&gt;fixtureMeta&lt;/code&gt; parameters. Use this metadata to decide whether to run the current test.&lt;/p&gt;
+&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-js&quot; data-lang=&quot;js&quot;&gt;&lt;span class=&quot;nx&quot;&gt;runner&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;filter&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;((&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;testName&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;,&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;fixtureName&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;,&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;fixturePath&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;,&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;testMeta&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;,&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;fixtureMeta&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;)&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;=&amp;gt;&lt;/span&gt; &lt;span class=&quot;p&quot;&gt;{&lt;/span&gt;
+    &lt;span class=&quot;k&quot;&gt;return&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;testMeta&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;mobile&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;===&lt;/span&gt; &lt;span class=&quot;s1&quot;&gt;'true'&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;&amp;amp;&amp;amp;&lt;/span&gt;
+        &lt;span class=&quot;nx&quot;&gt;fixtureMeta&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;env&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;===&lt;/span&gt; &lt;span class=&quot;s1&quot;&gt;'staging'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;;&lt;/span&gt;
+&lt;span class=&quot;p&quot;&gt;});&lt;/span&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h3&gt;&lt;a class=&quot;anchor&quot; id=&quot;run-dynamically-loaded-tests-2074&quot;&gt;&lt;/a&gt;⚙ Run Dynamically Loaded Tests (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/2074&quot;&gt;#2074&lt;/a&gt;) &lt;a class=&quot;permalink&quot; href=&quot;#run-dynamically-loaded-tests-2074&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
+&lt;p&gt;You can now run tests imported from external libraries or generated dynamically even if the &lt;code&gt;.js&lt;/code&gt; file you provide to TestCafe does not contain any tests.&lt;/p&gt;
+
+&lt;p&gt;Previously, this was not possible because TestCafe required test files to contain the &lt;a href=&quot;https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#fixtures&quot;&gt;fixture&lt;/a&gt; and &lt;a href=&quot;https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#tests&quot;&gt;test&lt;/a&gt; directives. Now you can bypass this check. To do this, provide the &lt;a href=&quot;https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#--disable-test-syntax-validation&quot;&gt;--disable-test-syntax-validation&lt;/a&gt; command line flag.&lt;/p&gt;
+&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-sh&quot; data-lang=&quot;sh&quot;&gt;testcafe safari test.js --disable-test-syntax-validation
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+&lt;p&gt;In the API, use the &lt;a href=&quot;https://devexpress.github.io/testcafe/documentation/using-testcafe/programming-interface/runner.html#run&quot;&gt;disableTestSyntaxValidation&lt;/a&gt; option.&lt;/p&gt;
+&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-js&quot; data-lang=&quot;js&quot;&gt;&lt;span class=&quot;nx&quot;&gt;runner&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;run&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;({&lt;/span&gt; &lt;span class=&quot;na&quot;&gt;disableTestSyntaxValidation&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;:&lt;/span&gt; &lt;span class=&quot;kc&quot;&gt;true&lt;/span&gt; &lt;span class=&quot;p&quot;&gt;})&lt;/span&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h2&gt;&lt;a class=&quot;anchor&quot; id=&quot;bug-fixes&quot;&gt;&lt;/a&gt;Bug Fixes &lt;a class=&quot;permalink&quot; href=&quot;#bug-fixes&quot;&gt;#&lt;/a&gt;&lt;/h2&gt;
+&lt;ul&gt;
+&lt;li&gt;Touch events are now simulated with correct touch properties (&lt;code&gt;touches&lt;/code&gt;, &lt;code&gt;targetTouches&lt;/code&gt;, &lt;code&gt;changedTouches&lt;/code&gt;) (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/2856&quot;&gt;#2856&lt;/a&gt;)&lt;/li&gt;
+&lt;li&gt;Google Chrome now closes correctly on macOS after tests are finished (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/2860&quot;&gt;#2860&lt;/a&gt;)&lt;/li&gt;
+&lt;li&gt;Internal attribute and node changes no longer provoke &lt;code&gt;MutationObserver&lt;/code&gt; notifications (&lt;a href=&quot;https://github.com/DevExpress/testcafe-hammerhead/issues/1769&quot;&gt;testcafe-hammerhead/#1769&lt;/a&gt;)&lt;/li&gt;
+&lt;li&gt;The &lt;code&gt;ECONNABORTED&lt;/code&gt; error is no longer raised (&lt;a href=&quot;https://github.com/DevExpress/testcafe-hammerhead/issues/1744&quot;&gt;testcafe-hammerhead/#1744&lt;/a&gt;)&lt;/li&gt;
+&lt;li&gt;Websites that use &lt;code&gt;Location.ancestorOrigins&lt;/code&gt; are now proxied correctly (&lt;a href=&quot;https://github.com/DevExpress/testcafe-hammerhead/issues/1342&quot;&gt;testcafe-hammerhead/#1342&lt;/a&gt;)&lt;/li&gt;
+&lt;/ul&gt;
+</description>
+        <pubDate>Wed, 07 Nov 2018 00:00:00 +0300</pubDate>
+        <link>http://devexpress.github.io/testcafe/blog/testcafe-v0-23-1-released.html</link>
+        <guid isPermaLink="true">http://devexpress.github.io/testcafe/blog/testcafe-v0-23-1-released.html</guid>
+        
+        
+      </item>
     
       <item>
         <title>TestCafe v0.23.0 Released</title>
@@ -724,139 +768,6 @@ Now automatic waiting is much smarter and chances that you need to wait manually
         <pubDate>Tue, 13 Jun 2017 00:00:00 +0300</pubDate>
         <link>http://devexpress.github.io/testcafe/blog/testcafe-v0-16-0-released.html</link>
         <guid isPermaLink="true">http://devexpress.github.io/testcafe/blog/testcafe-v0-16-0-released.html</guid>
-        
-        
-      </item>
-    
-      <item>
-        <title>TestCafe v0.15.0 Released</title>
-        <description>&lt;h1&gt;TestCafe v0.15.0 Released&lt;/h1&gt;
-&lt;p&gt;Plugins for React and Vue.js, TestCafe Docker image, support for Internet access proxies and lots of bug fixes.&lt;/p&gt;
-
-&lt;!--more--&gt;
-&lt;h2&gt;&lt;a class=&quot;anchor&quot; id=&quot;breaking-changes&quot;&gt;&lt;/a&gt;Breaking Changes &lt;a class=&quot;permalink&quot; href=&quot;#breaking-changes&quot;&gt;#&lt;/a&gt;&lt;/h2&gt;&lt;h3&gt;&lt;a class=&quot;anchor&quot; id=&quot;new-calls-to-selectors-withtext-method-no-longer-override-previous-calls&quot;&gt;&lt;/a&gt;New calls to selector&amp;#39;s withText method no longer override previous calls &lt;a class=&quot;permalink&quot; href=&quot;#new-calls-to-selectors-withtext-method-no-longer-override-previous-calls&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
-&lt;p&gt;We have changed the way the &lt;a href=&quot;https://devexpress.github.io/testcafe/documentation/test-api/selecting-page-elements/selectors/functional-style-selectors.html#withtext&quot;&gt;withText&lt;/a&gt;
-method behaves when it is called in a chain.&lt;/p&gt;
-&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-js&quot; data-lang=&quot;js&quot;&gt;&lt;span class=&quot;kr&quot;&gt;const&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;el&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;=&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;Selector&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'div'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;).&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;withText&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'This is'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;).&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;withText&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'my element'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
-&lt;p&gt;In previous versions, this selector searched for a &lt;code&gt;div&lt;/code&gt; with text &lt;code&gt;my element&lt;/code&gt; because the second call to &lt;code&gt;withText&lt;/code&gt; overrode the first one.&lt;/p&gt;
-
-&lt;p&gt;Now this code returns an element whose text contains both &lt;code&gt;This is&lt;/code&gt; and &lt;code&gt;my element&lt;/code&gt; as the second call compounds with the first one.&lt;/p&gt;
-&lt;h2&gt;&lt;a class=&quot;anchor&quot; id=&quot;enhancements&quot;&gt;&lt;/a&gt;Enhancements &lt;a class=&quot;permalink&quot; href=&quot;#enhancements&quot;&gt;#&lt;/a&gt;&lt;/h2&gt;&lt;h3&gt;&lt;a class=&quot;anchor&quot; id=&quot;plugin-for-testing-react-apps&quot;&gt;&lt;/a&gt;⚙ Plugin for testing React apps &lt;a class=&quot;permalink&quot; href=&quot;#plugin-for-testing-react-apps&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
-&lt;p&gt;In this release cycle, we have created a plugin for testing React applications.
-This plugin allows you to select React components by their names.&lt;/p&gt;
-&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-js&quot; data-lang=&quot;js&quot;&gt;&lt;span class=&quot;kr&quot;&gt;import&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;ReactSelector&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;from&lt;/span&gt; &lt;span class=&quot;s1&quot;&gt;'testcafe-react-selector'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;;&lt;/span&gt;
-
-&lt;span class=&quot;kr&quot;&gt;const&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;TodoList&lt;/span&gt;         &lt;span class=&quot;o&quot;&gt;=&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;ReactSelector&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'TodoApp TodoList'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-&lt;span class=&quot;kr&quot;&gt;const&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;itemsCountStatus&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;=&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;ReactSelector&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'TodoApp div'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-&lt;span class=&quot;kr&quot;&gt;const&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;itemsCount&lt;/span&gt;       &lt;span class=&quot;o&quot;&gt;=&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;ReactSelector&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'TodoApp div span'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
-&lt;p&gt;And it enables you to get React component&amp;#39;s &lt;code&gt;state&lt;/code&gt; and &lt;code&gt;props&lt;/code&gt;.&lt;/p&gt;
-&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-js&quot; data-lang=&quot;js&quot;&gt;&lt;span class=&quot;kr&quot;&gt;import&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;ReactSelector&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;from&lt;/span&gt; &lt;span class=&quot;s1&quot;&gt;'testcafe-react-selector'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;;&lt;/span&gt;
-
-&lt;span class=&quot;nx&quot;&gt;fixture&lt;/span&gt; &lt;span class=&quot;err&quot;&gt;`&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;TODO&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;list&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;test&lt;/span&gt;&lt;span class=&quot;err&quot;&gt;`&lt;/span&gt;
-    &lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;page&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'http://localhost:1337'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-
-&lt;span class=&quot;nx&quot;&gt;test&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'Check list item'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;,&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;async&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;t&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;=&amp;gt;&lt;/span&gt; &lt;span class=&quot;p&quot;&gt;{&lt;/span&gt;
-    &lt;span class=&quot;kr&quot;&gt;const&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;el&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;=&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;ReactSelector&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'TodoList'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-
-    &lt;span class=&quot;nx&quot;&gt;await&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;t&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;expect&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;el&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;getReact&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;().&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;props&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;priority&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;).&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;eql&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'High'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-    &lt;span class=&quot;nx&quot;&gt;await&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;t&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;expect&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;el&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;getReact&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;().&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;state&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;isActive&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;).&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;eql&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;kc&quot;&gt;false&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-&lt;span class=&quot;p&quot;&gt;});&lt;/span&gt;
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
-&lt;p&gt;To learn more, see the &lt;a href=&quot;https://github.com/DevExpress/testcafe-react-selectors/&quot;&gt;testcafe-react-selectors&lt;/a&gt; repository.&lt;/p&gt;
-&lt;h3&gt;&lt;a class=&quot;anchor&quot; id=&quot;plugin-for-testing-vuejs-apps&quot;&gt;&lt;/a&gt;⚙ Plugin for testing Vue.js apps &lt;a class=&quot;permalink&quot; href=&quot;#plugin-for-testing-vuejs-apps&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
-&lt;p&gt;In addition to the React plugin, we have released a plugin that facilitates testing Vue.js applications.&lt;/p&gt;
-
-&lt;p&gt;In the same manner, it allows you to select Vue.js components with &lt;code&gt;VueSelector&lt;/code&gt; selectors.&lt;/p&gt;
-&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-js&quot; data-lang=&quot;js&quot;&gt;&lt;span class=&quot;kr&quot;&gt;import&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;VueSelector&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;from&lt;/span&gt; &lt;span class=&quot;s1&quot;&gt;'testcafe-vue-selectors'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;;&lt;/span&gt;
-
-&lt;span class=&quot;kr&quot;&gt;const&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;rootVue&lt;/span&gt;   &lt;span class=&quot;o&quot;&gt;=&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;VueSelector&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;();&lt;/span&gt;
-&lt;span class=&quot;kr&quot;&gt;const&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;todoInput&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;=&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;VueSelector&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'todo-input'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-&lt;span class=&quot;kr&quot;&gt;const&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;todoItem&lt;/span&gt;  &lt;span class=&quot;o&quot;&gt;=&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;VueSelector&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'todo-list todo-item'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
-&lt;p&gt;These selectors allow you to get Vue component&amp;#39;s &lt;code&gt;props&lt;/code&gt;, &lt;code&gt;state&lt;/code&gt; and &lt;code&gt;computed&lt;/code&gt; properties.&lt;/p&gt;
-&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-js&quot; data-lang=&quot;js&quot;&gt;&lt;span class=&quot;kr&quot;&gt;import&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;VueSelector&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;from&lt;/span&gt; &lt;span class=&quot;s1&quot;&gt;'testcafe-vue-selector'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;;&lt;/span&gt;
-
-&lt;span class=&quot;nx&quot;&gt;fixture&lt;/span&gt; &lt;span class=&quot;err&quot;&gt;`&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;TODO&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;list&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;test&lt;/span&gt;&lt;span class=&quot;err&quot;&gt;`&lt;/span&gt;
-    &lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;page&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'http://localhost:1337'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-
-&lt;span class=&quot;nx&quot;&gt;test&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'Check list item'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;,&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;async&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;t&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;=&amp;gt;&lt;/span&gt; &lt;span class=&quot;p&quot;&gt;{&lt;/span&gt;
-    &lt;span class=&quot;kr&quot;&gt;const&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;todoItem&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;=&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;VueSelector&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'todo-item'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-
-    &lt;span class=&quot;nx&quot;&gt;await&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;t&lt;/span&gt;
-        &lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;expect&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;todoItem&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;getVue&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;().&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;props&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;priority&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;).&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;eql&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'High'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;)&lt;/span&gt;
-        &lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;expect&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;todoItem&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;getVue&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;().&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;state&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;isActive&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;).&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;eql&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;kc&quot;&gt;false&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;)&lt;/span&gt;
-        &lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;expect&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;todoItem&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;getVue&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;().&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;computed&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;text&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;).&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;eql&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'Item 1'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-&lt;span class=&quot;p&quot;&gt;});&lt;/span&gt;
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
-&lt;p&gt;To learn more, see the &lt;a href=&quot;https://github.com/DevExpress/testcafe-vue-selectors&quot;&gt;testcafe-vue-selectors&lt;/a&gt; repository.&lt;/p&gt;
-&lt;h3&gt;&lt;a class=&quot;anchor&quot; id=&quot;testcafe-docker-image-1141&quot;&gt;&lt;/a&gt;⚙ TestCafe Docker image (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1141&quot;&gt;#1141&lt;/a&gt;) &lt;a class=&quot;permalink&quot; href=&quot;#testcafe-docker-image-1141&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
-&lt;p&gt;We have created a Docker image with TestCafe, Chromium and Firefox preinstalled.&lt;/p&gt;
-
-&lt;p&gt;You no longer need to manually install browsers or the testing framework on your server.
-Pull the Docker image from the repository and run TestCafe immediately.&lt;/p&gt;
-&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-sh&quot; data-lang=&quot;sh&quot;&gt;docker pull testcafe/testcafe
-docker run -v //user/tests:/tests -it testcafe/testcafe firefox tests/&lt;span class=&quot;k&quot;&gt;**&lt;/span&gt;/&lt;span class=&quot;k&quot;&gt;*&lt;/span&gt;.js
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
-&lt;p&gt;To learn more, see &lt;a href=&quot;https://devexpress.github.io/testcafe/documentation/using-testcafe/using-testcafe-docker-image.html&quot;&gt;Using TestCafe Docker Image&lt;/a&gt;&lt;/p&gt;
-&lt;h3&gt;&lt;a class=&quot;anchor&quot; id=&quot;support-for-internet-access-proxies-1206&quot;&gt;&lt;/a&gt;⚙ Support for Internet access proxies (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1206&quot;&gt;#1206&lt;/a&gt;) &lt;a class=&quot;permalink&quot; href=&quot;#support-for-internet-access-proxies-1206&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
-&lt;p&gt;If your local network uses a proxy server to access the Internet, TestCafe can use it reach the external webpages.&lt;/p&gt;
-
-&lt;p&gt;To specify the proxy server, use a command line option&lt;/p&gt;
-&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-sh&quot; data-lang=&quot;sh&quot;&gt;testcafe chrome my-tests/&lt;span class=&quot;k&quot;&gt;**&lt;/span&gt;/&lt;span class=&quot;k&quot;&gt;*&lt;/span&gt;.js --proxy 172.0.10.10:8080
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
-&lt;p&gt;or a method in the API.&lt;/p&gt;
-&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-js&quot; data-lang=&quot;js&quot;&gt;&lt;span class=&quot;nx&quot;&gt;runner&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;useProxy&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'username:password@proxy.mycorp.com'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
-&lt;p&gt;Note that you can pass the credentials with the proxy server host.&lt;/p&gt;
-&lt;h3&gt;&lt;a class=&quot;anchor&quot; id=&quot;debugging-mode-option-1347&quot;&gt;&lt;/a&gt;⚙ Debugging mode option (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1347&quot;&gt;#1347&lt;/a&gt;) &lt;a class=&quot;permalink&quot; href=&quot;#debugging-mode-option-1347&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
-&lt;p&gt;As an alternative to calling the &lt;a href=&quot;https://devexpress.github.io/testcafe/documentation/test-api/debugging.html#client-side-debugging&quot;&gt;t.debug&lt;/a&gt; method
-in test code, you can now specify the &lt;code&gt;--debug-mode&lt;/code&gt; command line option to pause the test before the first action or assertion.
-When the test is paused, you can debug in the browser developer tools as well as continue test execution step by step.&lt;/p&gt;
-&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-sh&quot; data-lang=&quot;sh&quot;&gt;testcafe chrome my-tests/&lt;span class=&quot;k&quot;&gt;**&lt;/span&gt;/&lt;span class=&quot;k&quot;&gt;*&lt;/span&gt;.js --debug-mode
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
-&lt;p&gt;If you use TestCafe API, provide the &lt;code&gt;debugMode&lt;/code&gt; option to the &lt;code&gt;runner.run&lt;/code&gt; method.&lt;/p&gt;
-&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-js&quot; data-lang=&quot;js&quot;&gt;&lt;span class=&quot;nx&quot;&gt;runner&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;run&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;({&lt;/span&gt; &lt;span class=&quot;na&quot;&gt;debugMode&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;:&lt;/span&gt; &lt;span class=&quot;kc&quot;&gt;true&lt;/span&gt; &lt;span class=&quot;p&quot;&gt;});&lt;/span&gt;
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h3&gt;&lt;a class=&quot;anchor&quot; id=&quot;filtering-selectors-matching-set-by-attribute-1346&quot;&gt;&lt;/a&gt;⚙ Filtering selector&amp;#39;s matching set by attribute (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1346&quot;&gt;#1346&lt;/a&gt;) &lt;a class=&quot;permalink&quot; href=&quot;#filtering-selectors-matching-set-by-attribute-1346&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
-&lt;p&gt;You can now use the &lt;code&gt;withAttribute&lt;/code&gt; method to select elements that have a particular attribute set to a specific value.
-You can omit the attribute value to select elements that simply have the specified attribute.&lt;/p&gt;
-&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-js&quot; data-lang=&quot;js&quot;&gt;&lt;span class=&quot;kr&quot;&gt;const&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;el&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;=&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;Selector&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'div'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;).&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;withAttribute&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'attributeName'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;,&lt;/span&gt; &lt;span class=&quot;s1&quot;&gt;'value'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;).&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;nth&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;mi&quot;&gt;2&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h3&gt;&lt;a class=&quot;anchor&quot; id=&quot;hasattribute-method-added-to-dom-node-state-1045&quot;&gt;&lt;/a&gt;⚙ hasAttribute method added to DOM node state (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1045&quot;&gt;#1045&lt;/a&gt;) &lt;a class=&quot;permalink&quot; href=&quot;#hasattribute-method-added-to-dom-node-state-1045&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
-&lt;p&gt;For you convenience, the DOM node state object now provides the &lt;code&gt;hasAttribute&lt;/code&gt; method that allows you to determine if an element has a particular attribute.&lt;/p&gt;
-&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-js&quot; data-lang=&quot;js&quot;&gt;&lt;span class=&quot;kr&quot;&gt;const&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;el&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;=&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;Selector&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'div.button'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;);&lt;/span&gt;
-
-&lt;span class=&quot;nx&quot;&gt;t&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;expect&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;el&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;.&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;hasAttribute&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;s1&quot;&gt;'disabled'&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;)).&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;ok&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;();&lt;/span&gt;
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h3&gt;&lt;a class=&quot;anchor&quot; id=&quot;redirection-when-switching-between-roles-1339&quot;&gt;&lt;/a&gt;⚙ Redirection when switching between roles (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1339&quot;&gt;#1339&lt;/a&gt;) &lt;a class=&quot;permalink&quot; href=&quot;#redirection-when-switching-between-roles-1339&quot;&gt;#&lt;/a&gt;&lt;/h3&gt;
-&lt;p&gt;&lt;a href=&quot;https://devexpress.github.io/testcafe/documentation/test-api/authentication/user-roles.html&quot;&gt;User roles&lt;/a&gt; now provide a &lt;code&gt;preserveUrl&lt;/code&gt; option
-that allows you to save the webpage URL to which the browser was redirected after logging in. If you enable this option when creating a role,
-the browser will be redirected to the saved URL every time you switch to this role.&lt;/p&gt;
-&lt;div class=&quot;highlight&quot;&gt;&lt;pre&gt;&lt;code class=&quot;language-js&quot; data-lang=&quot;js&quot;&gt;&lt;span class=&quot;kr&quot;&gt;const&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;regularUser&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;=&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;Role&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;(&lt;/span&gt;&lt;span class=&quot;nx&quot;&gt;url&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;,&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;async&lt;/span&gt; &lt;span class=&quot;nx&quot;&gt;t&lt;/span&gt; &lt;span class=&quot;o&quot;&gt;=&amp;gt;&lt;/span&gt; &lt;span class=&quot;p&quot;&gt;{&lt;/span&gt;
-    &lt;span class=&quot;cm&quot;&gt;/* authentication code */&lt;/span&gt;
-&lt;span class=&quot;p&quot;&gt;},&lt;/span&gt; &lt;span class=&quot;p&quot;&gt;{&lt;/span&gt; &lt;span class=&quot;na&quot;&gt;preserveUrl&lt;/span&gt;&lt;span class=&quot;p&quot;&gt;:&lt;/span&gt; &lt;span class=&quot;kc&quot;&gt;true&lt;/span&gt; &lt;span class=&quot;p&quot;&gt;})&lt;/span&gt;
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h2&gt;&lt;a class=&quot;anchor&quot; id=&quot;bug-fixes&quot;&gt;&lt;/a&gt;Bug Fixes &lt;a class=&quot;permalink&quot; href=&quot;#bug-fixes&quot;&gt;#&lt;/a&gt;&lt;/h2&gt;
-&lt;ul&gt;
-&lt;li&gt;Fixed a bug where incorrect call site and callstack were generated for an assertion that failed in a class method (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1267&quot;&gt;#1267&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;Incorrect validation result no longer appears when a test controller is used inside an async function (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1285&quot;&gt;#1285&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;Click on the status panel no longer affects the page state (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1389&quot;&gt;#1389&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;The &lt;code&gt;input&lt;/code&gt; event is now raised with a correct selection value when input value was changed (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1388&quot;&gt;#1388&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;Inline source maps are now placed in transpiled files so that breakpoints work correctly (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1375&quot;&gt;#1375&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;&lt;code&gt;value&lt;/code&gt; and &lt;code&gt;selectedIndex&lt;/code&gt; in the &lt;code&gt;input&lt;/code&gt; event handler for the dropdown element are now valid (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1366&quot;&gt;#1366&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;A &lt;code&gt;presskey(&amp;#39;enter&amp;#39;)&lt;/code&gt; call now raises the &lt;code&gt;click&lt;/code&gt; event on a button element (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1424&quot;&gt;#1424&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;The cursor position in Monaco editor is now set correctly on the click action (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1385&quot;&gt;#1385&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;&lt;code&gt;hasScroll&lt;/code&gt; now works correctly if the &lt;code&gt;body&lt;/code&gt; has absolute positioning (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1353&quot;&gt;#1353&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;Text can now be typed into HTML5 input elements (&lt;a href=&quot;https://github.com/DevExpress/testcafe/issues/1327&quot;&gt;#1327&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;&lt;code&gt;focusin&lt;/code&gt; and &lt;code&gt;focusout&lt;/code&gt; events are now raised when the browser window is in the background (&lt;a href=&quot;https://github.com/DevExpress/testcafe-hammerhead/issues/1044&quot;&gt;testcafe-hammerhead/#1044&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;&lt;code&gt;caretPositionFromPoint&lt;/code&gt; and &lt;code&gt;caretRangeFromPoint&lt;/code&gt; now ignore TestCafe UI elements on the page (&lt;a href=&quot;https://github.com/DevExpress/testcafe-hammerhead/issues/1084&quot;&gt;testcafe-hammerhead/#1084&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;Images created with the &lt;code&gt;Image&lt;/code&gt; constructor are now loaded through the proxy (&lt;a href=&quot;https://github.com/DevExpress/testcafe-hammerhead/issues/1087&quot;&gt;testcafe-hammerhead/#1087&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;The &lt;code&gt;innerText&lt;/code&gt; return value is now clear of script and style code (&lt;a href=&quot;https://github.com/DevExpress/testcafe-hammerhead/issues/1079&quot;&gt;testcafe-hammerhead/#1079&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;Non-string values for element&amp;#39;s text properties are now converted to &lt;code&gt;String&lt;/code&gt; (&lt;a href=&quot;https://github.com/DevExpress/testcafe-hammerhead/issues/1091&quot;&gt;testcafe-hammerhead/#1091&lt;/a&gt;)&lt;/li&gt;
-&lt;li&gt;SVG elements are now processed correctly in IE (&lt;a href=&quot;https://github.com/DevExpress/testcafe-hammerhead/issues/1083&quot;&gt;testcafe-hammerhead/#1083&lt;/a&gt;)&lt;/li&gt;
-&lt;/ul&gt;
-</description>
-        <pubDate>Wed, 26 Apr 2017 00:00:00 +0300</pubDate>
-        <link>http://devexpress.github.io/testcafe/blog/testcafe-v0-15-0-released.html</link>
-        <guid isPermaLink="true">http://devexpress.github.io/testcafe/blog/testcafe-v0-15-0-released.html</guid>
         
         
       </item>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -65,6 +65,10 @@
 <lastmod>2018-10-25T00:00:00+03:00</lastmod>
 </url>
 <url>
+<loc>http://devexpress.github.io/testcafe/blog/testcafe-v0-23-1-released.html</loc>
+<lastmod>2018-11-07T00:00:00+03:00</lastmod>
+</url>
+<url>
 <loc>http://devexpress.github.io/testcafe/documentation/extending-testcafe/</loc>
 </url>
 <url>
@@ -357,10 +361,10 @@
 </url>
 <url>
 <loc>http://devexpress.github.io/testcafe/example/</loc>
-<lastmod>2018-11-06T14:08:52+03:00</lastmod>
+<lastmod>2018-11-07T19:07:08+03:00</lastmod>
 </url>
 <url>
 <loc>http://devexpress.github.io/testcafe/example/thank-you.html</loc>
-<lastmod>2018-11-06T14:08:52+03:00</lastmod>
+<lastmod>2018-11-07T19:07:08+03:00</lastmod>
 </url>
 </urlset>


### PR DESCRIPTION
\cc @AndreyBelym @AlexSkorkin 

Merge to update the website.

Preview at: https://vasilystrelyaev.github.io/testcafe/

Pay attention to:

Release notes
https://vasilystrelyaev.github.io/testcafe/blog/
https://vasilystrelyaev.github.io/testcafe/blog/testcafe-v0-23-1-released.html

New docs:
https://vasilystrelyaev.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#--test-meta-keyvaluekey2value2
https://vasilystrelyaev.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#--disable-test-syntax-validation
https://vasilystrelyaev.github.io/testcafe/documentation/using-testcafe/programming-interface/runner.html#filter