### PR TITLE
[docs] Add a roadmap

### DIFF
--- a/docs/articles/roadmap/README.md
+++ b/docs/articles/roadmap/README.md
@@ -5,11 +5,11 @@ permalink: /roadmap/
 ---
 # Roadmap
 
-This roadmap includes the most important features we have planned for the year 2019.
+This roadmap includes the most important features planned for 2019.
 
-This list is not exhaustive. We will update it with more entries as we receive your feedback.
+This list is not exhaustive and will be updated with more entries as we receive your feedback.
 
-Please vote on the features you want us to implement first (follow the link and leave a reaction on GitHub). This helps us prioritize and deliver what really matters to you.
+Please vote on the features you want us to implement first to help us prioritize our work. (Follow each link to leave a reaction on GitHub.)
 
 ## Highlighted Features
 

--- a/docs/articles/roadmap/README.md
+++ b/docs/articles/roadmap/README.md
@@ -1,0 +1,23 @@
+---
+layout: faq
+title: Roadmap
+permalink: /roadmap/
+---
+# Roadmap
+
+This roadmap outlines the most important features currently in our plans or in production.
+
+Please vote on the features you want us to implement first (follow the link and leave a reaction on GitHub). This helps us prioritize and deliver what really matters to you.
+
+Feature                                                                                           | Status
+------------------------------------------------------------------------------------------------- | -------------------
+[Visual Regression Testing](https://github.com/DevExpress/testcafe/issues/1207)                   | Under Consideration
+[Testing in Multiple Browser Windows](https://github.com/DevExpress/testcafe/issues/912)          | Under Consideration
+[Cucumber Integration](https://github.com/DevExpress/testcafe/issues/2835)                        | Under Consideration
+[Selector Debug Panel](https://github.com/DevExpress/testcafe/issues/3244)                        | Under Consideration
+[Entire Page Screenshots](https://github.com/DevExpress/testcafe/issues/1520)                     | Under Consideration
+[Custom Actions](https://github.com/DevExpress/testcafe/issues/1535)                              | Under Consideration
+[Custom TypeScript Compilation Options](https://github.com/DevExpress/testcafe/issues/1845)       | Under Consideration
+[Conditional Browser Skip](https://github.com/DevExpress/testcafe/issues/481)                     | Under Consideration
+
+> We make no guarantee that we implement all the features listed here. Our decisions depend on your feedback.

--- a/docs/articles/roadmap/README.md
+++ b/docs/articles/roadmap/README.md
@@ -16,13 +16,13 @@ Please vote on the features you want us to implement first (follow the link and 
 Feature                                                                                           | Status
 ------------------------------------------------------------------------------------------------- | -------------------
 [Visual Regression Testing](https://github.com/DevExpress/testcafe/issues/1207)                   | Under Consideration
+[Testing in Multiple Browser Windows](https://github.com/DevExpress/testcafe/issues/912)          | Under Consideration
 
 ## API
 
 Feature                                                                                           | Status
 ------------------------------------------------------------------------------------------------- | -------------------
 [Configuration File](https://github.com/DevExpress/testcafe/issues/3131)                          | **Implemented**
-[Testing in Multiple Browser Windows](https://github.com/DevExpress/testcafe/issues/912)          | Under Consideration
 [Screenshots of the Entire Page](https://github.com/DevExpress/testcafe/issues/1520)              | Under Consideration
 [Custom Actions](https://github.com/DevExpress/testcafe/issues/1535)                              | Under Consideration
 [Conditional Test Skip](https://github.com/DevExpress/testcafe/issues/1626)                       | Under Consideration

--- a/docs/articles/roadmap/README.md
+++ b/docs/articles/roadmap/README.md
@@ -15,7 +15,7 @@ Feature                                                                         
 [Testing in Multiple Browser Windows](https://github.com/DevExpress/testcafe/issues/912)          | Under Consideration
 [Cucumber Integration](https://github.com/DevExpress/testcafe/issues/2835)                        | Under Consideration
 [Selector Debug Panel](https://github.com/DevExpress/testcafe/issues/3244)                        | Under Consideration
-[Entire Page Screenshots](https://github.com/DevExpress/testcafe/issues/1520)                     | Under Consideration
+[Screenshots of the Entire Page](https://github.com/DevExpress/testcafe/issues/1520)              | Under Consideration
 [Custom Actions](https://github.com/DevExpress/testcafe/issues/1535)                              | Under Consideration
 [Custom TypeScript Compilation Options](https://github.com/DevExpress/testcafe/issues/1845)       | Under Consideration
 [Conditional Test Skip](https://github.com/DevExpress/testcafe/issues/1626)                       | Under Consideration

--- a/docs/articles/roadmap/README.md
+++ b/docs/articles/roadmap/README.md
@@ -11,18 +11,11 @@ This list is not exhaustive. We will update it with more entries as we receive y
 
 Please vote on the features you want us to implement first (follow the link and leave a reaction on GitHub). This helps us prioritize and deliver what really matters to you.
 
-## Highlighted
+## Highlighted Features
 
 Feature                                                                                           | Status
 ------------------------------------------------------------------------------------------------- | -------------------
 [Visual Regression Testing](https://github.com/DevExpress/testcafe/issues/1207)                   | Under Consideration
-
-## Visual Testing
-
-Feature                                                                                           | Status
-------------------------------------------------------------------------------------------------- | -------------------
-[Video Recording](https://github.com/DevExpress/testcafe/issues/2151)                             | **Implemented**
-[Screenshots of the Entire Page](https://github.com/DevExpress/testcafe/issues/1520)              | Under Consideration
 
 ## API
 
@@ -30,6 +23,7 @@ Feature                                                                         
 ------------------------------------------------------------------------------------------------- | -------------------
 [Configuration File](https://github.com/DevExpress/testcafe/issues/3131)                          | **Implemented**
 [Testing in Multiple Browser Windows](https://github.com/DevExpress/testcafe/issues/912)          | Under Consideration
+[Screenshots of the Entire Page](https://github.com/DevExpress/testcafe/issues/1520)              | Under Consideration
 [Custom Actions](https://github.com/DevExpress/testcafe/issues/1535)                              | Under Consideration
 [Conditional Test Skip](https://github.com/DevExpress/testcafe/issues/1626)                       | Under Consideration
 [Browser Information in Test Code](https://github.com/DevExpress/testcafe/issues/481)             | Under Consideration
@@ -38,13 +32,9 @@ Feature                                                                         
 
 Feature                                                                                           | Status
 ------------------------------------------------------------------------------------------------- | -------------------
-[Selector Debug Panel](https://github.com/DevExpress/testcafe/issues/3244)                        | Under Consideration
-
-## Rapid Development
-
-Feature                                                                                           | Status
-------------------------------------------------------------------------------------------------- | -------------------
+[Video Recording](https://github.com/DevExpress/testcafe/issues/2151)                             | **Implemented**
 [Live Mode](https://github.com/DevExpress/testcafe/issues/3215)                                   | **Implemented**
+[Selector Debug Panel](https://github.com/DevExpress/testcafe/issues/3244)                        | Under Consideration
 
 ## Ecosystem / Integrations
 

--- a/docs/articles/roadmap/README.md
+++ b/docs/articles/roadmap/README.md
@@ -18,6 +18,7 @@ Feature                                                                         
 [Entire Page Screenshots](https://github.com/DevExpress/testcafe/issues/1520)                     | Under Consideration
 [Custom Actions](https://github.com/DevExpress/testcafe/issues/1535)                              | Under Consideration
 [Custom TypeScript Compilation Options](https://github.com/DevExpress/testcafe/issues/1845)       | Under Consideration
-[Conditional Browser Skip](https://github.com/DevExpress/testcafe/issues/481)                     | Under Consideration
+[Conditional Test Skip](https://github.com/DevExpress/testcafe/issues/1626)                       | Under Consideration
+[Browser Information Available in Test Code](https://github.com/DevExpress/testcafe/issues/481)   | Under Consideration
 
 > We make no guarantee that we implement all the features listed here. Our decisions depend on your feedback.

--- a/docs/articles/roadmap/README.md
+++ b/docs/articles/roadmap/README.md
@@ -5,20 +5,50 @@ permalink: /roadmap/
 ---
 # Roadmap
 
-This roadmap outlines the most important features currently in our plans or in production.
+This roadmap includes the most important features we have planned for the year 2019.
+
+This list is not exhaustive. We will update it with more entries as we receive your feedback.
 
 Please vote on the features you want us to implement first (follow the link and leave a reaction on GitHub). This helps us prioritize and deliver what really matters to you.
+
+## Highlighted
 
 Feature                                                                                           | Status
 ------------------------------------------------------------------------------------------------- | -------------------
 [Visual Regression Testing](https://github.com/DevExpress/testcafe/issues/1207)                   | Under Consideration
-[Testing in Multiple Browser Windows](https://github.com/DevExpress/testcafe/issues/912)          | Under Consideration
-[Cucumber Integration](https://github.com/DevExpress/testcafe/issues/2835)                        | Under Consideration
-[Selector Debug Panel](https://github.com/DevExpress/testcafe/issues/3244)                        | Under Consideration
-[Screenshots of the Entire Page](https://github.com/DevExpress/testcafe/issues/1520)              | Under Consideration
-[Custom Actions](https://github.com/DevExpress/testcafe/issues/1535)                              | Under Consideration
-[Custom TypeScript Compilation Options](https://github.com/DevExpress/testcafe/issues/1845)       | Under Consideration
-[Conditional Test Skip](https://github.com/DevExpress/testcafe/issues/1626)                       | Under Consideration
-[Browser Information Available in Test Code](https://github.com/DevExpress/testcafe/issues/481)   | Under Consideration
 
-> We make no guarantee that we implement all the features listed here. Our decisions depend on your feedback.
+## Visual Testing
+
+Feature                                                                                           | Status
+------------------------------------------------------------------------------------------------- | -------------------
+[Video Recording](https://github.com/DevExpress/testcafe/issues/2151)                             | **Implemented**
+[Screenshots of the Entire Page](https://github.com/DevExpress/testcafe/issues/1520)              | Under Consideration
+
+## API
+
+Feature                                                                                           | Status
+------------------------------------------------------------------------------------------------- | -------------------
+[Configuration File](https://github.com/DevExpress/testcafe/issues/3131)                          | **Implemented**
+[Testing in Multiple Browser Windows](https://github.com/DevExpress/testcafe/issues/912)          | Under Consideration
+[Custom Actions](https://github.com/DevExpress/testcafe/issues/1535)                              | Under Consideration
+[Conditional Test Skip](https://github.com/DevExpress/testcafe/issues/1626)                       | Under Consideration
+[Browser Information in Test Code](https://github.com/DevExpress/testcafe/issues/481)             | Under Consideration
+
+## Debugging
+
+Feature                                                                                           | Status
+------------------------------------------------------------------------------------------------- | -------------------
+[Selector Debug Panel](https://github.com/DevExpress/testcafe/issues/3244)                        | Under Consideration
+
+## Rapid Development
+
+Feature                                                                                           | Status
+------------------------------------------------------------------------------------------------- | -------------------
+[Live Mode](https://github.com/DevExpress/testcafe/issues/3215)                                   | **Implemented**
+
+## Ecosystem / Integrations
+
+Feature                                                                                           | Status
+------------------------------------------------------------------------------------------------- | -------------------
+[Cucumber Integration](https://github.com/DevExpress/testcafe/issues/2835)                        | Under Consideration
+[Custom TypeScript Compilation Options](https://github.com/DevExpress/testcafe/issues/1845)       | Under Consideration

--- a/docs/nav/top-menu-items.yml
+++ b/docs/nav/top-menu-items.yml
@@ -1,4 +1,4 @@
-- text: Documentation
+- text: Docs
   url: /documentation/getting-started/
   highlightUrl: /documentation
 - text: GitHub
@@ -6,6 +6,8 @@
   external: true
 - text: FAQ
   url: /faq/
+- text: Roadmap
+  url: /roadmap/
 - text: Release Notes
   url: /blog/
 - text: Support


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs @miherlosev 

http://strelyaev-w8:8080/testcafe/roadmap/

WIP because we still need to provide meaningful titles and descriptions to all these features on GitHub.