### PR TITLE
[docs] Update the website 4/1/2019

### DIFF
--- a/documentation/continuous-integration/bitbucket-pipelines.html
+++ b/documentation/continuous-integration/bitbucket-pipelines.html
@@ -709,7 +709,7 @@ However, if you already have a Docker image prepared, you can <a href="#option-2
 
 <p>The following example shows a command that runs tests in Chromium in headless mode:</p>
 <div class="highlight"><pre><code class="language-json" data-lang="json"><span class="s2">"scripts"</span><span class="err">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-    </span><span class="nt">"test"</span><span class="p">:</span><span class="w">  </span><span class="s2">"testcafe 'chromium:headless --no-sandbox --disable-setuid-sandbox --window-size=1920x1080' tests/index-test.js"</span><span class="w">
+    </span><span class="nt">"test"</span><span class="p">:</span><span class="w">  </span><span class="s2">"testcafe 'chromium:headless --disable-setuid-sandbox --window-size=1920x1080' tests/index-test.js"</span><span class="w">
 </span><span class="p">}</span><span class="w">
 </span></code></pre></div>
 <p>For more information on how to configure a test run with the <code>testcafe</code> command, see <a href="../using-testcafe/command-line-interface.html">Command Line Interface</a>.</p>
@@ -719,7 +719,7 @@ However, if you already have a Docker image prepared, you can <a href="#option-2
 <p>If you need to start a custom Web server to host your application, use the <a href="../using-testcafe/command-line-interface.html#-a-command---app-command">--app</a> TestCafe option followed by a command that starts this server.
 TestCafe executes this command before tests are launched. After tests finish, TestCafe stops the server.</p>
 <div class="highlight"><pre><code class="language-json" data-lang="json"><span class="s2">"scripts"</span><span class="err">:</span><span class="w"> </span><span class="p">{</span><span class="w">
-  </span><span class="nt">"test"</span><span class="p">:</span><span class="w">  </span><span class="s2">"testcafe 'chromium:headless --no-sandbox --disable-setuid-sandbox --window-size=1920x1080' tests/index-test.js --app \"node server.js\""</span><span class="w">
+  </span><span class="nt">"test"</span><span class="p">:</span><span class="w">  </span><span class="s2">"testcafe 'chromium:headless --disable-setuid-sandbox --window-size=1920x1080' tests/index-test.js --app \"node server.js\""</span><span class="w">
 </span><span class="p">}</span><span class="w">
 </span></code></pre></div><h2><a class="anchor" id="step-3---trigger-a-bitbucket-pipelines-ci-build"></a>Step 3 - Trigger a Bitbucket Pipelines CI Build <a class="permalink" href="#step-3---trigger-a-bitbucket-pipelines-ci-build">#</a></h2>
 <p>Bitbucket Pipelines CI is now configured to trigger the build when you push commits to your repository or create a pull request.</p>

--- a/documentation/using-testcafe/using-testcafe-docker-image.html
+++ b/documentation/using-testcafe/using-testcafe-docker-image.html
@@ -744,7 +744,6 @@ Therefore, you can avoid manual installation of browsers and the testing framewo
 <li><a href="#test-in-docker-containers">Test in Docker Containers</a></li>
 <li><a href="#test-on-the-host-machine">Test on the Host Machine</a></li>
 <li><a href="#test-on-remote-devices">Test on Remote Devices</a></li>
-<li><a href="#test-heavy-websites">Test Heavy Websites</a></li>
 <li><a href="#proxy-settings">Proxy Settings</a></li>
 </ul>
 <h2><a class="anchor" id="install-docker-and-download-testcafe-image"></a>Install Docker and Download TestCafe Image <a class="permalink" href="#install-docker-and-download-testcafe-image">#</a></h2>
@@ -773,10 +772,8 @@ Therefore, you can avoid manual installation of browsers and the testing framewo
 <p>In modern Docker for Windows, you also need to share a drive to reach it from Docker containers. For more information, see <a href="https://docs.docker.com/docker-for-windows/#shared-drives">Docker for Windows documentation</a>.</p></li>
 <li><p><code>-it testcafe/testcafe</code> - runs TestCafe in the interactive mode with the console enabled;</p></li>
 <li><p><code>${TESTCAFE_ARGS}</code> - arguments passed to the <code>testcafe</code> command. You can use any arguments from the TestCafe <a href="command-line-interface.html">command line interface</a>;</p>
