### PR TITLE
[docs] Add a migration guide for v0.x.y -> v1.0.0

### DIFF
--- a/.md-lint/blog.json
+++ b/.md-lint/blog.json
@@ -1,0 +1,8 @@
+{
+    "MD009": { "br_spaces": 2 },
+    "MD013": false,
+    "MD007": false,
+    "MD036": false,
+    "MD024": false,
+    "MD029": {"style": "ordered"}
+}

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -452,6 +452,7 @@ gulp.task('lint-docs', () => {
         'docs/articles/**/*.md',
         '!docs/articles/faq/**/*.md',
         '!docs/articles/documentation/recipes/**/*.md',
+        '!docs/articles/blog/**/*.md',
         'examples/**/*.md'
     ]).then(files => {
         return lintFiles(files, require('./.md-lint/docs.json'));
@@ -463,6 +464,12 @@ gulp.task('lint-docs', () => {
         return lintFiles(files, require('./.md-lint/faq.json'));
     });
 
+    const lintBlog = globby([
+        'docs/articles/blog/**/*.md'
+    ]).then(files => {
+        return lintFiles(files, require('./.md-lint/blog.json'));
+    });
+
     const lintRecipes = globby([
         'docs/articles/documentation/recipes/**/*.md'
     ]).then(files => {
@@ -472,7 +479,7 @@ gulp.task('lint-docs', () => {
     const lintReadme    = lintFiles('README.md', require('./.md-lint/readme.json'));
     const lintChangelog = lintFiles('CHANGELOG.md', require('./.md-lint/changelog.json'));
 
-    return Promise.all([lintDocsAndExamples, lintReadme, lintChangelog, lintRecipes, lintFaq]);
+    return Promise.all([lintDocsAndExamples, lintReadme, lintChangelog, lintRecipes, lintFaq, lintBlog]);
 });
 
 gulp.task('clean-website', () => {

--- a/docs/articles/blog/2019-2-7-migration-from-testcafe-v0-x-y-to-v1-0-0.md
+++ b/docs/articles/blog/2019-2-7-migration-from-testcafe-v0-x-y-to-v1-0-0.md
@@ -7,6 +7,8 @@ permalink: /blog/:title.html
 
 TestCafe v1.0.0 release introduces minor changes to the behavior and programming interface. This document lists these changes and describes how to address them.
 
+<!--more-->
+
 * [Test Syntax Validation Disabled: All Input Files Are Executed](#test-syntax-validation-disabled-all-input-files-are-executed)
 * [Custom Request Hooks: Asynchronous API](#custom-request-hooks-asynchronous-api)
 * [Custom Reporter Plugins: Asynchronous API](#custom-reporter-plugins-asynchronous-api)

--- a/docs/articles/blog/2019-2-7-migration-from-testcafe-v0-x-y-to-v1-0-0.md
+++ b/docs/articles/blog/2019-2-7-migration-from-testcafe-v0-x-y-to-v1-0-0.md
@@ -50,63 +50,6 @@ const url = 'https://testPage';
 runFixture(fixtureName, url);
 ```
 
-## Custom Request Hooks: Asynchronous API
-
-[Request hook](../documentation/test-api/intercepting-http-requests/README.md) methods became asynchronous in TestCafe v1.0.0.
-
-If you use a [custom request hook](../documentation/test-api/intercepting-http-requests/creating-a-custom-http-request-hook.md), add the `async` keyword before the [onRequest](../documentation/test-api/intercepting-http-requests/creating-a-custom-http-request-hook.md#the-onrequest-method) and [onResponse](../documentation/test-api/intercepting-http-requests/creating-a-custom-http-request-hook.md#the-onresponse-method) methods.
-
-```js
-import { RequestHook } from 'testcafe';
-
-class MyRequestHook extends RequestHook {
-    constructor (requestFilterRules, responseEventConfigureOpts) {
-        super(requestFilterRules, responseEventConfigureOpts);
-        // ...
-    }
-    async onRequest (event) {
-        // ...
-    }
-    async onResponse (event) {
-        // ...
-    }
-}
-```
-
-### What Has Improved
-
-You can call asynchronous [fs](https://nodejs.org/api/fs.html) functions, invoke a [child_process](https://nodejs.org/api/child_process.html), or perform asynchronous network requests (to a database or any other server) from inside the hooks.
-
-## Custom Reporter Plugins: Asynchronous API
-
-TestCafe v1.0.0 also introduces asynchronous API for [reporter plugins](../documentation/extending-testcafe/reporter-plugin/README.md).
-
-If you maintain a custom reporter plugin, add the `async` keyword before each reporter method:
-
-* [reportTaskStart](../documentation/extending-testcafe/reporter-plugin/reporter-methods.md#reporttaskstart)
-* [reportFixtureStart](../documentation/extending-testcafe/reporter-plugin/reporter-methods.md#reportfixturestart)
-* [reportTestDone](../documentation/extending-testcafe/reporter-plugin/reporter-methods.md#reporttestdone)
-* [reportTaskDone](../documentation/extending-testcafe/reporter-plugin/reporter-methods.md#reporttaskdone)
-
-```js
-async reportTaskStart (startTime, userAgents, testCount) {
-    // ...
-},
-async reportFixtureStart (name, path, meta) {
-    // ...
-},
-async reportTestDone (name, testRunInfo, meta) {
-    // ...
-},
-async reportTaskDone (endTime, passed, warnings, result) {
-    // ...
-}
-```
-
-### What Has Improved
-
-Reporters can call asynchronous [fs](https://nodejs.org/api/fs.html) functions, invoke a [child_process](https://nodejs.org/api/child_process.html), or perform asynchronous network requests (to send an email, use REST API, connect to a database, etc).
-
 ## Programming Interface: Multiple Method Calls Prohibited
 
 Previous versions allowed you to call the [runner.src](../documentation/using-testcafe/programming-interface/runner.md#src), [runner.browsers](../documentation/using-testcafe/programming-interface/runner.md#browsers) and [runner.reporter](../documentation/using-testcafe/programming-interface/runner.md#reporter) methods several times to specify multiple test files, browsers or reporters.
@@ -137,3 +80,27 @@ runner
 ### What Has Improved
 
 This change was necessary to implement the [configuration file](../documentation/using-testcafe/configuration-file.md) in a way that is consistent with the API and command line interface.
+
+## Custom Request Hooks: Asynchronous API
+
+[Request hook](../documentation/test-api/intercepting-http-requests/README.md) methods became asynchronous in TestCafe v1.0.0.
+
+If the [onRequest](../documentation/test-api/intercepting-http-requests/creating-a-custom-http-request-hook.md#the-onrequest-method) or [onResponse](../documentation/test-api/intercepting-http-requests/creating-a-custom-http-request-hook.md#the-onresponse-method) method in your custom hook returns a Promise, TestCafe now waits for this Promise to resolve.
+
+This does not necessarily leads to unexpected behavior, but still be aware of possible side effects.
+
+### What Has Improved
+
+You can call asynchronous [fs](https://nodejs.org/api/fs.html) functions, invoke a [child_process](https://nodejs.org/api/child_process.html), or perform asynchronous network requests (to a database or any other server) from inside the hooks.
+
+## Custom Reporter Plugins: Asynchronous API
+
+TestCafe v1.0.0 also introduces asynchronous API for [reporter plugins](../documentation/extending-testcafe/reporter-plugin/README.md).
+
+Similarly to [request hooks](#custom-request-hooks-asynchronous-api), if any of the custom reporter's methods ([reportTaskStart](../documentation/extending-testcafe/reporter-plugin/reporter-methods.md#reporttaskstart), [reportFixtureStart](../documentation/extending-testcafe/reporter-plugin/reporter-methods.md#reportfixturestart), [reportTestDone](../documentation/extending-testcafe/reporter-plugin/reporter-methods.md#reporttestdone) or [reportTaskDone](../documentation/extending-testcafe/reporter-plugin/reporter-methods.md#reporttaskdone)) returns a Promise, this Promise is now awaited.
+
+Side effects may show up in certain cases.
+
+### What Has Improved
+
+Reporters can call asynchronous [fs](https://nodejs.org/api/fs.html) functions, invoke a [child_process](https://nodejs.org/api/child_process.html), or perform asynchronous network requests (to send an email, use REST API, connect to a database, etc).

--- a/docs/articles/blog/2019-2-7-migration-from-testcafe-v0-x-y-to-v1-0-0.md
+++ b/docs/articles/blog/2019-2-7-migration-from-testcafe-v0-x-y-to-v1-0-0.md
@@ -29,11 +29,11 @@ You can now load tests dynamically without additional customization. The followi
 **external-lib.js**
 
 ```js
-export default function runTests () {
-    fixture `External tests`
-        .page `http:///example.com`;
+export default function runFixture(name, url) {
+    fixture(name)
+        .page(url);
 
-    test('My Test', async t => {
+    test(`${url} test`, async t => {
         // ...
     });
 }
@@ -42,9 +42,12 @@ export default function runTests () {
 **test.js**
 
 ```js
-import runTests from './external-lib';
+import runFixture from './external-lib';
 
-runTests();
+const fixtureName = 'My fixture';
+const url = 'https://testPage';
+
+runFixture(fixtureName, url);
 ```
 
 ## Custom Request Hooks: Asynchronous API

--- a/docs/articles/blog/2019-2-7-migration-from-testcafe-v0-x-y-to-v1-0-0.md
+++ b/docs/articles/blog/2019-2-7-migration-from-testcafe-v0-x-y-to-v1-0-0.md
@@ -22,7 +22,7 @@ Starting with v1.0.0, input script files are **never** validated. This means tha
 
 The `--disable-test-syntax-validation` command line flag and the `disableTestSyntaxValidation` option for the [runner.run](../documentation/using-testcafe/programming-interface/runner.md#run) API method that disabled test syntax validation were removed in v1.0.0.
 
-### What Improved
+### What Has Improved
 
 You can now load tests dynamically without additional customization. The following example illustrates how tests can be imported from an external library.
 
@@ -70,7 +70,7 @@ class MyRequestHook extends RequestHook {
 }
 ```
 
-### What Improved
+### What Has Improved
 
 You can call asynchronous [fs](https://nodejs.org/api/fs.html) functions, invoke a [child_process](https://nodejs.org/api/child_process.html), or perform asynchronous network requests (to a database or any other server) from inside the hooks.
 
@@ -100,7 +100,7 @@ async reportTaskDone (endTime, passed, warnings, result) {
 }
 ```
 
-### What Improved
+### What Has Improved
 
 Reporters can call asynchronous [fs](https://nodejs.org/api/fs.html) functions, invoke a [child_process](https://nodejs.org/api/child_process.html), or perform asynchronous network requests (to send an email, use REST API, connect to a database, etc).
 
@@ -131,6 +131,6 @@ runner
     .reporter(['minimal', { name: 'json', output: 'report.json' }]);
 ```
 
-### What Improved
+### What Has Improved
 
 This change was necessary to implement the [configuration file](../documentation/using-testcafe/configuration-file.md) in a way that is consistent with the API and command line interface.

--- a/docs/articles/blog/2019-2-7-migration-from-testcafe-v0-x-y-to-v1-0-0.md
+++ b/docs/articles/blog/2019-2-7-migration-from-testcafe-v0-x-y-to-v1-0-0.md
@@ -22,6 +22,31 @@ Starting with v1.0.0, input script files are **never** validated. This means tha
 
 The `--disable-test-syntax-validation` command line flag and the `disableTestSyntaxValidation` option for the [runner.run](../documentation/using-testcafe/programming-interface/runner.md#run) API method that disabled test syntax validation were removed in v1.0.0.
 
+### What Improved
+
+You can now load tests dynamically without additional customization. The following example illustrates how tests can be imported from an external library.
+
+**external-lib.js**
+
+```js
+export default function runTests () {
+    fixture `External tests`
+        .page `http:///example.com`;
+
+    test('My Test', async t => {
+        // ...
+    });
+}
+```
+
+**test.js**
+
+```js
+import runTests from './external-lib';
+
+runTests();
+```
+
 ## Custom Request Hooks: Asynchronous API
 
 [Request hook](../documentation/test-api/intercepting-http-requests/README.md) methods became asynchronous in TestCafe v1.0.0.
@@ -44,6 +69,10 @@ class MyRequestHook extends RequestHook {
     }
 }
 ```
+
+### What Improved
+
+You can call asynchronous [fs](https://nodejs.org/api/fs.html) functions, invoke a [child_process](https://nodejs.org/api/child_process.html), or perform asynchronous network requests (to a database or any other server) from inside the hooks.
 
 ## Custom Reporter Plugins: Asynchronous API
 
@@ -71,6 +100,10 @@ async reportTaskDone (endTime, passed, warnings, result) {
 }
 ```
 
+### What Improved
+
+Reporters can call asynchronous [fs](https://nodejs.org/api/fs.html) functions, invoke a [child_process](https://nodejs.org/api/child_process.html), or perform asynchronous network requests (to send an email, use REST API, connect to a database, etc).
+
 ## Programming Interface: Multiple Method Calls Prohibited
 
 Previous versions allowed you to call the [runner.src](../documentation/using-testcafe/programming-interface/runner.md#src), [runner.browsers](../documentation/using-testcafe/programming-interface/runner.md#browsers) and [runner.reporter](../documentation/using-testcafe/programming-interface/runner.md#reporter) methods several times to specify multiple test files, browsers or reporters.
@@ -97,3 +130,7 @@ runner
     .browsers(['chrome', 'firefox:headless'])
     .reporter(['minimal', { name: 'json', output: 'report.json' }]);
 ```
+
+### What Improved
+
+This change was necessary to implement the [configuration file](../documentation/using-testcafe/configuration-file.md) in a way that is consistent with the API and command line interface.

--- a/docs/articles/blog/2019-2-7-migration-from-testcafe-v0-x-y-to-v1-0-0.md
+++ b/docs/articles/blog/2019-2-7-migration-from-testcafe-v0-x-y-to-v1-0-0.md
@@ -1,0 +1,97 @@
+---
+layout: post
+title: Migration from TestCafe v0.x.y to v1.0.0
+permalink: /blog/:title.html
+---
+# Migration from TestCafe v0.x.y to v1.0.0
+
+TestCafe v1.0.0 release introduces minor changes to the behavior and programming interface. This document lists these changes and describes how to address them.
+
+* [Test Syntax Validation Disabled: All Input Files Are Executed](#test-syntax-validation-disabled-all-input-files-are-executed)
+* [Custom Request Hooks: Asynchronous API](#custom-request-hooks-asynchronous-api)
+* [Custom Reporter Plugins: Asynchronous API](#custom-reporter-plugins-asynchronous-api)
+* [Programming Interface: Multiple Method Calls Prohibited](#programming-interface-multiple-method-calls-prohibited)
+
+## Test Syntax Validation Disabled: All Input Files Are Executed
+
+Previous versions performed *test syntax validation* within input script files before executing them. Only files that contained the [fixture](../documentation/test-api/test-code-structure.md#fixtures) and [test](../documentation/test-api/test-code-structure.md#tests) directives were executed.
+
+Starting with v1.0.0, input script files are **never** validated. This means that TestCafe executes all the scripts you specify as test sources. If you use Glob patterns to specify input test files, please recheck these patterns to avoid unintended file matches.
+
+The `--disable-test-syntax-validation` command line flag and the `disableTestSyntaxValidation` option for the [runner.run](../documentation/using-testcafe/programming-interface/runner.md#run) API method that disabled test syntax validation were removed in v1.0.0.
+
+## Custom Request Hooks: Asynchronous API
+
+[Request hook](../documentation/test-api/intercepting-http-requests/README.md) methods became asynchronous in TestCafe v1.0.0.
+
+If you use a [custom request hook](../documentation/test-api/intercepting-http-requests/creating-a-custom-http-request-hook.md), add the `async` keyword before the [onRequest](../documentation/test-api/intercepting-http-requests/creating-a-custom-http-request-hook.md#the-onrequest-method) and [onResponse](../documentation/test-api/intercepting-http-requests/creating-a-custom-http-request-hook.md#the-onresponse-method) methods.
+
+```js
+import { RequestHook } from 'testcafe';
+
+class MyRequestHook extends RequestHook {
+    constructor (requestFilterRules, responseEventConfigureOpts) {
+        super(requestFilterRules, responseEventConfigureOpts);
+        // ...
+    }
+    async onRequest (event) {
+        // ...
+    }
+    async onResponse (event) {
+        // ...
+    }
+}
+```
+
+## Custom Reporter Plugins: Asynchronous API
+
+TestCafe v1.0.0 also introduces asynchronous API for [reporter plugins](../documentation/extending-testcafe/reporter-plugin/README.md).
+
+If you maintain a custom reporter plugin, add the `async` keyword before each reporter method:
+
+* [reportTaskStart](../documentation/extending-testcafe/reporter-plugin/reporter-methods.md#reporttaskstart)
+* [reportFixtureStart](../documentation/extending-testcafe/reporter-plugin/reporter-methods.md#reportfixturestart)
+* [reportTestDone](../documentation/extending-testcafe/reporter-plugin/reporter-methods.md#reporttestdone)
+* [reportTaskDone](../documentation/extending-testcafe/reporter-plugin/reporter-methods.md#reporttaskdone)
+
+```js
+async reportTaskStart (startTime, userAgents, testCount) {
+    // ...
+},
+async reportFixtureStart (name, path, meta) {
+    // ...
+},
+async reportTestDone (name, testRunInfo, meta) {
+    // ...
+},
+async reportTaskDone (endTime, passed, warnings, result) {
+    // ...
+}
+```
+
+## Programming Interface: Multiple Method Calls Prohibited
+
+Previous versions allowed you to call the [runner.src](../documentation/using-testcafe/programming-interface/runner.md#src), [runner.browsers](../documentation/using-testcafe/programming-interface/runner.md#browsers) and [runner.reporter](../documentation/using-testcafe/programming-interface/runner.md#reporter) methods several times to specify multiple test files, browsers or reporters.
+
+```js
+const stream = fs.createWriteStream('report.json');
+
+runner
+    .src('/home/user/tests/fixture1.js')
+    .src('fixture5.js')
+    .browsers('chrome')
+    .browsers('firefox:headless')
+    .reporter('minimal')
+    .reporter('json', stream);
+```
+
+Starting with v1.0.0, pass arrays to these methods to specify multiple values.
+
+To use a reporter that writes to a file, add a `{ name, outStream }` object to an array (see the [runner.reporter](../documentation/using-testcafe/programming-interface/runner.md#reporter) description for details).
+
+```js
+runner
+    .src(['/home/user/tests/fixture1.js', 'fixture5.js'])
+    .browsers(['chrome', 'firefox:headless'])
+    .reporter(['minimal', { name: 'json', outStream: 'report.json' }]);
+```

--- a/docs/articles/blog/2019-2-7-migration-from-testcafe-v0-x-y-to-v1-0-0.md
+++ b/docs/articles/blog/2019-2-7-migration-from-testcafe-v0-x-y-to-v1-0-0.md
@@ -87,11 +87,11 @@ runner
 
 Starting with v1.0.0, pass arrays to these methods to specify multiple values.
 
-To use a reporter that writes to a file, add a `{ name, outStream }` object to an array (see the [runner.reporter](../documentation/using-testcafe/programming-interface/runner.md#reporter) description for details).
+To use a reporter that writes to a file, add a `{ name, output }` object to an array (see the [runner.reporter](../documentation/using-testcafe/programming-interface/runner.md#reporter) description for details).
 
 ```js
 runner
     .src(['/home/user/tests/fixture1.js', 'fixture5.js'])
     .browsers(['chrome', 'firefox:headless'])
-    .reporter(['minimal', { name: 'json', outStream: 'report.json' }]);
+    .reporter(['minimal', { name: 'json', output: 'report.json' }]);
 ```


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs 

Added a migration guide aka breaking changes report.

Have I missed anything?