### PR TITLE
Handle errors inside the request hook methods (close #3786)

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "source-map-support": "^0.5.5",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "1.6.8",
-    "testcafe-hammerhead": "14.6.8",
+    "testcafe-hammerhead": "14.6.9",
     "testcafe-legacy-api": "3.1.11",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/src/api/request-hooks/hook.js
+++ b/src/api/request-hooks/hook.js
@@ -1,5 +1,6 @@
 import { RequestFilterRule } from 'testcafe-hammerhead';
 import { castArray } from 'lodash';
+import { RequestHookNotImplementedMethodError } from '../../errors/test-run';
 
 export default class RequestHook {
     constructor (requestFilterRules, responseEventConfigureOpts) {
@@ -28,7 +29,7 @@ export default class RequestHook {
     }
 
     async onRequest (/*RequestEvent event*/) {
-        throw new Error('Not implemented');
+        throw new RequestHookNotImplementedMethodError('onRequest', this.constructor.name);
     }
 
     _onConfigureResponse (event) {
@@ -40,6 +41,6 @@ export default class RequestHook {
     }
 
     async onResponse (/*ResponseEvent event*/) {
-        throw new Error('Not implemented');
+        throw new RequestHookNotImplementedMethodError('onResponse', this.constructor.name);
     }
 }

--- a/src/errors/test-run/index.js
+++ b/src/errors/test-run/index.js
@@ -529,3 +529,24 @@ export class SetNativeDialogHandlerCodeWrongTypeError extends TestRunErrorBase {
         this.actualType = actualType;
     }
 }
+
+export class RequestHookUnhandledError extends TestRunErrorBase {
+    constructor (err, hookClassName, methodName) {
+        super(TEST_RUN_ERRORS.requestHookUnhandledError);
+
+        this.errMsg        = String(err);
+        this.hookClassName = hookClassName;
+        this.methodName    = methodName;
+    }
+}
+
+export class RequestHookNotImplementedMethodError extends TestRunErrorBase {
+    constructor (methodName, hookClassName) {
+        super(TEST_RUN_ERRORS.requestHookNotImplementedError);
+
+        this.methodName    = methodName;
+        this.hookClassName = hookClassName;
+    }
+
+}
+

--- a/src/errors/test-run/templates.js
+++ b/src/errors/test-run/templates.js
@@ -283,5 +283,15 @@ export default {
 
     [TEST_RUN_ERRORS.assertionUnawaitedPromiseError]: err => markup(err, `
         Attempted to run assertions on a Promise object. Did you forget to await it? If not, pass "{ allowUnawaitedPromise: true }" to the assertion options.
+    `),
+
+    [TEST_RUN_ERRORS.requestHookNotImplementedError]: err => markup(err, `
+        You should implement the "${err.methodName}" method in the "${err.hookClassName}" class.
+    `),
+
+    [TEST_RUN_ERRORS.requestHookUnhandledError]: err => markup(err, `
+        An unhandled error occurred in the "${err.methodName}" method of the "${err.hookClassName}" class:
+        
+        ${escapeHtml(err.errMsg)}
     `)
 };

--- a/src/errors/types.js
+++ b/src/errors/types.js
@@ -62,7 +62,9 @@ export const TEST_RUN_ERRORS = {
     roleSwitchInRoleInitializerError:                   'E58',
     assertionExecutableArgumentError:                   'E59',
     assertionWithoutMethodCallError:                    'E60',
-    assertionUnawaitedPromiseError:                     'E61'
+    assertionUnawaitedPromiseError:                     'E61',
+    requestHookNotImplementedError:                     'E62',
+    requestHookUnhandledError:                          'E63'
 };
 
 export const RUNTIME_ERRORS = {

--- a/test/functional/fixtures/api/es-next/request-hooks/test.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/test.js
@@ -1,4 +1,4 @@
-const expect = require('chai').expect;
+const { expect } = require('chai');
 
 describe('Request Hooks', () => {
     describe('RequestMock', () => {
@@ -37,6 +37,18 @@ describe('Request Hooks', () => {
 
         it('Conditional adding', () => {
             return runTests('./testcafe-fixtures/api/conditional-adding.js', 'Conditional adding');
+        });
+
+        it('Should handle errors inside the overridden methods', () => {
+            return runTests('./testcafe-fixtures/api/handle-errors.js', null, { only: 'chrome', shouldFail: true })
+                .catch(() => {
+                    expect(testReport.errs.length).eql(5);
+                    expect(testReport.errs[0]).contains('You should implement the "onRequest" method in the "Hook1" class.');
+                    expect(testReport.errs[1]).contains('You should implement the "onResponse" method in the "Hook1" class.');
+                    expect(testReport.errs[2]).contains('You should implement the "onResponse" method in the "Hook2" class.');
+                    expect(testReport.errs[3]).contains('You should implement the "onRequest" method in the "Hook3" class.');
+                    expect(testReport.errs[4]).contains('An unhandled error occurred in the "onResponse" method of the "Hook3" class:\n\nError: Unhandled error.');
+                });
         });
     });
 });

--- a/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/handle-errors.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/handle-errors.js
@@ -1,0 +1,38 @@
+import { RequestHook } from 'testcafe';
+
+const pageUrl = 'http://localhost:3000/fixtures/api/es-next/request-hooks/pages/index.html';
+
+class Hook1 extends RequestHook {
+    constructor () {
+        super(pageUrl);
+    }
+}
+
+class Hook2 extends RequestHook {
+    constructor () {
+        super(pageUrl);
+    }
+
+    async onRequest () {}
+}
+
+class Hook3 extends RequestHook {
+    constructor () {
+        super(pageUrl);
+    }
+
+    async onResponse () {
+        throw new Error('Unhandled error.');
+    }
+}
+
+const hook1 = new Hook1();
+const hook2 = new Hook2();
+const hook3 = new Hook3();
+
+fixture `Fixture`
+    .requestHooks(hook1, hook2, hook3);
+
+test('test', async t => {
+    await t.navigateTo(pageUrl);
+});

--- a/test/server/data/expected-test-run-errors/request-hook-method-not-implemented-error
+++ b/test/server/data/expected-test-run-errors/request-hook-method-not-implemented-error
@@ -1,0 +1,19 @@
+You should implement the "onRequest" method in the "MyHook" class.
+
+Browser: Chrome 15.0.874 / Mac OS X 10.8.1
+Screenshot: /unix/path/with/<tag>
+
+   18 |function func1 () {
+   19 |    record = createCallsiteRecord({ byFunctionName: 'func1' });
+   20 |}
+   21 |
+   22 |(function func2 () {
+ > 23 |    func1();
+   24 |})();
+   25 |
+   26 |stackTrace.filter.deattach(stackFilter);
+   27 |
+   28 |module.exports = record;
+
+   at func2 (testfile.js:23:5)
+   at Object.<anonymous> (testfile.js:24:3)

--- a/test/server/data/expected-test-run-errors/request-hook-unhandled-error
+++ b/test/server/data/expected-test-run-errors/request-hook-unhandled-error
@@ -1,0 +1,21 @@
+An unhandled error occurred in the "onRequest" method of the "MyHook" class:
+
+Error: Test error
+
+Browser: Chrome 15.0.874 / Mac OS X 10.8.1
+Screenshot: /unix/path/with/<tag>
+
+   18 |function func1 () {
+   19 |    record = createCallsiteRecord({ byFunctionName: 'func1' });
+   20 |}
+   21 |
+   22 |(function func2 () {
+ > 23 |    func1();
+   24 |})();
+   25 |
+   26 |stackTrace.filter.deattach(stackFilter);
+   27 |
+   28 |module.exports = record;
+
+   at func2 (testfile.js:23:5)
+   at Object.<anonymous> (testfile.js:24:3)

--- a/test/server/test-run-error-formatting-test.js
+++ b/test/server/test-run-error-formatting-test.js
@@ -6,65 +6,71 @@ const TEST_RUN_PHASE                                     = require('../../lib/te
 const { TEST_RUN_ERRORS, RUNTIME_ERRORS }                = require('../../lib/errors/types');
 const TestRunErrorFormattableAdapter                     = require('../../lib/errors/test-run/formattable-adapter');
 const testCallsite                                       = require('./data/test-callsite');
-const AssertionExecutableArgumentError                   = require('../../lib/errors/test-run').AssertionExecutableArgumentError;
-const AssertionWithoutMethodCallError                    = require('../../lib/errors/test-run').AssertionWithoutMethodCallError;
-const AssertionUnawaitedPromiseError                     = require('../../lib/errors/test-run').AssertionUnawaitedPromiseError;
-const ActionIntegerOptionError                           = require('../../lib/errors/test-run').ActionIntegerOptionError;
-const ActionPositiveIntegerOptionError                   = require('../../lib/errors/test-run').ActionPositiveIntegerOptionError;
-const ActionIntegerArgumentError                         = require('../../lib/errors/test-run').ActionIntegerArgumentError;
-const ActionPositiveIntegerArgumentError                 = require('../../lib/errors/test-run').ActionPositiveIntegerArgumentError;
-const ActionBooleanOptionError                           = require('../../lib/errors/test-run').ActionBooleanOptionError;
-const ActionBooleanArgumentError                         = require('../../lib/errors/test-run').ActionBooleanArgumentError;
-const ActionSpeedOptionError                             = require('../../lib/errors/test-run').ActionSpeedOptionError;
-const ActionSelectorError                                = require('../../lib/errors/test-run').ActionSelectorError;
-const ActionOptionsTypeError                             = require('../../lib/errors/test-run').ActionOptionsTypeError;
-const ActionStringArgumentError                          = require('../../lib/errors/test-run').ActionStringArgumentError;
-const ActionNullableStringArgumentError                  = require('../../lib/errors/test-run').ActionNullableStringArgumentError;
-const ActionStringOrStringArrayArgumentError             = require('../../lib/errors/test-run').ActionStringOrStringArrayArgumentError;
-const ActionStringArrayElementError                      = require('../../lib/errors/test-run').ActionStringArrayElementError;
-const PageLoadError                                      = require('../../lib/errors/test-run').PageLoadError;
-const UncaughtErrorOnPage                                = require('../../lib/errors/test-run').UncaughtErrorOnPage;
-const UncaughtErrorInTestCode                            = require('../../lib/errors/test-run').UncaughtErrorInTestCode;
-const UncaughtErrorInClientFunctionCode                  = require('../../lib/errors/test-run').UncaughtErrorInClientFunctionCode;
-const UncaughtNonErrorObjectInTestCode                   = require('../../lib/errors/test-run').UncaughtNonErrorObjectInTestCode;
-const UncaughtErrorInCustomDOMPropertyCode               = require('../../lib/errors/test-run').UncaughtErrorInCustomDOMPropertyCode;
-const UnhandledPromiseRejectionError                     = require('../../lib/errors/test-run').UnhandledPromiseRejectionError;
-const UncaughtExceptionError                             = require('../../lib/errors/test-run').UncaughtExceptionError;
-const ActionElementNotFoundError                         = require('../../lib/errors/test-run').ActionElementNotFoundError;
-const ActionElementIsInvisibleError                      = require('../../lib/errors/test-run').ActionElementIsInvisibleError;
-const ActionSelectorMatchesWrongNodeTypeError            = require('../../lib/errors/test-run').ActionSelectorMatchesWrongNodeTypeError;
-const ActionAdditionalElementNotFoundError               = require('../../lib/errors/test-run').ActionAdditionalElementNotFoundError;
-const ActionAdditionalElementIsInvisibleError            = require('../../lib/errors/test-run').ActionAdditionalElementIsInvisibleError;
-const ActionAdditionalSelectorMatchesWrongNodeTypeError  = require('../../lib/errors/test-run').ActionAdditionalSelectorMatchesWrongNodeTypeError;
-const ActionElementNonEditableError                      = require('../../lib/errors/test-run').ActionElementNonEditableError;
-const ActionElementNonContentEditableError               = require('../../lib/errors/test-run').ActionElementNonContentEditableError;
-const ActionRootContainerNotFoundError                   = require('../../lib/errors/test-run').ActionRootContainerNotFoundError;
-const ActionElementNotTextAreaError                      = require('../../lib/errors/test-run').ActionElementNotTextAreaError;
-const ActionIncorrectKeysError                           = require('../../lib/errors/test-run').ActionIncorrectKeysError;
-const ActionCannotFindFileToUploadError                  = require('../../lib/errors/test-run').ActionCannotFindFileToUploadError;
-const ActionElementIsNotFileInputError                   = require('../../lib/errors/test-run').ActionElementIsNotFileInputError;
-const ActionUnsupportedDeviceTypeError                   = require('../../lib/errors/test-run').ActionUnsupportedDeviceTypeError;
-const ActionInvalidScrollTargetError                     = require('../../lib/errors/test-run').ActionInvalidScrollTargetError;
-const ClientFunctionExecutionInterruptionError           = require('../../lib/errors/test-run').ClientFunctionExecutionInterruptionError;
-const ActionElementNotIframeError                        = require('../../lib/errors/test-run').ActionElementNotIframeError;
-const ActionIframeIsNotLoadedError                       = require('../../lib/errors/test-run').ActionIframeIsNotLoadedError;
-const CurrentIframeIsNotLoadedError                      = require('../../lib/errors/test-run').CurrentIframeIsNotLoadedError;
-const CurrentIframeNotFoundError                         = require('../../lib/errors/test-run').CurrentIframeNotFoundError;
-const CurrentIframeIsInvisibleError                      = require('../../lib/errors/test-run').CurrentIframeIsInvisibleError;
-const MissingAwaitError                                  = require('../../lib/errors/test-run').MissingAwaitError;
-const ExternalAssertionLibraryError                      = require('../../lib/errors/test-run').ExternalAssertionLibraryError;
-const DomNodeClientFunctionResultError                   = require('../../lib/errors/test-run').DomNodeClientFunctionResultError;
-const InvalidSelectorResultError                         = require('../../lib/errors/test-run').InvalidSelectorResultError;
-const NativeDialogNotHandledError                        = require('../../lib/errors/test-run').NativeDialogNotHandledError;
-const UncaughtErrorInNativeDialogHandler                 = require('../../lib/errors/test-run').UncaughtErrorInNativeDialogHandler;
-const SetNativeDialogHandlerCodeWrongTypeError           = require('../../lib/errors/test-run').SetNativeDialogHandlerCodeWrongTypeError;
-const CannotObtainInfoForElementSpecifiedBySelectorError = require('../../lib/errors/test-run').CannotObtainInfoForElementSpecifiedBySelectorError;
-const WindowDimensionsOverflowError                      = require('../../lib/errors/test-run').WindowDimensionsOverflowError;
-const ForbiddenCharactersInScreenshotPathError           = require('../../lib/errors/test-run').ForbiddenCharactersInScreenshotPathError;
-const InvalidElementScreenshotDimensionsError            = require('../../lib/errors/test-run').InvalidElementScreenshotDimensionsError;
-const SetTestSpeedArgumentError                          = require('../../lib/errors/test-run').SetTestSpeedArgumentError;
-const RoleSwitchInRoleInitializerError                   = require('../../lib/errors/test-run').RoleSwitchInRoleInitializerError;
-const ActionRoleArgumentError                            = require('../../lib/errors/test-run').ActionRoleArgumentError;
+
+const {
+    AssertionExecutableArgumentError,
+    AssertionWithoutMethodCallError,
+    AssertionUnawaitedPromiseError,
+    ActionIntegerOptionError,
+    ActionPositiveIntegerOptionError,
+    ActionIntegerArgumentError,
+    ActionPositiveIntegerArgumentError,
+    ActionBooleanOptionError,
+    ActionBooleanArgumentError,
+    ActionSpeedOptionError,
+    ActionSelectorError,
+    ActionOptionsTypeError,
+    ActionStringArgumentError,
+    ActionNullableStringArgumentError,
+    ActionStringOrStringArrayArgumentError,
+    ActionStringArrayElementError,
+    PageLoadError,
+    UncaughtErrorOnPage,
+    UncaughtErrorInTestCode,
+    UncaughtErrorInClientFunctionCode,
+    UncaughtNonErrorObjectInTestCode,
+    UncaughtErrorInCustomDOMPropertyCode,
+    UnhandledPromiseRejectionError,
+    UncaughtExceptionError,
+    ActionElementNotFoundError,
+    ActionElementIsInvisibleError,
+    ActionSelectorMatchesWrongNodeTypeError,
+    ActionAdditionalElementNotFoundError,
+    ActionAdditionalElementIsInvisibleError,
+    ActionAdditionalSelectorMatchesWrongNodeTypeError,
+    ActionElementNonEditableError,
+    ActionElementNonContentEditableError,
+    ActionRootContainerNotFoundError,
+    ActionElementNotTextAreaError,
+    ActionIncorrectKeysError,
+    ActionCannotFindFileToUploadError,
+    ActionElementIsNotFileInputError,
+    ActionUnsupportedDeviceTypeError,
+    ActionInvalidScrollTargetError,
+    ClientFunctionExecutionInterruptionError,
+    ActionElementNotIframeError,
+    ActionIframeIsNotLoadedError,
+    CurrentIframeIsNotLoadedError,
+    CurrentIframeNotFoundError,
+    CurrentIframeIsInvisibleError,
+    MissingAwaitError,
+    ExternalAssertionLibraryError,
+    DomNodeClientFunctionResultError,
+    InvalidSelectorResultError,
+    NativeDialogNotHandledError,
+    UncaughtErrorInNativeDialogHandler,
+    SetNativeDialogHandlerCodeWrongTypeError,
+    CannotObtainInfoForElementSpecifiedBySelectorError,
+    WindowDimensionsOverflowError,
+    ForbiddenCharactersInScreenshotPathError,
+    InvalidElementScreenshotDimensionsError,
+    SetTestSpeedArgumentError,
+    RoleSwitchInRoleInitializerError,
+    ActionRoleArgumentError,
+    RequestHookNotImplementedMethodError,
+    RequestHookUnhandledError
+} = require('../../lib/errors/test-run');
+
 const { createSimpleTestStream }                         = require('../functional/utils/stream');
 
 const TEST_FILE_STACK_ENTRY_RE = new RegExp('\\s*\\n?\\(' + escapeRegExp(require.resolve('./data/test-callsite')), 'g');
@@ -359,6 +365,14 @@ describe('Error formatting', () => {
 
         it('Should format "assertionUnawaitedPromiseError"', () => {
             assertErrorMessage('assertion-unawaited-promise-error', new AssertionUnawaitedPromiseError(testCallsite));
+        });
+
+        it('Should format "requestHookNotImplementedError"', () => {
+            assertErrorMessage('request-hook-method-not-implemented-error', new RequestHookNotImplementedMethodError('onRequest', 'MyHook'));
+        });
+
+        it('Should format "requestHookUnhandledError"', () => {
+            assertErrorMessage('request-hook-unhandled-error', new RequestHookUnhandledError(new Error('Test error'), 'MyHook', 'onRequest'));
         });
     });
 


### PR DESCRIPTION
@AndreyBelym @AlexKamaev @LavrovArtem 

First - this PR, next - https://github.com/DevExpress/testcafe-hammerhead/pull/2036

@VasilyStrelyaev check please messages in the error templates