-<div class="highlight"><pre><code class="language-sh" data-lang="sh">-it testcafe/testcafe <span class="s1">'chromium --no-sandbox,firefox'</span> /tests/test.js
+<div class="highlight"><pre><code class="language-sh" data-lang="sh">-it testcafe/testcafe chromium,firefox /tests/test.js
 </code></pre></div>
-<p>You can run tests in the Chromium and Firefox browsers preinstalled to the Docker image. Add the <code>--no-sandbox</code> flag to Chromium if the container is run in the unprivileged mode.</p>
-
 <p>You can pass a glob instead of the directory path in TestCafe parameters.</p>
 <div class="highlight"><pre><code class="language-sh" data-lang="sh">docker run -v //d/tests:/tests -it testcafe/testcafe firefox /tests/<span class="k">**</span>/<span class="k">*</span>.js
 </code></pre></div><blockquote><div class="blockquote-content"><p>If tests use other Node.js modules, these modules should be located in the tests directory or its child directories. TestCafe will not be able to find modules in the parent directories.</p>
@@ -829,13 +826,6 @@ Therefore, you can avoid manual installation of browsers and the testing framewo
 <div class="highlight"><pre><code class="language-sh" data-lang="sh">docker run --add-host<span class="o">=</span><span class="k">${</span><span class="nv">EXTERNAL_HOSTNAME</span><span class="k">}</span>:127.0.0.1 -p <span class="k">${</span><span class="nv">PORT1</span><span class="k">}</span>:<span class="k">${</span><span class="nv">PORT1</span><span class="k">}</span> -p <span class="k">${</span><span class="nv">PORT2</span><span class="k">}</span>:<span class="k">${</span><span class="nv">PORT2</span><span class="k">}</span> -v /d/tests:/tests -it testcafe/testcafe --hostname <span class="k">${</span><span class="nv">EXTERNAL_HOSTNAME</span><span class="k">}</span> --ports <span class="k">${</span><span class="nv">PORT1</span><span class="k">}</span>,<span class="k">${</span><span class="nv">PORT2</span><span class="k">}</span> remote /tests/test.js
 </code></pre></div>
 <p>where <code>${PORT1}</code> and <code>${PORT2}</code> are vacant container&#39;s ports, <code>${EXTERNAL_HOSTNAME}</code> is the host machine name.</p>
-<h2><a class="anchor" id="test-heavy-websites"></a>Test Heavy Websites <a class="permalink" href="#test-heavy-websites">#</a></h2>
-<p>If you are testing a heavy website, you may need to allocate extra resources for the Docker image.</p>
-
-<p>The most common case is when the temporary file storage <code>/dev/shm</code> runs out of free space. The following example shows how to allow additional space (1GB) for this storage using the <code>--shm-size</code> option.</p>
-<div class="highlight"><pre><code class="language-sh" data-lang="sh">docker run --shm-size<span class="o">=</span>1g -v /d/tests:/tests -it testcafe/testcafe firefox /tests/test.js
-</code></pre></div>
-<p>You can find a complete list of options that manage runtime constraints on resources in the <a href="https://docs.docker.com/engine/reference/run/#runtime-constraints-on-resources">Docker documentation</a>.</p>
 <h2><a class="anchor" id="proxy-settings"></a>Proxy Settings <a class="permalink" href="#proxy-settings">#</a></h2>
 <p>Use the TestCafe <a href="command-line-interface.html#--proxy-host">--proxy</a> and <a href="command-line-interface.html#--proxy-bypass-rules">--proxy-bypass</a> options to configure proxy settings.</p>
 <div class="highlight"><pre><code class="language-sh" data-lang="sh">docker run -v /d/tests:/tests -it testcafe/testcafe remote /tests/test.js --proxy proxy.mycorp.com

--- a/faq/index.html
+++ b/faq/index.html
@@ -424,6 +424,7 @@
 <li><a href="#when-i-run-a-testcafe-test-i-get-an-unexpected-error-what-can-cause-that">When I run a TestCafe test, I get an unexpected error. What can cause that?</a></li>
 <li><a href="#i-have-installed-testcafe-plugins-but-they-do-not-work-what-have-i-done-wrong">I have installed TestCafe plugins but they do not work. What have I done wrong?</a></li>
 <li><a href="#my-test-fails-because-testcafe-could-not-find-the-required-webpage-element-why-does-this-happen">My test fails because TestCafe could not find the required webpage element. Why does this happen?</a></li>
