### PR TITLE
[docs] Add a link to the configuration file example

### DIFF
--- a/docs/articles/documentation/using-testcafe/configuration-file.md
+++ b/docs/articles/documentation/using-testcafe/configuration-file.md
@@ -50,7 +50,9 @@ A configuration file can include the following settings:
 * [color](#color)
 * [noColor](#nocolor)
 
-> The configuration file supports [JSON5 syntax](https://json5.org/). This allows you to use JavaScript identifiers as object keys, single-quoted strings, comments and other JSON5 features.
+The configuration file supports [JSON5 syntax](https://json5.org/). This allows you to use JavaScript identifiers as object keys, single-quoted strings, comments and other JSON5 features.
+
+> You can find a complete configuration file example [in our GitHub repository](https://github.com/DevExpress/testcafe/blob/master/examples/.testcaferc.json).
 
 ## browsers
 


### PR DESCRIPTION
\cc @kirovboris 

Just adding a link to the config example we've created.

BTW, this link is broken so far because it points to the `master` branch.