### PR TITLE
[docs] Remove the Disable Syntax Validation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,13 @@ runner.filter((testName, fixtureName, fixturePath, testMeta, fixtureMeta) => {
 
 You can now run tests imported from external libraries or generated dynamically even if the `.js` file you provide to TestCafe does not contain any tests.
 
-Previously, this was not possible because TestCafe required test files to contain the [fixture](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#fixtures) and [test](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#tests) directives. Now you can bypass this check. To do this, provide the [--disable-test-syntax-validation](https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#--disable-test-syntax-validation) command line flag.
+Previously, this was not possible because TestCafe required test files to contain the [fixture](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#fixtures) and [test](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#tests) directives. Now you can bypass this check. To do this, provide the `--disable-test-syntax-validation` command line flag.
 
 ```sh
 testcafe safari test.js --disable-test-syntax-validation
 ```
 
-In the API, use the [disableTestSyntaxValidation](https://devexpress.github.io/testcafe/documentation/using-testcafe/programming-interface/runner.html#run) option.
+In the API, use the `disableTestSyntaxValidation` option.
 
 ```js
 runner.run({ disableTestSyntaxValidation: true })

--- a/docs/articles/blog/2018-11-7-testcafe-v0-23-1-released.md
+++ b/docs/articles/blog/2018-11-7-testcafe-v0-23-1-released.md
@@ -40,13 +40,13 @@ runner.filter((testName, fixtureName, fixturePath, testMeta, fixtureMeta) => {
 
 You can now run tests imported from external libraries or generated dynamically even if the `.js` file you provide to TestCafe does not contain any tests.
 
-Previously, this was not possible because TestCafe required test files to contain the [fixture](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#fixtures) and [test](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#tests) directives. Now you can bypass this check. To do this, provide the [--disable-test-syntax-validation](https://devexpress.github.io/testcafe/documentation/using-testcafe/command-line-interface.html#--disable-test-syntax-validation) command line flag.
+Previously, this was not possible because TestCafe required test files to contain the [fixture](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#fixtures) and [test](https://devexpress.github.io/testcafe/documentation/test-api/test-code-structure.html#tests) directives. Now you can bypass this check. To do this, provide the `--disable-test-syntax-validation` command line flag.
 
 ```sh
 testcafe safari test.js --disable-test-syntax-validation
 ```
 
-In the API, use the [disableTestSyntaxValidation](https://devexpress.github.io/testcafe/documentation/using-testcafe/programming-interface/runner.html#run) option.
+In the API, use the `disableTestSyntaxValidation` option.
 
 ```js
 runner.run({ disableTestSyntaxValidation: true })

--- a/docs/articles/documentation/using-testcafe/command-line-interface.md
+++ b/docs/articles/documentation/using-testcafe/command-line-interface.md
@@ -53,7 +53,6 @@ testcafe [options] <browser-list-comma-separated> <file-or-glob ...>
   * [--dev](#--dev)
   * [--qr-code](#--qr-code)
   * [--sf, --stop-on-first-fail](#--sf---stop-on-first-fail)
-  * [--disable-test-syntax-validation](#--disable-test-syntax-validation)
   * [--color](#--color)
   * [--no-color](#--no-color)
 
@@ -722,43 +721,6 @@ testcafe chrome my-tests --sf
 ```
 
 *Related configuration file property*: [stopOnFirstFail](configuration-file.md#stoponfirstfail).
-
-### --disable-test-syntax-validation
-
-Disables checks for `test` and `fixture` directives in test files. Use this flag to run dynamically loaded tests.
-
-TestCafe requires test files to have the [fixture](../test-api/test-code-structure.md#fixtures) and [test](../test-api/test-code-structure.md#tests) directives. Otherwise, an error is thrown.
-
-However, when you import tests from external libraries or generate them dynamically, the `.js` file provided to TestCafe may not contain any tests.
-
-**external-lib.js**
-
-```js
-export default function runTests () {
-    fixture `External tests`
-        .page `http:///example.com`;
-
-    test('My Test', async t => {
-        // ...
-    });
-}
-```
-
-**test.js**
-
-```js
-import runTests from './external-lib';
-
-runTests();
-```
-
-In this instance, specify the `--disable-test-syntax-validation` flag to bypass checks for test syntax.
-
-```sh
-testcafe safari test.js --disable-test-syntax-validation
-```
-
-*Related configuration file property*: [disableTestSyntaxValidation](configuration-file.md#disabletestsyntaxvalidation).
 
 ### --color
 

--- a/docs/articles/documentation/using-testcafe/configuration-file.md
+++ b/docs/articles/documentation/using-testcafe/configuration-file.md
@@ -46,7 +46,6 @@ A configuration file can include the following settings:
 * [developmentMode](#developmentmode)
 * [qrCode](#qrcode)
 * [stopOnFirstFail](#stoponfirstfail)
-* [disableTestSyntaxValidation](#disabletestsyntaxvalidation)
 * [color](#color)
 * [noColor](#nocolor)
 
@@ -676,21 +675,6 @@ Stops an entire test run if any test fails.
 
 *CLI*: [--sf, --stop-on-first-fail](command-line-interface.md#--sf---stop-on-first-fail)  
 *API*: [runner.run({ stopOnFirstFail })](programming-interface/runner.md#run)
-
-## disableTestSyntaxValidation
-
-Disables checks for `test` and `fixture` directives in test files. Enable this property to run dynamically loaded tests.
-
-```json
-{
-    "disableTestSyntaxValidation": true
-}
-```
-
-See the [--disable-test-syntax-validation](command-line-interface.md#--disable-test-syntax-validation) command line parameter for details.
-
-*CLI*: [--disable-test-syntax-validation](command-line-interface.md#--disable-test-syntax-validation)  
-*API*: [runner.run({ disableTestSyntaxValidation })](programming-interface/runner.md#run)
 
 ## color
 

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -437,7 +437,6 @@ Parameter         | Type    | Description                                       
 `pageLoadTimeout` | Number  | Specifies the time (in milliseconds) passed after the `DOMContentLoaded` event, within which TestCafe waits for the `window.load` event to fire. After the timeout passes or the `window.load` event is raised (whichever happens first), TestCafe starts the test. You can set this timeout to `0` to skip waiting for `window.load`. | `3000`
 `speed`           | Number  | Specifies the test execution speed. Should be a number between `1` (the fastest) and `0.01` (the slowest). If speed is also specified for an [individual action](../../test-api/actions/action-options.md#basic-action-options), the action speed setting overrides test speed. | `1`
 `stopOnFirstFail`    | Boolean | Defines whether to stop an entire test run if any test fails. This allows you not to wait for all the tests included in the test task to finish and allows focusing on the first error. | `false`
-`disableTestSyntaxValidation` | Boolean | Defines whether to disable checks for [test](../../test-api/test-code-structure.md#tests) and [fixture](../../test-api/test-code-structure.md#fixtures) directives in test files. Use this option to run dynamically loaded tests. See details in the [--disable-test-syntax-validation](../command-line-interface.md#--disable-test-syntax-validation) command line option description. | `false`
 
 After all tests are finished, call the [testcafe.close](testcafe.md#close) function to stop the TestCafe server.
 

--- a/docs/articles/documentation/using-testcafe/programming-interface/runner.md
+++ b/docs/articles/documentation/using-testcafe/programming-interface/runner.md
@@ -452,7 +452,6 @@ After all tests are finished, call the [testcafe.close](testcafe.md#close) funct
 * [pageLoadTimeout](../configuration-file.md#pageloadtimeout)
 * [speed](../configuration-file.md#speed)
 * [stopOnFirstFail](../configuration-file.md#stoponfirstfail)
-* [disableTestSyntaxValidation](../configuration-file.md#disabletestsyntaxvalidation)
 
 **Example**
 

--- a/examples/.testcaferc.json
+++ b/examples/.testcaferc.json
@@ -45,6 +45,5 @@
         "rejectUnauthorized": true
     },
     "developmentMode": true,
-    "qrCode": true,
-    "disableTestSyntaxValidation": true
+    "qrCode": true
 }


### PR DESCRIPTION
\cc @kirovboris @AlexKamaev 

Here I just remove the `Disable Syntax Validation` option.