+<li><a href="#testcafe-reports-that-a-request-has-failed-what-are-the-possible-reasons">TestCafe reports that a request has failed. What are the possible reasons?</a></li>
 </ul></li>
 </ul>
 <h2><a class="anchor" id="general-questions"></a>General Questions <a class="permalink" href="#general-questions">#</a></h2><h3><a class="anchor" id="i-have-heard-that-testcafe-does-not-use-selenium-how-does-it-operate"></a>I have heard that TestCafe does not use Selenium. How does it operate? <a class="permalink" href="#i-have-heard-that-testcafe-does-not-use-selenium-how-does-it-operate">#</a></h3>
@@ -559,16 +560,17 @@ Then you can use this module inside client functions and selectors.</p>
     <span class="kd">var</span> <span class="nx">text</span> <span class="o">=</span> <span class="nx">await</span> <span class="nx">clientFunction</span><span class="p">();</span>
 <span class="p">});</span>
 </code></pre></div><h3><a class="anchor" id="how-do-i-work-with-configuration-files-and-environment-variables"></a>How do I work with configuration files and environment variables? <a class="permalink" href="#how-do-i-work-with-configuration-files-and-environment-variables">#</a></h3>
-<p>TestCafe works without any configuration.
-It does not have any config files where you can place custom variables.
-However, you can introduce your own configuration file and import it to the test code.</p>
+<p>TestCafe allows you to specify settings in a <a href="../documentation/using-testcafe/configuration-file.html">configuration file</a>.</p>
 
-<p>For example, you need to pass a website&#39;s base URL to test code. In this instance, you can create the following <code>config.json</code> file:</p>
+<p>If you need to use custom properties in the configuration, create a separate configuration file and import it to the tests.</p>
+<blockquote><div class="blockquote-content"><p>Vote for the following GitHub issue if you want us to support custom properties in <code>.testcaferc.json</code>: <a href="https://github.com/DevExpress/testcafe/issues/3593">#3593</a></p>
+</div></blockquote>
+<p>For example, you can create the following <code>config.json</code> file to pass a website&#39;s base URL to test code:</p>
 <div class="highlight"><pre><code class="language-json" data-lang="json"><span class="p">{</span><span class="w">
     </span><span class="nt">"baseUrl"</span><span class="p">:</span><span class="w"> </span><span class="s2">"http://localhost/testcafe"</span><span class="w">
 </span><span class="p">}</span><span class="w">
 </span></code></pre></div>
-<p>In the test code, import it as you would do with a regular JavaScript module.</p>
+<p>In the test code, import it like a regular JavaScript module:</p>
 <div class="highlight"><pre><code class="language-js" data-lang="js"><span class="kr">import</span> <span class="nx">config</span> <span class="nx">from</span> <span class="s1">'./config'</span><span class="p">;</span>
 
 <span class="nx">fixture</span> <span class="err">`</span><span class="nx">Fixture</span><span class="err">`</span>
@@ -579,7 +581,7 @@ However, you can introduce your own configuration file and import it to the test
 <p>The following command passes the <code>env</code> argument to the test code:</p>
 <div class="highlight"><pre><code class="language-sh" data-lang="sh">testcafe chrome test.js --env<span class="o">=</span>development
 </code></pre></div>
-<p>In the test, use an argument parser library (like <code>minimist</code>) to parse custom arguments.</p>
+<p>In the test, use an argument parser library (like <code>minimist</code>) to parse custom arguments:</p>
 <div class="highlight"><pre><code class="language-js" data-lang="js"><span class="kr">import</span> <span class="nx">minimist</span> <span class="nx">from</span> <span class="s1">'minimist'</span><span class="p">;</span>
 
 <span class="kr">const</span> <span class="nx">args</span> <span class="o">=</span> <span class="nx">minimist</span><span class="p">(</span><span class="nx">process</span><span class="p">.</span><span class="nx">argv</span><span class="p">.</span><span class="nx">slice</span><span class="p">(</span><span class="mi">2</span><span class="p">));</span>
@@ -592,7 +594,7 @@ However, you can introduce your own configuration file and import it to the test
   <span class="nx">console</span><span class="p">.</span><span class="nx">log</span><span class="p">(</span><span class="s1">'Environment:'</span><span class="p">,</span> <span class="nx">environment</span><span class="p">);</span>
 <span class="p">});</span>
 </code></pre></div>
