### PR TITLE
[docs] Get ready for the TestCafe Studio official release

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can run TestCafe from a console, and its reports can be viewed in a CI syste
 
 TestCafe works great for JavaScript developers, but at some point you will need to delegate testing tasks to your Q&A department. If that's the case and you are looking for a codeless way to record and maintain tests compatible with your existing infrastructure, check out [TestCafe Studio](https://www.devexpress.com/products/testcafestudio/?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-ide) - a testing IDE built on top of the open-source TestCafe.
 
-Read the following article to learn how TestCafe Studio could fit into your workflow: [What's Better than TestCafe? TestCafe Studio](https://www.devexpress.com/products/testcafestudio/).
+Read the following article to learn how TestCafe Studio could fit into your workflow: [What's Better than TestCafe? TestCafe Studio](https://www.devexpress.com/products/testcafestudio/qa-end-to-end-web-testing.xml).
 
 ![Get Started with TestCafe Studio](https://raw.githubusercontent.com/DevExpress/testcafe/master/media/testcafe-studio-get-started.gif)
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can run TestCafe from a console, and its reports can be viewed in a CI syste
 
 ## TestCafe Studio: IDE for End-to-End Web Testing
 
-TestCafe is great for writing end-to-end tests in JavaScript, but sometimes coding is not the best option. [TestCafe Studio](https://www.devexpress.com/products/testcafestudio/?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-ide) allows you to record and maintain tests visually. Try it whether you want to delegate testing to a QA team that has lower JavaScript skills or simplify the way you create tests.
+TestCafe is great for writing end-to-end tests in JavaScript, but sometimes coding is not an option. [TestCafe Studio](https://www.devexpress.com/products/testcafestudio/?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-ide) allows you to record and maintain tests visually. Try it whether you want to delegate testing to a QA team that has lower JavaScript skills or simplify the way you create tests yourself.
 
 Read the following article to learn how TestCafe Studio could fit into your workflow: [What's Better than TestCafe? TestCafe Studio](https://www.devexpress.com/products/testcafestudio/).
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ You can run TestCafe from a console, and its reports can be viewed in a CI syste
 
 ## TestCafe Studio: IDE for End-to-End Web Testing
 
-TestCafe works great for JavaScript developers, but at some point you will need to delegate testing tasks to your Q&A department. If that's the case and you are looking for a codeless way to record and maintain tests compatible with your existing infrastructure, check out [TestCafe Studio](https://www.devexpress.com/products/testcafestudio/?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-ide) - a testing IDE built on top of the open-source TestCafe.
+We've got one more tool for you!
 
-Read the following article to learn how TestCafe Studio could fit into your workflow: [What's Better than TestCafe? TestCafe Studio](https://www.devexpress.com/products/testcafestudio/qa-end-to-end-web-testing.xml).
+Check out [TestCafe Studio](https://www.devexpress.com/products/testcafestudio/?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-ide): all the perks of TestCafe + GUI + Visual Test Recorder
 
 ![Get Started with TestCafe Studio](https://raw.githubusercontent.com/DevExpress/testcafe/master/media/testcafe-studio-get-started.gif)
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ You can run TestCafe from a console, and its reports can be viewed in a CI syste
 
 ## IDE for End-to-End Web Testing
 
-We've got one more tool for you!
+TestCafe is great for writing end-to-end tests in JavaScript, but sometimes coding is not the best option. [TestCafe Studio](https://www.devexpress.com/products/testcafestudio/?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-ide) allows you to record and maintain tests visually. Try it whether you want to delegate testing to a QA team that has lower JavaScript skills or simplify the way you create tests.
 
-Check out [TestCafe Studio](https://www.devexpress.com/products/testcafestudio/?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-ide): all the perks of TestCafe + GUI + Visual Test Recorder
+Read the following article to learn how TestCafe Studio could fit into your workflow: [What's Better than TestCafe? TestCafe Studio](https://www.devexpress.com/products/testcafestudio/).
 
 ![Get Started with TestCafe Studio](https://raw.githubusercontent.com/DevExpress/testcafe/master/media/testcafe-studio-get-started.gif)
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 ## Table of contents
 
 * [Features](#features)
-* [IDE for End-to-End Web Testing](#ide-for-end-to-end-web-testing)
+* [TestCafe Studio: IDE for End-to-End Web Testing](#testcafe-studio-ide-for-end-to-end-web-testing)
 * [Getting Started](#getting-started)
 * [Documentation](#documentation)
 * [Get Help](#get-help)
@@ -92,7 +92,7 @@ const macOSInput = Selector('.column').find('label').withText('MacOS').child('in
 You can run TestCafe from a console, and its reports can be viewed in a CI system's interface
 (TeamCity, Jenkins, Travis & etc.)
 
-## IDE for End-to-End Web Testing
+## TestCafe Studio: IDE for End-to-End Web Testing
 
 TestCafe is great for writing end-to-end tests in JavaScript, but sometimes coding is not the best option. [TestCafe Studio](https://www.devexpress.com/products/testcafestudio/?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-ide) allows you to record and maintain tests visually. Try it whether you want to delegate testing to a QA team that has lower JavaScript skills or simplify the way you create tests.
 

--- a/README.md
+++ b/README.md
@@ -276,32 +276,25 @@ TestCafe developers and community members made these plugins:
 
 ## Different Versions of TestCafe
 
-There is a line of products called `TestCafe`. Below are the similarities and key differences between them.
+| &nbsp; | [TestCafe](https://devexpress.github.io/testcafe) | [TestCafe Studio](https://www.devexpress.com/products/testcafestudio/?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-diff)  |
+| ------ |:-------------------------------------------------:|:-----------------------------------------------------------------------:|
+| No need for WebDriver, browser plugins or other tools | &#10003; | &#10003; |
+| Cross-platform and cross-browser out of the box | &#10003; | &#10003; |
+| Write tests in the latest JavaScript or TypeScript | &#10003; | &#10003; |
+| Clear and flexible [API](https://devexpress.github.io/testcafe/documentation/test-api/) supports ES6 and [PageModel pattern](https://devexpress.github.io/testcafe/documentation/recipes/using-page-model.html) | &#10003; | &#10003; |
+| Stable tests due to the [Smart Assertion Query Mechanism](https://devexpress.github.io/testcafe/documentation/test-api/assertions/#smart-assertion-query-mechanism) | &#10003; | &#10003; |
+| Tests run fast due to intelligent [Automatic Waiting Mechanism](https://devexpress.github.io/testcafe/documentation/test-api/waiting-for-page-elements-to-appear.html) and [Concurrent Test Execution](https://devexpress.github.io/testcafe/documentation/using-testcafe/common-concepts/concurrent-test-execution.html) | &#10003; | &#10003; |
+| Custom reporter plugins | &#10003; | &#10003; |
+| Use third-party Node.js modules in test scripts | &#10003; | &#10003; |
+| Integration with popular CI systems | &#10003; | &nbsp;&#10003;\* |
+| Free and open-source | &#10003; | &nbsp; |
+| [Visual Test Recorder](https://docs.devexpress.com/TestCafeStudio/400165/guides/record-tests?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-diff) | &nbsp; | &#10003; |
+| [Interactive Test Editor](https://docs.devexpress.com/TestCafeStudio/400190/user-interface/test-editor?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-diff) | &nbsp; | &#10003; |
+| [Automatic Selector Generation](https://docs.devexpress.com/TestCafeStudio/400407/guides/record-tests/element-selectors#auto-generated-element-selectors?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-diff) | &nbsp; | &#10003; |
+| [Run Configuration Manager](https://docs.devexpress.com/TestCafeStudio/400189/user-interface/run-configurations-dialog?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-diff) | &nbsp; | &#10003; |
+| [IDE-like GUI](https://docs.devexpress.com/TestCafeStudio/400181/user-interface/code-editor?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-diff) | &nbsp; | &#10003; |
 
-* All three versions share the same core features:
-  * No need for WebDriver, browser plugins or other tools.
-  * Cross-platform and cross-browser out of the box.
-
-* [**TestCafe**](https://testcafe.devexpress.com/)<br/>
-  *first released in 2013, commercial web application*
-  * Visual Test Recorder and web GUI to create, edit and run tests.
-  * You can record tests or edit them as JavaScript code.
-
-* [**TestCafe**](https://devexpress.github.io/testcafe) - you are here<br/>
-  *first released in 2016, free and open-source node.js application*
-  * You can write tests in the latest JavaScript or TypeScript.
-  * Clearer and more flexible [API](https://devexpress.github.io/testcafe/documentation/test-api/) supports ES6 and [PageModel pattern](https://devexpress.github.io/testcafe/documentation/recipes/using-page-model.html).
-  * More stable tests due to the [Smart Assertion Query Mechanism](https://devexpress.github.io/testcafe/documentation/test-api/assertions/#smart-assertion-query-mechanism).
-  * Tests run faster due to improved [Automatic Waiting Mechanism](https://devexpress.github.io/testcafe/documentation/test-api/waiting-for-page-elements-to-appear.html) and [Concurrent Test Execution](https://devexpress.github.io/testcafe/documentation/using-testcafe/common-concepts/concurrent-test-execution.html).
-  * Easy integration: it is a node.js solution with CLI and reporters for popular CI systems.
-  * You can extend it with [plugins](#plugins) and other Node.js modules.
-
-* [**TestCafe Studio**](https://www.devexpress.com/products/testcafestudio/?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-diff)<br/>
-  *Preview released in 2018, commercial desktop application*
-  * Based on the open-source TestCafe, and supports its major features.
-  * You can record tests or edit them as JavaScript or TypeScript code.
-  * New [Visual Test Recorder](https://docs.devexpress.com/TestCafeStudio/400165/guides/record-tests?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-diff) and [IDE-like GUI](https://docs.devexpress.com/TestCafeStudio/400176/guides/write-test-scripts?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-diff) to record, edit, run and debug tests.
-  * Currently available as a free preview version. The release version will replace the 2013 version of TestCafe.
+\* You can use open-source TestCafe to run TestCafe Studio tests in CI systems.
 
 ## Badge
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can run TestCafe from a console, and its reports can be viewed in a CI syste
 
 ## TestCafe Studio: IDE for End-to-End Web Testing
 
-TestCafe is great for writing end-to-end tests in JavaScript, but sometimes coding is not an option. [TestCafe Studio](https://www.devexpress.com/products/testcafestudio/?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-ide) allows you to record and maintain tests visually. Try it whether you want to delegate testing to a QA team that has lower JavaScript skills or simplify the way you create tests yourself.
+TestCafe works great for JavaScript developers, but at some point you will need to delegate testing tasks to your Q&A department. If that's the case and you are looking for a codeless way to record and maintain tests compatible with your existing infrastructure, check out [TestCafe Studio](https://www.devexpress.com/products/testcafestudio/?utm_source=github.com&utm_medium=referral&utm_campaign=tc-gh-ide) - a testing IDE built on top of the open-source TestCafe.
 
 Read the following article to learn how TestCafe Studio could fit into your workflow: [What's Better than TestCafe? TestCafe Studio](https://www.devexpress.com/products/testcafestudio/).
 

--- a/docs/articles/faq/README.md
+++ b/docs/articles/faq/README.md
@@ -36,7 +36,7 @@ Feel free to ask for more details.
 
 ### What is the difference between [TestCafe Studio](https://www.devexpress.com/products/testcafestudio/) and [open-source TestCafe](https://devexpress.github.io/testcafe)?
 
-TestCafe Studio is a testing IDE built on top of the open-source TestCafe engine. Try it whether you're looking to simplify the way you record your tests or want to delegate testing to a QA team that does not want to write JavaScript.
+TestCafe Studio is a testing IDE built on top of the open-source TestCafe engine. It simplifies the way you record tests and helps you delegate testing to a QA team that does not want to write JavaScript.
 
 Read the following article to learn how TestCafe Studio could fit into your workflow: [What's Better than TestCafe? TestCafe Studio](https://www.devexpress.com/products/testcafestudio/).
 

--- a/docs/articles/faq/README.md
+++ b/docs/articles/faq/README.md
@@ -38,7 +38,7 @@ Feel free to ask for more details.
 
 TestCafe Studio is a testing IDE built on top of the open-source TestCafe engine. It simplifies the way you record tests and helps you delegate testing to a QA team that does not want to write JavaScript.
 
-Read the following article to learn how TestCafe Studio could fit into your workflow: [What's Better than TestCafe? TestCafe Studio](https://www.devexpress.com/products/testcafestudio/).
+Read the following article to learn how TestCafe Studio could fit into your workflow: [What's Better than TestCafe? TestCafe Studio](https://www.devexpress.com/products/testcafestudio/qa-end-to-end-web-testing.xml).
 
 The table below compares TestCafe and TestCafe Studio:
 

--- a/docs/articles/faq/README.md
+++ b/docs/articles/faq/README.md
@@ -36,6 +36,12 @@ Feel free to ask for more details.
 
 ### What is the difference between [TestCafe Studio](https://www.devexpress.com/products/testcafestudio/) and [open-source TestCafe](https://devexpress.github.io/testcafe)?
 
+TestCafe Studio is a testing IDE built on top of the open-source TestCafe engine. Try it whether you're looking to simplify the way you record your tests or want to delegate testing to a QA team that does not want to write JavaScript.
+
+Read the following article to learn how TestCafe Studio could fit into your workflow: [What's Better than TestCafe? TestCafe Studio](https://www.devexpress.com/products/testcafestudio/).
+
+The table below compares TestCafe and TestCafe Studio:
+
 | &nbsp; | [TestCafe](https://devexpress.github.io/testcafe) | [TestCafe Studio](https://www.devexpress.com/products/testcafestudio/)  |
 | ------ |:-------------------------------------------------:|:-----------------------------------------------------------------------:|
 | No need for WebDriver, browser plugins or other tools | &#10003; | &#10003; |

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -239,6 +239,12 @@ test('My first test', async t => {
                     </p>
 
                     <a class="try-testcafe-studio-link" href="https://www.devexpress.com/products/testcafestudio/">Try TestCafe Studio IDE</a>
+
+                    <div class="article-link">
+                        <p>
+                            <a href="https://www.devexpress.com/products/testcafestudio/">Learn how TestCafe Studio could fit into your workflow.</a>
+                        </p>
+                    </div>
                 </div>
             </div>
         </div>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -239,12 +239,6 @@ test('My first test', async t => {
                     </p>
 
                     <a class="try-testcafe-studio-link" href="https://www.devexpress.com/products/testcafestudio/">Try TestCafe Studio IDE</a>
-
-                    <div class="article-link">
-                        <p>
-                            This is how TestCafe Studio <a href="https://www.devexpress.com/products/testcafestudio/">enables your QA team to create automated tests.</a>
-                        </p>
-                    </div>
                 </div>
             </div>
         </div>

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -242,7 +242,7 @@ test('My first test', async t => {
 
                     <div class="article-link">
                         <p>
-                            <a href="https://www.devexpress.com/products/testcafestudio/">Learn how TestCafe Studio could fit into your workflow.</a>
+                            This is how TestCafe Studio <a href="https://www.devexpress.com/products/testcafestudio/">enables your QA team to create automated tests.</a>
                         </p>
                     </div>
                 </div>


### PR DESCRIPTION
\cc @DevExpress/testcafe-docs 

`[WIP]` because links to the article are not yet finalized.

So, here I:
* add links to an article to FAQ and ~the GitHub README.md~
* update texts (corrected by Vova)
* change the GitHub README.md 'Different versions' section - replaced lists with a table, like on the website
* update the Studio animation on GitHub README.md
