### PR TITLE
[docs] Bitbucket Pipelines CI documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -91,6 +91,7 @@
 * [CONTINUOUS INTEGRATION](articles/documentation/continuous-integration/README.md)
   * [AppVeyor](articles/documentation/continuous-integration/appveyor.md)
   * [Azure DevOps](articles/documentation/continuous-integration/azure-devops.md)
+  * [Bitbucket Pipelines](articles/documentation/continuous-integration/bitbucket-pipelines.md)
   * [CircleCI](articles/documentation/continuous-integration/circleci.md)
   * [GitLab](articles/documentation/continuous-integration/gitlab.md)
   * [Jenkins](articles/documentation/continuous-integration/jenkins.md)

--- a/docs/articles/documentation/continuous-integration/README.md
+++ b/docs/articles/documentation/continuous-integration/README.md
@@ -11,6 +11,7 @@ This section describes how to integrate TestCafe into a build process on popular
 
 * [AppVeyor](appveyor.md)
 * [Azure DevOps](azure-devops.md)
+* [Bitbucket Pipelines CI](bitbucket-pipelines.md)
 * [CircleCI](circleci.md)
 * [GitLab](gitlab.md)
 * [Jenkins](jenkins.md)

--- a/docs/articles/documentation/continuous-integration/bitbucket-pipelines.md
+++ b/docs/articles/documentation/continuous-integration/bitbucket-pipelines.md
@@ -2,115 +2,111 @@
 layout: docs
 title: Run Tests in Bitbucket Pipelines
 permalink: /documentation/continuous-integration/bitbucket-pipelines.html
-redirect_from:
-  - /documentation/recipes/integrating-testcafe-with-ci-systems/bitbucket-pipelines.html
 ---
 # Run Tests in Bitbucket Pipelines CI
 
