### PR TITLE
Fix test file scanning for Windows (closes #3918)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "emittery": "^0.4.1",
     "endpoint-utils": "^1.0.2",
     "error-stack-parser": "^1.3.6",
-    "globby": "^3.0.1",
+    "globby": "^9.2.0",
     "graceful-fs": "^4.1.11",
     "graphlib": "^2.1.5",
     "import-lazy": "^3.1.0",

--- a/src/utils/parse-file-list.js
+++ b/src/utils/parse-file-list.js
@@ -66,8 +66,10 @@ async function getFiles (globTask) {
 }
 
 async function execFileGlobs (globs, baseDir) {
+    // NOTE: We have to create glob tasks, execute them and sort their results separately to preserve the same item order
+    // as in the older globby versions (<7.1.1)
     const tasks = globby.generateGlobTasks(globs, { cwd: baseDir, expandDirectories: false, onlyFiles: true });
-    const files = await Promise.all(tasks.map(task => getFiles(task)));
+    const files = await Promise.all(tasks.map(getFiles);
 
     return flatten(files);
 }

--- a/src/utils/parse-file-list.js
+++ b/src/utils/parse-file-list.js
@@ -69,7 +69,7 @@ async function execFileGlobs (globs, baseDir) {
     // NOTE: We have to create glob tasks, execute them and sort their results separately to preserve the same item order
     // as in the older globby versions (<7.1.1)
     const tasks = globby.generateGlobTasks(globs, { cwd: baseDir, expandDirectories: false, onlyFiles: true });
-    const files = await Promise.all(tasks.map(getFiles);
+    const files = await Promise.all(tasks.map(getFiles));
 
     return flatten(files);
 }

--- a/src/utils/parse-file-list.js
+++ b/src/utils/parse-file-list.js
@@ -4,7 +4,7 @@ import globby from 'globby';
 import isGlob from 'is-glob';
 import Compiler from '../compiler';
 import OS from 'os-family';
-import { isEmpty } from 'lodash';
+import { isEmpty, flatten } from 'lodash';
 import { stat } from '../utils/promisified-functions';
 
 const DEFAULT_TEST_LOOKUP_DIRS = ['test/', 'tests/'];
@@ -24,9 +24,12 @@ function modifyFileRoot (baseDir, file) {
 
 async function getDefaultDirs (baseDir) {
     return await globby(DEFAULT_TEST_LOOKUP_DIRS, {
-        cwd:    baseDir,
-        nocase: true,
-        silent: true
+        cwd:                baseDir,
+        absolute:           true,
+        caseSensitiveMatch: false,
+        expandDirectories:  false,
+        onlyDirectories:    true,
+        suppressErrors:     true
     });
 }
 
@@ -56,12 +59,25 @@ async function convertDirsToGlobs (fileList, baseDir) {
     return fileList.filter(file => !!file);
 }
 
+async function getFiles (globTask) {
+    const files = await globby(globTask.pattern, globTask.options);
+
+    return files.sort((fileA, fileB) => fileA.localeCompare(fileB));
+}
+
+async function execFileGlobs (globs, baseDir) {
+    const tasks = globby.generateGlobTasks(globs, { cwd: baseDir, expandDirectories: false, onlyFiles: true });
+    const files = await Promise.all(tasks.map(task => getFiles(task)));
+
+    return flatten(files);
+}
+
 export default async function parseFileList (fileList, baseDir) {
     if (isEmpty(fileList))
         fileList = await getDefaultDirs(baseDir);
 
     fileList = await convertDirsToGlobs(fileList, baseDir);
-    fileList = await globby(fileList, { cwd: baseDir });
+    fileList = await execFileGlobs(fileList, baseDir);
 
     return fileList.map(file => path.resolve(baseDir, file));
 }


### PR DESCRIPTION
Closes #3918. Luckily I found a function that allowed me to avoid rewriting half of the `globby` code. Can't write a test for the fixed even with `proxyquire`, because the issue was caused by the internals of `node-glob`.