### PR TITLE
Updated xammerhead

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "source-map-support": "^0.5.5",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "1.6.8",
-    "testcafe-hammerhead": "14.6.1",
+    "testcafe-hammerhead": "14.6.2",
     "testcafe-legacy-api": "3.1.11",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/src/client/automation/playback/click/click-command.js
+++ b/src/client/automation/playback/click/click-command.js
@@ -28,28 +28,6 @@ class ElementClickCommand {
     }
 }
 
-class ColorInputElementClickCommand extends ElementClickCommand {
-    constructor (eventState, eventArgs) {
-        super(eventState, eventArgs);
-    }
-
-    run () {
-        if (this.eventState.clickElement && browserUtils.isFirefox)
-            this._bindClickHandler(this.eventState.clickElement);
-
-        super.run();
-    }
-
-    _bindClickHandler (element) {
-        const onclick = e => {
-            eventUtils.preventDefault(e, true);
-            eventUtils.unbind(element, 'click', onclick);
-        };
-
-        eventUtils.bind(element, 'click', onclick);
-    }
-}
-
 class SelectElementClickCommand extends ElementClickCommand {
     constructor (eventState, eventArgs) {
         super(eventState, eventArgs);
@@ -121,7 +99,6 @@ export default function (eventState, eventArgs) {
     const elementBoundToLabel = getElementBoundToLabel(eventArgs.element);
     const isSelectElement     = domUtils.isSelectElement(eventArgs.element);
     const isOptionElement     = domUtils.isOptionElement(eventArgs.element);
-    const isColorInputElement = domUtils.isColorInputElement(eventState.clickElement);
     const isLabelledCheckbox  = elementBoundToLabel && domUtils.isCheckboxElement(elementBoundToLabel);
 
     if (isSelectElement)
@@ -129,9 +106,6 @@ export default function (eventState, eventArgs) {
 
     if (isOptionElement)
         return new OptionElementClickCommand(eventState, eventArgs);
-
-    if (isColorInputElement)
-        return new ColorInputElementClickCommand(eventState, eventArgs);
 
     if (isLabelledCheckbox)
         return new LabelledCheckboxElementClickCommand(eventState, eventArgs);

--- a/src/client/automation/playback/click/click-command.js
+++ b/src/client/automation/playback/click/click-command.js
@@ -9,7 +9,6 @@ const listeners      = hammerhead.eventSandbox.listeners;
 
 const domUtils   = testCafeCore.domUtils;
 const styleUtils = testCafeCore.styleUtils;
-const eventUtils = testCafeCore.eventUtils;
 
 const selectElementUI = testCafeUI.selectElement;
 


### PR DESCRIPTION
@AlexKamaev 

All inputs' native dialogs are prevented in hammerhead repository:
* https://github.com/DevExpress/testcafe-hammerhead/blob/8e5430e0b5a9d4b3f990e49959fadc67d060e3a1/src/client/sandbox/event/index.ts#L150
* https://github.com/DevExpress/testcafe-hammerhead/blob/3a9e84adb47a65037ff3259332b311f417985f64/src/client/sandbox/upload/index.ts#L79