### PR TITLE
Don't hide fixture info in the status panel

### DIFF
--- a/src/client/ui/status-bar/index.js
+++ b/src/client/ui/status-bar/index.js
@@ -42,8 +42,8 @@ const STATUS_DIV_CLASS                     = 'status';
 const WAITING_FAILED_CLASS                 = 'waiting-element-failed';
 const WAITING_SUCCESS_CLASS                = 'waiting-element-success';
 const LOADING_PAGE_TEXT                    = 'Loading Web Page...';
-const WAITING_FOR_ELEMENT_TEXT             = 'Waiting for an element to appear...';
-const WAITING_FOR_ASSERTION_EXECUTION_TEXT = 'Waiting for an assertion execution...';
+const WAITING_FOR_ELEMENT_TEXT             = 'Waiting for element to appear...';
+const WAITING_FOR_ASSERTION_EXECUTION_TEXT = 'Waiting for assertion execution...';
 const DEBUGGING_TEXT                       = 'Debugging test...';
 const TEST_FAILED_TEXT                     = 'Test failed';
 const UNLOCK_PAGE_TEXT                     = 'Unlock page';
@@ -53,14 +53,18 @@ const ANIMATION_DELAY                      = 500;
 const ANIMATION_UPDATE_INTERVAL            = 10;
 
 const VIEWS = {
-    all:                 { name: 'show-all-elements' },
-    hideFixture:         { name: 'hide-fixture', maxSize: 940, className: 'icon-status-view' },
-    hideStatus:          { name: 'hide-status', maxSize: 380, className: 'icon-unlock-buttons-view' },
-    hideStatusDebugging: { name: 'hide-status-debugging', maxSize: 740, className: 'icon-unlock-buttons-view' },
-    hideUnlockArea:      { name: 'hide-unlock-area', maxSize: 460, className: 'icon-buttons-view' },
-    onlyButtons:         { name: 'show-buttons-only', maxSize: 330, className: 'only-buttons-view' },
-    onlyIcon:            { name: 'show-icon-only', maxSize: 330, className: 'only-icon-view' }
+    all:                { name: 'show-all-elements', maxSize: Infinity },
+    hideFixture:        { name: 'hide-fixture', maxSize: 940, className: 'icon-status-view' },
+    hideStatus:         { name: 'hide-status-debugging', maxSize: 740, className: 'icon-unlock-buttons-view' },
+    hideUnlockArea:     { name: 'hide-unlock-area', maxSize: 460, className: 'icon-buttons-view' },
+    onlyButtons:        { name: 'show-buttons-only', maxSize: 330, className: 'only-buttons-view' },
+    onlyIconAndFixture: { name: 'show-icon-fixture-only', maxSize: Infinity, className: 'only-icon-fixture-view' },
+    onlyIcon:           { name: 'show-icon-only', maxSize: 380, className: 'only-icon-view' }
 };
+
+const REGULAR_VIEW_SEQUENCE   = [VIEWS.onlyIcon, VIEWS.onlyIconAndFixture];
+const WAITING_VIEW_SEQUENCE   = [VIEWS.onlyIcon, VIEWS.hideFixture, VIEWS.all];
+const DEBUGGING_VIEW_SEQUENCE = [VIEWS.onlyButtons, VIEWS.hideUnlockArea, VIEWS.hideStatus, VIEWS.hideFixture, VIEWS.all];
 
 export default class StatusBar extends serviceUtils.EventEmitter {
     constructor (userAgent, fixtureName, testName) {
@@ -276,26 +280,20 @@ export default class StatusBar extends serviceUtils.EventEmitter {
         this.currentView = newView;
     }
 
+    _getActualViewSequence () {
+        if (this.state.debugging)
+            return DEBUGGING_VIEW_SEQUENCE;
+
+        if (this.state.waiting)
+            return WAITING_VIEW_SEQUENCE;
+
+        return REGULAR_VIEW_SEQUENCE;
+    }
+
     _calculateActualView (windowWidth) {
-        const hideStatusMaxSize = this.state.debugging ? VIEWS.hideStatusDebugging.maxSize : VIEWS.hideStatus.maxSize;
-
-        if (windowWidth >= VIEWS.hideFixture.maxSize)
-            return VIEWS.all;
-
-        if (windowWidth < VIEWS.hideFixture.maxSize && windowWidth >= hideStatusMaxSize)
-            return VIEWS.hideFixture;
-
-        if (this.state.debugging) {
-            if (windowWidth < hideStatusMaxSize && windowWidth >= VIEWS.hideUnlockArea.maxSize)
-                return VIEWS.hideStatus;
-
-            if (windowWidth < VIEWS.hideUnlockArea.maxSize && windowWidth >= VIEWS.onlyButtons.maxSize)
-                return VIEWS.hideUnlockArea;
-
-            return VIEWS.onlyButtons;
-        }
-
-        return VIEWS.onlyIcon;
+        return this
+            ._getActualViewSequence()
+            .reduce((currentView, nextView) => currentView.maxSize >= windowWidth ? currentView : nextView);
     }
 
     _setFixtureContainerWidth () {
@@ -469,6 +467,7 @@ export default class StatusBar extends serviceUtils.EventEmitter {
 
         nativeMethods.nodeTextContentSetter.call(this.statusDiv, '');
         this.progressBar.hide();
+        this._recalculateSizes();
     }
 
     _showWaitingStatus () {
@@ -476,6 +475,7 @@ export default class StatusBar extends serviceUtils.EventEmitter {
 
         nativeMethods.nodeTextContentSetter.call(this.statusDiv, waitingStatusText);
         this._setStatusDivLeftMargin();
+        this._recalculateSizes();
         this.progressBar.show();
     }
 
@@ -493,6 +493,8 @@ export default class StatusBar extends serviceUtils.EventEmitter {
                 this.progressBar.determinateIndicator.reset();
 
                 this._resetState();
+                this._recalculateSizes();
+
                 resolve();
             }, forceReset ? 0 : ANIMATION_DELAY);
         });

--- a/src/client/ui/styles.less
+++ b/src/client/ui/styles.less
@@ -639,6 +639,17 @@
             }
         }
 
+        &.only-icon-fixture-view {
+            .info-container {
+                width: 100%;
+            }
+
+            .status-container {
+                width: 0;
+                display: none;
+            }
+        }
+
         &.only-icon-view {
             .container {
                 margin-left: 0;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4479386/51840362-e9cb9300-231c-11e9-9509-66bb3e35e9a2.png)

![image](https://user-images.githubusercontent.com/4479386/51840458-31521f00-231d-11e9-95f1-709b95af2885.png)

![image](https://user-images.githubusercontent.com/4479386/51840477-3f07a480-231d-11e9-82d7-243840190264.png)

After:
![image](https://user-images.githubusercontent.com/4479386/51840411-18496e00-231d-11e9-866c-08a9a3011ec1.png)


![image](https://user-images.githubusercontent.com/4479386/51840335-d7515980-231c-11e9-9845-afbad06d18d7.png)

![image](https://user-images.githubusercontent.com/4479386/51840574-78401480-231d-11e9-95d2-f42cc51e10f1.png)

