### PR TITLE
fix scrolling when page has negative margins (#2601)

### DIFF
--- a/src/client/core/utils/style.js
+++ b/src/client/core/utils/style.js
@@ -89,17 +89,17 @@ function hasBodyScroll (el) {
 
     const documentElement = domUtils.findDocument(el).documentElement;
 
-    let negativeMarginCompensateValue = 0;
+    let bodyScrollHeight = el.scrollHeight;
 
     if (browserUtils.isChrome || browserUtils.isFirefox) {
         const { top: bodyTop }     = el.getBoundingClientRect();
         const { top: documentTop } = documentElement.getBoundingClientRect();
 
-        negativeMarginCompensateValue = documentTop - bodyTop;
+        bodyScrollHeight = bodyScrollHeight - documentTop + bodyTop;
     }
 
     return (scrollableHorizontally || scrollableVertically) &&
-           el.scrollHeight - negativeMarginCompensateValue > documentElement.scrollHeight;
+           bodyScrollHeight > documentElement.scrollHeight;
 }
 
 function hasHTMLElementScroll (el) {

--- a/src/client/core/utils/style.js
+++ b/src/client/core/utils/style.js
@@ -89,8 +89,17 @@ function hasBodyScroll (el) {
 
     const documentElement = domUtils.findDocument(el).documentElement;
 
+    let negativeMarginCompensateValue = 0;
+
+    if (browserUtils.isChrome || browserUtils.isFirefox) {
+        const { top: bodyTop }     = el.getBoundingClientRect();
+        const { top: documentTop } = documentElement.getBoundingClientRect();
+
+        negativeMarginCompensateValue = documentTop - bodyTop;
+    }
+
     return (scrollableHorizontally || scrollableVertically) &&
-           el.scrollHeight > documentElement.scrollHeight;
+           el.scrollHeight - negativeMarginCompensateValue > documentElement.scrollHeight;
 }
 
 function hasHTMLElementScroll (el) {

--- a/test/functional/fixtures/regression/gh-2601/pages/index.html
+++ b/test/functional/fixtures/regression/gh-2601/pages/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8"/>
+    <title></title>
+    <style>
+        html, body {
+            height: 100%;
+        }
+        body {
+            overflow-x: hidden;
+        }
+        div {
+            margin-top: -200px;
+        }
+        button {
+            margin-top: 2000px;
+            background-color: red;
+        }
+    </style>
+</head>
+<body>
+<div>
+    <button>click me</button>
+</div>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-2601/pages/index.html
+++ b/test/functional/fixtures/regression/gh-2601/pages/index.html
@@ -23,5 +23,12 @@
 <div>
     <button>click me</button>
 </div>
+<script>
+    var button = document.querySelector('button');
+
+    button.addEventListener('click', function () {
+        window.clicked = true;
+    });
+</script>
 </body>
 </html>

--- a/test/functional/fixtures/regression/gh-2601/test.js
+++ b/test/functional/fixtures/regression/gh-2601/test.js
@@ -3,5 +3,3 @@ describe('[Regression](GH-2601) - Scroll to element when page has elements with 
         return runTests('testcafe-fixtures/index.js');
     });
 });
-
-

--- a/test/functional/fixtures/regression/gh-2601/test.js
+++ b/test/functional/fixtures/regression/gh-2601/test.js
@@ -1,0 +1,7 @@
+describe('[Regression](GH-2601) - Scroll to element when page has elements with negative margin', function () {
+    it('Scroll to element when page has elements with negative margin', function () {
+        return runTests('testcafe-fixtures/index.js');
+    });
+});
+
+

--- a/test/functional/fixtures/regression/gh-2601/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-2601/testcafe-fixtures/index.js
@@ -1,0 +1,6 @@
+fixture `GH-2601 - Scroll to element when page has elements with negative margin`
+    .page `http://localhost:3000/fixtures/regression/gh-2601/pages/index.html`;
+
+test('Scroll to element when page has elements with negative margin', async (t) => {
+    await t.click('button');
+});

--- a/test/functional/fixtures/regression/gh-2601/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-2601/testcafe-fixtures/index.js
@@ -1,6 +1,17 @@
+import { ClientFunction } from 'testcafe';
+
+const getClicked = ClientFunction(() => {
+    return window.clicked;
+});
+
 fixture `GH-2601 - Scroll to element when page has elements with negative margin`
     .page `http://localhost:3000/fixtures/regression/gh-2601/pages/index.html`;
 
 test('Scroll to element when page has elements with negative margin', async (t) => {
     await t.click('button');
+
+    const isClicked = await getClicked();
+
+    await t.expect(isClicked).eql(true);
+
 });


### PR DESCRIPTION
The problem appears if:
1. Body has overflow: auto (here it implicitly has overflow-y auto)
2. Body has defined height
3. Body has a child with negative margin
This markup leads to incorrect calculations of html scrollHeight