### PR TITLE
Modify Reporter API to handle additional info

### DIFF
--- a/src/notifications/warning-log.js
+++ b/src/notifications/warning-log.js
@@ -1,15 +1,23 @@
 import renderTemplate from '../utils/render-template';
 
 export default class WarningLog {
-    constructor () {
-        this.messages = [];
+    constructor (parentLog = null) {
+        this.parentLog = parentLog;
+        this.messages  = [];
+    }
+
+    addPlainMessage (msg) {
+        // NOTE: avoid duplicates
+        if (this.messages.indexOf(msg) < 0)
+            this.messages.push(msg);
     }
 
     addWarning () {
         const msg = renderTemplate.apply(null, arguments);
 
-        // NOTE: avoid duplicates
-        if (this.messages.indexOf(msg) < 0)
-            this.messages.push(msg);
+        this.addPlainMessage(msg);
+
+        if (this.parentLog)
+            this.parentLog.addPlainMessage(msg);
     }
 }

--- a/src/notifications/warning-log.js
+++ b/src/notifications/warning-log.js
@@ -1,8 +1,8 @@
 import renderTemplate from '../utils/render-template';
 
 export default class WarningLog {
-    constructor (parentLog = null) {
-        this.parentLog = parentLog;
+    constructor (globalLog = null) {
+        this.globalLog = globalLog;
         this.messages  = [];
     }
 
@@ -17,7 +17,7 @@ export default class WarningLog {
 
         this.addPlainMessage(msg);
 
-        if (this.parentLog)
-            this.parentLog.addPlainMessage(msg);
+        if (this.globalLog)
+            this.globalLog.addPlainMessage(msg);
     }
 }

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -19,6 +19,7 @@ import ROLE_PHASE from '../role/phase';
 import ReporterPluginHost from '../reporter/plugin-host';
 import BrowserConsoleMessages from './browser-console-messages';
 import { UNSTABLE_NETWORK_MODE_HEADER } from '../browser/connection/unstable-network-mode';
+import WarningLog from '../notifications/warning-log';
 import WARNING_MESSAGE from '../notifications/warning-message';
 
 import {
@@ -50,10 +51,12 @@ const MAX_RESPONSE_DELAY              = 3000;
 const ALL_DRIVER_TASKS_ADDED_TO_QUEUE_EVENT = 'all-driver-tasks-added-to-queue';
 
 export default class TestRun extends EventEmitter {
-    constructor (test, browserConnection, screenshotCapturer, warningLog, opts) {
+    constructor (test, browserConnection, screenshotCapturer, globalWarningLog, opts) {
         super();
 
         this[testRunMarker] = true;
+
+        this.warningLog = new WarningLog(globalWarningLog);
 
         this.opts              = opts;
         this.test              = test;
@@ -100,13 +103,11 @@ export default class TestRun extends EventEmitter {
         this.disableDebugBreakpoints = false;
         this.debugReporterPluginHost = new ReporterPluginHost({ noColors: false });
 
-        this.browserManipulationQueue = new BrowserManipulationQueue(browserConnection, screenshotCapturer, warningLog);
+        this.browserManipulationQueue = new BrowserManipulationQueue(browserConnection, screenshotCapturer, this.warningLog);
 
         this.debugLog = new TestRunDebugLog(this.browserConnection.userAgent);
 
         this.quarantine = null;
-
-        this.warningLog = warningLog;
 
         this.injectable.scripts.push('/testcafe-core.js');
         this.injectable.scripts.push('/testcafe-ui.js');

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -105,6 +105,22 @@ describe('Reporter', () => {
             meta:    {
                 run: 'run-001'
             }
+        },
+        {
+            name:    'fixture3test2',
+            skip:    true,
+            fixture: fixtureMocks[2],
+            meta:    {
+                run: 'run-001'
+            }
+        },
+        {
+            name:    'fixture3test3',
+            skip:    false,
+            fixture: fixtureMocks[2],
+            meta:    {
+                run: 'run-001'
+            }
         }
     ];
 
@@ -116,6 +132,7 @@ describe('Reporter', () => {
             unstable:          true,
             browserConnection: browserConnectionMocks[0],
             errs:              [],
+            warningLog:        { messages: [] },
             quarantine:        {
                 attempts: [['1', '2'], []]
             }
@@ -126,6 +143,7 @@ describe('Reporter', () => {
             test:              testMocks[1],
             unstable:          false,
             browserConnection: browserConnectionMocks[0],
+            warningLog:        { messages: [] },
 
             errs: [
                 { text: 'err1' },
@@ -138,8 +156,8 @@ describe('Reporter', () => {
             test:              testMocks[2],
             unstable:          false,
             browserConnection: browserConnectionMocks[0],
-            errs:              []
-
+            errs:              [],
+            warningLog:        { messages: [] },
         },
 
         //fixture2test1
@@ -147,7 +165,8 @@ describe('Reporter', () => {
             test:              testMocks[3],
             unstable:          false,
             browserConnection: browserConnectionMocks[0],
-            errs:              []
+            errs:              [],
+            warningLog:        { messages: [] },
         },
 
         //fixture2test2
@@ -155,7 +174,8 @@ describe('Reporter', () => {
             test:              testMocks[4],
             unstable:          false,
             browserConnection: browserConnectionMocks[0],
-            errs:              []
+            errs:              [],
+            warningLog:        { messages: [] },
         },
 
         //fixture3test1
@@ -163,7 +183,26 @@ describe('Reporter', () => {
             test:              testMocks[5],
             unstable:          false,
             browserConnection: browserConnectionMocks[0],
-            errs:              []
+            errs:              [],
+            warningLog:        { messages: [] },
+        },
+
+        //fixture3test2
+        {
+            test:              testMocks[6],
+            unstable:          true,
+            browserConnection: browserConnectionMocks[1],
+            errs:              [],
+            warningLog:        { messages: [] },
+        },
+
+        //fixture3test3
+        {
+            test:              testMocks[7],
+            unstable:          true,
+            browserConnection: browserConnectionMocks[1],
+            errs:              [],
+            warningLog:        { messages: ['warning2'] }
         }
     ];
 
@@ -174,6 +213,7 @@ describe('Reporter', () => {
             unstable:          true,
             browserConnection: browserConnectionMocks[1],
             errs:              [],
+            warningLog:        { messages: [] },
             quarantine:        {
                 attempts: [['1', '2'], []]
             }
@@ -184,8 +224,8 @@ describe('Reporter', () => {
             test:              testMocks[1],
             unstable:          false,
             browserConnection: browserConnectionMocks[1],
-
-            errs: [{ text: 'err1' }]
+            errs:              [{ text: 'err1' }],
+            warningLog:        { messages: [] }
         },
 
         //fixture1test3
@@ -193,7 +233,8 @@ describe('Reporter', () => {
             test:              testMocks[2],
             unstable:          false,
             browserConnection: browserConnectionMocks[1],
-            errs:              []
+            errs:              [],
+            warningLog:        { messages: [] }
         },
 
         //fixture2test1
@@ -201,7 +242,8 @@ describe('Reporter', () => {
             test:              testMocks[3],
             unstable:          false,
             browserConnection: browserConnectionMocks[1],
-            errs:              []
+            errs:              [],
+            warningLog:        { messages: [] }
         },
 
         //fixture2test2
@@ -209,7 +251,8 @@ describe('Reporter', () => {
             test:              testMocks[4],
             unstable:          false,
             browserConnection: browserConnectionMocks[1],
-            errs:              []
+            errs:              [],
+            warningLog:        { messages: [] }
         },
 
         //fixture3test1
@@ -217,7 +260,26 @@ describe('Reporter', () => {
             test:              testMocks[5],
             unstable:          true,
             browserConnection: browserConnectionMocks[1],
-            errs:              [{ text: 'err1' }]
+            errs:              [{ text: 'err1' }],
+            warningLog:        { messages: ['warning1'] }
+        },
+
+        //fixture3test2
+        {
+            test:              testMocks[6],
+            unstable:          true,
+            browserConnection: browserConnectionMocks[1],
+            errs:              [],
+            warningLog:        { messages: [] }
+        },
+
+        //fixture3test3
+        {
+            test:              testMocks[7],
+            unstable:          true,
+            browserConnection: browserConnectionMocks[1],
+            errs:              [],
+            warningLog:        { messages: ['warning2', 'warning3'] }
         }
     ];
 
@@ -255,7 +317,8 @@ describe('Reporter', () => {
             this.warningLog = {
                 messages: [
                     'warning1',
-                    'warning2'
+                    'warning2',
+                    'warning3'
                 ]
             };
         }
@@ -337,7 +400,7 @@ describe('Reporter', () => {
                         'Chrome',
                         'Firefox'
                     ],
-                    6
+                    7
                 ]
             },
             {
@@ -359,6 +422,7 @@ describe('Reporter', () => {
                     'fixture1test1',
                     {
                         errs:       [],
+                        warnings:   [],
                         durationMs: 74000,
                         unstable:   true,
                         skipped:    false,
@@ -404,6 +468,7 @@ describe('Reporter', () => {
                             }
                         ],
 
+                        warnings:       [],
                         durationMs:     74000,
                         unstable:       false,
                         skipped:        false,
@@ -438,6 +503,7 @@ describe('Reporter', () => {
                     'fixture1test3',
                     {
                         errs:           [],
+                        warnings:       [],
                         durationMs:     74000,
                         unstable:       false,
                         skipped:        false,
@@ -470,6 +536,7 @@ describe('Reporter', () => {
                     'fixture2test1',
                     {
                         errs:           [],
+                        warnings:       [],
                         durationMs:     74000,
                         unstable:       false,
                         skipped:        false,
@@ -492,6 +559,7 @@ describe('Reporter', () => {
                     'fixture2test2',
                     {
                         errs:           [],
+                        warnings:       [],
                         durationMs:     74000,
                         unstable:       false,
                         skipped:        false,
@@ -528,6 +596,53 @@ describe('Reporter', () => {
                             }
                         ],
 
+                        warnings:       ['warning1'],
+                        durationMs:     74000,
+                        unstable:       true,
+                        skipped:        false,
+                        quarantine:     null,
+                        screenshotPath: null,
+                        screenshots:    []
+                    },
+                    {
+                        run: 'run-001'
+                    }
+                ]
+            },
+            'test-run-done resolved',
+            'test-run-done resolved',
+            'test-run-start resolved',
+            'test-run-start resolved',
+            {
+                method: 'reportTestDone',
+                args:   [
+                    'fixture3test2',
+                    {
+                        errs:           [],
+                        warnings:       [],
+                        durationMs:     74000,
+                        unstable:       true,
+                        skipped:        true,
+                        quarantine:     null,
+                        screenshotPath: null,
+                        screenshots:    []
+                    },
+                    {
+                        run: 'run-001'
+                    }
+                ]
+            },
+            'test-run-done resolved',
+            'test-run-done resolved',
+            'test-run-start resolved',
+            'test-run-start resolved',
+            {
+                method: 'reportTestDone',
+                args:   [
+                    'fixture3test3',
+                    {
+                        errs:           [],
+                        warnings:       ['warning2', 'warning3'],
                         durationMs:     74000,
                         unstable:       true,
                         skipped:        false,
@@ -546,8 +661,9 @@ describe('Reporter', () => {
                 method: 'reportTaskDone',
                 args:   [
                     new Date('1970-01-01T00:15:25.000Z'),
-                    4,
-                    ['warning1', 'warning2']
+                    5,
+                    ['warning1', 'warning2', 'warning3'],
+                    { passedCount: 5, failedCount: 2, skippedCount: 1 }
                 ]
             },
             'task-done resolved'

--- a/test/server/warning-log-test.js
+++ b/test/server/warning-log-test.js
@@ -3,43 +3,47 @@ const WarningLog = require('../../lib/notifications/warning-log');
 const WARNINGS   = require('../../lib/notifications/warning-message');
 
 
+const TYPE_ERROR_TEXT   = 'TypeError';
+const SYNTAX_ERROR_TEXT = 'SyntaxError';
+
+
 describe('Warning log', () => {
     it('Should render and store warnings', () => {
         const log = new WarningLog();
 
-        log.addWarning(WARNINGS.screenshotError, 'TypeError');
+        log.addWarning(WARNINGS.screenshotError, TYPE_ERROR_TEXT);
         log.addWarning(WARNINGS.screenshotError, 'SyntaxError');
 
         expect(log.messages).eql([
-            'Was unable to take a screenshot due to an error.\n\nTypeError',
-            'Was unable to take a screenshot due to an error.\n\nSyntaxError'
+            'Was unable to take a screenshot due to an error.\n\n' + TYPE_ERROR_TEXT,
+            'Was unable to take a screenshot due to an error.\n\n' + SYNTAX_ERROR_TEXT
         ]);
     });
 
     it('Should remove duplicates', () => {
         const log = new WarningLog();
 
-        log.addWarning(WARNINGS.screenshotError, 'TypeError');
-        log.addWarning(WARNINGS.screenshotError, 'TypeError');
+        log.addWarning(WARNINGS.screenshotError, TYPE_ERROR_TEXT);
+        log.addWarning(WARNINGS.screenshotError, TYPE_ERROR_TEXT);
 
         expect(log.messages).eql([
-            'Was unable to take a screenshot due to an error.\n\nTypeError'
+            'Was unable to take a screenshot due to an error.\n\n' + TYPE_ERROR_TEXT
         ]);
     });
 
     it('Should add messages to the parent log', () => {
-        const parentLog = new WarningLog();
-        const log       = new WarningLog(parentLog);
+        const globalLog = new WarningLog();
+        const log       = new WarningLog(globalLog);
 
 
-        log.addWarning(WARNINGS.screenshotError, 'TypeError');
+        log.addWarning(WARNINGS.screenshotError, TYPE_ERROR_TEXT);
 
         expect(log.messages).eql([
-            'Was unable to take a screenshot due to an error.\n\nTypeError'
+            'Was unable to take a screenshot due to an error.\n\n' + TYPE_ERROR_TEXT
         ]);
 
-        expect(parentLog.messages).eql([
-            'Was unable to take a screenshot due to an error.\n\nTypeError'
+        expect(globalLog.messages).eql([
+            'Was unable to take a screenshot due to an error.\n\n' + TYPE_ERROR_TEXT
         ]);
     });
 });

--- a/test/server/warning-log-test.js
+++ b/test/server/warning-log-test.js
@@ -1,0 +1,45 @@
+const expect     = require('chai').expect;
+const WarningLog = require('../../lib/notifications/warning-log');
+const WARNINGS   = require('../../lib/notifications/warning-message');
+
+
+describe('Warning log', () => {
+    it('Should render and store warnings', () => {
+        const log = new WarningLog();
+
+        log.addWarning(WARNINGS.screenshotError, 'TypeError');
+        log.addWarning(WARNINGS.screenshotError, 'SyntaxError');
+
+        expect(log.messages).eql([
+            'Was unable to take a screenshot due to an error.\n\nTypeError',
+            'Was unable to take a screenshot due to an error.\n\nSyntaxError'
+        ]);
+    });
+
+    it('Should remove duplicates', () => {
+        const log = new WarningLog();
+
+        log.addWarning(WARNINGS.screenshotError, 'TypeError');
+        log.addWarning(WARNINGS.screenshotError, 'TypeError');
+
+        expect(log.messages).eql([
+            'Was unable to take a screenshot due to an error.\n\nTypeError'
+        ]);
+    });
+
+    it('Should add messages to the parent log', () => {
+        const parentLog = new WarningLog();
+        const log       = new WarningLog(parentLog);
+
+
+        log.addWarning(WARNINGS.screenshotError, 'TypeError');
+
+        expect(log.messages).eql([
+            'Was unable to take a screenshot due to an error.\n\nTypeError'
+        ]);
+
+        expect(parentLog.messages).eql([
+            'Was unable to take a screenshot due to an error.\n\nTypeError'
+        ]);
+    });
+});


### PR DESCRIPTION
Part of #2753

Sum up changes in APIs:
#### 
#### The [testRunInfo](https://devexpress.github.io/testcafe/documentation/extending-testcafe/reporter-plugin/reporter-methods.html#testruninfo-object) object has the additional `warnings` field

Now `testRunInfo` has the following structure:

Property            | Type             | Description
------------------- | ---------------- | --------------------------------------------------------
`errs`              | Array of Strings | An array of errors that occurred during the test run.
**`warnings`**     | **Array of Strings** | **An array of warnings that occurred during the test run.**
`durationMs`        | Number           | The time spent on test execution (in milliseconds).
`unstable`          | Boolean          | Specifies if the test is marked as unstable.
`screenshotPath`    | String           | The path where screenshots are saved.
`screenshots`       | Array of Objects | An array of [screenshot](#screenshots-object) objects.
`quarantine`        | Object           | A [quarantine](#quarantine-object) object.
`skipped`           | Boolean          | Specifies if the test was skipped.

#### The [reportTaskDone](https://devexpress.github.io/testcafe/documentation/extending-testcafe/reporter-plugin/reporter-methods.html#reporttaskdone) method is async and has an additional parameter

Now it has a new 4th argument called `result` and has the following signature:
```
async reportTaskDone (endTime, passed, warnings, result)
```

Parameter  | Type             | Description
---------- | ---------------- | ----------------------------------------------
`endTime`  | Date             | The date and time when testing completed.
`passed`   | Number           | The number of passed tests.
`warnings` | Array of Strings | An array of warnings that occurred during the test session.
**`result`** | **Object** | **A `result` object representing total numbers of tests in the test session.**


The `result` object has the following structure:

Property            | Type             | Description
------------------- | ---------------- | --------------------------------------------------------
`passedCount`              | Number            | The total number of passed tests in the test session.
`failedCount`     | Number           |  The total number of failed tests in the test session.
`skippedCount`        | Number           |  The total number of skipped tests in the test session.

#### All [reporters methods](https://devexpress.github.io/testcafe/documentation/extending-testcafe/reporter-plugin/reporter-method) are async now

All reporters  method can be async and have the following signatures:
```
async reportTaskStart (startTime, userAgents, testCount)
async reportFixtureStart (name, path, meta)
async reportTestDone (name, testRunInfo, meta)
async reportTaskDone (endTime, passed, warnings, result)
```