### PR TITLE
fix testcaferc metadata filter

### DIFF
--- a/src/cli/argument-parser.js
+++ b/src/cli/argument-parser.js
@@ -6,7 +6,7 @@ import { RUNTIME_ERRORS } from '../errors/types';
 import { assertType, is } from '../errors/runtime/type-assertions';
 import getViewPortWidth from '../utils/get-viewport-width';
 import { wordWrap, splitQuotedText } from '../utils/string';
-import { getSSLOptions, getVideoOptions, getMetaOptions } from '../utils/get-options';
+import { getSSLOptions, getVideoOptions, getMetaOptions, getGrepOptions } from '../utils/get-options';
 import getFilterFn from '../utils/get-filter-fn';
 
 const REMOTE_ALIAS_RE = /^remote(?::(\d*))?$/;
@@ -45,18 +45,6 @@ export default class CLIArgumentParser {
         assertType(is.nonNegativeNumberString, null, 'Port number', value);
 
         return parseInt(value, 10);
-    }
-
-    static _optionValueToRegExp (name, value) {
-        if (value === void 0)
-            return value;
-
-        try {
-            return new RegExp(value);
-        }
-        catch (err) {
-            throw new GeneralError(MESSAGE.optionValueIsNotValidRegExp, name);
-        }
     }
 
     static _getDescription () {
@@ -127,10 +115,10 @@ export default class CLIArgumentParser {
 
     async _parseFilteringOptions () {
         if (this.opts.testGrep)
-            this.opts.testGrep = CLIArgumentParser._optionValueToRegExp('--test-grep', this.opts.testGrep);
+            this.opts.testGrep = getGrepOptions('--test-grep', this.opts.testGrep);
 
         if (this.opts.fixtureGrep)
-            this.opts.fixtureGrep = CLIArgumentParser._optionValueToRegExp('--fixture-grep', this.opts.fixtureGrep);
+            this.opts.fixtureGrep = getGrepOptions('--fixture-grep', this.opts.fixtureGrep);
 
         if (this.opts.testMeta)
             this.opts.testMeta = await getMetaOptions('--test-meta', this.opts.testMeta);

--- a/src/cli/argument-parser.js
+++ b/src/cli/argument-parser.js
@@ -6,7 +6,7 @@ import { RUNTIME_ERRORS } from '../errors/types';
 import { assertType, is } from '../errors/runtime/type-assertions';
 import getViewPortWidth from '../utils/get-viewport-width';
 import { wordWrap, splitQuotedText } from '../utils/string';
-import { getSSLOptions, getVideoOptions } from '../utils/get-options';
+import { getSSLOptions, getVideoOptions, getMetaOptions } from '../utils/get-options';
 import getFilterFn from '../utils/get-filter-fn';
 
 const REMOTE_ALIAS_RE = /^remote(?::(\d*))?$/;
@@ -45,6 +45,18 @@ export default class CLIArgumentParser {
         assertType(is.nonNegativeNumberString, null, 'Port number', value);
 
         return parseInt(value, 10);
+    }
+
+    static _optionValueToRegExp (name, value) {
+        if (value === void 0)
+            return value;
+
+        try {
+            return new RegExp(value);
+        }
+        catch (err) {
+            throw new GeneralError(MESSAGE.optionValueIsNotValidRegExp, name);
+        }
     }
 
     static _getDescription () {
@@ -113,7 +125,19 @@ export default class CLIArgumentParser {
         return true;
     }
 
-    _parseFilteringOptions () {
+    async _parseFilteringOptions () {
+        if (this.opts.testGrep)
+            this.opts.testGrep = CLIArgumentParser._optionValueToRegExp('--test-grep', this.opts.testGrep);
+
+        if (this.opts.fixtureGrep)
+            this.opts.fixtureGrep = CLIArgumentParser._optionValueToRegExp('--fixture-grep', this.opts.fixtureGrep);
+
+        if (this.opts.testMeta)
+            this.opts.testMeta = await getMetaOptions('--test-meta', this.opts.testMeta);
+
+        if (this.opts.fixtureMeta)
+            this.opts.fixtureMeta = await getMetaOptions('--fixture-meta', this.opts.fixtureMeta);
+
         this.filter = getFilterFn(this.opts);
     }
 
@@ -228,7 +252,6 @@ export default class CLIArgumentParser {
             return;
         }
 
-        this._parseFilteringOptions();
         this._parseSelectorTimeout();
         this._parseAssertionTimeout();
         this._parsePageLoadTimeout();
@@ -239,6 +262,7 @@ export default class CLIArgumentParser {
         this._parseConcurrency();
         this._parseFileList();
 
+        await this._parseFilteringOptions();
         await this._parseVideoOptions();
         await this._parseSslOptions();
         await this._parseReporters();

--- a/src/configuration/index.js
+++ b/src/configuration/index.js
@@ -3,7 +3,7 @@ import { stat, readFile } from '../utils/promisified-functions';
 import Option from './option';
 import optionSource from './option-source';
 import { cloneDeep, castArray } from 'lodash';
-import { getSSLOptions } from '../utils/get-options';
+import { getSSLOptions, getGrepOptions } from '../utils/get-options';
 import OPTION_NAMES from './option-names';
 import getFilterFn from '../utils/get-filter-fn';
 import resolvePathRelativelyCwd from '../utils/resolve-path-relatively-cwd';
@@ -132,6 +132,12 @@ export default class Configuration {
 
         if (!filterOption.value)
             return;
+
+        if (filterOption.value.testGrep)
+            filterOption.value.testGrep = getGrepOptions(OPTION_NAMES.filterTestGrep, filterOption.value.testGrep);
+
+        if (filterOption.value.fixtureGrep)
+            filterOption.value.fixtureGrep = getGrepOptions(OPTION_NAMES.filterFixtureGrep, filterOption.value.fixtureGrep);
 
         filterOption.value = getFilterFn(filterOption.value);
     }

--- a/src/configuration/option-conversion.js
+++ b/src/configuration/option-conversion.js
@@ -1,5 +1,5 @@
 import { GeneralError } from '../errors/runtime';
-import MESSAGE from '../errors/runtime/message';
+import { RUNTIME_ERRORS } from '../errors/types';
 
 export function optionValueToRegExp (name, value) {
     if (value === void 0)
@@ -9,7 +9,7 @@ export function optionValueToRegExp (name, value) {
         return new RegExp(value);
     }
     catch (err) {
-        throw new GeneralError(MESSAGE.optionValueIsNotValidRegExp, name);
+        throw new GeneralError(RUNTIME_ERRORS.optionValueIsNotValidRegExp, name);
     }
 }
 
@@ -24,14 +24,14 @@ export function optionValueToKeyValue (name, value) {
         const [key, val] = pair.split('=');
 
         if (!key || !val)
-            throw new GeneralError(MESSAGE.optionValueIsNotValidKeyValue, name);
+            throw new GeneralError(RUNTIME_ERRORS.optionValueIsNotValidKeyValue, name);
 
         obj[key] = val;
         return obj;
     }, {});
 
     if (Object.keys(keyValue).length === 0)
-        throw new GeneralError(MESSAGE.optionValueIsNotValidKeyValue, name);
+        throw new GeneralError(RUNTIME_ERRORS.optionValueIsNotValidKeyValue, name);
 
     return keyValue;
 }

--- a/src/configuration/option-conversion.js
+++ b/src/configuration/option-conversion.js
@@ -16,6 +16,9 @@ export function optionValueToRegExp (name, value) {
 export function optionValueToKeyValue (name, value) {
     if (value === void 0)
         return value;
+        
+    if (typeof value === "object") 
+        return value;
 
     const keyValue = value.split(',').reduce((obj, pair) => {
         const [key, val] = pair.split('=');

--- a/src/configuration/option-conversion.js
+++ b/src/configuration/option-conversion.js
@@ -1,5 +1,5 @@
 import { GeneralError } from '../errors/runtime';
-import { RUNTIME_ERRORS } from '../errors/types';
+import MESSAGE from '../errors/runtime/message';
 
 export function optionValueToRegExp (name, value) {
     if (value === void 0)
@@ -9,7 +9,7 @@ export function optionValueToRegExp (name, value) {
         return new RegExp(value);
     }
     catch (err) {
-        throw new GeneralError(RUNTIME_ERRORS.optionValueIsNotValidRegExp, name);
+        throw new GeneralError(MESSAGE.optionValueIsNotValidRegExp, name);
     }
 }
 
@@ -24,14 +24,14 @@ export function optionValueToKeyValue (name, value) {
         const [key, val] = pair.split('=');
 
         if (!key || !val)
-            throw new GeneralError(RUNTIME_ERRORS.optionValueIsNotValidKeyValue, name);
+            throw new GeneralError(MESSAGE.optionValueIsNotValidKeyValue, name);
 
         obj[key] = val;
         return obj;
     }, {});
 
     if (Object.keys(keyValue).length === 0)
-        throw new GeneralError(RUNTIME_ERRORS.optionValueIsNotValidKeyValue, name);
+        throw new GeneralError(MESSAGE.optionValueIsNotValidKeyValue, name);
 
     return keyValue;
 }

--- a/src/configuration/option-conversion.js
+++ b/src/configuration/option-conversion.js
@@ -16,8 +16,8 @@ export function optionValueToRegExp (name, value) {
 export function optionValueToKeyValue (name, value) {
     if (value === void 0)
         return value;
-        
-    if (typeof value === "object") 
+
+    if (typeof value === 'object')
         return value;
 
     const keyValue = value.split(',').reduce((obj, pair) => {

--- a/src/configuration/option-names.js
+++ b/src/configuration/option-names.js
@@ -3,6 +3,8 @@ export default {
     browsers:               'browsers',
     concurrency:            'concurrency',
     filter:                 'filter',
+    filterTestGrep:         'filter.testGrep',
+    filterFixtureGrep:      'filter.fixtureGrep',
     reporter:               'reporter',
     ssl:                    'ssl',
     speed:                  'speed',

--- a/src/utils/get-filter-fn.js
+++ b/src/utils/get-filter-fn.js
@@ -1,5 +1,4 @@
 import { isMatch } from 'lodash';
-import { optionValueToRegExp, optionValueToKeyValue } from '../configuration/option-conversion';
 
 function isAllFilteringOptionsAreUndefined (opts) {
     return [
@@ -10,15 +9,6 @@ function isAllFilteringOptionsAreUndefined (opts) {
         opts.test,
         opts.fixture
     ].every(item => item === void 0);
-}
-
-function prepareOptionValues (opts) {
-    opts.testGrep    = optionValueToRegExp('--test-grep', opts.testGrep);
-    opts.fixtureGrep = optionValueToRegExp('--fixture-grep', opts.fixtureGrep);
-    opts.testMeta    = optionValueToKeyValue('--test-meta', opts.testMeta);
-    opts.fixtureMeta = optionValueToKeyValue('--fixture-meta', opts.fixtureMeta);
-
-    return opts;
 }
 
 function createFilterFn (opts) {
@@ -48,8 +38,6 @@ function createFilterFn (opts) {
 export default function (opts) {
     if (isAllFilteringOptionsAreUndefined(opts))
         return void 0;
-
-    opts = prepareOptionValues(opts);
 
     return createFilterFn(opts);
 }

--- a/src/utils/get-filter-fn.js
+++ b/src/utils/get-filter-fn.js
@@ -1,14 +1,18 @@
 import { isMatch } from 'lodash';
 
+const FILTERING_OPTIONS = {
+    testGrep:    'testGrep',
+    fixtureGrep: 'fixtureGrep',
+    testMeta:    'testMeta',
+    fixtureMeta: 'fixtureMeta',
+    test:        'test',
+    fixture:     'fixture'
+};
+
 function isAllFilteringOptionsAreUndefined (opts) {
-    return [
-        opts.testGrep,
-        opts.fixtureGrep,
-        opts.testMeta,
-        opts.fixtureMeta,
-        opts.test,
-        opts.fixture
-    ].every(item => item === void 0);
+    return Object
+        .keys(FILTERING_OPTIONS)
+        .every(option => opts[option] === void 0);
 }
 
 function createFilterFn (opts) {

--- a/src/utils/get-options/grep.js
+++ b/src/utils/get-options/grep.js
@@ -1,0 +1,14 @@
+import { GeneralError } from "../../errors/runtime";
+import MESSAGE from "../../errors/runtime/message";
+
+export default function (optionName, value) {
+    if (value === void 0)
+        return value;
+
+    try {
+        return new RegExp(value);
+    }
+    catch (err) {
+        throw new GeneralError(MESSAGE.optionValueIsNotValidRegExp, optionName);
+    }
+}

--- a/src/utils/get-options/grep.js
+++ b/src/utils/get-options/grep.js
@@ -1,5 +1,5 @@
-import { GeneralError } from "../../errors/runtime";
-import MESSAGE from "../../errors/runtime/message";
+import { GeneralError } from '../../errors/runtime';
+import { RUNTIME_ERRORS } from '../../errors/types';
 
 export default function (optionName, value) {
     if (value === void 0)
@@ -9,6 +9,6 @@ export default function (optionName, value) {
         return new RegExp(value);
     }
     catch (err) {
-        throw new GeneralError(MESSAGE.optionValueIsNotValidRegExp, optionName);
+        throw new GeneralError(RUNTIME_ERRORS.optionValueIsNotValidRegExp, optionName);
     }
 }

--- a/src/utils/get-options/index.js
+++ b/src/utils/get-options/index.js
@@ -1,5 +1,6 @@
 import getSSLOptions from './ssl';
 import getVideoOptions from './video';
 import getMetaOptions from './meta';
+import getGrepOptions from './grep';
 
-export { getVideoOptions, getSSLOptions, getMetaOptions };
+export { getVideoOptions, getSSLOptions, getMetaOptions, getGrepOptions };

--- a/src/utils/get-options/index.js
+++ b/src/utils/get-options/index.js
@@ -1,4 +1,5 @@
 import getSSLOptions from './ssl';
 import getVideoOptions from './video';
+import getMetaOptions from './meta';
 
-export { getVideoOptions, getSSLOptions };
+export { getVideoOptions, getSSLOptions, getMetaOptions };

--- a/src/utils/get-options/meta.js
+++ b/src/utils/get-options/meta.js
@@ -1,0 +1,22 @@
+import baseGetOptions from './base';
+import ERROR_MESSAGES from '../../errors/runtime/message';
+import { GeneralError } from '../../errors/runtime';
+
+
+export default function (optionName, options) {
+    const metaOptions = baseGetOptions(options, {
+        skipOptionValueTypeConversion: true,
+
+        onOptionParsed (key, value) {
+            if (!key || !value)
+                throw new GeneralError(ERROR_MESSAGES.optionValueIsNotValidKeyValue, optionName);
+
+            return String(value);
+        }
+    });
+
+    if (Object.keys(metaOptions).length === 0)
+        throw new GeneralError(ERROR_MESSAGES.optionValueIsNotValidKeyValue, optionName);
+
+    return metaOptions;
+}

--- a/src/utils/get-options/meta.js
+++ b/src/utils/get-options/meta.js
@@ -3,11 +3,11 @@ import ERROR_MESSAGES from '../../errors/runtime/message';
 import { GeneralError } from '../../errors/runtime';
 
 
-export default function (optionName, options) {
-    const metaOptions = baseGetOptions(options, {
+export default async function (optionName, options) {
+    const metaOptions = await baseGetOptions(options, {
         skipOptionValueTypeConversion: true,
 
-        onOptionParsed (key, value) {
+        async onOptionParsed (key, value) {
             if (!key || !value)
                 throw new GeneralError(ERROR_MESSAGES.optionValueIsNotValidKeyValue, optionName);
 

--- a/src/utils/get-options/meta.js
+++ b/src/utils/get-options/meta.js
@@ -1,5 +1,5 @@
 import baseGetOptions from './base';
-import ERROR_MESSAGES from '../../errors/runtime/message';
+import { RUNTIME_ERRORS } from '../../errors/types';
 import { GeneralError } from '../../errors/runtime';
 
 
@@ -9,14 +9,14 @@ export default async function (optionName, options) {
 
         async onOptionParsed (key, value) {
             if (!key || !value)
-                throw new GeneralError(ERROR_MESSAGES.optionValueIsNotValidKeyValue, optionName);
+                throw new GeneralError(RUNTIME_ERRORS.optionValueIsNotValidKeyValue, optionName);
 
             return String(value);
         }
     });
 
     if (Object.keys(metaOptions).length === 0)
-        throw new GeneralError(ERROR_MESSAGES.optionValueIsNotValidKeyValue, optionName);
+        throw new GeneralError(RUNTIME_ERRORS.optionValueIsNotValidKeyValue, optionName);
 
     return metaOptions;
 }

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -218,6 +218,8 @@ describe('CLI argument parser', function () {
         it('Should filter by test meta with "--test-meta" option', function () {
             return parse('--test-meta meta=test')
                 .then(function (parser) {
+                    expect(parser.opts.testMeta).to.be.deep.equal({ meta: 'test' });
+
                     expect(parser.filter(null, null, null, { meta: 'test' })).to.be.true;
                     expect(parser.filter(null, null, null, { another: 'meta', meta: 'test' })).to.be.true;
                     expect(parser.filter(null, null, null, {})).to.be.false;
@@ -228,11 +230,47 @@ describe('CLI argument parser', function () {
         it('Should filter by fixture meta with "--fixture-meta" option', function () {
             return parse('--fixture-meta meta=test,more=meta')
                 .then(function (parser) {
+                    expect(parser.opts.fixtureMeta).to.be.deep.equal({ meta: 'test', more: 'meta' });
+
                     expect(parser.filter(null, null, null, null, { meta: 'test', more: 'meta' })).to.be.true;
                     expect(parser.filter(null, null, null, null, { another: 'meta', meta: 'test', more: 'meta' })).to.be.true;
                     expect(parser.filter(null, null, null, null, {})).to.be.false;
                     expect(parser.filter(null, null, null, null, { meta: 'test' })).to.be.false;
                     expect(parser.filter(null, null, null, null, { meta: 'test', more: 'another' })).to.be.false;
+                });
+        });
+
+        it('Should throw an error if invalid meta is specified', () => {
+            return parse('--fixture-meta meta')
+                .then(() => {
+                    throw new Error('Promise rejection expected');
+                })
+                .catch(function (error) {
+                    expect(error.message).contains('The "--fixture-meta" option value is not a valid key-value pair.');
+
+                    return parse('--fixture-meta =test');
+                })
+                .then(() => {
+                    throw new Error('Promise rejection expected');
+                })
+                .catch(function (error) {
+                    expect(error.message).contains('The "--fixture-meta" option value is not a valid key-value pair.');
+
+                    return parse('--test-meta meta');
+                })
+                .then(() => {
+                    throw new Error('Promise rejection expected');
+                })
+                .catch(function (error) {
+                    expect(error.message).contains('The "--test-meta" option value is not a valid key-value pair.');
+
+                    return parse('--test-meta =test');
+                })
+                .then(() => {
+                    throw new Error('Promise rejection expected');
+                })
+                .catch(function (error) {
+                    expect(error.message).contains('The "--test-meta" option value is not a valid key-value pair.');
                 });
         });
 

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -45,6 +45,7 @@ describe('Configuration', () => {
             'filter':      {
                 'fixture':     'testFixture',
                 'test':        'some test',
+                'testGrep':    'Hello [Ww]orld',
                 'fixtureGrep': '^Unstable'
             }
         });

--- a/test/server/util-test.js
+++ b/test/server/util-test.js
@@ -163,9 +163,52 @@ describe('Utils', () => {
         expect(getCommonPath([paths[1], paths[2], paths[3]])).eql(paths[0]);
     });
 
-    it('Get Filter Fn', () => {
-        expect(getFilterFn({})).is.undefined;
-        expect(getFilterFn({ fixture: 'test' })).to.be.a('function');
+    describe('Get Filter Fn', () => {
+        it('Should return "undefined" if no filtering options were specified', () => {
+            expect(getFilterFn({})).is.undefined;
+        });
+
+        it('Should filter by a test name', () => {
+            const filter = getFilterFn({ test: 'test' });
+
+            expect(filter('test', void 0, void 0, void 0, void 0)).to.be.true;
+            expect(filter('test2', void 0, void 0, void 0, void 0)).to.be.false;
+        });
+
+        it('Should filter by a fixture name', () => {
+            const filter = getFilterFn({ fixture: 'fixture' });
+
+            expect(filter(void 0, 'fixture', void 0, void 0, void 0)).to.be.true;
+            expect(filter(void 0, 'fixture1', void 0, void 0, void 0)).to.be.false;
+        });
+
+        it('Should filter by a test name RegExp', () => {
+            const filter = getFilterFn({ testGrep: /test\d/ });
+
+            expect(filter('test1', void 0, void 0, void 0, void 0)).to.be.true;
+            expect(filter('testX', void 0, void 0, void 0, void 0)).to.be.false;
+        });
+
+        it('Should filter by a fixture name RegExp', () => {
+            const filter = getFilterFn({ fixtureGrep: /fixture\d/ });
+
+            expect(filter(void 0, 'fixture1', void 0, void 0, void 0)).to.be.true;
+            expect(filter(void 0, 'fixtureA', void 0, void 0, void 0)).to.be.false;
+        });
+
+        it('Should filter by a test meta', () => {
+            const filter = getFilterFn({ testMeta: { test: 'meta' } });
+
+            expect(filter(void 0, void 0, void 0, { test: 'meta' }, void 0)).to.be.true;
+            expect(filter(void 0, void 0, void 0, { test: 'metaX' }, void 0)).to.be.false;
+        });
+
+        it('Should filter by a fixture meta', () => {
+            const filter = getFilterFn({ fixtureMeta: { fixture: 'meta' } });
+
+            expect(filter(void 0, void 0, void 0, void 0, { fixture: 'meta' })).to.be.true;
+            expect(filter(void 0, void 0, void 0, void 0, { fixture: 'metaX' })).to.be.false;
+        });
     });
 
     describe('Moment Module Loader', () => {


### PR DESCRIPTION
Fixes the broken metadata filters in the testcaferc.json.
Currently you can only use the metadata filter via the command line. The testcaferc passes an object to optionValueToKeyValue which it currently doesn't support. This adds support for objects.