### PR TITLE
keypress should not raise on Android (closes #2236)

### DIFF
--- a/src/client/automation/playback/press/key-press-simulator.js
+++ b/src/client/automation/playback/press/key-press-simulator.js
@@ -118,7 +118,7 @@ export default class KeyPressSimulator {
 
         this._addKeyPropertyToEventOptions(eventOptions);
 
-        const raiseDefault = eventSimulator.keypress(activeElement, extend(eventOptions, modifiersState));
+        const raiseDefault = browserUtils.isAndroid || eventSimulator.keypress(activeElement, extend(eventOptions, modifiersState));
 
         if (!raiseDefault)
             return raiseDefault;

--- a/src/client/automation/playback/type/index.js
+++ b/src/client/automation/playback/type/index.js
@@ -11,6 +11,7 @@ import getKeyProperties from '../../utils/get-key-properties';
 
 const Promise               = hammerhead.Promise;
 const extend                = hammerhead.utils.extend;
+const browserUtils          = hammerhead.utils.browser;
 const eventSimulator        = hammerhead.eventSandbox.eventSimulator;
 const elementEditingWatcher = hammerhead.eventSandbox.elementEditingWatcher;
 
@@ -197,7 +198,7 @@ export default class TypeAutomation {
 
         this.eventArgs = this._calculateEventArguments(true);
 
-        this.eventState.simulateTypeChar = eventSimulator.keypress(this.eventArgs.element, this.eventArgs.options);
+        this.eventState.simulateTypeChar = browserUtils.isAndroid || eventSimulator.keypress(this.eventArgs.element, this.eventArgs.options);
     }
 
     _keyup () {

--- a/test/client/fixtures/automation/detection-element-after-events-simulation-test.js
+++ b/test/client/fixtures/automation/detection-element-after-events-simulation-test.js
@@ -818,11 +818,11 @@ $(document).ready(function () {
                 const expectedEventMonitorObject = {
                     elementsOneKeydownRaised:  true,
                     elementsOneKeypressRaised: true && !browserUtils.isAndroid,
-                    elementsOneKeyupRaised:    false,
+                    elementsOneKeyupRaised:    browserUtils.isAndroid,
 
                     elementsTwoKeydownRaised:  false,
                     elementsTwoKeypressRaised: false,
-                    elementsTwoKeyupRaised:    true
+                    elementsTwoKeyupRaised:    true && !browserUtils.isAndroid
                 };
 
                 deepEqual(eventMonitorObject, expectedEventMonitorObject);

--- a/test/client/fixtures/automation/detection-element-after-events-simulation-test.js
+++ b/test/client/fixtures/automation/detection-element-after-events-simulation-test.js
@@ -783,13 +783,17 @@ $(document).ready(function () {
         type
             .run()
             .then(function () {
-                ok(eventMonitorObject.elementsOneKeydownRaised);
-                ok(!eventMonitorObject.elementsOneKeypressRaised);
-                ok(!eventMonitorObject.elementsOneKeyupRaised);
+                const expectedEventMonitorObject = {
+                    elementsOneKeydownRaised:  true,
+                    elementsOneKeypressRaised: false,
+                    elementsOneKeyupRaised:    false,
 
-                ok(!eventMonitorObject.elementsTwoKeydownRaised);
-                ok(eventMonitorObject.elementsTwoKeypressRaised);
-                ok(eventMonitorObject.elementsTwoKeyupRaised);
+                    elementsTwoKeydownRaised:  false,
+                    elementsTwoKeypressRaised: true && !browserUtils.isAndroid,
+                    elementsTwoKeyupRaised:    true
+                };
+
+                deepEqual(eventMonitorObject, expectedEventMonitorObject);
 
                 equal($input1[0].value, '');
                 equal($input2[0].value, 'a');
@@ -811,13 +815,17 @@ $(document).ready(function () {
         type
             .run()
             .then(function () {
-                ok(eventMonitorObject.elementsOneKeydownRaised);
-                ok(eventMonitorObject.elementsOneKeypressRaised);
-                ok(!eventMonitorObject.elementsOneKeyupRaised);
+                const expectedEventMonitorObject = {
+                    elementsOneKeydownRaised:  true,
+                    elementsOneKeypressRaised: true && !browserUtils.isAndroid,
+                    elementsOneKeyupRaised:    false,
 
-                ok(!eventMonitorObject.elementsTwoKeydownRaised);
-                ok(!eventMonitorObject.elementsTwoKeypressRaised);
-                ok(eventMonitorObject.elementsTwoKeyupRaised);
+                    elementsTwoKeydownRaised:  false,
+                    elementsTwoKeypressRaised: false,
+                    elementsTwoKeyupRaised:    true
+                };
+
+                deepEqual(eventMonitorObject, expectedEventMonitorObject);
 
                 equal($input1[0].value, 'a');
                 equal($input2[0].value, '');
@@ -839,13 +847,17 @@ $(document).ready(function () {
         type
             .run()
             .then(function () {
-                ok(eventMonitorObject.elementsOneKeydownRaised);
-                ok(eventMonitorObject.elementsOneKeypressRaised);
-                ok(eventMonitorObject.elementsOneKeyupRaised);
+                const expectedEventMonitorObject = {
+                    elementsOneKeydownRaised:  true,
+                    elementsOneKeypressRaised: true && !browserUtils.isAndroid,
+                    elementsOneKeyupRaised:    true,
 
-                ok(!eventMonitorObject.elementsTwoKeydownRaised);
-                ok(!eventMonitorObject.elementsTwoKeypressRaised);
-                ok(!eventMonitorObject.elementsTwoKeyupRaised);
+                    elementsTwoKeydownRaised:  false,
+                    elementsTwoKeypressRaised: false,
+                    elementsTwoKeyupRaised:    false
+                };
+
+                deepEqual(eventMonitorObject, expectedEventMonitorObject);
 
                 equal($input1[0].value, 'a');
                 equal($input2[0].value, '');

--- a/test/client/fixtures/automation/key-press-simulation-test.js
+++ b/test/client/fixtures/automation/key-press-simulation-test.js
@@ -124,7 +124,10 @@ $(document).ready(function () {
     });
 
     function testKeysPress (keySequence, expectedEvents) {
-        const events          = expectedEvents.filter(event => !browserUtils.isAndroid || event.type !== 'keypress');
+        const events = expectedEvents.filter(function (event) {
+            return !browserUtils.isAndroid || event.type !== 'keypress';
+        });
+
         const keyCombinations = parseKeySequence(keySequence).combinations;
         const pressAutomation = new PressAutomation(keyCombinations, {});
 

--- a/test/client/fixtures/automation/key-press-simulation-test.js
+++ b/test/client/fixtures/automation/key-press-simulation-test.js
@@ -124,13 +124,14 @@ $(document).ready(function () {
     });
 
     function testKeysPress (keySequence, expectedEvents) {
+        const events          = expectedEvents.filter(event => !browserUtils.isAndroid || event.type !== 'keypress');
         const keyCombinations = parseKeySequence(keySequence).combinations;
         const pressAutomation = new PressAutomation(keyCombinations, {});
 
         pressAutomation
             .run()
             .then(function () {
-                equal(eventsLog, createCheckingLog(expectedEvents), 'events are correct');
+                equal(eventsLog, createCheckingLog(events), 'events are correct');
                 start();
             });
     }

--- a/test/client/fixtures/automation/press-test.js
+++ b/test/client/fixtures/automation/press-test.js
@@ -187,13 +187,18 @@ $(document).ready(function () {
 
         const press = new PressAutomation(parseKeySequence('a A shift+a ! enter shift+1 shift+!').combinations, {});
 
+        const expectedkeydownKeyProperty  = 'aAShiftAShift!EnterShift!Shift!';
+        const expectedkeypressKeyProperty =  browserUtils.isAndroid ? '' : 'aAA!Enter!!';
+        const expectedkeyupKeyProperty    = 'aAAShift!ShiftEnter!Shift!Shift';
+        const expectedTextAreaValue       = 'aAA!\n!!';
+
         press
             .run()
             .then(function () {
-                equal(keydownKeyProperty, 'aAShiftAShift!EnterShift!Shift!');
-                equal(keypressKeyProperty, 'aAA!Enter!!');
-                equal(keyupKeyProperty, 'aAAShift!ShiftEnter!Shift!Shift');
-                equal(textarea.value, 'aAA!\n!!');
+                equal(keydownKeyProperty, expectedkeydownKeyProperty);
+                equal(keypressKeyProperty, expectedkeypressKeyProperty);
+                equal(keyupKeyProperty, expectedkeyupKeyProperty);
+                equal(textarea.value, expectedTextAreaValue);
                 start();
             });
     });

--- a/test/client/fixtures/automation/press-test.js
+++ b/test/client/fixtures/automation/press-test.js
@@ -187,17 +187,17 @@ $(document).ready(function () {
 
         const press = new PressAutomation(parseKeySequence('a A shift+a ! enter shift+1 shift+!').combinations, {});
 
-        const expectedkeydownKeyProperty  = 'aAShiftAShift!EnterShift!Shift!';
-        const expectedkeypressKeyProperty =  browserUtils.isAndroid ? '' : 'aAA!Enter!!';
-        const expectedkeyupKeyProperty    = 'aAAShift!ShiftEnter!Shift!Shift';
+        const expectedKeydownKeyProperty  = 'aAShiftAShift!EnterShift!Shift!';
+        const expectedKeypressKeyProperty =  browserUtils.isAndroid ? '' : 'aAA!Enter!!';
+        const expectedKeyupKeyProperty    = 'aAAShift!ShiftEnter!Shift!Shift';
         const expectedTextAreaValue       = 'aAA!\n!!';
 
         press
             .run()
             .then(function () {
-                equal(keydownKeyProperty, expectedkeydownKeyProperty);
-                equal(keypressKeyProperty, expectedkeypressKeyProperty);
-                equal(keyupKeyProperty, expectedkeyupKeyProperty);
+                equal(keydownKeyProperty, expectedKeydownKeyProperty);
+                equal(keypressKeyProperty, expectedKeypressKeyProperty);
+                equal(keyupKeyProperty, expectedKeyupKeyProperty);
                 equal(textarea.value, expectedTextAreaValue);
                 start();
             });

--- a/test/client/fixtures/automation/regression-test.js
+++ b/test/client/fixtures/automation/regression-test.js
@@ -599,7 +599,9 @@ $(document).ready(function () {
                 startNext();
             });
 
-        expect(3);
+        const expectedAssertionCount = browserUtils.isAndroid ? 2 : 3;
+
+        expect(expectedAssertionCount);
     });
 
     asyncTest('B254340 - type in input with type="email"', function () {

--- a/test/client/fixtures/automation/submit-on-enter-test.js
+++ b/test/client/fixtures/automation/submit-on-enter-test.js
@@ -282,9 +282,10 @@ $(document).ready(function () {
             ok(inlineSubmitHandlerExecuted, 'inline submit handler executed');
             ok(buttonClickHandlerExecuted, 'button click handler executed');
             ok(inputKeydownHandlerExecuted, 'input keydown handler executed');
-            ok(inputKeypressHandlerExecuted, 'input keydown handler executed');
-            ok(inputKeyupHandlerExecuted, 'input keydown handler executed');
+            ok(inputKeyupHandlerExecuted, 'input keyup handler executed');
 
+            if (!browserUtils.isAndroid)
+                ok(inputKeypressHandlerExecuted, 'input keypress handler executed');
 
             start();
         };
@@ -345,10 +346,13 @@ $(document).ready(function () {
             ok(submitHandlerExecuted, 'submit handler executed');
             ok(inlineSubmitHandlerExecuted, 'inline submit handler executed');
             ok(inputKeydownHandlerExecuted, 'input keydown handler executed');
-            ok(inputKeypressHandlerExecuted, 'input keydown handler executed');
-            ok(inputKeyupHandlerExecuted, 'input keydown handler executed');
+            ok(inputKeyupHandlerExecuted, 'input keyup handler executed');
+
             if (!needToPreventEvent)
                 ok(submitFunctionCalled, 'submit function called');
+
+            if (!browserUtils.isAndroid)
+                ok(inputKeypressHandlerExecuted, 'input keypress handler executed');
 
             start();
         };

--- a/test/client/fixtures/automation/type-test.js
+++ b/test/client/fixtures/automation/type-test.js
@@ -54,10 +54,15 @@ $(document).ready(function () {
         type
             .run()
             .then(function () {
-                equal(keydownCount, 2, 'keydown event raises twice');
-                equal(keyupCount, 2, 'keyup event raises twice');
-                equal(keypressCount, 2, 'keypress event raises twice');
-                equal(mouseclickCount, 1, 'click event raises once');
+                const expectedKeydownCount    = 2;
+                const expectedKeypressCount   = browserUtils.isAndroid ? 0 : 2;
+                const expectedKeyupCount      = 2;
+                const expectedMouseClickCount = 1;
+
+                equal(keydownCount, expectedKeydownCount, 'keydown event raises twice');
+                equal(keyupCount, expectedKeyupCount, 'keyup event raises twice');
+                equal(keypressCount, expectedKeypressCount, 'keypress event raises twice');
+                equal(mouseclickCount, expectedMouseClickCount, 'click event raises once');
 
                 start();
             });
@@ -86,22 +91,24 @@ $(document).ready(function () {
             });
     });
 
-    asyncTest('correct keyCode', function () {
-        const key = 'k';
+    if (!browserUtils.isAndroid) {
+        asyncTest('correct keyCode', function () {
+            const key = 'k';
 
-        $commonInput[0].onkeypress = function (e) {
-            equal((e || window.event).keyCode, key.charCodeAt(0), 'keypress event argument is correct');
-        };
+            $commonInput[0].onkeypress = function (e) {
+                equal((e || window.event).keyCode, key.charCodeAt(0), 'keypress event argument is correct');
+            };
 
-        const type = new TypeAutomation($commonInput[0], key, new TypeOptions({ offsetX: 5, offsetY: 5 }));
+            const type = new TypeAutomation($commonInput[0], key, new TypeOptions({ offsetX: 5, offsetY: 5 }));
 
-        type
-            .run()
-            .then(function () {
-                expect(1);
-                start();
-            });
-    });
+            type
+                .run()
+                .then(function () {
+                    expect(1);
+                    start();
+                });
+        });
+    }
 
     asyncTest('typetext to inner input', function () {
         const $outerDiv = $('<div></div>')
@@ -183,13 +190,17 @@ $(document).ready(function () {
 
         const type = new TypeAutomation($commonInput[0], text, new TypeOptions({ paste: true, offsetX: 5, offsetY: 5 }));
 
+        const expectedKeydownCount  = 1;
+        const expectedKeypressCount = browserUtils.isAndroid ? 0 : 1;
+        const expectedKeyupCount    = 1;
+
         type
             .run()
             .then(function () {
                 equal($commonInput[0].value, text, 'text entered in one keystroke');
-                equal(keydownCount, 1, 'keydown event raises once');
-                equal(keyupCount, 1, 'keyup event raises once');
-                equal(keypressCount, 1, 'keypress event raises once');
+                equal(keydownCount, expectedKeydownCount, 'keydown event raises once');
+                equal(keyupCount, expectedKeyupCount, 'keyup event raises once');
+                equal(keypressCount, expectedKeypressCount, 'keypress event raises once');
                 start();
             });
     });
@@ -238,42 +249,44 @@ $(document).ready(function () {
             });
     });
 
-    asyncTest('change event must not be raised if keypress was prevented (B253816)', function () {
-        const $input  = $('<input type="text" />').addClass(TEST_ELEMENT_CLASS).appendTo('body');
+    if (!browserUtils.isAndroid) {
+        asyncTest('change event must not be raised if keypress was prevented (B253816)', function () {
+            const $input = $('<input type="text" />').addClass(TEST_ELEMENT_CLASS).appendTo('body');
 
-        let changed = false;
+            let changed = false;
 
-        $input.bind('change', function () {
-            changed = true;
-        });
-
-        const firstType = new TypeAutomation($input[0], 'test', new TypeOptions({ offsetX: 5, offsetY: 5 }));
-
-        firstType
-            .run()
-            .then(function () {
-                $input[0].blur();
-
-                ok(changed, 'check change event was raised if keypress was not prevented');
-
-                changed = false;
-
-                $input.bind('keypress', function (e) {
-                    e.target.value += String.fromCharCode(e.keyCode);
-                    return false;
-                });
-
-                const secondType = new TypeAutomation($input[0], 'new', new TypeOptions({ offsetX: 5, offsetY: 5 }));
-
-                return secondType.run();
-            })
-            .then(function () {
-                $input[0].blur();
-
-                ok(!changed, 'check change event was not raised if keypress was prevented');
-                start();
+            $input.bind('change', function () {
+                changed = true;
             });
-    });
+
+            const firstType = new TypeAutomation($input[0], 'test', new TypeOptions({ offsetX: 5, offsetY: 5 }));
+
+            firstType
+                .run()
+                .then(function () {
+                    $input[0].blur();
+
+                    ok(changed, 'check change event was raised if keypress was not prevented');
+
+                    changed = false;
+
+                    $input.bind('keypress', function (e) {
+                        e.target.value += String.fromCharCode(e.keyCode);
+                        return false;
+                    });
+
+                    const secondType = new TypeAutomation($input[0], 'new', new TypeOptions({ offsetX: 5, offsetY: 5 }));
+
+                    return secondType.run();
+                })
+                .then(function () {
+                    $input[0].blur();
+
+                    ok(!changed, 'check change event was not raised if keypress was prevented');
+                    start();
+                });
+        });
+    }
 
     asyncTest('keypress args must contain charCode of the symbol, not keyCode', function () {
         const $input   = $('<input type="text" />').addClass(TEST_ELEMENT_CLASS).appendTo('body');
@@ -395,10 +408,16 @@ $(document).ready(function () {
         type
             .run()
             .then(function () {
-                equal(keydownKeyProperty, 'aA Enter');
-                equal(keypressKeyProperty, 'aA Enter');
-                equal(keyupKeyProperty, 'aA Enter');
-                equal(textarea.value, 'aA \n');
+                const expectedKeydownKeyProperty  = 'aA Enter';
+                const expectedKeypressKeyProperty = browserUtils.isAndroid ? '' : 'aA Enter';
+                const expectedKeyupKeyProperty    = 'aA Enter';
+                const expectedTextareaValue       = 'aA \n';
+
+                equal(keydownKeyProperty, expectedKeydownKeyProperty);
+                equal(keypressKeyProperty, expectedKeypressKeyProperty);
+                equal(keyupKeyProperty, expectedKeyupKeyProperty);
+                equal(textarea.value, expectedTextareaValue);
+
                 start();
             });
     });


### PR DESCRIPTION
`Keypress` event should not raise on Android. I checked both Firefox and Chrome