### PR TITLE
[docs] Emphasize that postfixes for browser aliases do not work with 'path:'

### DIFF
--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -110,6 +110,8 @@ In `Unix` shells like `bash`, `zsh`, `csh` (macOS, Linux, Windows Subsystem for 
 testcafe 'path:`C:\Program Files (x86)\Firefox Portable\firefox.exe`' tests/sample-fixture.js
 ```
 
+> Do not use the `path:` prefix if you need to run a browser in the [headless mode](common-concepts/browsers/testing-in-headless-mode.md), use [device emulation](common-concepts/browsers/using-chrome-device-emulation.md) or [user profiles](common-concepts/browsers/user-profiles.md). Specify the [browser alias](common-concepts/browsers/browser-support.md#locally-installed-browsers) in these cases.
+
 ### Testing in Headless Mode
 
 To run tests in the headless mode in Google Chrome or Firefox, use the `:headless` postfix:

--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -125,7 +125,7 @@ See [Testing in Headless Mode](common-concepts/browsers/testing-in-headless-mode
 To run tests in Chrome's device emulation mode, specify `:emulation` and [device parameters](common-concepts/browsers/using-chrome-device-emulation.md#emulator-parameters).
 
 ```sh
-testcafe "chrome:emulation:device=iphone 6" tests/sample-fixture.js
+testcafe "chrome:emulation:device=iphone X" tests/sample-fixture.js
 ```
 
 See [Using Chrome Device Emulation](common-concepts/browsers/using-chrome-device-emulation.md) for more details.

--- a/docs/articles/documentation/using-testcafe/common-concepts/browsers/testing-in-headless-mode.md
+++ b/docs/articles/documentation/using-testcafe/common-concepts/browsers/testing-in-headless-mode.md
@@ -5,7 +5,7 @@ permalink: /documentation/using-testcafe/common-concepts/browsers/testing-in-hea
 ---
 # Testing in Headless Mode
 
-TestCafe allows you to run tests in Google Chrome and Mozilla Firefox without any visible UI shell - in the headless mode ([Chrome Headless](https://developers.google.com/web/updates/2017/04/headless-chrome), [Firefox Headless](https://developer.mozilla.org/en-US/Firefox/Headless_mode)). Use the `headless` browser parameter to launch a browser in the headless mode.
+TestCafe allows you to run tests in Google Chrome and Mozilla Firefox without any visible UI shell - in the headless mode ([Chrome Headless](https://developers.google.com/web/updates/2017/04/headless-chrome), [Firefox Headless](https://developer.mozilla.org/en-US/Firefox/Headless_mode)). Use the `:headless` parameter to launch a browser in the headless mode.
 
 ```sh
 testcafe "chrome:headless" tests/sample-fixture.js
@@ -18,7 +18,7 @@ runner
     .run();
 ```
 
-Specify a path to the browser executable if you use a portable version of the browser:
+Specify a path to the browser executable if you use a portable version of the browser. Use the [browser alias](browser-support.md#locally-installed-browsers) instead of the `path:` prefix.
 
 ```sh
 testcafe "firefox:path/to/firefox:headless" tests/sample-fixture.js

--- a/docs/articles/documentation/using-testcafe/common-concepts/browsers/user-profiles.md
+++ b/docs/articles/documentation/using-testcafe/common-concepts/browsers/user-profiles.md
@@ -7,7 +7,7 @@ permalink: /documentation/using-testcafe/common-concepts/browsers/user-profiles.
 
 By default, TestCafe launches browsers (Google Chrome and Mozilla Firefox so far) with a clean profile, i.e. without extensions, bookmarks and other profile settings. This was done to minimize the influence of profile parameters on test runs.
 
-However, if you need to start a browser with the current user profile, you can do this by specifying the `:userProfile` browser flag.
+However, if you need to start a browser with the current user profile, you can do this by specifying the `:userProfile` flag after the [browser alias](browser-support.md#locally-installed-browsers).
 
 ```sh
 testcafe firefox:userProfile tests/test.js
@@ -18,4 +18,10 @@ runner
     .src('tests/fixture1.js')
     .browsers('firefox:userProfile')
     .run();
+```
+
+When you pass the `:userProfile` flag to a portable browser, also use the [browser alias](browser-support.md#locally-installed-browsers). The `path:` prefix does not work in this case.
+
+```sh
+testcafe chrome:d:\chrome_portable\chrome.exe:userProfile tests/test.js
 ```

--- a/docs/articles/documentation/using-testcafe/common-concepts/browsers/using-chrome-device-emulation.md
+++ b/docs/articles/documentation/using-testcafe/common-concepts/browsers/using-chrome-device-emulation.md
@@ -8,13 +8,13 @@ permalink: /documentation/using-testcafe/common-concepts/browsers/using-chrome-d
 You can run test in Chrome's built-in [device emulator](https://developers.google.com/web/tools/chrome-devtools/device-mode/). To do this, use the `emulation` browser parameter. Specify the target device with the `device` parameter.
 
 ```sh
-testcafe "chrome:emulation:device=iphone 6" tests/sample-fixture.js
+testcafe "chrome:emulation:device=iphone X" tests/sample-fixture.js
 ```
 
 ```js
 runner
     .src('tests/sample-fixture.js')
-    .browsers('chrome:emulation:device=iphone 6')
+    .browsers('chrome:emulation:device=iphone X')
     .run();
 ```
 
@@ -34,14 +34,20 @@ runner
 You can combine both device emulation and headless mode.
 
 ```sh
-testcafe "chrome:headless:emulation:device=iphone 6;cdpPort=9223" tests/sample-fixture.js
+testcafe "chrome:headless:emulation:device=iphone X;cdpPort=9223" tests/sample-fixture.js
 ```
 
 ```js
 runner
     .src('tests/sample-fixture.js')
-    .browsers('chrome:headless:emulation:device=iphone 6;cdpPort=9223')
+    .browsers('chrome:headless:emulation:device=iphone X;cdpPort=9223')
     .run();
+```
+
+To enable device emulation in a portable Chrome, also use the [browser alias](browser-support.md#locally-installed-browsers). The `path:` prefix does not work in this case.
+
+```sh
+testcafe "chrome:d:\chrome_portable\chrome.exe:emulation:device=iphone X" tests/test.js
 ```
 
 ## Emulator Parameters

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -163,7 +163,11 @@ Use the `path:` prefix. Enclose the path in backticks if it contains spaces.
 runner.browsers('path:`C:\\Program Files\\Internet Explorer\\iexplore.exe`');
 ```
 
-> Do not use the `path:` prefix if you need to run a browser in the [headless mode](../common-concepts/browsers/testing-in-headless-mode.md), use [device emulation](../common-concepts/browsers/using-chrome-device-emulation.md) or [user profiles](../common-concepts/browsers/user-profiles.md). Specify the [browser alias](../common-concepts/browsers/browser-support.md#locally-installed-browsers) in these cases.
+Do not use the `path:` prefix if you need to run a browser in the [headless mode](../common-concepts/browsers/testing-in-headless-mode.md), use [device emulation](../common-concepts/browsers/using-chrome-device-emulation.md) or [user profiles](../common-concepts/browsers/user-profiles.md). Specify the [browser alias](#using-browser-aliases) in these cases and omit backticks.
+
+```js
+runner.browsers('chrome:D:\\Google Chrome Portable\\GoogleChromePortable.exe:headless');
+```
 
 #### Specifying the Path with Command Line Parameters
 
@@ -172,6 +176,12 @@ runner.browsers({
     path: 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
     cmd: '--new-window'
 });
+```
+
+You cannot pass browser parameters in the `path` property for the [headless mode](../common-concepts/browsers/testing-in-headless-mode.md), [device emulation](../common-concepts/browsers/using-chrome-device-emulation.md) or [user profiles](../common-concepts/browsers/user-profiles.md). To enable these features, use a string with a [browser alias](#using-browser-aliases).
+
+```js
+runner.browsers('chrome:D:\\Google Chrome Portable\\GoogleChromePortable.exe:headless --new-window')
 ```
 
 #### Passing a Remote Browser Connection

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -174,10 +174,10 @@ You can add postfixes to browser aliases to run tests in the [headless mode](../
 runner.browsers('chrome:headless');
 ```
 
-For portable browsers, use the browser alias followed by the path to an exacutable.
+For portable browsers, use the browser alias followed by the path to an executable.
 
 ```js
-runner.browsers('firefox:/home/user/apps/firerox.app:userProfile');
+runner.browsers('firefox:/home/user/apps/firefox.app:userProfile');
 ```
 
 > The `path:` prefix does not support postfixes.

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -149,24 +149,12 @@ runner.browsers(['safari', 'chrome']);
 runner.browsers('saucelabs:Chrome@52.0:Windows 8.1');
 ```
 
-* using [headless mode](../common-concepts/browsers/testing-in-headless-mode.md)
-
-```js
-runner.browsers('chrome:headless');
-```
-
 #### Specifying the Path to the Browser Executable
 
 Use the `path:` prefix. Enclose the path in backticks if it contains spaces.
 
 ```js
 runner.browsers('path:`C:\\Program Files\\Internet Explorer\\iexplore.exe`');
-```
-
-Do not use the `path:` prefix if you need to run a browser in the [headless mode](../common-concepts/browsers/testing-in-headless-mode.md), use [device emulation](../common-concepts/browsers/using-chrome-device-emulation.md) or [user profiles](../common-concepts/browsers/user-profiles.md). Specify the [browser alias](#using-browser-aliases) in these cases and omit backticks.
-
-```js
-runner.browsers('chrome:D:\\Google Chrome Portable\\GoogleChromePortable.exe:headless');
 ```
 
 #### Specifying the Path with Command Line Parameters
@@ -178,11 +166,21 @@ runner.browsers({
 });
 ```
 
-You cannot pass browser parameters in the `path` property for the [headless mode](../common-concepts/browsers/testing-in-headless-mode.md), [device emulation](../common-concepts/browsers/using-chrome-device-emulation.md) or [user profiles](../common-concepts/browsers/user-profiles.md). To enable these features, use a string with a [browser alias](#using-browser-aliases).
+#### Headless Mode, Device Emulation and User Profiles
+
+You can add postfixes to browser aliases to run tests in the [headless mode](../common-concepts/browsers/testing-in-headless-mode.md), use [Chrome device emulation](../common-concepts/browsers/using-chrome-device-emulation.md) or [user profiles](../common-concepts/browsers/user-profiles.md).
 
 ```js
-runner.browsers('chrome:D:\\Google Chrome Portable\\GoogleChromePortable.exe:headless --dns-prefetch-disable')
+runner.browsers('chrome:headless');
 ```
+
+For portable browsers, use the browser alias followed by the path to an exacutable.
+
+```js
+runner.browsers('firefox:/home/user/apps/firerox.app:userProfile');
+```
+
+> The `path:` prefix does not support postfixes.
 
 #### Passing a Remote Browser Connection
 

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -181,7 +181,7 @@ runner.browsers({
 You cannot pass browser parameters in the `path` property for the [headless mode](../common-concepts/browsers/testing-in-headless-mode.md), [device emulation](../common-concepts/browsers/using-chrome-device-emulation.md) or [user profiles](../common-concepts/browsers/user-profiles.md). To enable these features, use a string with a [browser alias](#using-browser-aliases).
 
 ```js
-runner.browsers('chrome:D:\\Google Chrome Portable\\GoogleChromePortable.exe:headless --new-window')
+runner.browsers('chrome:D:\\Google Chrome Portable\\GoogleChromePortable.exe:headless --dns-prefetch-disable')
 ```
 
 #### Passing a Remote Browser Connection

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -163,6 +163,8 @@ Use the `path:` prefix. Enclose the path in backticks if it contains spaces.
 runner.browsers('path:`C:\\Program Files\\Internet Explorer\\iexplore.exe`');
 ```
 
+> Do not use the `path:` prefix if you need to run a browser in the [headless mode](../common-concepts/browsers/testing-in-headless-mode.md), use [device emulation](../common-concepts/browsers/using-chrome-device-emulation.md) or [user profiles](../common-concepts/browsers/user-profiles.md). Specify the [browser alias](../common-concepts/browsers/browser-support.md#locally-installed-browsers) in these cases.
+
 #### Specifying the Path with Command Line Parameters
 
 ```js


### PR DESCRIPTION
\cc @kirovboris @AndreyBelym 

fixes #3216 