-You can automatically run tests as a part of your build process using TestCafe and [Bitbucket Pipelines CI](https://bitbucket.org/product/features/pipelines).
-The Bitbucket Pipelines support Docker containers, and there are some available with both Chrome and Firefox browsers included (also in headless mode).
+You can automatically run TestCafe tests as a part of your build process on [Bitbucket Pipelines CI](https://bitbucket.org/product/features/pipelines).
 
-Suppose you have a Bitbucket project for which you need to automatically run tests in the cloud when the project is modified. To do this, go through the following steps.
+Suppose you have a Bitbucket project for which you need to automatically run tests in the cloud when the project is modified. To do this, go through the following steps:
 
-* [Step 1 - Install TestCafe and create tests](#step-1---install-testcafe-and-create-tests)
-* [Step 2 - Configure Bitbucket Pipelines to run for your project](#step-2---enable-bitbucket-pipelines-for-your-project)
-* [Step 3 - Add the `test` script to package.json](#step-3---add-the-test-script-to-packagejson)
-* [Step 4 - Trigger a Bitbucket Pipelines build](#step-4---trigger-a-bitbucket-pipelines-ci-build)
+* [Step 1 - Install TestCafe and Create Tests](#step-1---install-testcafe-and-create-tests)
+* [Step 2 - Enable Bitbucket Pipelines for Your Project](#step-2---enable-bitbucket-pipelines-for-your-project)
+  * [Option 1 - Use TestCafe Docker Image](#option-1---use-testcafe-docker-image)
+  * [Option 2 - Install TestCafe on a Docker Image](#option-2---install-testcafe-on-a-docker-image)
+* [Step 3 - Trigger a Bitbucket Pipelines Build](#step-3---trigger-a-bitbucket-pipelines-ci-build)
 
-> TestCafe provides an [example](https://github.com/DevExpress/testcafe/tree/master/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/) that can show you how to run tests in Chrome with Bitbucket Pipelines CI.
+> TestCafe provides an [example](https://github.com/DevExpress/testcafe/tree/master/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/) that shows how to run tests in Chrome with Bitbucket Pipelines CI.
 
-## Step 1 - Install TestCafe and create tests
+## Step 1 - Install TestCafe and Create Tests
 
 Install TestCafe [locally](../using-testcafe/installing-testcafe.md#locally) in your project and [create tests](../getting-started/README.md#creating-a-test).
 
-## Step 2 - Enable Bitbucket Pipelines for your project
+## Step 2 - Enable Bitbucket Pipelines for Your Project
 
-1. To enable the Bitbucket Pipelines for your project you need to create a `bitbucket-pipelines.yml` file in your project root folder.
-2. Configuring the right environment can be tedious but luckily Bitbucket Pipelines can use Docker containers, some already configured to work with Chrome and Firefox. You can [use a TestCafe Docker image](#option-1---use-testcafe-docker-image) with pre-installed software.
+To enable Bitbucket Pipelines for your project, create a `bitbucket-pipelines.yml` file in the project's root folder.
+
+Bitbucket Pipelines CI allows you to avoid manual environment configuration and use Docker containers set up to work with Chrome and Firefox. You can [use a TestCafe Docker image](#option-1---use-testcafe-docker-image) with pre-installed software.
 However, if you already have a Docker image prepared to deploy your web application and run tests, you can [install TestCafe on this image before testing](#option-2---install-testcafe-on-a-docker-image).
-3. Configure the template to execute on Pull Request update
 
-For more templates or more information about the Pipelines see the [Atlassian Bitbucket Support page](https://confluence.atlassian.com/bitbucket/get-started-with-bitbucket-pipelines-792298921.html)
+For more information about how to get started with Pipelines, see the [Atlassian Bitbucket support page](https://confluence.atlassian.com/bitbucket/get-started-with-bitbucket-pipelines-792298921.html).
 
 ### Option 1 - Use TestCafe Docker Image
 
-In the `image` field of the `bitbucket-pipelines.yml` file you can set the `testcafe/testcafe` image and then use the custom launcher when the PR is updated:
+Specify the `testcafe/testcafe` image name in the `image` field of the [bitbucket-pipelines.yml file](https://confluence.atlassian.com/bitbucket/configure-bitbucket-pipelines-yml-792298910.html). Then, configure a pipeline that installs the project's dependencies and triggers a custom TestCafe launcher when you push commits and create pull requests.
 
-    ```yaml
-    image: testcafe/testcafe
-    pipelines:
-      pull-requests:
-        '**':
-          - step:
-              script:
-                - npm ci
-                - /opt/testcafe/docker/testcafe-docker.sh firefox:headless,chromium tests/**/*
+```yaml
+image: testcafe/testcafe
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          script:
+            - npm ci
+            - /opt/testcafe/docker/testcafe-docker.sh firefox:headless,chromium tests/**/*
 
-      branches:
-        master:
-          - step:
-              script:
-                - npm ci
-                - /opt/testcafe/docker/testcafe-docker.sh firefox:headless,chromium tests/**/*
-    ```
+  branches:
+    master:
+      - step:
+          script:
+            - npm ci
+            - /opt/testcafe/docker/testcafe-docker.sh firefox:headless,chromium tests/**/*
+```
 
-The custom launcher script `/opt/testcafe/docker/testcafe-docker.sh` points to a script that prepares the environment to run a browser and starts TestCafe. Its arguments are standard TestCafe [command line parameters](../using-testcafe/command-line-interface.md).
+The custom launcher script `/opt/testcafe/docker/testcafe-docker.sh` prepares the environment to run a browser and starts TestCafe. Its arguments are standard TestCafe [command line parameters](../using-testcafe/command-line-interface.md).
 
 Commit and push this file to your repository.
 
 ### Option 2 - Install TestCafe on a Docker Image
 
-Open the `bitbucket-pipelines.yml` file and use an image with Node.js with browsers already installed in it:
+Use the `image` field in the [bitbucket-pipelines.yml file](https://confluence.atlassian.com/bitbucket/configure-bitbucket-pipelines-yml-792298910.html) to specify a desired Docker image with Node.js and browsers installed. Then, configure a pipeline that installs the project's dependencies and runs tests when you push commits and create pull requests.
 
-    ```yaml
-    # Replace '10.14' with the latest Node.js LTS version
-    # available on Docker Hub
-    image: circleci/node:10.14-browsers
-    pipelines:
-      pull-requests:
-        '**':
-          - step:
-              script:
-                - npm ci
-                - npm test
+```yaml
+# Replace '10.14' with the latest Node.js LTS version
+# available on Docker Hub
+image: circleci/node:10.14-browsers
+pipelines:
+  pull-requests:
+    '**':
+      - step:
+          script:
+            - npm ci
+            - npm test
 
-      branches:
-        master:
-          - step:
-              script:
-                - npm ci
-                - npm test
-    ```
+  branches:
+    master:
+      - step:
+          script:
+            - npm ci
+            - npm test
+```
 
-    Commit and push this file to your repository.
+To specify how npm should run TestCafe, add the `test` script to the project's `package.json` file and execute the `testcafe` command in this script.
 
-## Step 3 - Add the `test` script to package.json
+The following example shows a command that runs tests in Chromium in headless mode.
 
-To test a project, Bitbucket Pipelines runs test scripts. For Node.js projects, the default test script is `npm test`.
-
-**Note**: if you used [Option #1](#option-1---use-testcafe-docker-image) you can skip this step already and go to [Step 4](#step-4---trigger-a-bitbucket-pipelines-ci-build).
-
-To tell npm how to run your tests, add the `test` script to the project's package.json file. Use `testcafe` command in the script to run tests in Chrome in Headless mode.
-
-```text
+```json
 "scripts": {
     "test":  "testcafe 'chromium:headless --no-sandbox --disable-setuid-sandbox --window-size=1920x1080' tests/index-test.js"
 }
 ```
 
-For more information on how to configure a test run using a `testcafe` command, see [Command Line Interface](../using-testcafe/command-line-interface.md).
+For more information on how to configure a test run with the `testcafe` command, see [Command Line Interface](../using-testcafe/command-line-interface.md).
 
-**Note:** If your app requires starting a custom web server, use the `--app` TestCafe option to specify a command that starts your server.
-This command will be automatically executed before running tests. After tests are finished, TestCafe will stop the app server.
+Commit the changes and push them to your repository.
 
-```text
+### Tip: Start a Custom Web Server
+
+If you need to start a custom Web server to host your application, use the [--app](../using-testcafe/command-line-interface.md#-a-command---app-command) TestCafe option followed by a command that starts this server.
+TestCafe executes this command automatically before tests are launched. After tests finish, TestCafe stops the server.
+
+```json
 "scripts": {
   "test":  "testcafe 'chromium:headless --no-sandbox --disable-setuid-sandbox --window-size=1920x1080' tests/index-test.js --app \"node server.js\""
 }
 ```
 
-## Step 5 - Trigger a Bitbucket Pipeplines CI build
+## Step 3 - Trigger a Bitbucket Pipelines CI Build
 
-You can trigger a Bitbucket Pipeplines CI build by pushing commits to your repository or creating a pull request.
+Bitbucket Pipeplines CI is now configured to trigger the build when you push commits to your repository or create a pull request.
 
-To check if the build passed or failed, go to the Pipelines status page in your project page.
+To check if the build has passed or failed, open your project's page and go to the Pipelines status page.

--- a/docs/articles/documentation/continuous-integration/bitbucket-pipelines.md
+++ b/docs/articles/documentation/continuous-integration/bitbucket-pipelines.md
@@ -1,0 +1,80 @@
+---
+layout: docs
+title: Run Tests in Bitbucket Pipelines
+permalink: /documentation/continuous-integration/bitbucket-pipelines.html
+redirect_from:
+  - /documentation/recipes/integrating-testcafe-with-ci-systems/bitbucket-pipelines.html
+---
+# Run Tests in Bitbucket Pipelines CI
+
+You can automatically run tests as a part of your build process using TestCafe and [Bitbucket Pipelines CI](https://bitbucket.org/product/features/pipelines).
+The Bitbucket Pipelines support Docker containers, and there are some available with both Chrome e Firefox browsers included (also in headless mode)
+
+Suppose you have a Bitbucket project for which you need to automatically run tests in the cloud when the project is modified. To do this, go through the following steps.
+
+* [Step 1 - Install TestCafe and create tests](#step-1---install-testcafe-and-create-tests)
+* [Step 2 - Configure Bitbucket Pipelines to run for your project](#step-2---enable-bitbucket-pipelines-for-your-project)
+* [Step 3 - Add the `test` script to package.json](#step-3---add-the-test-script-to-packagejson)
+* [Step 4 - Trigger a Bitbucket Pipelines build](#step-4---trigger-a-bitbucket-pipelines-ci-build)
+
+> TestCafe provides an [example](https://github.com/DevExpress/testcafe/tree/master/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/) that can show you how to run tests in Chrome with Bitbucket Pipelines CI.
+
+## Step 1 - Install TestCafe and create tests
+
+Install TestCafe [locally](../using-testcafe/installing-testcafe.md#locally) in your project and [create tests](../getting-started/README.md#creating-a-test).
+
+## Step 2 - Enable Bitbucket Pipelines for your project
+
+1. To enable the Bitbucket Pipelines for your project you need to create a `bitbucket-pipelines.yml` file in your project root folder.
+2. Configuring the right environment can be tedious but luckily Bitbucket Pipelines can use Docker containers, some already configured to work with Chrome and Firefox. The `zenika/alpine-chrome:with-node` image comes already configured and ready to use for Chrome headless or Puppeteer.
+3. An example template can have the following content to run on Pull Requests:
+
+    ```yaml
+    image: zenika/alpine-chrome:with-node
+    pipelines:
+      pull-requests:
+        '**':
+          - step:
+              script:
+                - npm ci
+                - npm test
+
+      branches:
+        master:
+          - step:
+              script:
+                - npm ci
+                - npm test
+    ```
+
+    Commit and push this file to your repository.
+
+For more templates or more information about the Pipelines see the [Atlassian Bitbucket Support page](https://confluence.atlassian.com/bitbucket/get-started-with-bitbucket-pipelines-792298921.html)
+
+## Step 3 - Add the `test` script to package.json
+
+To test a project, Bitbucket Pipelines runs test scripts. For Node.js projects, the default test script is `npm test`.
+To tell npm how to run your tests, add the `test` script to the project's package.json file. Use `testcafe` command in the script to run tests in Chrome in Headless mode.
+
+```text
+"scripts": {
+    "test":  "testcafe 'chromium:headless --no-sandbox --disable-setuid-sandbox --window-size=1920x1080' tests/index-test.js"
+}
+```
+
+For more information on how to configure a test run using a `testcafe` command, see [Command Line Interface](../using-testcafe/command-line-interface.md).
+
+**Note:** If your app requires starting a custom web server, use the `--app` TestCafe option to specify a command that starts your server.
+This command will be automatically executed before running tests. After tests are finished, TestCafe will stop the app server.
+
+```text
+"scripts": {
+  "test":  "testcafe 'chromium:headless --no-sandbox --disable-setuid-sandbox --window-size=1920x1080' tests/index-test.js --app \"node server.js\""
+}
+```
+
+## Step 5 - Trigger a Bitbucket Pipeplines CI build
+
+You can trigger a Bitbucket Pipeplines CI build by pushing commits to your repository or creating a pull request.
+
+To check if the build passed or failed, go to the Pipelines status page in your project page.

--- a/docs/articles/documentation/continuous-integration/bitbucket-pipelines.md
+++ b/docs/articles/documentation/continuous-integration/bitbucket-pipelines.md
@@ -30,7 +30,6 @@ Install TestCafe [locally](../using-testcafe/installing-testcafe.md#locally) in 
 However, if you already have a Docker image prepared to deploy your web application and run tests, you can [install TestCafe on this image before testing](#option-2---install-testcafe-on-a-docker-image).
 3. Configure the template to execute on Pull Request update
 
-
 For more templates or more information about the Pipelines see the [Atlassian Bitbucket Support page](https://confluence.atlassian.com/bitbucket/get-started-with-bitbucket-pipelines-792298921.html)
 
 ### Option 1 - Use TestCafe Docker Image

--- a/docs/articles/documentation/continuous-integration/bitbucket-pipelines.md
+++ b/docs/articles/documentation/continuous-integration/bitbucket-pipelines.md
@@ -8,7 +8,7 @@ redirect_from:
 # Run Tests in Bitbucket Pipelines CI
 
 You can automatically run tests as a part of your build process using TestCafe and [Bitbucket Pipelines CI](https://bitbucket.org/product/features/pipelines).
-The Bitbucket Pipelines support Docker containers, and there are some available with both Chrome e Firefox browsers included (also in headless mode).
+The Bitbucket Pipelines support Docker containers, and there are some available with both Chrome and Firefox browsers included (also in headless mode).
 
 Suppose you have a Bitbucket project for which you need to automatically run tests in the cloud when the project is modified. To do this, go through the following steps.
 

--- a/docs/nav/nav-menu.yml
+++ b/docs/nav/nav-menu.yml
@@ -197,6 +197,8 @@
     url: /documentation/continuous-integration/appveyor.md
   - name: Azure DevOps
     url: /documentation/continuous-integration/azure-devops.md
+  - name: Bitbucket Pipelines
+    url: /documentation/continuous-integration/bitbucket-pipelines.md
   - name: CircleCI
     url: /documentation/continuous-integration/circleci.md
   - name: GitLab

--- a/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/README.md
+++ b/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/README.md
@@ -1,0 +1,14 @@
+# Example: Running Tests in Chrome Using Bitbucket Pipelines CI
+
+*A set of sample files that help you learn how to run TestCafe tests in the cloud using Chrome (Headless) with Bitbucket Pipelines CI.*
+
+## Running the example
+
+1. Clone the TestCafe repository to your machine.
+
+     ```sh
+     git clone https://github.com/DevExpress/testcafe.git
+     ```
+
+2. Create a new Bitbucket repository and copy the sample files from *examples/running-tests-in-chrome-using-bitbucket-pipelines-ci* to your repository.
+3. Go through steps described in the [Running Tests in Bitbucket Pipelines CI](http://devexpress.github.io/testcafe/documentation/recipes/running-tests-in-chrome-using-bitbucket-pipelines-ci.html) topic.

--- a/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/bitbucket-pipelines.yml
+++ b/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/bitbucket-pipelines.yml
@@ -1,4 +1,4 @@
-image: zenika/alpine-chrome:with-node
+image: circleci/node:10.14-browsers
     pipelines:
       pull-requests:
         '**':

--- a/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/bitbucket-pipelines.yml
+++ b/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/bitbucket-pipelines.yml
@@ -1,0 +1,15 @@
+image: zenika/alpine-chrome:with-node
+    pipelines:
+      pull-requests:
+        '**':
+          - step:
+              script:
+                - npm ci
+                - npm test
+
+      branches:
+        master:
+          - step:
+              script:
+                - npm ci
+                - npm test

--- a/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/index.html
+++ b/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/index.html
@@ -1,0 +1,12 @@
+<html>
+ <head>
+  <script type="text/javascript">
+  function change() {
+    document.getElementById("click-here").value = "Hello!";
+  }
+ </script>
+ </head>
+<body>
+  <input type="button" value="Click here" id="click-here" onclick="change()"></input>
+</body>
+</html>

--- a/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/package.json
+++ b/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "running-tests-using-bitbucket-pipelines",
+  "version": "1.0.0",
+  "description": "An example of how to run TestCafe tests in the cloud using Chrome with Bitbucket Pipelines CI.",
+  "main": "server.js",
+  "scripts": {
+    "test": "testcafe 'chromium:headless --no-sandbox --disable-setuid-sandbox --window-size=1920x1080' tests/index-test.js --app \"node server.js\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DevExpress/testcafe.git"
+  },
+  "author": "Developer Express Inc. (https://devexpress.com)",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/DevExpress/testcafe/issues"
+  },
+  "homepage": "https://github.com/DevExpress/testcafe#readme",
+  "dependencies": {
+    "connect": "^3.4.1",
+    "serve-static": "^1.11.1"
+  },
+  "devDependencies": {
+    "testcafe": "*"
+  }
+}

--- a/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/server.js
+++ b/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/server.js
@@ -1,0 +1,6 @@
+const connect     = require('connect');
+const serveStatic = require('serve-static');
+
+connect().use(serveStatic(__dirname)).listen(9090, () => {
+    process.stdout.write('Server running on 9090...\n');
+});

--- a/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/tests/index-test.js
+++ b/examples/running-tests-in-chrome-using-bitbucket-pipelines-ci/tests/index-test.js
@@ -1,0 +1,10 @@
+import { Selector } from 'testcafe';
+
+fixture `Check if the button text changes`
+    .page `http://localhost:9090/index.html`;
+
+test('My test', async t => {
+    await t
+        .click('#click-here')
+        .expect(Selector('#click-here').value).eql('Hello!');
+});


### PR DESCRIPTION
This PR adds some documentation on how to setup Testcafe in a new continuous integration as the Bitbucket Pipelines .
The Travis CI documentation and example have been used as baseline for this documentation.

Let me know if I need to change any formality or anything else in here.