### PR TITLE
Add reportTestStart method to reporting system (close #3715)

### DIFF
--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -150,7 +150,10 @@ export default class Reporter {
 
             try {
                 await this.plugin.reportTestStart(reportItem.test.name);
-            } catch (err) {}
+            }
+            catch (err) {
+                return;
+            }
         });
 
         task.on('test-run-done', async testRun => {

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -148,12 +148,8 @@ export default class Reporter {
             if (!reportItem.startTime)
                 reportItem.startTime = new Date();
 
-            try {
-                await this.plugin.reportTestStart(reportItem.test.name);
-            }
-            catch (err) {
-                return;
-            }
+            if (this.plugin.reportTestStart)
+                await this.plugin.reportTestStart(reportItem.test.name, reportItem.test.meta);
         });
 
         task.on('test-run-done', async testRun => {

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -142,11 +142,15 @@ export default class Reporter {
             await this.plugin.reportFixtureStart(first.fixture.name, first.fixture.path, first.fixture.meta);
         });
 
-        task.on('test-run-start', testRun => {
+        task.on('test-run-start', async testRun => {
             const reportItem = this._getReportItemForTestRun(testRun);
 
             if (!reportItem.startTime)
                 reportItem.startTime = new Date();
+
+            try {
+                await this.plugin.reportTestStart(reportItem.test.name);
+            } catch (err) {}
         });
 
         task.on('test-run-done', async testRun => {

--- a/src/reporter/plugin-host.js
+++ b/src/reporter/plugin-host.js
@@ -143,9 +143,10 @@ export default class ReporterPluginHost {
         throw new Error('Not implemented');
     }
 
-    async reportTestStart (/* name, testMeta */) {
-        throw new Error('Not implemented');
-    }
+    // NOTE: It's an optional method
+    // async reportTestStart (/* name, testMeta */) {
+    //     throw new Error('Not implemented');
+    // }
 
     async reportTestDone (/* name, testRunInfo */) {
         throw new Error('Not implemented');

--- a/src/reporter/plugin-host.js
+++ b/src/reporter/plugin-host.js
@@ -143,6 +143,10 @@ export default class ReporterPluginHost {
         throw new Error('Not implemented');
     }
 
+    async reportTestStart (/* name, testRunInfo */) {
+        throw new Error('Not implemented');
+    }
+
     async reportTestDone (/* name, testRunInfo */) {
         throw new Error('Not implemented');
     }

--- a/src/reporter/plugin-host.js
+++ b/src/reporter/plugin-host.js
@@ -143,7 +143,7 @@ export default class ReporterPluginHost {
         throw new Error('Not implemented');
     }
 
-    async reportTestStart (/* name, testRunInfo */) {
+    async reportTestStart (/* name, testMeta */) {
         throw new Error('Not implemented');
     }
 

--- a/src/runner/browser-job.js
+++ b/src/runner/browser-job.js
@@ -39,7 +39,9 @@ export default class BrowserJob extends AsyncEventEmitter {
         testRunController.on('test-run-create', async testRunInfo => {
             await this.emit('test-run-create', testRunInfo);
         });
-        testRunController.on('test-run-start', async () => this._onTestRunStart(testRunController.testRun));
+        testRunController.on('test-run-start', async () => {
+            await this.emit('test-run-start', testRunController.testRun);
+        });
         testRunController.on('test-run-ready', async () => {
             await this.emit('test-run-ready', testRunController);
         });

--- a/src/runner/browser-job.js
+++ b/src/runner/browser-job.js
@@ -78,10 +78,6 @@ export default class BrowserJob extends AsyncEventEmitter {
         this.testRunControllerQueue.unshift(testRunController);
     }
 
-    async _onTestRunStart (testRun) {
-        await this.emit('test-run-start', testRun);
-    }
-
     async _onTestRunDone (testRunController) {
         this.total++;
 

--- a/src/runner/browser-job.js
+++ b/src/runner/browser-job.js
@@ -36,12 +36,18 @@ export default class BrowserJob extends AsyncEventEmitter {
         const testRunController = new TestRunController(test, index + 1, this.proxy, this.screenshots, this.warningLog,
             this.fixtureHookController, this.opts);
 
-        testRunController.on('test-run-create', testRunInfo => this.emit('test-run-create', testRunInfo));
-        testRunController.on('test-run-start', () => this._onTestRunStart(testRunController.testRun));
-        testRunController.on('test-run-ready', () => this.emit('test-run-ready', testRunController));
-        testRunController.on('test-run-restart', () => this._onTestRunRestart(testRunController));
-        testRunController.on('test-run-before-done', () => this.emit('test-run-before-done', testRunController));
-        testRunController.on('test-run-done', () => this._onTestRunDone(testRunController));
+        testRunController.on('test-run-create', async testRunInfo => {
+            await this.emit('test-run-create', testRunInfo);
+        });
+        testRunController.on('test-run-start', async () => this._onTestRunStart(testRunController.testRun));
+        testRunController.on('test-run-ready', async () => {
+            await this.emit('test-run-ready', testRunController);
+        });
+        testRunController.on('test-run-restart', async () => this._onTestRunRestart(testRunController));
+        testRunController.on('test-run-before-done', async () => {
+            await this.emit('test-run-before-done', testRunController);
+        });
+        testRunController.on('test-run-done', async () => this._onTestRunDone(testRunController));
 
         return testRunController;
     }

--- a/src/runner/browser-job.js
+++ b/src/runner/browser-job.js
@@ -37,7 +37,7 @@ export default class BrowserJob extends AsyncEventEmitter {
             this.fixtureHookController, this.opts);
 
         testRunController.on('test-run-create', testRunInfo => this.emit('test-run-create', testRunInfo));
-        testRunController.on('test-run-start', () => this.emit('test-run-start', testRunController.testRun));
+        testRunController.on('test-run-start', () => this._onTestRunStart(testRunController.testRun));
         testRunController.on('test-run-ready', () => this.emit('test-run-ready', testRunController));
         testRunController.on('test-run-restart', () => this._onTestRunRestart(testRunController));
         testRunController.on('test-run-before-done', () => this.emit('test-run-before-done', testRunController));
@@ -68,6 +68,10 @@ export default class BrowserJob extends AsyncEventEmitter {
     _onTestRunRestart (testRunController) {
         this._removeFromCompletionQueue(testRunController);
         this.testRunControllerQueue.unshift(testRunController);
+    }
+
+    async _onTestRunStart (testRun) {
+        await this.emit('test-run-start', testRun);
     }
 
     async _onTestRunDone (testRunController) {

--- a/src/runner/task.js
+++ b/src/runner/task.js
@@ -27,7 +27,9 @@ export default class Task extends AsyncEventEmitter {
     }
 
     _assignBrowserJobEventHandlers (job) {
-        job.on('test-run-start', testRun => this.emit('test-run-start', testRun));
+        job.on('test-run-start', async testRun => {
+            await this.emit('test-run-start', testRun);
+        });
 
         job.on('test-run-done', async testRun => {
             await this.emit('test-run-done', testRun);

--- a/src/runner/test-run-controller.js
+++ b/src/runner/test-run-controller.js
@@ -195,7 +195,9 @@ export default class TestRunController extends AsyncEventEmitter {
             return null;
         }
 
-        testRun.once('start', () => this.emit('test-run-start'));
+        testRun.once('start', async () => {
+            await this.emit('test-run-start');
+        });
         testRun.once('ready', () => {
             if (!this.quarantine || this._isFirstQuarantineAttempt())
                 this.emit('test-run-ready');

--- a/src/runner/test-run-controller.js
+++ b/src/runner/test-run-controller.js
@@ -198,9 +198,9 @@ export default class TestRunController extends AsyncEventEmitter {
         testRun.once('start', async () => {
             await this.emit('test-run-start');
         });
-        testRun.once('ready', () => {
+        testRun.once('ready', async () => {
             if (!this.quarantine || this._isFirstQuarantineAttempt())
-                this.emit('test-run-ready');
+                await this.emit('test-run-ready');
         });
         testRun.once('before-done', () => this._testRunBeforeDone());
         testRun.once('done', () => this._testRunDone());

--- a/test/functional/fixtures/api/es-next/page-load-timeout/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/api/es-next/page-load-timeout/testcafe-fixtures/index-test.js
@@ -2,6 +2,10 @@ import { ClientFunction } from 'testcafe';
 
 fixture `page-load-timeout`;
 
+// NOTE: For slow mobile browsers on CI machines the internal methods chain (parsing the tested web page, emitting appropriate events, calling the reporter methods)
+// can take a long time
+const expectedTimeoutForLongLoadPages = 5000;
+
 test
     .page('http://localhost:3000/fixtures/api/es-next/page-load-timeout/pages/window-load.html')
     ('Wait for window.load (set timeout via an option)', async t => {
@@ -35,7 +39,7 @@ test
             };
         });
 
-        await t.expect(startTestTime - pageOpenedTime).lt(1000);
+        await t.expect(result).lt(expectedTimeoutForLongLoadPages);
     });
 
 test
@@ -48,5 +52,5 @@ test
             };
         });
 
-        await t.expect(startTestTime - pageOpenedTime).lt(1000);
+        await t.expect(startTestTime - pageOpenedTime).lt(expectedTimeoutForLongLoadPages);
     });

--- a/test/functional/fixtures/api/es-next/page-load-timeout/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/api/es-next/page-load-timeout/testcafe-fixtures/index-test.js
@@ -39,7 +39,7 @@ test
             };
         });
 
-        await t.expect(result).lt(expectedTimeoutForLongLoadPages);
+        await t.expect(startTestTime - pageOpenedTime).lt(expectedTimeoutForLongLoadPages);
     });
 
 test

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -359,6 +359,13 @@ describe('Reporter', () => {
                     .then(() => log.push({ method: 'reportFixtureStart', args: Array.prototype.slice.call(arguments) }));
             },
 
+            reportTestStart: function (...args) {
+                expect(args[0]).to.be.an('string');
+
+                return delay(1000)
+                    .then(() => log.push({ method: 'reportTestStart', args: args }));
+            },
+
             reportTestDone: function (...args) {
                 expect(args[1].durationMs).to.be.an('number');
 
@@ -413,6 +420,15 @@ describe('Reporter', () => {
                 ]
             },
             'task-start resolved',
+            {
+                method: 'reportTestStart',
+                args:   [
+                    'fixture1test1',
+                    {
+                        run: 'run-001'
+                    }
+                ]
+            },
             'test-run-start resolved',
             'test-run-start resolved',
             {
@@ -445,6 +461,15 @@ describe('Reporter', () => {
             },
             'test-run-done resolved',
             'test-run-done resolved',
+            {
+                method: 'reportTestStart',
+                args:   [
+                    'fixture1test2',
+                    {
+                        run: 'run-001'
+                    }
+                ]
+            },
             'test-run-start resolved',
             'test-run-start resolved',
             {
@@ -494,6 +519,15 @@ describe('Reporter', () => {
             },
             'test-run-done resolved',
             'test-run-done resolved',
+            {
+                method: 'reportTestStart',
+                args:   [
+                    'fixture1test3',
+                    {
+                        run: 'run-001'
+                    }
+                ]
+            },
             'test-run-start resolved',
             'test-run-start resolved',
             {
@@ -527,6 +561,15 @@ describe('Reporter', () => {
             },
             'test-run-done resolved',
             'test-run-done resolved',
+            {
+                method: 'reportTestStart',
+                args:   [
+                    'fixture2test1',
+                    {
+                        run: 'run-001'
+                    }
+                ]
+            },
             'test-run-start resolved',
             'test-run-start resolved',
             {
@@ -550,6 +593,15 @@ describe('Reporter', () => {
             },
             'test-run-done resolved',
             'test-run-done resolved',
+            {
+                method: 'reportTestStart',
+                args:   [
+                    'fixture2test2',
+                    {
+                        run: 'run-001'
+                    }
+                ]
+            },
             'test-run-start resolved',
             'test-run-start resolved',
             {
@@ -581,6 +633,15 @@ describe('Reporter', () => {
             },
             'test-run-done resolved',
             'test-run-done resolved',
+            {
+                method: 'reportTestStart',
+                args:   [
+                    'fixture3test1',
+                    {
+                        run: 'run-001'
+                    }
+                ]
+            },
             'test-run-start resolved',
             'test-run-start resolved',
             {
@@ -610,6 +671,15 @@ describe('Reporter', () => {
             },
             'test-run-done resolved',
             'test-run-done resolved',
+            {
+                method: 'reportTestStart',
+                args:   [
+                    'fixture3test2',
+                    {
+                        run: 'run-001'
+                    }
+                ]
+            },
             'test-run-start resolved',
             'test-run-start resolved',
             {
@@ -633,6 +703,15 @@ describe('Reporter', () => {
             },
             'test-run-done resolved',
             'test-run-done resolved',
+            {
+                method: 'reportTestStart',
+                args:   [
+                    'fixture3test3',
+                    {
+                        run: 'run-001'
+                    }
+                ]
+            },
             'test-run-start resolved',
             'test-run-start resolved',
             {


### PR DESCRIPTION
To work correctly with such reporters as Allure and have ability to add something to report during current test execution process I added reportTestStart method to reporting system 
Related feature request: https://github.com/DevExpress/testcafe/issues/3715
