### PR TITLE
Gh2918: Fixed t.takeElementScreenshots for color corrected Displays

### DIFF
--- a/src/screenshots/crop.js
+++ b/src/screenshots/crop.js
@@ -15,9 +15,28 @@ function markSeedToId (markSeed) {
     return id;
 }
 
+const FILTER_THRESHOLD = 10;
+
+/**
+ * @param {import('pngjs').PNG} pngImage
+ * @param {number[]} markSeed
+ */
 export function calculateMarkPosition (pngImage, markSeed) {
-    const mark      = Buffer.from(markSeed);
-    const markIndex = pngImage.data.indexOf(mark);
+    const mark = Buffer.from(markSeed);
+    const filtImg = Buffer.from(pngImage.data);
+
+    // Some browsers render colors differently.
+    // This approach creates a filtered extreme of the screenshot.
+    // The mark can be found in this version.
+    // A color channel with a value smaller than BW_THRESHOLD
+    // becomes 0. Otherwise it becomes 255.
+    // i.e. rgba(5, 7, 3, 2) => rgba(0, 0, 0, 0), rgba(11, 3, 0, 0) => rgba(255, 0, 0, 0)
+    for (let pixel = 0; pixel < filtImg.length; pixel += 4) {
+        for (let channel = 0; channel < 4; channel++)
+            filtImg[pixel + channel] = filtImg[pixel + channel] < FILTER_THRESHOLD ? 0 : 255;
+    }
+
+    const markIndex = filtImg.indexOf(mark);
 
     if (markIndex < 0)
         return null;

--- a/src/screenshots/utils.js
+++ b/src/screenshots/utils.js
@@ -1,5 +1,5 @@
 import { PNG } from 'pngjs';
-import { map, flatten, times, constant } from 'lodash';
+import { times, constant } from 'lodash';
 import generateId from 'nanoid/generate';
 import { MARK_LENGTH, MARK_HEIGHT, MARK_BYTES_PER_PIXEL } from './constants';
 
@@ -10,7 +10,12 @@ export function generateScreenshotMark () {
     const id = generateId(ALPHABET, MARK_LENGTH);
 
     // NOTE: array of RGB values
-    const markSeed = flatten(map(id, bit => bit === '0' ? [0, 0, 0, 255] : [255, 255, 255, 255]));
+    const markSeed = [];
+
+    for (const bit of id) {
+        if (bit === '0') markSeed.push(0, 0, 0, 255);
+        else markSeed.push(255, 255, 255, 255);
+    }
 
     // NOTE: macOS browsers can't display an element, if it's CSS height is lesser than 1.
     // It happens on Retina displays, because they have more than 1 physical pixel in a CSS pixel.


### PR DESCRIPTION
Fixed the Case "screen color correction that leads to changes in intensities of black and white colors" in the [issue #2918 (t.takeElementScreenshots can't detect page area in some cases)](https://github.com/DevExpress/testcafe/issues/2918)

This approach applies a filter to each pixel in the screenshot. For each color channel it is checked if its value is below a certain threshold [`const FILTER_THRESHOLD = 10;`](https://github.com/DevExpress/testcafe/compare/master...htho:gh2918-color?expand=1#diff-18bfae1c3f4abf76c5f7d0e60f15e02aR19). If that is the case, the channels value is set to 0. Otherwise it is set to 255.

I also changed how the [markSeed](https://github.com/DevExpress/testcafe/compare/master...htho:gh2918-color?expand=1#diff-f39695e88b00dc40f1c4dc6ae621d026L13) is created. I had a hard time understanding what happens there. I think this approach is a little more readable und probably more performant.

About tests: Although I think, I could learn how to write tests, I don't know how to test this specific case. I think a png File with this problem should become part of the repository. I took a quick look and didn't see something similar.