-<p>To set an environment variable use the following command on Windows.</p>
+<p>To set an environment variable, use the following command on Windows:</p>
 <div class="highlight"><pre><code class="language-sh" data-lang="sh"><span class="nb">set </span><span class="nv">DEV_MODE</span><span class="o">=</span><span class="nb">true
 </span>testcafe chrome test.js
 </code></pre></div>
@@ -647,7 +649,7 @@ to use the plugin in other projects as well, install it globally.</p>
 
 <ul>
 <li>one of the <a href="../documentation/test-api/selecting-page-elements/selectors/">selectors</a> you used in test code does not match any DOM element, or</li>
-<li>you have tried to specify an <a href="https://devexpress.github.io/testcafe/documentation/test-api/actions/#selecting-target-elements">action&#39;s target element</a> using a wrong CSS selector or a client-side function that returns no element.</li>
+<li>you used a incorrect CSS selector or a client-side function that returns no element to specify an <a href="../documentation/test-api/actions/#selecting-target-elements">action&#39;s target element</a>.</li>
 </ul>
 
 <p>To determine the cause of this issue, do the following:</p>
@@ -664,22 +666,64 @@ to use the plugin in other projects as well, install it globally.</p>
 <li>the element is present on the page;</li>
 <li>the element is visible (TestCafe considers it visible if it does not have <code>display</code> set to <code>none</code>,
 <code>visibility</code> set to <code>hidden</code> or the zero <code>width</code> or <code>height</code>);</li>
-<li>the element&#39;s part targeted by the action is visible (the center of the element by default;
-it can be changed using the
-<a href="https://devexpress.github.io/testcafe/documentation/test-api/actions/action-options.html#mouse-action-options"><code>offsetX</code> and <code>offsetY</code></a>
-parameters);</li>
+<li>the element&#39;s part targeted by the action is visible (the center of the element, or a point specified by the <a href="../documentation/test-api/actions/action-options.html#mouse-action-options"><code>offsetX</code> and <code>offsetY</code></a> parameters);</li>
 <li>the element is not in an <code>&lt;iframe&gt;</code> (if it is, use the
-<a href="https://devexpress.github.io/testcafe/documentation/test-api/working-with-iframes.html">t.switchToIframe</a> method
+<a href="../documentation/test-api/working-with-iframes.html">t.switchToIframe</a> method
 to switch to the appropriate <code>&lt;iframe&gt;</code>).</li>
 </ul>
 
-<p>Also, try running the test at full screen.
+<p>Also, try running the test in full screen.
 Use the <a href="../documentation/test-api/actions/resize-window.html#maximizing-the-window">t.maximizeWindow</a>
 and <a href="../documentation/test-api/actions/resize-window.html#setting-the-window-size">t.resizeWindow</a> actions
 to control the browser window size. If the test passes, it means your webpage hides
 the target element when the window is resized to smaller dimensions.</p>
 
 <p>Finally, try updating TestCafe to the latest version to see if the problem persists.</p>
