### PR TITLE
[docs] correct npm install instructions

### DIFF
--- a/docs/articles/documentation/continuous-integration/azure-devops.md
+++ b/docs/articles/documentation/continuous-integration/azure-devops.md
@@ -12,7 +12,7 @@ This topic describes how to integrate TestCafe tests into an [Azure DevOps Serve
 Open the repository's root directory and execute the following command:
 
 ```sh
-npm --save-dev testcafe
+npm install --save-dev testcafe
 ```
 
 This command installs the latest TestCafe version locally and adds it to the `devDependencies` section in the `package.json` file.

--- a/docs/articles/documentation/continuous-integration/circleci.md
+++ b/docs/articles/documentation/continuous-integration/circleci.md
@@ -98,7 +98,7 @@ jobs:
 Next, add `testcafe` and `testcafe-reporter-xunit` to project's development dependencies. Open the repository root and execute the following command:
 
 ```sh
-npm --save-dev testcafe testcafe-reporter-xunit
+npm install --save-dev testcafe testcafe-reporter-xunit
 ```
 
 This command installs the `testcafe` and `testcafe-reporter-xunit` modules locally and adds them to `package.json`.

--- a/docs/articles/documentation/continuous-integration/gitlab.md
+++ b/docs/articles/documentation/continuous-integration/gitlab.md
@@ -45,7 +45,7 @@ You can install TestCafe from `npm` before tests are run if you use a Docker ima
 First, add TestCafe to your project development dependencies. Open the repository root and execute the following command:
 
 ```sh
-npm --save-dev testcafe
+npm install --save-dev testcafe
 ```
 
 This installs the latest TestCafe version locally and adds it to the `devDependencies` section in the `package.json` file.

--- a/docs/articles/documentation/recipes/debug-tests/webstorm.md
+++ b/docs/articles/documentation/recipes/debug-tests/webstorm.md
@@ -12,7 +12,7 @@ This topic describes how to debug TestCafe tests in [WebStorm](https://www.jetbr
 Execute the following command to install TestCafe locally and add it to the `devDependencies` section in `package.json`:
 
 ```sh
-npm --save-dev testcafe
+npm install --save-dev testcafe
 ```
 
 ```json


### PR DESCRIPTION
This PR fixes incorrect npm install instructions:
~npm --save-dev~ --> `npm install --save-dev`

---

Hi all,

Nice work with testcafe 🚀 While looking through the documentation, I noticed that the command to install testcafe as a devDependency was incorrect. Hence, this PR fixes it. I read through the [contributing guidelines](https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#contribute-to-documentation), but did not open any issue as this PR is so minor.

Cheers

