### PR TITLE
Renamed the '.reporter' method parameter from 'outStream' to 'output'

### DIFF
--- a/src/cli/argument-parser.js
+++ b/src/cli/argument-parser.js
@@ -191,10 +191,10 @@ export default class CLIArgumentParser {
             if (separatorIndex < 0)
                 return { name: reporter };
 
-            const name = reporter.substring(0, separatorIndex);
-            const file = reporter.substring(separatorIndex + 1);
+            const name   = reporter.substring(0, separatorIndex);
+            const output = reporter.substring(separatorIndex + 1);
 
-            return { name, file };
+            return { name, output };
         });
     }
 

--- a/src/runner/bootstrapper.js
+++ b/src/runner/bootstrapper.js
@@ -111,7 +111,7 @@ export default class Bootstrapper {
     }
 
     async _getReporterPlugins () {
-        const stdoutReporters = filter(this.reporters, r => isUndefined(r.file) || r.file === process.stdout);
+        const stdoutReporters = filter(this.reporters, r => isUndefined(r.output) || r.output === process.stdout);
 
         if (stdoutReporters.length > 1)
             throw new GeneralError(MESSAGE.multipleStdoutReporters, stdoutReporters.map(r => r.name).join(', '));

--- a/src/runner/bootstrapper.js
+++ b/src/runner/bootstrapper.js
@@ -119,10 +119,10 @@ export default class Bootstrapper {
         if (!this.reporters.length)
             Bootstrapper._addDefaultReporter(this.reporters);
 
-        return Promise.all(this.reporters.map(async ({ name, file }) => {
+        return Promise.all(this.reporters.map(async ({ name, output }) => {
             let pluginFactory = name;
 
-            const outStream = await this._ensureOutStream(file);
+            const outStream = await this._ensureOutStream(output);
 
             if (typeof pluginFactory !== 'function') {
                 try {

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -332,11 +332,11 @@ export default class Runner extends EventEmitter {
         return this;
     }
 
-    reporter (name, fileOrStream) {
+    reporter (name, output) {
         if (this.apiMethodWasCalled.reporter)
             throw new GeneralError(MESSAGE.multipleAPIMethodCallForbidden, OPTION_NAMES.reporter);
 
-        let reporters = prepareReporters(name, fileOrStream);
+        let reporters = prepareReporters(name, output);
 
         reporters = this._prepareArrayParameter(reporters);
 

--- a/src/utils/prepare-reporters.js
+++ b/src/utils/prepare-reporters.js
@@ -18,26 +18,18 @@ function validateReporterOutput (obj) {
         throw new GeneralError(MESSAGE.invalidReporterOutput);
 }
 
-export default function (name, file) {
+export default function (name, output) {
     let reporters = [];
 
     if (name instanceof Array)
         reporters = name.map(r => typeof r === 'string' || typeof r === 'function' ? { name: r } : r);
     else {
-        const reporter = { name, file };
+        const reporter = { name, output };
 
         reporters.push(reporter);
     }
 
-    reporters.forEach(r => {
-        if (r.outStream === void 0)
-            return;
-
-        r.file = r.outStream;
-
-        delete r.outStream;
-    });
-    reporters.forEach(r => validateReporterOutput(r.file));
+    reporters.forEach(r => validateReporterOutput(r.output));
 
     return reporters;
 }

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -24,12 +24,12 @@ describe('Reporter', () => {
             only:     ['chrome'],
             reporter: [
                 {
-                    name:      'json',
-                    outStream: stream1
+                    name:   'json',
+                    output: stream1
                 },
                 {
-                    name:      'list',
-                    outStream: stream2
+                    name:   'list',
+                    output: stream2
                 }
             ]
         })
@@ -50,8 +50,8 @@ describe('Reporter', () => {
             only:     ['chrome'],
             reporter: [
                 {
-                    name:      'json',
-                    outStream: stream
+                    name:   'json',
+                    output: stream
                 }
             ]
         };
@@ -69,8 +69,8 @@ describe('Reporter', () => {
             only:     ['chrome'],
             reporter: [
                 {
-                    name:      'json',
-                    outStream: stream
+                    name:   'json',
+                    output: stream
                 }
             ]
         };
@@ -96,8 +96,8 @@ describe('Reporter', () => {
             only:     ['chrome'],
             reporter: [
                 {
-                    name:      'json',
-                    outStream: process.stdout
+                    name:   'json',
+                    output: process.stdout
                 }
             ]
         };
@@ -125,8 +125,8 @@ describe('Reporter', () => {
             only:     ['chrome'],
             reporter: [
                 {
-                    name:      'json',
-                    outStream: process.stderr
+                    name:   'json',
+                    output: process.stderr
                 }
             ]
         };
@@ -154,8 +154,8 @@ describe('Reporter', () => {
             only:     ['chrome'],
             reporter: [
                 {
-                    name:      'json',
-                    outStream: void 0
+                    name:   'json',
+                    output: void 0
                 }
             ]
         };
@@ -175,8 +175,8 @@ describe('Reporter', () => {
             only:     ['chrome'],
             reporter: [
                 {
-                    name:      'json',
-                    outStream: stream
+                    name:   'json',
+                    output: stream
                 }
             ]
         };
@@ -195,12 +195,12 @@ describe('Reporter', () => {
             only:     ['chrome'],
             reporter: [
                 {
-                    name:      'list',
-                    outStream: testStream
+                    name:   'list',
+                    output: testStream
                 },
                 {
-                    name:      'list',
-                    outStream: reportFileName
+                    name:   'list',
+                    output: reportFileName
                 }
             ]
         })
@@ -221,8 +221,8 @@ describe('Reporter', () => {
 
             reporter: [
                 {
-                    name:      'json',
-                    outStream: stream
+                    name:   'json',
+                    output: stream
                 }
             ]
         };

--- a/test/functional/fixtures/run-options/stop-on-first-fail/test.js
+++ b/test/functional/fixtures/run-options/stop-on-first-fail/test.js
@@ -34,8 +34,8 @@ describe('Stop test task on first failed test', () => {
             shouldFail:      true,
             stopOnFirstFail: true,
             reporter:        [{
-                name:      'spec',
-                outStream: stream
+                name:   'spec',
+                output: stream
             }]
         }).catch(() => {
             const pluginHost  = new ReporterPluginHost({ noColors: true });

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -447,9 +447,9 @@ describe('CLI argument parser', function () {
         return parse('-r list,json:' + filePath)
             .then(function (parser) {
                 expect(parser.opts.reporter[0].name).eql('list');
-                expect(parser.opts.reporter[0].outStream).to.be.undefined;
+                expect(parser.opts.reporter[0].output).to.be.undefined;
                 expect(parser.opts.reporter[1].name).eql('json');
-                expect(parser.opts.reporter[1].file).eql(path.resolve(cwd, filePath));
+                expect(parser.opts.reporter[1].output).eql(path.resolve(cwd, filePath));
             });
     });
 

--- a/test/server/util-test.js
+++ b/test/server/util-test.js
@@ -226,7 +226,7 @@ describe('Utils', () => {
             expect(result).instanceOf(Array);
             expect(result.length).eql(1);
             expect(result[0].name).eql('minimal');
-            expect(result[0].outStream).is.undefined;
+            expect(result[0].output).is.undefined;
         });
 
         it('Array of string names', () => {
@@ -253,7 +253,7 @@ describe('Utils', () => {
 
             expect(result.length).eql(1);
             expect(result[0].name).eql('minimal');
-            expect(result[0].file).eql('path/to/file');
+            expect(result[0].output).eql('path/to/file');
         });
 
         it('Array of names and output streams', () => {


### PR DESCRIPTION
@AndreyBelym 