### PR TITLE
[docs] Add the Lock bot configuration file

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,38 @@
+# Configuration for Lock Threads - https://github.com/dessant/lock-threads
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 10
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: false
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: false
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related bugs or feature requests.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: true
+
+# Limit to only `issues` or `pulls`
+only: issues
+
+# Optionally, specify configuration settings just for `issues` or `pulls`
+# issues:
+#   exemptLabels:
+#     - help-wanted
+#   lockLabel: outdated
+
+# pulls:
+#   daysUntilLock: 30
+
+# Repository to extend settings from
+# _extends: repo

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -8,7 +8,9 @@ daysUntilLock: 10
 skipCreatedBefore: false
 
 # Issues and pull requests with these labels will be ignored. Set to `[]` to disable
-exemptLabels: []
+exemptLabels:
+   - STATE: Need response
+   - STATE: Need clarification
 
 # Label to add before locking, such as `outdated`. Set to `false` to disable
 lockLabel: false
@@ -17,7 +19,9 @@ lockLabel: false
 lockComment: >
   This thread has been automatically locked since there has not been
   any recent activity after it was closed. Please open a new issue for
-  related bugs or feature requests.
+  related [bugs](https://github.com/DevExpress/testcafe/issues/new?template=bug-report.md) or [feature requests](https://github.com/DevExpress/testcafe/issues/new?template=feature_request.md).
+  For TestCafe API, usage and configuration inquiries, we recommend asking them on [StackOverflow](https://stackoverflow.com/questions/ask?tags=testcafe).
+    
 
 # Assign `resolved` as the reason for locking. Set to `false` to disable
 setLockReason: true


### PR DESCRIPTION
This bot will lock any closed threads (bugs, enhancements, questions) after 10 days of inactivity. 

Pull requests are ignored. We can lock them too if necessary.

We can configure the bot later according to our requirements. 

I will enable the bot when the config file is merged into master.