### PR TITLE
[docs] Describe video recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -237,7 +237,7 @@ See [Connect to TestCafe Server over HTTPS](https://devexpress.github.io/testcaf
 
 #### :gear: Construct Screenshot Paths with Patterns ([#2152](https://github.com/DevExpress/testcafe/issues/2152))
 
-You can now use patterns to construct paths to screenshots. TestCafe provides a number of placeholders you can include in the path, for example, `${DATE}`, `${TIME}`, `${USERAGENT}`, etc. For a complete list, refer to the command line [--screenshot-path-pattern flag description](https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#-p---screenshot-path-pattern).
+You can now use patterns to construct paths to screenshots. TestCafe provides a number of placeholders you can include in the path, for example, `${DATE}`, `${TIME}`, `${USERAGENT}`, etc. For a complete list, refer to the command line [--screenshot-path-pattern flag description](https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#-p-pattern---screenshot-path-pattern-pattern).
 
 You specify a screenshot path pattern when you run tests. Each time TestCafe takes a screenshot, it substitutes the placeholders with actual values and saves the screenshot to the resulting path.
 

--- a/docs/articles/blog/2018-08-02-testcafe-v0-21-0-released.md
+++ b/docs/articles/blog/2018-08-02-testcafe-v0-21-0-released.md
@@ -57,7 +57,7 @@ See [Connect to TestCafe Server over HTTPS](https://devexpress.github.io/testcaf
 
 ### ⚙ Construct Screenshot Paths with Patterns ([#2152](https://github.com/DevExpress/testcafe/issues/2152))
 
-You can now use patterns to construct paths to screenshots. TestCafe provides a number of placeholders you can include in the path, for example, `${DATE}`, `${TIME}`, `${USERAGENT}`, etc. For a complete list, refer to the command line [--screenshot-path-pattern flag description](https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#-p---screenshot-path-pattern).
+You can now use patterns to construct paths to screenshots. TestCafe provides a number of placeholders you can include in the path, for example, `${DATE}`, `${TIME}`, `${USERAGENT}`, etc. For a complete list, refer to the command line [--screenshot-path-pattern flag description](https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#-p-pattern---screenshot-path-pattern-pattern).
 
 You specify a screenshot path pattern when you run tests. Each time TestCafe takes a screenshot, it substitutes the placeholders with actual values and saves the screenshot to the resulting path.
 

--- a/docs/articles/blog/2018-08-02-testcafe-v0-21-0-released.md
+++ b/docs/articles/blog/2018-08-02-testcafe-v0-21-0-released.md
@@ -57,7 +57,7 @@ See [Connect to TestCafe Server over HTTPS](https://devexpress.github.io/testcaf
 
 ### ⚙ Construct Screenshot Paths with Patterns ([#2152](https://github.com/DevExpress/testcafe/issues/2152))
 
-You can now use patterns to construct paths to screenshots. TestCafe provides a number of placeholders you can include in the path, for example, `${DATE}`, `${TIME}`, `${USERAGENT}`, etc. For a complete list, refer to the command line [--screenshot-path-pattern flag description](https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#-p-pattern---screenshot-path-pattern-pattern).
+You can now use patterns to construct paths to screenshots. TestCafe provides a number of placeholders you can include in the path, for example, `${DATE}`, `${TIME}`, `${USERAGENT}`, etc. For a complete list, refer to the command line [--screenshot-path-pattern flag description](https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#-p---screenshot-path-pattern).
 
 You specify a screenshot path pattern when you run tests. Each time TestCafe takes a screenshot, it substitutes the placeholders with actual values and saves the screenshot to the resulting path.
 

--- a/docs/articles/documentation/test-api/actions/take-screenshot.md
+++ b/docs/articles/documentation/test-api/actions/take-screenshot.md
@@ -6,13 +6,11 @@ checked: true
 ---
 # Take Screenshot
 
-This topic describes how to take screenshots of the tested page.
+This topic describes how to use test actions to take screenshots of the tested page.
 
-> Important! Screenshot actions are not supported when you run tests in [remote browsers](../../using-testcafe/common-concepts/browsers/browser-support.md#browsers-on-remote-devices).
+> Important! Screenshot actions are ignored if the screenshot directory is not specified with the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [-s (--screenshots)](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option.
 
-**Note**: these actions require .NET 4.0 or newer installed on Windows machines and an [ICCCM/EWMH-compliant window manager](https://en.wikipedia.org/wiki/Comparison_of_X_window_managers) on Linux.
-
-> Important! Screenshot actions are ignored if the screenshot directory is not specified with the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [--screenshots](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option.
+See [Screenshots](../../using-testcafe/common-concepts/screenshots-and-videos.md#screenshots) for more information about this feature.
 
 ## Take a Screenshot of the Entire Page
 
@@ -51,7 +49,7 @@ Takes a screenshot of the specified page element.
 Parameter                | Type   | Description
 ------------------------ | ------ | -----------------------------------------------------------------------------------------------------
 `selector`               | Function &#124; String &#124; Selector &#124; Snapshot &#124; Promise | Identifies the webpage element whose screenshot should be taken. See [Selecting Target Elements](README.md#selecting-target-elements).
-`path`&#160;*(optional)* | String | The screenshot file's relative path and name. The path is relative to the root directory specified by using the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [screenshots](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option. This path overrides the relative path the default or custom [path patterns](../../using-testcafe/common-concepts/screenshots-and-videos.md#where-screenshots-and-videos-are-saved) specify.
+`path`&#160;*(optional)* | String | The screenshot file's relative path and name. The path is relative to the root directory specified by using the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [-s (--screenshots)](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option. This path overrides the relative path the default or custom [path patterns](../../using-testcafe/common-concepts/screenshots-and-videos.md#where-screenshots-and-videos-are-saved) specify.
 `options`&#160;*(optional)*   | Object | Options that define how the screenshot is taken. See details below.
 
 ```js

--- a/docs/articles/documentation/test-api/actions/take-screenshot.md
+++ b/docs/articles/documentation/test-api/actions/take-screenshot.md
@@ -22,7 +22,7 @@ t.takeScreenshot( [path] )
 
 Parameter           | Type   | Description
 ------------------- | ------ | -----------------------------------------------------------------------------------------------------
-`path`&#160;*(optional)* | String | The screenshot file's relative path and name. The path is relative to the base directory specified by the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [screenshots](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option. This path overrides the relative path the default or custom [path patterns](../../using-testcafe/command-line-interface.md#path-patterns) specify.
+`path`&#160;*(optional)* | String | The screenshot file's relative path and name. The path is relative to the base directory specified by the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [screenshots](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option. This path overrides the relative path the default or custom [path patterns](../../using-testcafe/command-line-interface.md#screenshot-path-patterns) specify.
 
 The following example shows how to use the `t.takeScreenshot` action:
 
@@ -51,7 +51,7 @@ Takes a screenshot of the specified page element.
 Parameter                | Type   | Description
 ------------------------ | ------ | -----------------------------------------------------------------------------------------------------
 `selector`               | Function &#124; String &#124; Selector &#124; Snapshot &#124; Promise | Identifies the webpage element whose screenshot should be taken. See [Selecting Target Elements](README.md#selecting-target-elements).
-`path`&#160;*(optional)* | String | The screenshot file's relative path and name. The path is relative to the root directory specified by using the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [screenshots](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option. This path overrides the relative path the default or custom [path patterns](../../using-testcafe/command-line-interface.md#path-patterns) specify.
+`path`&#160;*(optional)* | String | The screenshot file's relative path and name. The path is relative to the root directory specified by using the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [screenshots](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option. This path overrides the relative path the default or custom [path patterns](../../using-testcafe/command-line-interface.md#screenshot-path-patterns) specify.
 `options`&#160;*(optional)*   | Object | Options that define how the screenshot is taken. See details below.
 
 ```js

--- a/docs/articles/documentation/test-api/actions/take-screenshot.md
+++ b/docs/articles/documentation/test-api/actions/take-screenshot.md
@@ -22,7 +22,7 @@ t.takeScreenshot( [path] )
 
 Parameter           | Type   | Description
 ------------------- | ------ | -----------------------------------------------------------------------------------------------------
-`path`&#160;*(optional)* | String | The screenshot file's relative path and name. The path is relative to the base directory specified by the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [screenshots](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option. This path overrides the relative path the default or custom [path patterns](../../using-testcafe/command-line-interface.md#screenshot-path-patterns) specify.
+`path`&#160;*(optional)* | String | The screenshot file's relative path and name. The path is relative to the base directory specified by the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [-s (--screenshots)](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option. This path overrides the relative path the default or custom [path patterns](../../using-testcafe/common-concepts/screenshots-and-videos.md#paths-where-screenshots-and-videos-are-saved) specify.
 
 The following example shows how to use the `t.takeScreenshot` action:
 
@@ -51,7 +51,7 @@ Takes a screenshot of the specified page element.
 Parameter                | Type   | Description
 ------------------------ | ------ | -----------------------------------------------------------------------------------------------------
 `selector`               | Function &#124; String &#124; Selector &#124; Snapshot &#124; Promise | Identifies the webpage element whose screenshot should be taken. See [Selecting Target Elements](README.md#selecting-target-elements).
-`path`&#160;*(optional)* | String | The screenshot file's relative path and name. The path is relative to the root directory specified by using the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [screenshots](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option. This path overrides the relative path the default or custom [path patterns](../../using-testcafe/command-line-interface.md#screenshot-path-patterns) specify.
+`path`&#160;*(optional)* | String | The screenshot file's relative path and name. The path is relative to the root directory specified by using the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [screenshots](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option. This path overrides the relative path the default or custom [path patterns](../../using-testcafe/common-concepts/screenshots-and-videos.md#paths-where-screenshots-and-videos-are-saved) specify.
 `options`&#160;*(optional)*   | Object | Options that define how the screenshot is taken. See details below.
 
 ```js

--- a/docs/articles/documentation/test-api/actions/take-screenshot.md
+++ b/docs/articles/documentation/test-api/actions/take-screenshot.md
@@ -22,7 +22,7 @@ t.takeScreenshot( [path] )
 
 Parameter           | Type   | Description
 ------------------- | ------ | -----------------------------------------------------------------------------------------------------
-`path`&#160;*(optional)* | String | The screenshot file's relative path and name. The path is relative to the base directory specified by the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [-s (--screenshots)](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option. This path overrides the relative path the default or custom [path patterns](../../using-testcafe/common-concepts/screenshots-and-videos.md#paths-where-screenshots-and-videos-are-saved) specify.
+`path`&#160;*(optional)* | String | The screenshot file's relative path and name. The path is relative to the base directory specified by the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [-s (--screenshots)](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option. This path overrides the relative path the default or custom [path patterns](../../using-testcafe/common-concepts/screenshots-and-videos.md#where-screenshots-and-videos-are-saved) specify.
 
 The following example shows how to use the `t.takeScreenshot` action:
 
@@ -51,7 +51,7 @@ Takes a screenshot of the specified page element.
 Parameter                | Type   | Description
 ------------------------ | ------ | -----------------------------------------------------------------------------------------------------
 `selector`               | Function &#124; String &#124; Selector &#124; Snapshot &#124; Promise | Identifies the webpage element whose screenshot should be taken. See [Selecting Target Elements](README.md#selecting-target-elements).
-`path`&#160;*(optional)* | String | The screenshot file's relative path and name. The path is relative to the root directory specified by using the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [screenshots](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option. This path overrides the relative path the default or custom [path patterns](../../using-testcafe/common-concepts/screenshots-and-videos.md#paths-where-screenshots-and-videos-are-saved) specify.
+`path`&#160;*(optional)* | String | The screenshot file's relative path and name. The path is relative to the root directory specified by using the [runner.screenshots](../../using-testcafe/programming-interface/runner.md#screenshots) API method or the [screenshots](../../using-testcafe/command-line-interface.md#-s-path---screenshots-path) command line option. This path overrides the relative path the default or custom [path patterns](../../using-testcafe/common-concepts/screenshots-and-videos.md#where-screenshots-and-videos-are-saved) specify.
 `options`&#160;*(optional)*   | Object | Options that define how the screenshot is taken. See details below.
 
 ```js

--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -26,10 +26,10 @@ testcafe [options] <browser-list-comma-separated> <file-or-glob ...>
   * [-r \<name\[:output\],\[...\]\>, --reporter \<name\[:output\],\[...\]\>](#-r-nameoutput---reporter-nameoutput)
   * [-s \<path\>, --screenshots \<path\>](#-s-path---screenshots-path)
   * [-S, --screenshots-on-fails](#-s---screenshots-on-fails)
-  * [-p, --screenshot-path-pattern](#-p---screenshot-path-pattern)
+  * [-p \<pattern\>, --screenshot-path-pattern \<pattern\>](#-p-pattern---screenshot-path-pattern-pattern)
   * [--video \<basePath\>](#--video-basepath)
   * [--video-options \<option=value\[,option2=value2,...\]\>](#--video-options-optionvalueoption2value2)
-  * [--video-encoding-options \<option=value\[,option2=value2,...\]\>](##--video-encoding-options-optionvalueoption2value2)
+  * [--video-encoding-options \<option=value\[,option2=value2,...\]\>](#--video-encoding-options-optionvalueoption2value2)
   * [-q, --quarantine-mode](#-q---quarantine-mode)
   * [-d, --debug-mode](#-d---debug-mode)
   * [--debug-on-fail](#--debug-on-fail)
@@ -310,7 +310,7 @@ If TestCafe takes screenshots when a test fails (see [--screenshots-on-fails](#-
 * `${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/errors/${FILE_INDEX}.png`;
 * `${DATE}_${TIME}/test-${TEST_INDEX}/run-${QUARANTINE_ATTEMPT}/${USERAGENT}/errors/${FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is enabled.
 
-You can also use the [--screenshot-path-pattern](#-p---screenshot-path-pattern) option to specify a custom pattern.
+You can also use the [--screenshot-path-pattern](#-p-pattern---screenshot-path-pattern-pattern) option to specify a custom pattern.
 
 ### -S, --screenshots-on-fails
 
@@ -326,7 +326,7 @@ testcafe all tests/sample-fixture.js -S -s screenshots
 
 *Related configuration file property*: [takeScreenshotsOnFails](configuration-file.md#takescreenshotsonfails).
 
-### -p, --screenshot-path-pattern
+### -p \<pattern\>, --screenshot-path-pattern \<pattern\>
 
 Specifies a custom pattern to compose screenshot files' relative path and name. This pattern overrides the default [path pattern](#screenshot-path-patterns).
 
@@ -377,7 +377,9 @@ If TestCafe is unable to find the FFmpeg library automatically, do one of the fo
 
 Videos are saved in the `.mp4` format.
 
-Use the [--video-options](#--video-options-optionvalueoption2value2) and [--video-encoding-options](##--video-encoding-options-optionvalueoption2value2) flags to provide options that define how videos are recorded.
+Use the [--video-options](#--video-options-optionvalueoption2value2) and [--video-encoding-options](#--video-encoding-options-optionvalueoption2value2) flags to provide options that define how videos are recorded.
+
+*Overrides a configuration file property*: [videoPath](configuration-file.md#videopath).
 
 #### Video Path Patterns
 
@@ -386,7 +388,7 @@ The relative path to a video file and its name are composed according to the fol
 * `${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.mp4` if the [quarantine mode](#-q---quarantine-mode) is disabled;
 * `${DATE}_${TIME}/test-${TEST_INDEX}/run-${QUARANTINE_ATTEMPT}/${USERAGENT}/${FILE_INDEX}.mp4` if the [quarantine mode](#-q---quarantine-mode) is enabled.
 
-These patterns use the same placeholders as the [screenshot path patterns](#-p---screenshot-path-pattern). Pass the `pathPattern` parameter in [--video-options](#--video-options-optionvalueoption2value2) to specify a custom pattern.
+These patterns use the same placeholders as the [screenshot path patterns](#-p-pattern---screenshot-path-pattern-pattern). Pass the `pathPattern` parameter in [--video-options](#--video-options-optionvalueoption2value2) to specify a custom pattern.
 
 ### --video-options \<option=value\[,option2=value2,...\]\>
 
@@ -403,7 +405,7 @@ Option | Type | Description | Default Value
 `failedOnly` | Boolean | `true` to record only failed tests; `false` to record all tests. | `false`
 `singleFile` | Boolean | `true` to save the entire recording as a single file; `false` to create a separate file for each test. | `false`
 `ffmpegPath` | String | The path to the FFmpeg codec executable. | Auto-detected
-`pathPattern` | String | A pattern that defines how TestCafe composes the relative path to a video file and the file name. Use the same placeholders as in the [screenshot path patterns](#-p---screenshot-path-pattern). See an example below. | See [--video](#--video-basepath).
+`pathPattern` | String | A pattern that defines how TestCafe composes the relative path to a video file and the file name. Use the same placeholders as in the [screenshot path patterns](#-p-pattern---screenshot-path-pattern-pattern). See an example below. | See [--video](#--video-basepath).
 `timeStamp` | Date | The timestamp recorded as the video creation time. | The moment when the test task starts.
 
 The following example shows how to specify a custom path pattern:
@@ -413,6 +415,8 @@ testcafe chrome test.js --video videos/ --video-options pathPattern=${TEST_INDEX
 ```
 
 > Use the [--video](#--video-basepath) flag to enable video recording.
+
+*Overrides a configuration file property*: [videoOptions](configuration-file.md#videooptions).
 
 ### --video-encoding-options \<option=value\[,option2=value2,...\]\>
 
@@ -425,6 +429,8 @@ testcafe chrome test.js --video videos/ --video-encoding-options r=20,aspect=4:3
 You can pass all the options supported by the FFmpeg library. Refer to [the FFmpeg documentation](https://ffmpeg.org/ffmpeg.html#Options) for information about the available options.
 
 > Use the [--video](#--video-basepath) flag to enable video recording.
+
+*Overrides a configuration file property*: [videoEncodingOptions](configuration-file.md#videoencodingoptions).
 
 ### -q, --quarantine-mode
 

--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -322,6 +322,12 @@ testcafe all tests/sample-fixture.js -s screenshots -p '${DATE}_${TIME}/test-${T
 
 See [Path Pattern Placeholders](common-concepts/screenshots-and-videos.md#path-pattern-placeholders) for information about the available placeholders.
 
+In Windows `cmd.exe` shell, enclose the pattern in double quotes if it contains spaces:
+
+```sh
+testcafe all tests/sample-fixture.js -s screenshots -p "${DATE} ${TIME}/test ${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png"
+```
+
 > Use the [-s (--screenshots)](#-s-path---screenshots-path) flag to enable screenshots.
 
 *Related configuration file property*: [screenshotPathPattern](configuration-file.md#screenshotpathpattern).
@@ -331,7 +337,7 @@ See [Path Pattern Placeholders](common-concepts/screenshots-and-videos.md#path-p
 Enables TestCafe to record videos of test runs and specifies the base directory to save these videos.
 
 ```sh
-testcafe chrome test.js --video reports/screen-captures/
+testcafe chrome test.js --video reports/screen-captures
 ```
 
 See [Record Videos](common-concepts/screenshots-and-videos.md#record-videos) for details.
@@ -343,7 +349,7 @@ See [Record Videos](common-concepts/screenshots-and-videos.md#record-videos) for
 Specifies options that define how TestCafe records videos of test runs.
 
 ```sh
-testcafe chrome test.js --video videos/ --video-options singleFile=true,failedOnly=true
+testcafe chrome test.js --video videos --video-options singleFile=true,failedOnly=true
 ```
 
 See [Basic Video Options](common-concepts/screenshots-and-videos.md#basic-video-options) for details.
@@ -357,7 +363,7 @@ See [Basic Video Options](common-concepts/screenshots-and-videos.md#basic-video-
 Specifies video encoding options.
 
 ```sh
-testcafe chrome test.js --video videos/ --video-encoding-options r=20,aspect=4:3
+testcafe chrome test.js --video videos --video-encoding-options r=20,aspect=4:3
 ```
 
 See [Video Encoding Options](common-concepts/screenshots-and-videos.md#video-encoding-options) for details.

--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -342,7 +342,7 @@ testcafe chrome test.js --video reports/screen-captures
 
 See [Record Videos](common-concepts/screenshots-and-videos.md#record-videos) for details.
 
-*Overrides a configuration file property*: [videoPath](configuration-file.md#videopath).
+*Related configuration file property*: [videoPath](configuration-file.md#videopath).
 
 ### --video-options \<option=value\[,option2=value2,...\]\>
 
@@ -356,7 +356,7 @@ See [Basic Video Options](common-concepts/screenshots-and-videos.md#basic-video-
 
 > Use the [--video](#--video-basepath) flag to enable video recording.
 
-*Overrides a configuration file property*: [videoOptions](configuration-file.md#videooptions).
+*Related configuration file property*: [videoOptions](configuration-file.md#videooptions).
 
 ### --video-encoding-options \<option=value\[,option2=value2,...\]\>
 
@@ -370,7 +370,7 @@ See [Video Encoding Options](common-concepts/screenshots-and-videos.md#video-enc
 
 > Use the [--video](#--video-basepath) flag to enable video recording.
 
-*Overrides a configuration file property*: [videoEncodingOptions](configuration-file.md#videoencodingoptions).
+*Related configuration file property*: [videoEncodingOptions](configuration-file.md#videoencodingoptions).
 
 ### -q, --quarantine-mode
 

--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -296,29 +296,15 @@ Enables screenshots and specifies the base directory where they are saved.
 testcafe all tests/sample-fixture.js -s screenshots
 ```
 
+See [Screenshots](common-concepts/screenshots-and-videos.md#screenshots) for details.
+
 *Related configuration file property*: [screenshotPath](configuration-file.md#screenshotpath).
-
-#### Screenshot Path Patterns
-
-The captured screenshots are organized into subdirectories within the base directory. The following path patterns are used to define a relative path and name for screenshots the [Take Screenshot](../test-api/actions/take-screenshot.md) actions take:
-
-* `${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is disabled;
-* `${DATE}_${TIME}/test-${TEST_INDEX}/run-${QUARANTINE_ATTEMPT}/${USERAGENT}/${FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is enabled.
-
-If TestCafe takes screenshots when a test fails (see [--screenshots-on-fails](#-s---screenshots-on-fails) option), the following path patterns are used:
-
-* `${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/errors/${FILE_INDEX}.png`;
-* `${DATE}_${TIME}/test-${TEST_INDEX}/run-${QUARANTINE_ATTEMPT}/${USERAGENT}/errors/${FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is enabled.
-
-You can also use the [--screenshot-path-pattern](#-p-pattern---screenshot-path-pattern-pattern) option to specify a custom pattern.
 
 ### -S, --screenshots-on-fails
 
-Takes a screenshot whenever a test fails. Screenshots are saved to the directory specified in the [--screenshots](#-s-path---screenshots-path) option.
+Takes a screenshot whenever a test fails. Screenshots are saved to the directory specified in the [-s (--screenshots)](#-s-path---screenshots-path) option.
 
-For example, the following command runs tests from the
-  `sample-fixture.js` file in all browsers, takes screenshots if tests fail,
-  and saves the screenshots to the `screenshots` directory:
+For example, the following command runs tests from the `sample-fixture.js` file in all browsers, takes screenshots if tests fail, and saves the screenshots to the `screenshots` directory:
 
 ```sh
 testcafe all tests/sample-fixture.js -S -s screenshots
@@ -328,34 +314,15 @@ testcafe all tests/sample-fixture.js -S -s screenshots
 
 ### -p \<pattern\>, --screenshot-path-pattern \<pattern\>
 
-Specifies a custom pattern to compose screenshot files' relative path and name. This pattern overrides the default [path pattern](#screenshot-path-patterns).
-
-You can use the following placeholders in the pattern:
-
-Placeholder | Description
------------ | ------------
-`${DATE}` | The test run's start date (YYYY-MM-DD).
-`${TIME}` | The test run's start time (HH-mm-ss).
-`${TEST_INDEX}` | The test's index.
-`${FILE_INDEX}` | The screenshot file's index.
-`${QUARANTINE_ATTEMPT}` | The [quarantine](programming-interface/runner.md#quarantine-mode) attempt's number. If the quarantine mode is disabled, the `${QUARANTINE_ATTEMPT}` placeholder's value is 1.
-`${FIXTURE}` | The fixture's name.
-`${TEST}` | The test's name.
-`${USERAGENT}` | The combination of `${BROWSER}`, `${BROWSER_VERSION}`, `${OS}`, and `${OS_VERSION}` (separated by underscores).
-`${BROWSER}` | The browser's name.
-`${BROWSER_VERSION}` | The browser's version.
-`${OS}` | The operation system's name.
-`${OS_VERSION}` | The operation system's version.
+Specifies a custom pattern to compose screenshot files' relative path and name.
 
 ```sh
 testcafe all tests/sample-fixture.js -s screenshots -p '${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png'
 ```
 
-In Windows `cmd.exe` shell, use double quotes because single quotes do not escape spaces.
+See [Path Pattern Placeholders](common-concepts/screenshots-and-videos.md#path-pattern-placeholders) for information about the available placeholders.
 
-```sh
-testcafe all tests/sample-fixture.js -s screenshots -p "${DATE} ${TIME}/test ${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png"
-```
+> Use the [-s (--screenshots)](#-s-path---screenshots-path) flag to enable screenshots.
 
 *Related configuration file property*: [screenshotPathPattern](configuration-file.md#screenshotpathpattern).
 
@@ -367,28 +334,9 @@ Enables TestCafe to record videos of test runs and specifies the base directory 
 testcafe chrome test.js --video reports/screen-captures/
 ```
 
-> Important! You need to install [the FFmpeg library](https://ffmpeg.org/) to record videos.
-
-If TestCafe is unable to find the FFmpeg library automatically, do one of the following:
-
-* Add the FFmpeg installation directory to the system's `PATH` environment variable;
-* Specify the path to the FFmpeg executable in the `FFMPEG_PATH` environment variable or the `ffmpegPath` parameter in [--video-options](#--video-options-optionvalueoption2value2);
-* Install the `@ffmpeg-installer/ffmpeg` package from npm.
-
-Videos are saved in the `.mp4` format.
-
-Use the [--video-options](#--video-options-optionvalueoption2value2) and [--video-encoding-options](#--video-encoding-options-optionvalueoption2value2) flags to provide options that define how videos are recorded.
+See [Record Videos](common-concepts/screenshots-and-videos.md#record-videos) for details.
 
 *Overrides a configuration file property*: [videoPath](configuration-file.md#videopath).
-
-#### Video Path Patterns
-
-The relative path to a video file and its name are composed according to the following patterns:
-
-* `${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.mp4` if the [quarantine mode](#-q---quarantine-mode) is disabled;
-* `${DATE}_${TIME}/test-${TEST_INDEX}/run-${QUARANTINE_ATTEMPT}/${USERAGENT}/${FILE_INDEX}.mp4` if the [quarantine mode](#-q---quarantine-mode) is enabled.
-
-These patterns use the same placeholders as the [screenshot path patterns](#-p-pattern---screenshot-path-pattern-pattern). Pass the `pathPattern` parameter in [--video-options](#--video-options-optionvalueoption2value2) to specify a custom pattern.
 
 ### --video-options \<option=value\[,option2=value2,...\]\>
 
@@ -398,21 +346,7 @@ Specifies options that define how TestCafe records videos of test runs.
 testcafe chrome test.js --video videos/ --video-options singleFile=true,failedOnly=true
 ```
 
-The following options are available:
-
-Option | Type | Description | Default Value
------- | ---- | ----------- | --------------
-`failedOnly` | Boolean | `true` to record only failed tests; `false` to record all tests. | `false`
-`singleFile` | Boolean | `true` to save the entire recording as a single file; `false` to create a separate file for each test. | `false`
-`ffmpegPath` | String | The path to the FFmpeg codec executable. | Auto-detected
-`pathPattern` | String | A pattern that defines how TestCafe composes the relative path to a video file and the file name. Use the same placeholders as in the [screenshot path patterns](#-p-pattern---screenshot-path-pattern-pattern). See an example below. | See [--video](#--video-basepath).
-`timeStamp` | Date | The timestamp recorded as the video creation time. | The moment when the test task starts.
-
-The following example shows how to specify a custom path pattern:
-
-```sh
-testcafe chrome test.js --video videos/ --video-options pathPattern=${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.mp4
-```
+See [Basic Video Options](common-concepts/screenshots-and-videos.md#basic-video-options) for details.
 
 > Use the [--video](#--video-basepath) flag to enable video recording.
 
@@ -426,7 +360,7 @@ Specifies video encoding options.
 testcafe chrome test.js --video videos/ --video-encoding-options r=20,aspect=4:3
 ```
 
-You can pass all the options supported by the FFmpeg library. Refer to [the FFmpeg documentation](https://ffmpeg.org/ffmpeg.html#Options) for information about the available options.
+See [Video Encoding Options](common-concepts/screenshots-and-videos.md#video-encoding-options) for details.
 
 > Use the [--video](#--video-basepath) flag to enable video recording.
 

--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -27,6 +27,9 @@ testcafe [options] <browser-list-comma-separated> <file-or-glob ...>
   * [-s \<path\>, --screenshots \<path\>](#-s-path---screenshots-path)
   * [-S, --screenshots-on-fails](#-s---screenshots-on-fails)
   * [-p, --screenshot-path-pattern](#-p---screenshot-path-pattern)
+  * [--video \<basePath\>](#--video-basepath)
+  * [--video-options \<option=value\[,option2=value2,...\]\>](#--video-options-optionvalueoption2value2)
+  * [--video-encoding-options \<option=value\[,option2=value2,...\]\>](##--video-encoding-options-optionvalueoption2value2)
   * [-q, --quarantine-mode](#-q---quarantine-mode)
   * [-d, --debug-mode](#-d---debug-mode)
   * [--debug-on-fail](#--debug-on-fail)
@@ -295,17 +298,17 @@ testcafe all tests/sample-fixture.js -s screenshots
 
 *Related configuration file property*: [screenshotPath](configuration-file.md#screenshotpath).
 
-#### Path Patterns
+#### Screenshot Path Patterns
 
 The captured screenshots are organized into subdirectories within the base directory. The following path patterns are used to define a relative path and name for screenshots the [Take Screenshot](../test-api/actions/take-screenshot.md) actions take:
 
-* `${DATE}_${TIME}\test-${TEST_INDEX}\${USERAGENT}\${FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is disabled;
-* `${DATE}_${TIME}\test-${TEST_INDEX}\run-${QUARANTINE_ATTEMPT}\${USERAGENT}\${FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is enabled.
+* `${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is disabled;
+* `${DATE}_${TIME}/test-${TEST_INDEX}/run-${QUARANTINE_ATTEMPT}/${USERAGENT}/${FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is enabled.
 
 If TestCafe takes screenshots when a test fails (see [--screenshots-on-fails](#-s---screenshots-on-fails) option), the following path patterns are used:
 
-* `${DATE}_${TIME}\test-${TEST_INDEX}\${USERAGENT}\errors\${FILE_INDEX}.png`;
-* `${DATE}_${TIME}\test-${TEST_INDEX}\run-${QUARANTINE_ATTEMPT}\${USERAGENT}\errors\${FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is enabled.
+* `${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/errors/${FILE_INDEX}.png`;
+* `${DATE}_${TIME}/test-${TEST_INDEX}/run-${QUARANTINE_ATTEMPT}/${USERAGENT}/errors/${FILE_INDEX}.png` if the [quarantine mode](#-q---quarantine-mode) is enabled.
 
 You can also use the [--screenshot-path-pattern](#-p---screenshot-path-pattern) option to specify a custom pattern.
 
@@ -325,7 +328,7 @@ testcafe all tests/sample-fixture.js -S -s screenshots
 
 ### -p, --screenshot-path-pattern
 
-Specifies a custom pattern to compose screenshot files' relative path and name. This pattern overrides the default [path pattern](#path-patterns).
+Specifies a custom pattern to compose screenshot files' relative path and name. This pattern overrides the default [path pattern](#screenshot-path-patterns).
 
 You can use the following placeholders in the pattern:
 
@@ -355,6 +358,73 @@ testcafe all tests/sample-fixture.js -s screenshots -p "${DATE} ${TIME}/test ${T
 ```
 
 *Related configuration file property*: [screenshotPathPattern](configuration-file.md#screenshotpathpattern).
+
+### --video \<basePath\>
+
+Enables TestCafe to record videos of test runs and specifies the base directory to save these videos.
+
+```sh
+testcafe chrome test.js --video reports/screen-captures/
+```
+
+> Important! You need to install [the FFmpeg library](https://ffmpeg.org/) to record videos.
+
+If TestCafe is unable to find the FFmpeg library automatically, do one of the following:
+
+* Add the FFmpeg installation directory to the system's `PATH` environment variable;
+* Specify the path to the FFmpeg executable in the `FFMPEG_PATH` environment variable or the `ffmpegPath` parameter in [--video-options](#--video-options-optionvalueoption2value2);
+* Install the `@ffmpeg-installer/ffmpeg` package from npm.
+
+Videos are saved in the `.mp4` format.
+
+Use the [--video-options](#--video-options-optionvalueoption2value2) and [--video-encoding-options](##--video-encoding-options-optionvalueoption2value2) flags to provide options that define how videos are recorded.
+
+#### Video Path Patterns
+
+The relative path to a video file and its name are composed according to the following patterns:
+
+* `${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.mp4` if the [quarantine mode](#-q---quarantine-mode) is disabled;
+* `${DATE}_${TIME}/test-${TEST_INDEX}/run-${QUARANTINE_ATTEMPT}/${USERAGENT}/${FILE_INDEX}.mp4` if the [quarantine mode](#-q---quarantine-mode) is enabled.
+
+These patterns use the same placeholders as the [screenshot path patterns](#-p---screenshot-path-pattern). Pass the `pathPattern` parameter in [--video-options](#--video-options-optionvalueoption2value2) to specify a custom pattern.
+
+### --video-options \<option=value\[,option2=value2,...\]\>
+
+Specifies options that define how TestCafe records videos of test runs.
+
+```sh
+testcafe chrome test.js --video videos/ --video-options singleFile=true,failedOnly=true
+```
+
+The following options are available:
+
+Option | Type | Description | Default Value
+------ | ---- | ----------- | --------------
+`failedOnly` | Boolean | `true` to record only failed tests; `false` to record all tests. | `false`
+`singleFile` | Boolean | `true` to save the entire recording as a single file; `false` to create a separate file for each test. | `false`
+`ffmpegPath` | String | The path to the FFmpeg codec executable. | Auto-detected
+`pathPattern` | String | A pattern that defines how TestCafe composes the relative path to a video file and the file name. Use the same placeholders as in the [screenshot path patterns](#-p---screenshot-path-pattern). See an example below. | See [--video](#--video-basepath).
+`timeStamp` | Date | The timestamp recorded as the video creation time. | The moment when the test task starts.
+
+The following example shows how to specify a custom path pattern:
+
+```sh
+testcafe chrome test.js --video videos/ --video-options pathPattern=${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.mp4
+```
+
+> Use the [--video](#--video-basepath) flag to enable video recording.
+
+### --video-encoding-options \<option=value\[,option2=value2,...\]\>
+
+Specifies video encoding options.
+
+```sh
+testcafe chrome test.js --video videos/ --video-encoding-options r=20,aspect=4:3
+```
+
+You can pass all the options supported by the FFmpeg library. Refer to [the FFmpeg documentation](https://ffmpeg.org/ffmpeg.html#Options) for information about the available options.
+
+> Use the [--video](#--video-basepath) flag to enable video recording.
 
 ### -q, --quarantine-mode
 

--- a/docs/articles/documentation/using-testcafe/common-concepts/README.md
+++ b/docs/articles/documentation/using-testcafe/common-concepts/README.md
@@ -7,5 +7,6 @@ permalink: /documentation/using-testcafe/common-concepts/
 
 * [Browsers](browsers/README.md)
 * [Concurrent Test Execution](concurrent-test-execution.md)
+* [Screenshots and Videos](screenshots-and-videos.md)
 * [Reporters](reporters.md)
 * [Connect to the TestCafe Server over HTTPS](connect-to-the-testcafe-server-over-https.md)

--- a/docs/articles/documentation/using-testcafe/common-concepts/screenshots-and-videos.md
+++ b/docs/articles/documentation/using-testcafe/common-concepts/screenshots-and-videos.md
@@ -8,11 +8,12 @@ permalink: /documentation/using-testcafe/common-concepts/screenshots-and-videos.
 TestCafe allows you to take screenshots of the webpage under test and record videos of test runs.
 
 * [Screenshots](#screenshots)
+  * [Prerequisites for Screenshots](#prerequisites-for-screenshots)
   * [Enable Screenshots](#enable-screenshots)
   * [Take Screenshots at Arbitrary Moments During Test Run](#take-screenshots-at-arbitrary-moments-during-test-run)
   * [Take Screenshots When a Test Fails](#take-screenshots-when-a-test-fails)
 * [Record Videos](#record-videos)
-  * [Prerequisites](#prerequisites)
+  * [Prerequisites for Video Recording](#prerequisites-for-video-recording)
   * [Enable Video Recording](#enable-video-recording)
   * [Basic Video Options](#basic-video-options)
   * [Video Encoding Options](#video-encoding-options)
@@ -24,6 +25,14 @@ TestCafe allows you to take screenshots of the webpage under test and record vid
   * [Path Pattern Placeholders](#path-pattern-placeholders)
 
 ## Screenshots
+
+TestCafe allows you to take screenshots of the webpage under test at any moment during test run, or automatically whenever a test fails.
+
+> Important! Screenshots are not supported when you run tests in [remote browsers](browsers/browser-support.md#browsers-on-remote-devices).
+
+### Prerequisites for Screenshots
+
+Screenshots require .NET 4.0 or newer installed on Windows machines and an [ICCCM/EWMH-compliant window manager](https://en.wikipedia.org/wiki/Comparison_of_X_window_managers) on Linux.
 
 ### Enable Screenshots
 
@@ -98,7 +107,9 @@ You can configure TestCafe to automatically take a screenshot whenever a test fa
 
 TestCafe allows you to record videos of test runs.
 
-### Prerequisites
+> Important! Video recording is supported in Google Chrome and Mozilla Firefox only. TestCafe cannot record videos when you run tests in [remote browsers](browsers/browser-support.md#browsers-on-remote-devices).
+
+### Prerequisites for Video Recording
 
 You need to install [the FFmpeg library](https://ffmpeg.org/) to record videos.
 

--- a/docs/articles/documentation/using-testcafe/common-concepts/screenshots-and-videos.md
+++ b/docs/articles/documentation/using-testcafe/common-concepts/screenshots-and-videos.md
@@ -16,7 +16,7 @@ TestCafe allows you to take screenshots of the webpage under test and record vid
   * [Enable Video Recording](#enable-video-recording)
   * [Basic Video Options](#basic-video-options)
   * [Video Encoding Options](#video-encoding-options)
-* [Paths Where Screenshots and Videos Are Saved](#paths-where-screenshots-and-videos-are-saved)
+* [Where Screenshots and Videos Are Saved](#where-screenshots-and-videos-are-saved)
   * [Default Path Patterns](#default-path-patterns)
   * [Custom Path Patterns](#custom-path-patterns)
     * [Screenshot Custom Path Pattern](#screenshot-custom-path-pattern)
@@ -32,24 +32,24 @@ To enable TestCafe to take screenshots, use either of the following:
 * the [-s (--screenshots)](../command-line-interface.md#-s-path---screenshots-path) command line flag,
 
     ```sh
-    testcafe chrome test.js -s artifacts/screenshots/
+    testcafe chrome test.js -s artifacts/screenshots
     ```
 
 * the [runner.screenshots](../programming-interface/runner.md#screenshots) API method,
 
     ```js
-    runner.screenshots('artifacts/screenshots/');
+    runner.screenshots('artifacts/screenshots');
     ```
 
 * the [screenshotPath](../configuration-file.md#screenshotpath) configuration file property.
 
     ```json
     {
-        "screenshotPath": "artifacts/screenshots/"
+        "screenshotPath": "artifacts/screenshots"
     }
     ```
 
-You must provide the base path where TestCafe stores screenshots to this flag, method or property. See [Paths Where Screenshots and Videos Are Saved](#paths-where-screenshots-and-videos-are-saved) for more information on where screenshots and videos are saved.
+You must provide the base path where TestCafe stores screenshots to this flag, method or property. See [Where Screenshots and Videos Are Saved](#where-screenshots-and-videos-are-saved) for more information.
 
 ### Take Screenshots at Arbitrary Moments During Test Run
 
@@ -77,13 +77,13 @@ You can configure TestCafe to automatically take a screenshot whenever a test fa
 * the [-S (--screenshots-on-fails)](../command-line-interface.md#-s---screenshots-on-fails) command line flag,
 
     ```sh
-    testcafe chrome tests/sample-fixture.js -S -s artifacts/screenshots/
+    testcafe chrome tests/sample-fixture.js -S -s artifacts/screenshots
     ```
 
 * the `takeOnFails` parameter of the [runner.screenshots](../programming-interface/runner.md#screenshots) API method,
 
     ```js
-    runner.screenshots('artifacts/screenshots/', true);
+    runner.screenshots('artifacts/screenshots', true);
     ```
 
 * the [takeScreenshotsOnFails](../configuration-file.md#takescreenshotsonfails) configuration file property.
@@ -117,24 +117,26 @@ Use either of the following to enable video recording:
 * the [--video](../command-line-interface.md#--video-basepath) command line flag,
 
     ```sh
-    testcafe chrome test.js --video artifacts/videos/
+    testcafe chrome test.js --video artifacts/videos
     ```
 
 * the [runner.video](../programming-interface/runner.md#video) API method,
 
     ```js
-    runner.video('artifacts/videos/');
+    runner.video('artifacts/videos');
     ```
 
 * the [videoPath](../configuration-file.md#videopath) configuration file property.
 
     ```json
     {
-        "videoPath": "artifacts/videos/"
+        "videoPath": "artifacts/videos"
     }
     ```
 
-You must provide the base path where TestCafe stores videos to this flag, method or property. See [Paths Where Screenshots and Videos Are Saved](#paths-where-screenshots-and-videos-are-saved) for more information on where screenshots and videos are saved.
+You must provide the base path where TestCafe stores videos to this flag, method or property. See [Where Screenshots and Videos Are Saved](#where-screenshots-and-videos-are-saved) for more information.
+
+TestCafe records all the tests and saves the recording of each test in a separate file. To change this behavior, use the `failedOnly` and `singleFile` [video options](#basic-video-options).
 
 ### Basic Video Options
 
@@ -145,20 +147,20 @@ Option | Type | Description | Default Value
 `failedOnly` | Boolean | `true` to record only failed tests; `false` to record all tests. | `false`
 `singleFile` | Boolean | `true` to save the entire recording as a single file; `false` to create a separate file for each test. | `false`
 `ffmpegPath` | String | The path to the FFmpeg codec executable. | Auto-detected
-`pathPattern` | String | A pattern that defines how TestCafe composes the relative path to a video file and the file name. See [Paths Where Screenshots and Videos Are Saved](#paths-where-screenshots-and-videos-are-saved). | See [Default Path Patterns](#default-path-patterns).
+`pathPattern` | String | A pattern that defines how TestCafe composes the relative path to a video file and the file name. See [Where Screenshots and Videos Are Saved](#where-screenshots-and-videos-are-saved). | See [Default Path Patterns](#default-path-patterns).
 
 You can specify video options in either of the following ways:
 
 * the [--video-options](../command-line-interface.md#--video-options-optionvalueoption2value2) command line flag,
 
     ```sh
-    testcafe chrome test.js --video artifacts/videos/ --video-options singleFile=true,failedOnly=true,pathPattern=${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.mp4
+    testcafe chrome test.js --video artifacts/videos --video-options singleFile=true,failedOnly=true,pathPattern=${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.mp4
     ```
 
 * the `options` parameter of the [runner.video](../programming-interface/runner.md#video) API method,
 
     ```js
-    runner.video('artifacts/videos/', {
+    runner.video('artifacts/videos', {
         singleFile: true,
         failedOnly: true,
         pathPattern: '${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.mp4'
@@ -186,13 +188,13 @@ To provide video encoding options, use either of the following:
 * the [--video-encoding-options](../command-line-interface.md#--video-encoding-options-optionvalueoption2value2) command line flag,
 
     ```sh
-    testcafe chrome test.js --video artifacts/videos/ --video-encoding-options r=20,aspect=4:3
+    testcafe chrome test.js --video artifacts/videos --video-encoding-options r=20,aspect=4:3
     ```
 
 * the `encodingOptions` parameter of the [runner.video](../programming-interface/runner.md#video) API method,
 
     ```js
-    runner.video('artifacts/videos/', { }, {
+    runner.video('artifacts/videos', { }, {
         r: 20,
         aspect: '4:3'
     });
@@ -209,7 +211,7 @@ To provide video encoding options, use either of the following:
     }
     ```
 
-## Paths Where Screenshots and Videos Are Saved
+## Where Screenshots and Videos Are Saved
 
 You specify the base path to the directory that stores screenshots or videos when you turn these features on. See [Enable Screenshots](#enable-screenshots) and [Enable Video Recording](#enable-video-recording).
 
@@ -246,19 +248,19 @@ To specify a path pattern for screenshots, use one of the following:
 * the [-p (--screenshot-path-pattern)](../command-line-interface.md#-p-pattern---screenshot-path-pattern-pattern) command line flag,
 
     ```sh
-    testcafe chrome test.js -s artifacts/screenshots/ -p '${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png'
+    testcafe chrome test.js -s artifacts/screenshots -p '${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png'
     ```
 
     In Windows `cmd.exe` shell, enclose the pattern in double quotes if it contains spaces:
 
     ```sh
-    testcafe chrome test.js -s artifacts/screenshots/ -p "${DATE} ${TIME}/test ${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png"
+    testcafe chrome test.js -s artifacts/screenshots -p "${DATE} ${TIME}/test ${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png"
     ```
 
 * the `pathPattern` parameter of the [runner.screenshots](../programming-interface/runner.md#screenshots) API method,
 
     ```js
-    runner.screenshots('artifacts/screenshots/', true, '${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png');
+    runner.screenshots('artifacts/screenshots', true, '${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png');
     ```
 
 * the [screenshotPathPattern](../configuration-file.md#screenshotpathpattern) configuration file property.

--- a/docs/articles/documentation/using-testcafe/common-concepts/screenshots-and-videos.md
+++ b/docs/articles/documentation/using-testcafe/common-concepts/screenshots-and-videos.md
@@ -1,0 +1,295 @@
+---
+layout: docs
+title: Screenshots and Videos
+permalink: /documentation/using-testcafe/common-concepts/screenshots-and-videos.html
+---
+# Screenshots and Videos
+
+TestCafe allows you to take screenshots of the webpage under test and record videos of test runs.
+
+* [Screenshots](#screenshots)
+  * [Enable Screenshots](#enable-screenshots)
+  * [Take Screenshots at Arbitrary Moments During Test Run](#take-screenshots-at-arbitrary-moments-during-test-run)
+  * [Take Screenshots When a Test Fails](#take-screenshots-when-a-test-fails)
+* [Record Videos](#record-videos)
+  * [Prerequisites](#prerequisites)
+  * [Enable Video Recording](#enable-video-recording)
+  * [Basic Video Options](#basic-video-options)
+  * [Video Encoding Options](#video-encoding-options)
+* [Paths Where Screenshots and Videos Are Saved](#paths-where-screenshots-and-videos-are-saved)
+  * [Default Path Patterns](#default-path-patterns)
+  * [Custom Path Patterns](#custom-path-patterns)
+    * [Screenshot Custom Path Pattern](#screenshot-custom-path-pattern)
+    * [Video Custom Path Pattern](#video-custom-path-pattern)
+  * [Path Pattern Placeholders](#path-pattern-placeholders)
+
+## Screenshots
+
+### Enable Screenshots
+
+To enable TestCafe to take screenshots, use either of the following:
+
+* the [-s (--screenshots)](../command-line-interface.md#-s-path---screenshots-path) command line flag,
+
+    ```sh
+    testcafe chrome test.js -s artifacts/screenshots/
+    ```
+
+* the [runner.screenshots](../programming-interface/runner.md#screenshots) API method,
+
+    ```js
+    runner.screenshots('artifacts/screenshots/');
+    ```
+
+* the [screenshotPath](../configuration-file.md#screenshotpath) configuration file property.
+
+    ```json
+    {
+        "screenshotPath": "artifacts/screenshots/"
+    }
+    ```
+
+You must provide the base path where TestCafe stores screenshots to this flag, method or property. See [Paths Where Screenshots and Videos Are Saved](#paths-where-screenshots-and-videos-are-saved) for more information on where screenshots and videos are saved.
+
+### Take Screenshots at Arbitrary Moments During Test Run
+
+You can take screenshots at any moment during test run. Use the [t.takeScreenshot](../../test-api/actions/take-screenshot.md#take-a-screenshot-of-the-entire-page) action to take a screenshot of the entire page, or the [t.takeElementScreenshot](../../test-api/actions/take-screenshot.md#take-a-screenshot-of-a-page-element) action to capture a particular element.
+
+```js
+fixture `My fixture`
+    .page `http://devexpress.github.io/testcafe/example/`;
+
+test('Take a screenshot of a fieldset', async t => {
+    await t
+        .typeText('#developer-name', 'Peter Parker')
+        .click('#tried-test-cafe')
+        .typeText('#comments', 'I think TestCafe is awesome!')
+        .takeElementScreenshot('#comments')
+        .click('#submit-button')
+        .takeScreenshot();
+});
+```
+
+### Take Screenshots When a Test Fails
+
+You can configure TestCafe to automatically take a screenshot whenever a test fails. Use either of the following:
+
+* the [-S (--screenshots-on-fails)](../command-line-interface.md#-s---screenshots-on-fails) command line flag,
+
+    ```sh
+    testcafe chrome tests/sample-fixture.js -S -s artifacts/screenshots/
+    ```
+
+* the `takeOnFails` parameter of the [runner.screenshots](../programming-interface/runner.md#screenshots) API method,
+
+    ```js
+    runner.screenshots('artifacts/screenshots/', true);
+    ```
+
+* the [takeScreenshotsOnFails](../configuration-file.md#takescreenshotsonfails) configuration file property.
+
+    ```json
+    {
+        "takeScreenshotsOnFails": true
+    }
+    ```
+
+## Record Videos
+
+TestCafe allows you to record videos of test runs.
+
+### Prerequisites
+
+You need to install [the FFmpeg library](https://ffmpeg.org/) to record videos.
+
+If TestCafe is unable to find the FFmpeg library automatically, do one of the following:
+
+* Add the FFmpeg installation directory to the system's `PATH` environment variable;
+* Specify the path to the FFmpeg executable in the `FFMPEG_PATH` environment variable or the `ffmpegPath` parameter in [video options](#basic-video-options);
+* Install the `@ffmpeg-installer/ffmpeg` package from npm.
+
+Videos are saved in the `.mp4` format.
+
+### Enable Video Recording
+
+Use either of the following to enable video recording:
+
+* the [--video](../command-line-interface.md#--video-basepath) command line flag,
+
+    ```sh
+    testcafe chrome test.js --video artifacts/videos/
+    ```
+
+* the [runner.video](../programming-interface/runner.md#video) API method,
+
+    ```js
+    runner.video('artifacts/videos/');
+    ```
+
+* the [videoPath](../configuration-file.md#videopath) configuration file property.
+
+    ```json
+    {
+        "videoPath": "artifacts/videos/"
+    }
+    ```
+
+You must provide the base path where TestCafe stores videos to this flag, method or property. See [Paths Where Screenshots and Videos Are Saved](#paths-where-screenshots-and-videos-are-saved) for more information on where screenshots and videos are saved.
+
+### Basic Video Options
+
+TestCafe supports the following video options:
+
+Option | Type | Description | Default Value
+------ | ---- | ----------- | --------------
+`failedOnly` | Boolean | `true` to record only failed tests; `false` to record all tests. | `false`
+`singleFile` | Boolean | `true` to save the entire recording as a single file; `false` to create a separate file for each test. | `false`
+`ffmpegPath` | String | The path to the FFmpeg codec executable. | Auto-detected
+`pathPattern` | String | A pattern that defines how TestCafe composes the relative path to a video file and the file name. See [Paths Where Screenshots and Videos Are Saved](#paths-where-screenshots-and-videos-are-saved). | See [Default Path Patterns](#default-path-patterns).
+
+You can specify video options in either of the following ways:
+
+* the [--video-options](../command-line-interface.md#--video-options-optionvalueoption2value2) command line flag,
+
+    ```sh
+    testcafe chrome test.js --video artifacts/videos/ --video-options singleFile=true,failedOnly=true,pathPattern=${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.mp4
+    ```
+
+* the `options` parameter of the [runner.video](../programming-interface/runner.md#video) API method,
+
+    ```js
+    runner.video('artifacts/videos/', {
+        singleFile: true,
+        failedOnly: true,
+        pathPattern: '${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.mp4'
+    });
+    ```
+
+* the [videoOptions](../configuration-file.md#videooptions) configuration file property.
+
+    ```json
+    {
+        "videoOptions": {
+            "singleFile": true,
+            "failedOnly": true,
+            "pathPattern": "${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.mp4"
+        }
+    }
+    ```
+
+### Video Encoding Options
+
+You can specify all the options supported by the FFmpeg library. Refer to [the FFmpeg documentation](https://ffmpeg.org/ffmpeg.html#Options) for information about the available options.
+
+To provide video encoding options, use either of the following:
+
+* the [--video-encoding-options](../command-line-interface.md#--video-encoding-options-optionvalueoption2value2) command line flag,
+
+    ```sh
+    testcafe chrome test.js --video artifacts/videos/ --video-encoding-options r=20,aspect=4:3
+    ```
+
+* the `encodingOptions` parameter of the [runner.video](../programming-interface/runner.md#video) API method,
+
+    ```js
+    runner.video('artifacts/videos/', { }, {
+        r: 20,
+        aspect: '4:3'
+    });
+    ```
+
+* the [videoEncodingOptions](../configuration-file.md#videoencodingoptions) configuration file property.
+
+    ```json
+    {
+        "videoEncodingOptions": {
+            "r": 20,
+            "aspect": "4:3"
+        }
+    }
+    ```
+
+## Paths Where Screenshots and Videos Are Saved
+
+You specify the base path to the directory that stores screenshots or videos when you turn these features on. See [Enable Screenshots](#enable-screenshots) and [Enable Video Recording](#enable-video-recording).
+
+Inside the base directory, screenshots and videos are organized into subdirectories and named according to the [default](#default-path-patterns) or [custom](#custom-path-patterns) *path patterns*.
+
+> When you pass a specific path to the [t.takeScreenshot](../../test-api/actions/take-screenshot.md#take-a-screenshot-of-the-entire-page) or [t.takeElementScreenshot](../../test-api/actions/take-screenshot.md#take-a-screenshot-of-a-page-element) action, this path overrides the relative path defined by the [default](#default-path-patterns) or [custom path pattern](#custom-path-patterns).
+
+### Default Path Patterns
+
+TestCafe composes paths to screenshots and videos according to the following pattern:
+
+```sh
+${DATE}_${TIME}/${TEST_ID}/${RUN_ID}/${USERAGENT}/${FILE_INDEX}.<ext>
+```
+
+where `<ext>` is `.png` for screenshots and `.mp4` for videos. See the meaning of other placeholders in the [Path Pattern Placeholders](#path-pattern-placeholders) section.
+
+When TestCafe takes a screenshot because a test fails (see [Take Screenshots When a Test Fails](#take-screenshots-when-a-test-fails)), it adds the `errors` subfolder to the pattern.
+
+```sh
+${DATE}_${TIME}/${TEST_ID}/${RUN_ID}/${USERAGENT}/errors/${FILE_INDEX}.png
+```
+
+### Custom Path Patterns
+
+You can override the default path pattern for both screenshots and videos.
+
+To compose a custom pattern, use placeholders described in the [Path Pattern Placeholders](#path-pattern-placeholders) section.
+
+#### Screenshot Custom Path Pattern
+
+To specify a path pattern for screenshots, use one of the following:
+
+* the [-p (--screenshot-path-pattern)](../command-line-interface.md#-p-pattern---screenshot-path-pattern-pattern) command line flag,
+
+    ```sh
+    testcafe chrome test.js -s artifacts/screenshots/ -p '${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png'
+    ```
+
+    In Windows `cmd.exe` shell, enclose the pattern in double quotes if it contains spaces:
+
+    ```sh
+    testcafe chrome test.js -s artifacts/screenshots/ -p "${DATE} ${TIME}/test ${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png"
+    ```
+
+* the `pathPattern` parameter of the [runner.screenshots](../programming-interface/runner.md#screenshots) API method,
+
+    ```js
+    runner.screenshots('artifacts/screenshots/', true, '${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png');
+    ```
+
+* the [screenshotPathPattern](../configuration-file.md#screenshotpathpattern) configuration file property.
+
+    ```json
+    {
+        "screenshotPathPattern": "${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png"
+    }
+    ```
+
+#### Video Custom Path Pattern
+
+To specify a custom path pattern for videos, pass the `pathPattern` parameter to [video options](#basic-video-options).
+
+### Path Pattern Placeholders
+
+The following placeholders are used in screenshot and video path patterns:
+
+Placeholder | Description
+----------- | ------------
+`${DATE}` | The test run's start date (YYYY-MM-DD).
+`${TIME}` | The test run's start time (HH-mm-ss).
+`${TEST_INDEX}` | The test's index.
+`${FILE_INDEX}` | The screenshot file's index.
+`${QUARANTINE_ATTEMPT}` | The [quarantine](../programming-interface/runner.md#quarantine-mode) attempt's number. If the quarantine mode is disabled, the `${QUARANTINE_ATTEMPT}` placeholder's value is 1.
+`${FIXTURE}` | The fixture's name.
+`${TEST}` | The test's name.
+`${USERAGENT}` | The combination of `${BROWSER}`, `${BROWSER_VERSION}`, `${OS}`, and `${OS_VERSION}` (separated by underscores).
+`${BROWSER}` | The browser's name.
+`${BROWSER_VERSION}` | The browser's version.
+`${OS}` | The operation system's name.
+`${OS_VERSION}` | The operation system's version.
+`${TEST_ID}` | Resolves to `test-${TEST_INDEX}` if TestCafe can associate this screenshot or video with a specific test; resolves to an empty string otherwise (for instance, when a single video is recorded for the entire test run).
+`${RUN_ID}` | Resolves to `run-${QUARANTINE_ATTEMPT}` for screenshots taken when [quarantine mode](../programming-interface/runner.md#quarantine-mode) is enabled; resolves to an empty string for videos and for screenshots taken when [quarantine mode](../programming-interface/runner.md#quarantine-mode) is disabled.

--- a/docs/articles/documentation/using-testcafe/configuration-file.md
+++ b/docs/articles/documentation/using-testcafe/configuration-file.md
@@ -19,6 +19,9 @@ A configuration file can include the following settings:
 * [screenshotPath](#screenshotpath)
 * [takeScreenshotsOnFails](#takescreenshotsonfails)
 * [screenshotPathPattern](#screenshotpathpattern)
+* [videoPath](#videopath)
+* [videoOptions](#videooptions)
+* [videoEncodingOptions](#videoencodingoptions)
 * [quarantineMode](#quarantinemode)
 * [debugMode](#debugmode)
 * [debugOnFail](#debugonfail)
@@ -201,7 +204,7 @@ Enables screenshots and specifies the base directory where they are saved.
 }
 ```
 
-See [Path Patterns](command-line-interface.md#path-patterns) for more information on how TestCafe organizes screenshots into subdirectories.
+See [Screenshot Path Patterns](command-line-interface.md#screenshot-path-patterns) for more information on how TestCafe organizes screenshots into subdirectories.
 
 *CLI*: [-s, --screenshots](command-line-interface.md#-s-path---screenshots-path)  
 *API*: [runner.screenshots](programming-interface/runner.md#screenshots)
@@ -231,10 +234,70 @@ Specifies a custom pattern to compose screenshot files' relative path and name.
 }
 ```
 
-See the [--screenshot-path-pattern](command-line-interface.md#-p---screenshot-path-pattern) command line parameter for information about the available placeholders.
+See the [--screenshot-path-pattern](command-line-interface.md#-p-pattern---screenshot-path-pattern-pattern) command line parameter for information about the available placeholders.
 
-*CLI*: [-p, --screenshot-path-pattern](command-line-interface.md#-p---screenshot-path-pattern)  
+*CLI*: [-p, --screenshot-path-pattern](command-line-interface.md#-p-pattern---screenshot-path-pattern-pattern)  
 *API*: [runner.screenshots](programming-interface/runner.md#screenshots)
+
+## videoPath
+
+Enables TestCafe to record videos of test runs and specifies the base directory to save these videos.
+
+```json
+{
+    "videoPath": "reports/screen-captures/"
+}
+```
+
+See [Video Path Patterns](command-line-interface.md#video-path-patterns) for more information on how TestCafe organizes videos into subdirectories.
+
+Use the [videoOptions](#videooptions) and [videoEncodingOptions](#videoencodingoptions) properties to provide options that define how videos are recorded.
+
+See the [--video](command-line-interface.md#--video-basepath) command line parameter description for details on video recording.
+
+*CLI*: [--video](command-line-interface.md#--video-basepath)  
+*API*: [runner.video](programming-interface/runner.md#video)
+
+## videoOptions
+
+Specifies options that define how TestCafe records videos of test runs.
+
+```json
+{
+    "videoOptions": {
+        "singleFile": true,
+        "failedOnly": true,
+        "pathPattern": "${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.mp4"
+    }
+}
+```
+
+See the [--video-options](command-line-interface.md#--video-options-optionvalueoption2value2) command line parameter description for the available options.
+
+> Use the [videoPath](#videopath) option to enable video recording.
+
+*CLI*: [--video-options](command-line-interface.md#--video-options-optionvalueoption2value2)  
+*API*: [runner.video](programming-interface/runner.md#video)
+
+## videoEncodingOptions
+
+Specifies video encoding options.
+
+```json
+{
+    "videoEncodingOptions": {
+        "r": 20,
+        "aspect": "4:3"
+    }
+}
+```
+
+You can pass all the options supported by the FFmpeg library. Refer to [the FFmpeg documentation](https://ffmpeg.org/ffmpeg.html#Options) for information about the available options.
+
+> Use the [videoPath](#videopath) option to enable video recording.
+
+*CLI*: [--video-encoding-options](command-line-interface.md#--video-encoding-options-optionvalueoption2value2)  
+*API*: [runner.video](programming-interface/runner.md#video)
 
 ## quarantineMode
 

--- a/docs/articles/documentation/using-testcafe/configuration-file.md
+++ b/docs/articles/documentation/using-testcafe/configuration-file.md
@@ -247,7 +247,7 @@ Enables TestCafe to record videos of test runs and specifies the base directory 
 
 ```json
 {
-    "videoPath": "reports/screen-captures/"
+    "videoPath": "reports/screen-captures"
 }
 ```
 

--- a/docs/articles/documentation/using-testcafe/configuration-file.md
+++ b/docs/articles/documentation/using-testcafe/configuration-file.md
@@ -204,7 +204,7 @@ Enables screenshots and specifies the base directory where they are saved.
 }
 ```
 
-See [Screenshot Path Patterns](command-line-interface.md#screenshot-path-patterns) for more information on how TestCafe organizes screenshots into subdirectories.
+See [Screenshots](common-concepts/screenshots-and-videos.md#screenshots) for details.
 
 *CLI*: [-s, --screenshots](command-line-interface.md#-s-path---screenshots-path)  
 *API*: [runner.screenshots](programming-interface/runner.md#screenshots)
@@ -234,7 +234,9 @@ Specifies a custom pattern to compose screenshot files' relative path and name.
 }
 ```
 
-See the [--screenshot-path-pattern](command-line-interface.md#-p-pattern---screenshot-path-pattern-pattern) command line parameter for information about the available placeholders.
+See [Path Pattern Placeholders](common-concepts/screenshots-and-videos.md#path-pattern-placeholders) for information about the available placeholders.
+
+> Use the [screenshotPath](#screenshotpath) option to enable screenshots.
 
 *CLI*: [-p, --screenshot-path-pattern](command-line-interface.md#-p-pattern---screenshot-path-pattern-pattern)  
 *API*: [runner.screenshots](programming-interface/runner.md#screenshots)
@@ -249,11 +251,7 @@ Enables TestCafe to record videos of test runs and specifies the base directory 
 }
 ```
 
-See [Video Path Patterns](command-line-interface.md#video-path-patterns) for more information on how TestCafe organizes videos into subdirectories.
-
-Use the [videoOptions](#videooptions) and [videoEncodingOptions](#videoencodingoptions) properties to provide options that define how videos are recorded.
-
-See the [--video](command-line-interface.md#--video-basepath) command line parameter description for details on video recording.
+See [Record Videos](common-concepts/screenshots-and-videos.md#record-videos) for details.
 
 *CLI*: [--video](command-line-interface.md#--video-basepath)  
 *API*: [runner.video](programming-interface/runner.md#video)
@@ -272,7 +270,7 @@ Specifies options that define how TestCafe records videos of test runs.
 }
 ```
 
-See the [--video-options](command-line-interface.md#--video-options-optionvalueoption2value2) command line parameter description for the available options.
+See [Basic Video Options](common-concepts/screenshots-and-videos.md#basic-video-options) for the available options.
 
 > Use the [videoPath](#videopath) option to enable video recording.
 

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -221,16 +221,13 @@ screenshots(path [, takeOnFails, pathPattern]) → this
 
 Parameter                  | Type    | Description                                                                   | Default
 -------------------------- | ------- | ----------------------------------------------------------------------------- | -------
-`path`                     | String  | The base path where the screenshots are saved. Note that to construct a complete path to these screenshots, TestCafe uses default [path patterns](../command-line-interface.md#screenshot-path-patterns). You can override these patterns using the method's `screenshotPathPattern` parameter.
+`path`                     | String  | The base path where the screenshots are saved. Note that to construct a complete path to these screenshots, TestCafe uses default [path patterns](../common-concepts/screenshots-and-videos.md#default-path-patterns). You can override these patterns using the method's `screenshotPathPattern` parameter.
 `takeOnFails`&#160;*(optional)* | Boolean | Specifies if screenshots should be taken automatically when a test fails. | `false`
-`sceenshotPathPattern`&#160;*(optional)* | String | The pattern to compose screenshot files' relative path and name. See [--screenshot-path-pattern](../command-line-interface.md#-p-pattern---screenshot-path-pattern-pattern) for information about the available placeholders.
-
-The `screenshots` function should be called to allow TestCafe to take screenshots
-when the [t.takeScreenshot](../../test-api/actions/take-screenshot.md) action is called from test code.
-
-Set the `takeOnFails` parameter to `true` to take a screenshot when a test fails.
+`sceenshotPathPattern`&#160;*(optional)* | String | The pattern to compose screenshot files' relative path and name. See [Path Pattern Placeholders](../common-concepts/screenshots-and-videos.md#path-pattern-placeholders) for information about the available placeholders.
 
 > Important! TestCafe does not take screenshots if the `screenshots` function is not called.
+
+See [Screenshots](../common-concepts/screenshots-and-videos.md#screenshots) for details.
 
 *Related configuration file properties*:
 
@@ -254,19 +251,11 @@ video(path [, options, encodingOptions]) → this
 
 Parameter                | Type                        | Description
 ------------------------ | --------------------------- | -----------
-`path`                   | String                      | The base directory where videos are saved. Relative paths to video files are composed according to [path patterns](../command-line-interface.md#video-path-patterns). You can also use the `options.pathPattern` property to specify a custom pattern.
-`options`&#160;*(optional)* | Object | Options that define how videos are recorded. See the [--video-options](../command-line-interface.md#--video-options-optionvalueoption2value2) command line flag description for a list of options.
+`path`                   | String                      | The base directory where videos are saved. Relative paths to video files are composed according to [path patterns](../common-concepts/screenshots-and-videos.md#default-path-patterns). You can also use the `options.pathPattern` property to specify a custom pattern.
+`options`&#160;*(optional)* | Object | Options that define how videos are recorded. See [Basic Video Options](../common-concepts/screenshots-and-videos.md#basic-video-options) for a list of options.
 `encodingOptions`&#160;*(optional)* | Object | Options that specify video encoding. You can pass all the options supported by the FFmpeg library. Refer to [the FFmpeg documentation](https://ffmpeg.org/ffmpeg.html#Options) for information about the available options.
 
-> Important! You need to install [the FFmpeg library](https://ffmpeg.org/) to record videos.
-
-If TestCafe is unable to find the FFmpeg library automatically, do one of the following:
-
-* Add the FFmpeg installation directory to the system's `PATH` environment variable;
-* Specify the path to the FFmpeg executable in the `FFMPEG_PATH` environment variable or the `options.ffmpegPath` parameter;
-* Install the `@ffmpeg-installer/ffmpeg` package from npm.
-
-Videos are saved in the `.mp4` format.
+See [Record Videos](../common-concepts/screenshots-and-videos.md#record-videos) for details.
 
 *Overrides configuration file properties*:
 

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -223,7 +223,7 @@ Parameter                  | Type    | Description                              
 -------------------------- | ------- | ----------------------------------------------------------------------------- | -------
 `path`                     | String  | The base path where the screenshots are saved. Note that to construct a complete path to these screenshots, TestCafe uses default [path patterns](../command-line-interface.md#screenshot-path-patterns). You can override these patterns using the method's `screenshotPathPattern` parameter.
 `takeOnFails`&#160;*(optional)* | Boolean | Specifies if screenshots should be taken automatically when a test fails. | `false`
-`sceenshotPathPattern`&#160;*(optional)* | String | The pattern to compose screenshot files' relative path and name. See [--screenshot-path-pattern](../command-line-interface.md#-p---screenshot-path-pattern) for information about the available placeholders.
+`sceenshotPathPattern`&#160;*(optional)* | String | The pattern to compose screenshot files' relative path and name. See [--screenshot-path-pattern](../command-line-interface.md#-p-pattern---screenshot-path-pattern-pattern) for information about the available placeholders.
 
 The `screenshots` function should be called to allow TestCafe to take screenshots
 when the [t.takeScreenshot](../../test-api/actions/take-screenshot.md) action is called from test code.
@@ -263,10 +263,16 @@ Parameter                | Type                        | Description
 If TestCafe is unable to find the FFmpeg library automatically, do one of the following:
 
 * Add the FFmpeg installation directory to the system's `PATH` environment variable;
-* Specify the path to the FFmpeg executable in the `FFMPEG_PATH` environment variable or the `ffmpegPath` parameter in [--video-options](#--video-options-optionvalueoption2value2);
+* Specify the path to the FFmpeg executable in the `FFMPEG_PATH` environment variable or the `options.ffmpegPath` parameter;
 * Install the `@ffmpeg-installer/ffmpeg` package from npm.
 
 Videos are saved in the `.mp4` format.
+
+*Overrides configuration file properties*:
+
+* [videoPath](../configuration-file.md#videopath)
+* [videoOptions](../configuration-file.md#videooptions)
+* [videoEncodingOptions](../configuration-file.md#videoencodingoptions)
 
 **Example**
 

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -42,6 +42,7 @@ createTestCafe('localhost', 1337, 1338)
     * [Specifying the Path with Command Line Parameters](#specifying-the-path-with-command-line-parameters)
     * [Passing a Remote Browser Connection](#passing-a-remote-browser-connection)
 * [screenshots](#screenshots)
+* [video](#video)
 * [reporter](#reporter)
     * [Specifying the Reporter](#specifying-the-reporter)
     * [Saving the Report to a File](#saving-the-report-to-a-file)
@@ -220,7 +221,7 @@ screenshots(path [, takeOnFails, pathPattern]) → this
 
 Parameter                  | Type    | Description                                                                   | Default
 -------------------------- | ------- | ----------------------------------------------------------------------------- | -------
-`path`                     | String  | The base path where the screenshots are saved. Note that to construct a complete path to these screenshots, TestCafe uses default [path patterns](../command-line-interface.md#path-patterns). You can override these patterns using the method's `screenshotPathPattern` parameter.
+`path`                     | String  | The base path where the screenshots are saved. Note that to construct a complete path to these screenshots, TestCafe uses default [path patterns](../command-line-interface.md#screenshot-path-patterns). You can override these patterns using the method's `screenshotPathPattern` parameter.
 `takeOnFails`&#160;*(optional)* | Boolean | Specifies if screenshots should be taken automatically when a test fails. | `false`
 `sceenshotPathPattern`&#160;*(optional)* | String | The pattern to compose screenshot files' relative path and name. See [--screenshot-path-pattern](../command-line-interface.md#-p---screenshot-path-pattern) for information about the available placeholders.
 
@@ -241,6 +242,43 @@ Set the `takeOnFails` parameter to `true` to take a screenshot when a test fails
 
 ```js
 runner.screenshots('reports/screenshots/', true, '${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png');
+```
+
+### video
+
+Enables TestCafe to record videos of test runs.
+
+```text
+video(path [, options, encodingOptions]) → this
+```
+
+Parameter                | Type                        | Description
+------------------------ | --------------------------- | -----------
+`path`                   | String                      | The base directory where videos are saved. Relative paths to video files are composed according to [path patterns](../command-line-interface.md#video-path-patterns). You can also use the `options.pathPattern` property to specify a custom pattern.
+`options`&#160;*(optional)* | Object | Options that define how videos are recorded. See the [--video-options](../command-line-interface.md#--video-options-optionvalueoption2value2) command line flag description for a list of options.
+`encodingOptions`&#160;*(optional)* | Object | Options that specify video encoding. You can pass all the options supported by the FFmpeg library. Refer to [the FFmpeg documentation](https://ffmpeg.org/ffmpeg.html#Options) for information about the available options.
+
+> Important! You need to install [the FFmpeg library](https://ffmpeg.org/) to record videos.
+
+If TestCafe is unable to find the FFmpeg library automatically, do one of the following:
+
+* Add the FFmpeg installation directory to the system's `PATH` environment variable;
+* Specify the path to the FFmpeg executable in the `FFMPEG_PATH` environment variable or the `ffmpegPath` parameter in [--video-options](#--video-options-optionvalueoption2value2);
+* Install the `@ffmpeg-installer/ffmpeg` package from npm.
+
+Videos are saved in the `.mp4` format.
+
+**Example**
+
+```js
+runner.video('reports/videos/', {
+    singleFile: true,
+    failedOnly: true,
+    pathPattern: '${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.mp4'
+}, {
+    r: 20,
+    aspect: '4:3'
+});
 ```
 
 ### reporter

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -221,7 +221,7 @@ screenshots(path [, takeOnFails, pathPattern]) → this
 
 Parameter                  | Type    | Description                                                                   | Default
 -------------------------- | ------- | ----------------------------------------------------------------------------- | -------
-`path`                     | String  | The base path where the screenshots are saved. Note that to construct a complete path to these screenshots, TestCafe uses default [path patterns](../common-concepts/screenshots-and-videos.md#default-path-patterns). You can override these patterns using the method's `screenshotPathPattern` parameter.
+`path`                     | String  | The base path where the screenshots are saved. Note that to construct a complete path to these screenshots, TestCafe uses the default [path patterns](../common-concepts/screenshots-and-videos.md#default-path-patterns). You can override these patterns using the method's `screenshotPathPattern` parameter.
 `takeOnFails`&#160;*(optional)* | Boolean | Specifies if screenshots should be taken automatically when a test fails. | `false`
 `sceenshotPathPattern`&#160;*(optional)* | String | The pattern to compose screenshot files' relative path and name. See [Path Pattern Placeholders](../common-concepts/screenshots-and-videos.md#path-pattern-placeholders) for information about the available placeholders.
 

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -257,7 +257,7 @@ Parameter                | Type                        | Description
 
 See [Record Videos](../common-concepts/screenshots-and-videos.md#record-videos) for details.
 
-*Overrides configuration file properties*:
+*Related configuration file properties*:
 
 * [videoPath](../configuration-file.md#videopath)
 * [videoOptions](../configuration-file.md#videooptions)
@@ -296,7 +296,7 @@ To use multiple reporters, pass an array to this method. This array can include 
 
 Note that if you use multiple reporters, only one can write to `stdout`.
 
-*Overrides configuration file property*: [reporter](../configuration-file.md#reporter)
+*Related configuration file property*: [reporter](../configuration-file.md#reporter)
 
 #### Specifying the Reporter
 

--- a/docs/nav/nav-menu.yml
+++ b/docs/nav/nav-menu.yml
@@ -42,6 +42,8 @@
       url: /documentation/using-testcafe/common-concepts/concurrent-test-execution.md
     - name: Live Mode
       url: /documentation/using-testcafe/common-concepts/live-mode.md
+    - name: Screenshots and Videos
+      url: /documentation/using-testcafe/common-concepts/screenshots-and-videos.md
     - name: Reporters
       url: /documentation/using-testcafe/common-concepts/reporters.md
     - name: Connect to the TestCafe Server over HTTPS

--- a/examples/.testcaferc.json
+++ b/examples/.testcaferc.json
@@ -8,6 +8,16 @@
     "screenshotPath": "/home/user/tests/screenshots/",
     "screenshotPathPattern": "${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png",
     "takeScreenshotsOnFails": true,
+    "videoPath": "reports/screen-captures/",
+    "videoOptions": {
+        "singleFile": true,
+        "failedOnly": true,
+        "pathPattern": "${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.mp4"
+    },
+    "videoEncodingOptions": {
+        "r": 20,
+        "aspect": "4:3"
+    },
     "quarantineMode": true,
     "debugMode": true,
     "debugOnFail": true,

--- a/examples/.testcaferc.json
+++ b/examples/.testcaferc.json
@@ -8,7 +8,7 @@
     "screenshotPath": "/home/user/tests/screenshots/",
     "screenshotPathPattern": "${DATE}_${TIME}/test-${TEST_INDEX}/${USERAGENT}/${FILE_INDEX}.png",
     "takeScreenshotsOnFails": true,
-    "videoPath": "reports/screen-captures/",
+    "videoPath": "reports/screen-captures",
     "videoOptions": {
         "singleFile": true,
         "failedOnly": true,


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs 

It's awfully cross-linked (even between screenshots and video stuff), so ideally I should separate a `Screenshots and Videos` topic to gather it all.

And I haven't described the new `${GENERIC_TEST_NAME}` and `${GENERIC_RUN_NAME}` path patterns yet. Their description will fit well only when we create the `Screenshots and Videos` topic. As I've discussed with @AndreyBelym , the only good reason for customers to use them is if they want a configuration file setting that would work for both enabled and disabled quarantine mode. IDK how important this is.