+<h3><a class="anchor" id="testcafe-reports-that-a-request-has-failed-what-are-the-possible-reasons"></a>TestCafe reports that a request has failed. What are the possible reasons? <a class="permalink" href="#testcafe-reports-that-a-request-has-failed-what-are-the-possible-reasons">#</a></h3>
+<p>When TestCafe does not receive a successful response from a server, it outputs the following error:</p>
+<div class="highlight"><pre><code class="language-text" data-lang="text">A request to https://www.example.com has failed. Use quarantine mode to perform additional attempts to execute this test.
+</code></pre></div>
+<p>You can use <a href="../documentation/using-testcafe/command-line-interface.html#-q---quarantine-mode">quarantine mode</a> to complete the tests if this problem occurs infrequently.</p>
+
+<p>However, we recommend that you determine the cause of this issue and address it.</p>
+
+<p>This error can occur in the following situations:</p>
+<h4><a class="anchor" id="the-web-server-is-not-responding"></a>The Web server is not responding <a class="permalink" href="#the-web-server-is-not-responding">#</a></h4>
+<p>Check if the Web and DNS servers are online and configured to accept requests to this URL.</p>
+<h4><a class="anchor" id="unstable-or-improperly-configured-network-connection"></a>Unstable or improperly configured network connection <a class="permalink" href="#unstable-or-improperly-configured-network-connection">#</a></h4>
+<ul>
+<li>Check the network connection&#39;s settings.</li>
+<li>Ensure that your network equipment works properly. If possible, establish a direct connection to the Internet/Web server.</li>
+<li>Check the proxy server&#39;s settings or try a different proxy server.</li>
+<li>Use VPN.</li>
+<li>Connect to a different network.</li>
+</ul>
+<h4><a class="anchor" id="not-enough-resources-in-the-container-or-ci-system"></a>Not enough resources in the container or CI system <a class="permalink" href="#not-enough-resources-in-the-container-or-ci-system">#</a></h4>
+<p>If you run TestCafe in a container or CI system, use the following steps to diagnose resource shortage:</p>
+
+<ul>
+<li>Increase the container&#39;s resource limits.</li>
+<li>Set the <a href="../documentation/using-testcafe/common-concepts/concurrent-test-execution.html">concurrency factor</a> to <code>1</code>.</li>
+<li>Deploy the application&#39;s Web server on a separate machine.</li>
+<li>Run tests on a local device outside a container.</li>
+</ul>
+
+<p>If this fixes the tests, it indicates that they require additional resources. You can address this in the following ways:</p>
+
+<ul>
+<li>Adjust the container&#39;s or environment&#39;s settings to allocate more resources.</li>
+<li>If you use a cloud-based CI system, ask the service provider for an upgrade or consider a different CI service with better hardware or smaller loads.</li>
+</ul>
+
+<p>According to users&#39; feedback, the following CI systems work best with TestCafe:</p>
+
+<ul>
+<li><a href="../documentation/continuous-integration/azure-devops.html">Azure Pipelines</a></li>
+<li><a href="../documentation/continuous-integration/gitlab.html">GitLab</a></li>
+<li><a href="../documentation/continuous-integration/travis.html">TravisCI</a></li>
+<li><a href="../documentation/continuous-integration/circleci.html">CircleCI</a></li>
+<li><a href="../documentation/continuous-integration/appveyor.html">AppVeyor</a></li>
+</ul>
 
 
         </div>

--- a/faq/index.html
+++ b/faq/index.html
@@ -649,7 +649,7 @@ to use the plugin in other projects as well, install it globally.</p>
 
 <ul>
 <li>one of the <a href="../documentation/test-api/selecting-page-elements/selectors/">selectors</a> you used in test code does not match any DOM element, or</li>
-<li>you used a incorrect CSS selector or a client-side function that returns no element to specify an <a href="../documentation/test-api/actions/#selecting-target-elements">action&#39;s target element</a>.</li>
+<li>you used an incorrect CSS selector or a client-side function that returns no element to specify an <a href="../documentation/test-api/actions/#selecting-target-elements">action&#39;s target element</a>.</li>
 </ul>
 
 <p>To determine the cause of this issue, do the following:</p>

--- a/faq/index.html
+++ b/faq/index.html
@@ -681,7 +681,8 @@ the target element when the window is resized to smaller dimensions.</p>
 <p>Finally, try updating TestCafe to the latest version to see if the problem persists.</p>
 <h3><a class="anchor" id="testcafe-reports-that-a-request-has-failed-what-are-the-possible-reasons"></a>TestCafe reports that a request has failed. What are the possible reasons? <a class="permalink" href="#testcafe-reports-that-a-request-has-failed-what-are-the-possible-reasons">#</a></h3>
 <p>When TestCafe does not receive a successful response from a server, it outputs the following error:</p>
-<div class="highlight"><pre><code class="language-text" data-lang="text">A request to https://www.example.com has failed. Use quarantine mode to perform additional attempts to execute this test.
+<div class="highlight"><pre><code class="language-text" data-lang="text">A request to https://www.example.com has failed.
+Use quarantine mode to perform additional attempts to execute this test.
 </code></pre></div>
 <p>You can use <a href="../documentation/using-testcafe/command-line-interface.html#-q---quarantine-mode">quarantine mode</a> to complete the tests if this problem occurs infrequently.</p>
 

--- a/feed.xml
+++ b/feed.xml
@@ -5,8 +5,8 @@
     <description></description>
     <link>https://devexpress.github.io/testcafe/</link>
     <atom:link href="https://devexpress.github.io/testcafe/feed.xml" rel="self" type="application/rss+xml"/>
