### PR TITLE
Disable tests with Roles for Azure tasks

### DIFF
--- a/test/functional/fixtures/api/coffeescript/smoke/test.js
+++ b/test/functional/fixtures/api/coffeescript/smoke/test.js
@@ -1,8 +1,9 @@
 const expect = require('chai').expect;
 
 describe('[CoffeeScript] Smoke tests', function () {
+    // TODO: IMPORTANT: Azure test tasks hang when a role is used in a test, fix it immediately
     it('Should run non-trivial tests', function () {
-        return runTests('./testcafe-fixtures/non-trivial-test.coffee', null, { selectorTimeout: 5000 });
+        return runTests('./testcafe-fixtures/non-trivial-test.coffee', null, { skip: ['safari', 'chrome-osx', 'firefox-osx', 'ipad', 'iphone'], selectorTimeout: 5000 });
     });
 
     it('Should produce correct callsites on error', function () {

--- a/test/functional/fixtures/api/es-next/roles/test.js
+++ b/test/functional/fixtures/api/es-next/roles/test.js
@@ -12,83 +12,86 @@ const TEST_WITH_IFRAME_FAILED_RUN_OPTIONS = {
     selectorTimeout: IFRAME_SELECTOR_TIMEOUT
 };
 
-describe('[API] t.useRole()', function () {
-    it('Should initialize and switch roles', function () {
-        return runTests('./testcafe-fixtures/use-role-test.js', null, { only: 'chrome,ie,firefox' });
-    });
+// TODO: IMPORTANT: Azure test tasks hang when a role is used in a test, fix it immediately
+if (config.currentEnvironmentName !== config.testingEnvironmentNames.osXDesktopAndMSEdgeBrowsers && config.currentEnvironmentName !== config.testingEnvironmentNames.mobileBrowsers) {
+    describe('[API] t.useRole()', function () {
+        it('Should initialize and switch roles', function () {
+            return runTests('./testcafe-fixtures/use-role-test.js', null, { only: 'chrome,ie,firefox' });
+        });
 
-    it('Should switch to Role.anonymous()', function () {
-        return runTests('./testcafe-fixtures/anonymous-role-test.js');
-    });
+        it('Should switch to Role.anonymous()', function () {
+            return runTests('./testcafe-fixtures/anonymous-role-test.js');
+        });
 
-    it('Should have clean configuration in role initializer', function () {
-        return runTests('./testcafe-fixtures/configuration-test.js', 'Clear configuration', TEST_WITH_IFRAME_FAILED_RUN_OPTIONS)
-            .catch(function (errs) {
-                expect(errs[0]).contains('- Error in Role initializer - A native alert dialog was invoked');
-                expect(errs[0]).contains('> 34 |    await t.click(showAlertBtn);');
-            });
-    });
-
-    it('Should restore configuration after role initializer', function () {
-        return runTests('./testcafe-fixtures/configuration-test.js', 'Restore configuration', TEST_WITH_IFRAME_RUN_OPTIONS);
-    });
-
-    it('Should preserve URL if option specified', function () {
-        return runTests('./testcafe-fixtures/preserve-url-test.js', 'Preserve url test', TEST_WITH_IFRAME_RUN_OPTIONS);
-    });
-
-    describe('Errors', function () {
-        it('Should fail all tests that use role with the initiliazer error', function () {
-            return runTests('./testcafe-fixtures/init-error-test.js', null, {
-                shouldFail: true,
-                only:       'chrome,ie,firefox'
-            })
+        it('Should have clean configuration in role initializer', function () {
+            return runTests('./testcafe-fixtures/configuration-test.js', 'Clear configuration', TEST_WITH_IFRAME_FAILED_RUN_OPTIONS)
                 .catch(function (errs) {
-                    const testedBrowsers = config.currentEnvironment.browsers;
+                    expect(errs[0]).contains('- Error in Role initializer - A native alert dialog was invoked');
+                    expect(errs[0]).contains('> 34 |    await t.click(showAlertBtn);');
+                });
+        });
 
-                    if (testedBrowsers.length === 1 && Array.isArray(errs))
-                        errs = { [testedBrowsers[0].alias]: errs };
+        it('Should restore configuration after role initializer', function () {
+            return runTests('./testcafe-fixtures/configuration-test.js', 'Restore configuration', TEST_WITH_IFRAME_RUN_OPTIONS);
+        });
 
-                    const browsers = Object.keys(errs);
+        it('Should preserve URL if option specified', function () {
+            return runTests('./testcafe-fixtures/preserve-url-test.js', 'Preserve url test', TEST_WITH_IFRAME_RUN_OPTIONS);
+        });
 
-                    expect(browsers.length).eql(config.currentEnvironment.browsers.length);
+        describe('Errors', function () {
+            it('Should fail all tests that use role with the initiliazer error', function () {
+                return runTests('./testcafe-fixtures/init-error-test.js', null, {
+                    shouldFail: true,
+                    only:       'chrome,ie,firefox'
+                })
+                    .catch(function (errs) {
+                        const testedBrowsers = config.currentEnvironment.browsers;
 
-                    browsers.forEach(function (browser) {
-                        expect(errs[browser].length).eql(2);
+                        if (testedBrowsers.length === 1 && Array.isArray(errs))
+                            errs = { [testedBrowsers[0].alias]: errs };
 
-                        errs[browser].forEach(function (err) {
-                            expect(err).contains('- Error in Role initializer - Error: Hey!');
-                            expect(err).contains('>  5 |    throw new Error(\'Hey!\');');
+                        const browsers = Object.keys(errs);
+
+                        expect(browsers.length).eql(config.currentEnvironment.browsers.length);
+
+                        browsers.forEach(function (browser) {
+                            expect(errs[browser].length).eql(2);
+
+                            errs[browser].forEach(function (err) {
+                                expect(err).contains('- Error in Role initializer - Error: Hey!');
+                                expect(err).contains('>  5 |    throw new Error(\'Hey!\');');
+                            });
                         });
+
                     });
+            });
 
-                });
+            it('Should fail if role switched within initializer', function () {
+                return runTests('./testcafe-fixtures/errors-test.js', 'Role switch in initializer', { shouldFail: true })
+                    .catch(function (errs) {
+                        expect(errs[0]).contains('- Error in Role initializer - Role cannot be switched while another role is being initialized.');
+                        expect(errs[0]).contains('> 4 |    await t.useRole(Role.anonymous());');
+                    });
+            });
+
+            it('Should throw error if useRole argument is not a Role', function () {
+                return runTests('./testcafe-fixtures/errors-test.js', 'useRole argument', { shouldFail: true })
+                    .catch(function (errs) {
+                        expect(errs[0]).contains('The "role" argument is expected to be a Role instance, but it was object.');
+                        expect(errs[0]).contains('> 16 |    await t.useRole({});');
+                    });
+            });
+
+            it('Should fail if there error occurred while restoring configuration', function () {
+                return runTests('./testcafe-fixtures/errors-test.js', 'Error restoring configuration', TEST_WITH_IFRAME_FAILED_RUN_OPTIONS)
+                    .catch(function (errs) {
+                        expect(errs[0]).contains('- Error while restoring configuration after Role switch -');
+                        expect(errs[0]).contains('The iframe in which the test is currently operating does not exist anymore.');
+                        expect(errs[0]).contains('> 29 |        .useRole(Role.anonymous());');
+                    });
+            });
+
         });
-
-        it('Should fail if role switched within initializer', function () {
-            return runTests('./testcafe-fixtures/errors-test.js', 'Role switch in initializer', { shouldFail: true })
-                .catch(function (errs) {
-                    expect(errs[0]).contains('- Error in Role initializer - Role cannot be switched while another role is being initialized.');
-                    expect(errs[0]).contains('> 4 |    await t.useRole(Role.anonymous());');
-                });
-        });
-
-        it('Should throw error if useRole argument is not a Role', function () {
-            return runTests('./testcafe-fixtures/errors-test.js', 'useRole argument', { shouldFail: true })
-                .catch(function (errs) {
-                    expect(errs[0]).contains('The "role" argument is expected to be a Role instance, but it was object.');
-                    expect(errs[0]).contains('> 16 |    await t.useRole({});');
-                });
-        });
-
-        it('Should fail if there error occurred while restoring configuration', function () {
-            return runTests('./testcafe-fixtures/errors-test.js', 'Error restoring configuration', TEST_WITH_IFRAME_FAILED_RUN_OPTIONS)
-                .catch(function (errs) {
-                    expect(errs[0]).contains('- Error while restoring configuration after Role switch -');
-                    expect(errs[0]).contains('The iframe in which the test is currently operating does not exist anymore.');
-                    expect(errs[0]).contains('> 29 |        .useRole(Role.anonymous());');
-                });
-        });
-
     });
-});
+}

--- a/test/functional/fixtures/api/typescript/smoke/test.js
+++ b/test/functional/fixtures/api/typescript/smoke/test.js
@@ -1,8 +1,9 @@
 const expect = require('chai').expect;
 
 describe('[TypeScript] Smoke tests', function () {
+    // TODO: IMPORTANT: Azure test tasks hang when a role is used in a test, fix it immediately
     it('Should run non-trivial tests', function () {
-        return runTests('./testcafe-fixtures/non-trivial-test.ts', null, { selectorTimeout: 5000 });
+        return runTests('./testcafe-fixtures/non-trivial-test.ts', null, { skip: ['safari', 'chrome-osx', 'firefox-osx', 'ipad', 'iphone'], selectorTimeout: 5000 });
     });
 
     it('Should produce correct callsites on error', function () {

--- a/test/functional/fixtures/regression/gh-2015/test.js
+++ b/test/functional/fixtures/regression/gh-2015/test.js
@@ -1,6 +1,7 @@
 describe('[Regression](GH-2015)', function () {
+    // TODO: IMPORTANT: Azure test tasks hang when a role is used in a test, fix it immediately
     it('Should restore local storage correctly on UseRole with PreserveUrl', function () {
-        return runTests('./testcafe-fixtures/index.js');
+        return runTests('./testcafe-fixtures/index.js', '', { skip: ['safari', 'chrome-osx', 'firefox-osx', 'ipad', 'iphone'] });
     });
 });
 

--- a/test/functional/fixtures/regression/gh-2282/test.js
+++ b/test/functional/fixtures/regression/gh-2282/test.js
@@ -1,5 +1,6 @@
 describe('[Regression](GH-2282)', function () {
+    // TODO: IMPORTANT: Azure test tasks hang when a role is used in a test, fix it immediately
     it('Cookies should be restored correctly when User Roles with the preserveUrl option are used', function () {
-        return runTests('testcafe-fixtures/index.js');
+        return runTests('testcafe-fixtures/index.js', '', { skip: ['safari', 'chrome-osx', 'firefox-osx', 'ipad', 'iphone'] });
     });
 });


### PR DESCRIPTION
I want to disable these tests for Azure because fixing them can take an indefinite amount of time. The disabled tests still run on Appveyor and Travis. I will fix them in a separate PR. 