### PR TITLE
add ffmpeg package to docker image (closes #3572)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ COPY docker/testcafe-docker.sh /opt/testcafe/docker/testcafe-docker.sh
 
 RUN apk --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ upgrade && \
  apk --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ add \
- nodejs nodejs-npm chromium firefox xwininfo xvfb dbus eudev ttf-freefont fluxbox procps
+ nodejs nodejs-npm chromium firefox xwininfo xvfb dbus eudev ttf-freefont fluxbox procps ffmpeg
 
 RUN npm install -g /opt/testcafe/${packageId} && \
  npm cache clean --force && \


### PR DESCRIPTION
This change seems to be sufficient to enable video recording in the docker image.