### PR TITLE
Allow to use roles for pages with hash-based havigation (close #2195)

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "source-map-support": "^0.5.5",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "1.6.8",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/3094015/testcafe-hammerhead-14.6.2.zip",
+    "testcafe-hammerhead": "14.6.3",
     "testcafe-legacy-api": "3.1.11",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "source-map-support": "^0.5.5",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "1.6.8",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/3090363/testcafe-hammerhead-14.6.2.zip",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/3094015/testcafe-hammerhead-14.6.2.zip",
     "testcafe-legacy-api": "3.1.11",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "source-map-support": "^0.5.5",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "1.6.8",
-    "testcafe-hammerhead": "14.6.2",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/3090363/testcafe-hammerhead-14.6.2.zip",
     "testcafe-legacy-api": "3.1.11",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/src/api/structure/fixture.js
+++ b/src/api/structure/fixture.js
@@ -4,6 +4,7 @@ import TestingUnit from './testing-unit';
 import wrapTestFunction from '../wrap-test-function';
 import assertRequestHookType from '../request-hooks/assert-type';
 import { flattenDeep as flatten } from 'lodash';
+import { SPECIAL_BLANK_PAGE } from 'testcafe-hammerhead';
 
 export default class Fixture extends TestingUnit {
     constructor (testFile) {
@@ -11,7 +12,7 @@ export default class Fixture extends TestingUnit {
 
         this.path = testFile.filename;
 
-        this.pageUrl = 'about:blank';
+        this.pageUrl = SPECIAL_BLANK_PAGE;
 
         this.beforeEachFn = null;
         this.afterEachFn  = null;

--- a/src/api/test-page-url.js
+++ b/src/api/test-page-url.js
@@ -2,6 +2,7 @@ import path from 'path';
 import OS from 'os-family';
 import { APIError } from '../errors/runtime';
 import { RUNTIME_ERRORS } from '../errors/types';
+import { SPECIAL_BLANK_PAGE } from 'testcafe-hammerhead';
 
 const PROTOCOL_RE           = /^([\w-]+?)(?=:\/\/)/;
 const SUPPORTED_PROTOCOL_RE = /^(https?|file):/;
@@ -29,12 +30,12 @@ export function assertUrl (url, callsiteName) {
     const hasUnsupportedProtocol = protocol && !SUPPORTED_PROTOCOL_RE.test(url);
     const isWinAbsolutePath      = OS.win && WIN_ABSOLUTE_PATH_RE.test(url);
 
-    if (hasUnsupportedProtocol && !isWinAbsolutePath && url !== 'about:blank')
+    if (hasUnsupportedProtocol && !isWinAbsolutePath && url !== SPECIAL_BLANK_PAGE)
         throw new APIError(callsiteName, RUNTIME_ERRORS.unsupportedUrlProtocol, url, protocol[0]);
 }
 
 export function resolvePageUrl (url, testFileName) {
-    if (SUPPORTED_PROTOCOL_RE.test(url) || url === 'about:blank')
+    if (SUPPORTED_PROTOCOL_RE.test(url) || url === SPECIAL_BLANK_PAGE)
         return url;
 
     if (isAbsolutePath(url) || RELATIVE_PATH_RE.test(url))

--- a/src/client/driver/command-executors/execute-navigate-to.js
+++ b/src/client/driver/command-executors/execute-navigate-to.js
@@ -17,7 +17,7 @@ export default function executeNavigateTo (command) {
         .then(() => {
             const requestBarrier = new RequestBarrier();
 
-            hammerhead.navigateTo(command.url);
+            hammerhead.navigateTo(command.url, command.forceReload);
 
             return hammerhead.Promise.all([requestBarrier.wait(), pageUnloadBarrier.wait()]);
         })

--- a/src/role/index.js
+++ b/src/role/index.js
@@ -6,10 +6,7 @@ import wrapTestFunction from '../api/wrap-test-function';
 import { resolvePageUrl } from '../api/test-page-url';
 import { NavigateToCommand } from '../test-run/commands/actions';
 import roleMarker from './marker-symbol';
-import delay from '../utils/delay';
 import { StateSnapshot } from 'testcafe-hammerhead';
-
-const COOKIE_SYNC_DELAY = 100;
 
 class Role extends EventEmitter {
     constructor (loginPage, initFn, options = {}) {
@@ -30,17 +27,19 @@ class Role extends EventEmitter {
     }
 
     async _navigateToLoginPage (testRun) {
-        const navigateCommand = new NavigateToCommand({ url: this.loginPage });
+        const navigateCommand = new NavigateToCommand({
+            url:         this.loginPage,
+            forceReload: true
+        });
 
         await testRun.executeCommand(navigateCommand);
     }
 
     async _storeStateSnapshot (testRun) {
-        if (!this.initErr) {
-            // NOTE: give Hammerhead time to sync cookies from client
-            await delay(COOKIE_SYNC_DELAY);
-            this.stateSnapshot = await testRun.getStateSnapshot();
-        }
+        if (this.initErr)
+            return;
+
+        this.stateSnapshot = await testRun.getStateSnapshot();
     }
 
     async _executeInitFn (testRun) {

--- a/src/test-run/bookmark.js
+++ b/src/test-run/bookmark.js
@@ -1,5 +1,6 @@
 import TEST_RUN_PHASE from '../test-run/phase';
 import { TEST_RUN_ERRORS } from '../errors/types';
+import { SPECIAL_BLANK_PAGE } from 'testcafe-hammerhead';
 
 import {
     SwitchToMainWindowCommand,
@@ -15,13 +16,12 @@ import {
     CurrentIframeIsNotLoadedError
 } from '../errors/test-run';
 
-
 export default class TestRunBookmark {
     constructor (testRun, role) {
         this.testRun = testRun;
         this.role    = role;
 
-        this.url             = 'about:blank';
+        this.url             = SPECIAL_BLANK_PAGE;
         this.dialogHandler   = testRun.activeDialogHandler;
         this.iframeSelector  = testRun.activeIframeSelector;
         this.speed           = testRun.speed;
@@ -84,8 +84,8 @@ export default class TestRunBookmark {
         }
     }
 
-    async _restorePage (url, stateSnapshot) {
-        const navigateCommand = new NavigateToCommand({ url, stateSnapshot });
+    async _restorePage (url, stateSnapshot, forceReload) {
+        const navigateCommand = new NavigateToCommand({ url, stateSnapshot, forceReload });
 
         await this.testRun.executeCommand(navigateCommand);
     }
@@ -105,9 +105,9 @@ export default class TestRunBookmark {
             await this._restoreDialogHandler();
 
             const preserveUrl = this.role.opts.preserveUrl;
-            const url = preserveUrl ? this.role.url : this.url;
+            const url         = preserveUrl ? this.role.url : this.url;
 
-            await this._restorePage(url, JSON.stringify(stateSnapshot));
+            await this._restorePage(url, JSON.stringify(stateSnapshot), true);
 
             if (!preserveUrl)
                 await this._restoreWorkingFrame();

--- a/src/test-run/commands/actions.js
+++ b/src/test-run/commands/actions.js
@@ -251,7 +251,8 @@ export class NavigateToCommand extends CommandBase {
     _getAssignableProperties () {
         return [
             { name: 'url', type: urlArgument, required: true },
-            { name: 'stateSnapshot', type: nullableStringArgument, defaultValue: null }
+            { name: 'stateSnapshot', type: nullableStringArgument, defaultValue: null },
+            { name: 'forceReload', type: booleanArgument, defaultValue: false }
         ];
     }
 }

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -21,7 +21,7 @@ import BrowserConsoleMessages from './browser-console-messages';
 import { UNSTABLE_NETWORK_MODE_HEADER } from '../browser/connection/unstable-network-mode';
 import WarningLog from '../notifications/warning-log';
 import WARNING_MESSAGE from '../notifications/warning-message';
-import { StateSnapshot } from 'testcafe-hammerhead';
+import { StateSnapshot, SPECIAL_ERROR_PAGE } from 'testcafe-hammerhead';
 
 import {
     isCommandRejectableByPageError,
@@ -231,7 +231,7 @@ export default class TestRun extends AsyncEventEmitter {
 
         this.pendingPageError = new PageLoadError(err, ctx.reqOpts.url);
 
-        ctx.redirect(ctx.toProxyUrl('about:error'));
+        ctx.redirect(ctx.toProxyUrl(SPECIAL_ERROR_PAGE));
     }
 
     // Test function execution

--- a/src/test-run/session-controller.js
+++ b/src/test-run/session-controller.js
@@ -43,16 +43,12 @@ export default class SessionController extends Session {
     }
 
     onPageRequest (ctx) {
-        const requireStateSwitch   = this.requireStateSwitch;
         const pendingStateSnapshot = this.pendingStateSnapshot;
 
         super.onPageRequest(ctx);
 
-        if (requireStateSwitch && ctx.req.headers[UNSTABLE_NETWORK_MODE_HEADER]) {
-            this.requireStateSwitch = true;
-
+        if (pendingStateSnapshot && ctx.req.headers[UNSTABLE_NETWORK_MODE_HEADER])
             this.pendingStateSnapshot = pendingStateSnapshot;
-        }
     }
     // API
     static getSession (testRun) {

--- a/test/functional/fixtures/api/es-next/roles/pages/page-with-hash-navigation.html
+++ b/test/functional/fixtures/api/es-next/roles/pages/page-with-hash-navigation.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <h1 id="header"></h1>
+    <a id="anchor" href="#login">log in</a>
+    <input id="button" type="button" value="log in">
+    <script>
+        var onHashChange = function () {
+            var newHash = location.hash;
+
+            if (newHash === '') {
+                if (localStorage.getItem('isLoggedIn')) {
+                    header.textContent = 'Authorized';
+                    header.style.display = 'block';
+                    anchor.style.display = 'none';
+                    button.style.display = 'none';
+                }
+                else {
+                    header.textContent = 'Unauthorized';
+                    anchor.style.display = 'block';
+                    button.style.display = 'none';
+                }
+            }
+            else if (newHash === '#login') {
+                if (localStorage.getItem('isLoggedIn'))
+                    return location.hash = '';
+
+                header.style.display = 'none';
+                anchor.style.display = 'none';
+                button.style.display = 'block';
+
+                button.addEventListener('click', function() {
+                    localStorage.setItem('isLoggedIn', 'true');
+                    location.hash = '';
+                });
+            }
+        };
+
+        onHashChange();
+
+        window.addEventListener('hashchange', onHashChange);
+    </script>
+</body>
+</html>

--- a/test/functional/fixtures/api/es-next/roles/test.js
+++ b/test/functional/fixtures/api/es-next/roles/test.js
@@ -39,6 +39,16 @@ if (config.currentEnvironmentName !== config.testingEnvironmentNames.osXDesktopA
             return runTests('./testcafe-fixtures/preserve-url-test.js', 'Preserve url test', TEST_WITH_IFRAME_RUN_OPTIONS);
         });
 
+        describe('Should allways reload role`s login url', () => {
+            it('Hash-based navigation', () => {
+                return runTests('./testcafe-fixtures/hash-based-navigation-test.js', null, { only: 'chrome' });
+            });
+
+            it('Test run url and roles`s login url are same', () => {
+                return runTests('./testcafe-fixtures/same-url-test.js', null, { only: 'chrome' });
+            });
+        });
+
         describe('Errors', function () {
             it('Should fail all tests that use role with the initiliazer error', function () {
                 return runTests('./testcafe-fixtures/init-error-test.js', null, {

--- a/test/functional/fixtures/api/es-next/roles/testcafe-fixtures/hash-based-navigation-test.js
+++ b/test/functional/fixtures/api/es-next/roles/testcafe-fixtures/hash-based-navigation-test.js
@@ -1,0 +1,29 @@
+import { Role, Selector } from 'testcafe';
+import { setFlag, hasFlag } from './utils';
+
+fixture `Should always reload the target url`
+    .page `http://localhost:3000/fixtures/api/es-next/roles/pages/page-with-hash-navigation.html`
+    .beforeEach(async () => {
+        await setFlag();
+    });
+
+const role = Role(`http://localhost:3000/fixtures/api/es-next/roles/pages/page-with-hash-navigation.html#login`,
+    async t => {
+        await t.click('input');
+    }, { preserveUrl: true });
+
+test('First role initialization', async t => {
+    await t
+        .expect(hasFlag()).ok()
+        .useRole(role)
+        .expect(hasFlag()).notOk()
+        .expect(Selector('h1').innerText).eql('Authorized');
+});
+
+test('Using of the initialized role', async t => {
+    await t
+        .expect(hasFlag()).ok()
+        .useRole(role)
+        .expect(hasFlag()).notOk()
+        .expect(Selector('h1').innerText).eql('Authorized');
+});

--- a/test/functional/fixtures/api/es-next/roles/testcafe-fixtures/same-url-test.js
+++ b/test/functional/fixtures/api/es-next/roles/testcafe-fixtures/same-url-test.js
@@ -1,0 +1,36 @@
+import { Role, ClientFunction } from 'testcafe';
+import { hasFlag, setFlag } from './utils';
+
+const loginPageUrl = 'http://localhost:3000/fixtures/api/es-next/roles/pages/login-page.html';
+
+fixture `Same url test`
+    .page(loginPageUrl)
+    .beforeEach(async () => {
+        await setFlag();
+    });
+
+const role = Role(loginPageUrl, async t => {
+    await t
+        .typeText('input[name="name"]', 'User')
+        .click('input[value="LogIn"]');
+});
+
+const getToken = ClientFunction(() => {
+    return localStorage.getItem('token');
+});
+
+test('First role initialization', async t => {
+    await t
+        .expect(hasFlag()).ok()
+        .useRole(role)
+        .expect(hasFlag()).notOk()
+        .expect(getToken()).eql('123456789User');
+});
+
+test('Using of the initialized role', async t => {
+    await t
+        .expect(hasFlag()).ok()
+        .useRole(role)
+        .expect(hasFlag()).notOk()
+        .expect(getToken()).eql('123456789User');
+});

--- a/test/functional/fixtures/api/es-next/roles/testcafe-fixtures/utils.js
+++ b/test/functional/fixtures/api/es-next/roles/testcafe-fixtures/utils.js
@@ -1,0 +1,11 @@
+import { ClientFunction } from 'testcafe';
+
+const setFlag = ClientFunction(() => {
+    window.flag = true;
+});
+const hasFlag = ClientFunction(() => !!window.flag);
+
+export {
+    setFlag,
+    hasFlag
+};

--- a/test/server/test-run-commands-test.js
+++ b/test/server/test-run-commands-test.js
@@ -757,7 +757,8 @@ describe('Test run commands', () => {
             const commandObj = {
                 type:          TYPE.navigateTo,
                 url:           'localhost',
-                stateSnapshot: 'stateSnapshot'
+                stateSnapshot: 'stateSnapshot',
+                forceReload:   true
             };
 
             const command = createCommand(commandObj);
@@ -765,7 +766,8 @@ describe('Test run commands', () => {
             expect(JSON.parse(JSON.stringify(command))).eql({
                 type:          TYPE.navigateTo,
                 url:           'localhost',
-                stateSnapshot: 'stateSnapshot'
+                stateSnapshot: 'stateSnapshot',
+                forceReload:   true
             });
         });
 

--- a/test/server/util-test.js
+++ b/test/server/util-test.js
@@ -1,20 +1,20 @@
-const path            = require('path');
-const { PassThrough } = require('stream');
-const Module          = require('module');
-const fs              = require('fs');
-const del             = require('del');
-const OS              = require('os-family');
-const { expect }      = require('chai');
-const { noop }        = require('lodash');
-const correctFilePath = require('../../lib/utils/correct-file-path');
-const escapeUserAgent = require('../../lib/utils/escape-user-agent');
-const parseFileList   = require('../../lib/utils/parse-file-list');
-const TempDirectory   = require('../../lib/utils/temp-directory');
+const path                             = require('path');
+const { PassThrough }                  = require('stream');
+const Module                           = require('module');
+const fs                               = require('fs');
+const del                              = require('del');
+const OS                               = require('os-family');
+const { expect }                       = require('chai');
+const { noop }                         = require('lodash');
+const correctFilePath                  = require('../../lib/utils/correct-file-path');
+const escapeUserAgent                  = require('../../lib/utils/escape-user-agent');
+const parseFileList                    = require('../../lib/utils/parse-file-list');
+const TempDirectory                    = require('../../lib/utils/temp-directory');
 const { getConcatenatedValuesString }  = require('../../lib/utils/string');
-const getCommonPath            = require('../../lib/utils/get-common-path');
-const resolvePathRelativelyCwd = require('../../lib/utils/resolve-path-relatively-cwd');
-const getFilterFn              = require('../../lib/utils/get-filter-fn');
-const prepareReporters         = require('../../lib/utils/prepare-reporters');
+const getCommonPath                    = require('../../lib/utils/get-common-path');
+const resolvePathRelativelyCwd         = require('../../lib/utils/resolve-path-relatively-cwd');
+const getFilterFn                      = require('../../lib/utils/get-filter-fn');
+const prepareReporters                 = require('../../lib/utils/prepare-reporters');
 const { replaceLeadingSpacesWithNbsp } = require('../../lib/errors/test-run/utils');
 
 const {


### PR DESCRIPTION
Changes:
* force reload if role's login url is different with fixture's url only in hash
* remove getting snapshot delay (https://github.com/DevExpress/testcafe/pull/3625/files#diff-7583ad80662fdf889e6e058fbf571d42L40). It's necessary, because at present we don't use service messages for cookie synchronization.
* use `StateSnapshot.empty()` instead of `null`.
* export special pages(`about:blank`, `about:error`) from hammerhead and use them as constants.

At first review this PR, next - [this](https://github.com/DevExpress/testcafe-hammerhead/pull/1974) in the hammerhead repository.