-    <pubDate>Mon, 01 Apr 2019 18:35:14 +0300</pubDate>
-    <lastBuildDate>Mon, 01 Apr 2019 18:35:14 +0300</lastBuildDate>
+    <pubDate>Mon, 01 Apr 2019 19:20:53 +0300</pubDate>
+    <lastBuildDate>Mon, 01 Apr 2019 19:20:53 +0300</lastBuildDate>
     <generator>Jekyll v3.8.4</generator>
     
       <item>

--- a/feed.xml
+++ b/feed.xml
@@ -5,8 +5,8 @@
     <description></description>
     <link>https://devexpress.github.io/testcafe/</link>
     <atom:link href="https://devexpress.github.io/testcafe/feed.xml" rel="self" type="application/rss+xml"/>
-    <pubDate>Mon, 01 Apr 2019 18:28:17 +0300</pubDate>
-    <lastBuildDate>Mon, 01 Apr 2019 18:28:17 +0300</lastBuildDate>
+    <pubDate>Mon, 01 Apr 2019 18:35:14 +0300</pubDate>
+    <lastBuildDate>Mon, 01 Apr 2019 18:35:14 +0300</lastBuildDate>
     <generator>Jekyll v3.8.4</generator>
     
       <item>

--- a/feed.xml
+++ b/feed.xml
@@ -5,8 +5,8 @@
     <description></description>
     <link>https://devexpress.github.io/testcafe/</link>
     <atom:link href="https://devexpress.github.io/testcafe/feed.xml" rel="self" type="application/rss+xml"/>
-    <pubDate>Tue, 05 Mar 2019 14:49:21 +0300</pubDate>
-    <lastBuildDate>Tue, 05 Mar 2019 14:49:21 +0300</lastBuildDate>
+    <pubDate>Mon, 01 Apr 2019 18:28:17 +0300</pubDate>
+    <lastBuildDate>Mon, 01 Apr 2019 18:28:17 +0300</lastBuildDate>
     <generator>Jekyll v3.8.4</generator>
     
       <item>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -406,10 +406,10 @@
 </url>
 <url>
 <loc>https://devexpress.github.io/testcafe/example/</loc>
-<lastmod>2019-03-05T14:49:18+03:00</lastmod>
+<lastmod>2019-04-01T18:28:13+03:00</lastmod>
 </url>
 <url>
 <loc>https://devexpress.github.io/testcafe/example/thank-you.html</loc>
-<lastmod>2019-03-05T14:49:18+03:00</lastmod>
+<lastmod>2019-04-01T18:28:13+03:00</lastmod>
 </url>
 </urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -406,10 +406,10 @@
 </url>
 <url>
 <loc>https://devexpress.github.io/testcafe/example/</loc>
-<lastmod>2019-04-01T18:35:11+03:00</lastmod>
+<lastmod>2019-04-01T19:20:49+03:00</lastmod>
 </url>
 <url>
 <loc>https://devexpress.github.io/testcafe/example/thank-you.html</loc>
-<lastmod>2019-04-01T18:35:11+03:00</lastmod>
+<lastmod>2019-04-01T19:20:49+03:00</lastmod>
 </url>
 </urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -406,10 +406,10 @@
 </url>
 <url>
 <loc>https://devexpress.github.io/testcafe/example/</loc>
-<lastmod>2019-04-01T18:28:13+03:00</lastmod>
+<lastmod>2019-04-01T18:35:11+03:00</lastmod>
 </url>
 <url>
 <loc>https://devexpress.github.io/testcafe/example/thank-you.html</loc>
-<lastmod>2019-04-01T18:28:13+03:00</lastmod>
+<lastmod>2019-04-01T18:35:11+03:00</lastmod>
 </url>
 </urlset>


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs 

Merge to update the website.

Preview at http://vasilystrelyaev.github.io/testcafe/.

Highlights:
* updated FAQ: http://vasilystrelyaev.github.io/testcafe/faq/#testcafe-reports-that-a-request-has-failed-what-are-the-possible-reasons
* removed info about `shm` from the Docker topic: http://vasilystrelyaev.github.io/testcafe/documentation/using-testcafe/using-testcafe-docker-image.html
* removed info about the `--no-sandbox` flag from the Docker and CI integration topics