### PR TITLE
added reportPath as parameter to reportTaskStart

### DIFF
--- a/docs/articles/documentation/extending-testcafe/reporter-plugin/README.md
+++ b/docs/articles/documentation/extending-testcafe/reporter-plugin/README.md
@@ -60,7 +60,7 @@ Once the reporter has been scaffolded out, go to the reporter directory and open
 You would need to implement four [reporter methods](reporter-methods.md).
 
 ```js
-reportTaskStart (/* startTime, userAgents, testCount */) {
+reportTaskStart (/* startTime, userAgents, testCount, reportPath */) {
     throw new Error('Not implemented');
 },
 

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -131,7 +131,7 @@ export default class Reporter {
             const userAgents = task.browserConnectionGroups.map(group => group[0].userAgent);
             const first      = this.reportQueue[0];
 
-            await this.plugin.reportTaskStart(startTime, userAgents, this.testCount);
+            await this.plugin.reportTaskStart(startTime, userAgents, this.testCount, this.outStream ? this.outStream.path : '');
             await this.plugin.reportFixtureStart(first.fixture.name, first.fixture.path, first.fixture.meta);
         });
 

--- a/src/reporter/plugin-host.js
+++ b/src/reporter/plugin-host.js
@@ -135,7 +135,7 @@ export default class ReporterPluginHost {
 
 
     // Abstract methods implemented in plugin
-    async reportTaskStart (/* startTime, userAgents, testCount */) {
+    async reportTaskStart (/* startTime, userAgents, testCount, reportPath */) {
         throw new Error('Not implemented');
     }
 

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -337,7 +337,8 @@ describe('Reporter', () => {
                         'Chrome',
                         'Firefox'
                     ],
-                    6
+                    6,
+                    ''
                 ]
             },
             {


### PR DESCRIPTION
added reportPath as parameter to the `reportTaskStart()` to have the path to the reporter output file (if set) in the (custom) reporter. This can be used to write other files in this location as well.