### PR TITLE
Fix TypeScript compiler for configurations with moduleResolution (closes #3970, #3976)

### DIFF
--- a/src/configuration/configuration-base.js
+++ b/src/configuration/configuration-base.js
@@ -1,10 +1,11 @@
+import { isAbsolute } from 'path';
 import debug from 'debug';
+import JSON5 from 'json5';
+import { cloneDeep, castArray } from 'lodash';
 import { stat, readFile } from '../utils/promisified-functions';
 import Option from './option';
 import optionSource from './option-source';
-import { cloneDeep, castArray } from 'lodash';
 import resolvePathRelativelyCwd from '../utils/resolve-path-relatively-cwd';
-import JSON5 from 'json5';
 import renderTemplate from '../utils/render-template';
 import WARNING_MESSAGES from '../notifications/warning-message';
 import log from '../cli/log';
@@ -14,7 +15,7 @@ const DEBUG_LOGGER = debug('testcafe:configuration');
 export default class Configuration {
     constructor (configurationFileName) {
         this._options  = {};
-        this._filePath = resolvePathRelativelyCwd(configurationFileName);
+        this._filePath = isAbsolute(configurationFileName) ? configurationFileName : resolvePathRelativelyCwd(configurationFileName);
         this._overridenOptions = [];
     }
 

--- a/src/configuration/default-values.js
+++ b/src/configuration/default-values.js
@@ -23,9 +23,10 @@ export const DEFAULT_TYPESCRIPT_COMPILER_OPTIONS = {
     inlineSourceMap:         true,
     noImplicitAny:           false,
     module:                  1 /* ts.ModuleKind.CommonJS */,
-    target:                  2 /* ES6 */,
+    moduleResolution:        2 /* ts.ModuleResolutionKind.Node */,
+    target:                  3 /* ts.ScriptTarget.ES2016 */,
     suppressOutputPathCheck: true,
     skipLibCheck:            true
 };
 
-export const TYPESCRIPT_COMPILER_NON_OVERRIDABLE_OPTIONS = ['module', 'target'];
+export const TYPESCRIPT_COMPILER_NON_OVERRIDABLE_OPTIONS = ['module', 'moduleResolution', 'target'];

--- a/src/configuration/default-values.js
+++ b/src/configuration/default-values.js
@@ -30,3 +30,14 @@ export const DEFAULT_TYPESCRIPT_COMPILER_OPTIONS = {
 };
 
 export const TYPESCRIPT_COMPILER_NON_OVERRIDABLE_OPTIONS = ['module', 'moduleResolution', 'target'];
+
+export const TYPESCRIPT_BLACKLISTED_OPTIONS = [
+    'incremental',
+    'tsBuildInfoFile',
+    'emitDeclarationOnly',
+    'declarationMap',
+    'declarationDir',
+    'composite',
+    'outFile',
+    'out'
+];

--- a/src/configuration/typescript-configuration.js
+++ b/src/configuration/typescript-configuration.js
@@ -5,6 +5,9 @@ import { intersection } from 'lodash';
 import WARNING_MESSAGES from '../notifications/warning-message';
 import renderTemplate from '../utils/render-template';
 
+const lazyRequire = require('import-lazy')(require);
+const typescript  = lazyRequire('typescript');
+
 const DEFAULT_CONFIGURATION_FILENAME = 'tsconfig.json';
 
 export default class TypescriptConfiguration extends Configuration {
@@ -15,13 +18,55 @@ export default class TypescriptConfiguration extends Configuration {
             this._ensureOptionWithValue(option, DEFAULT_TYPESCRIPT_COMPILER_OPTIONS[option], optionSource.configuration);
     }
 
+    // NOTE: define this as a static prop to avoid requiring TypeScript at start
+    get POSSIBLE_VALUES_MAP () {
+        return {
+            'module': typescript.ModuleKind,
+
+            'moduleResolution': {
+                'classic': typescript.ModuleResolutionKind.Classic,
+                'node':    typescript.ModuleResolutionKind.NodeJs
+            },
+
+            'target': {
+                'es6': typescript.ScriptTarget.ES2015,
+
+                ...typescript.ScriptTarget
+            }
+        };
+    }
+
     async init () {
         const opts = await this._load();
 
-        if (opts && opts.compilerOptions)
+        if (opts && opts.compilerOptions) {
+            this._normalizeOpts(opts.compilerOptions);
+
             this.mergeOptions(opts.compilerOptions);
+        }
 
         this._notifyThatOptionsCannotBeOverriden();
+    }
+
+    _normalizeTSOption (optionValue, optionEnum) {
+        if (typeof optionValue === 'number')
+            return optionValue;
+
+        const optionKey = Object.keys(optionEnum).filter(key => key.toLowerCase() === optionValue.toLowerCase())[0];
+
+        if (!optionKey)
+            return optionValue;
+
+        return optionEnum[optionKey];
+    }
+
+    _normalizeOpts (opts) {
+        for (const option of TYPESCRIPT_COMPILER_NON_OVERRIDABLE_OPTIONS) {
+            if (!opts[option])
+                continue;
+
+            opts[option] = this._normalizeTSOption(opts[option], this.POSSIBLE_VALUES_MAP[option]);
+        }
     }
 
     _notifyThatOptionsCannotBeOverriden () {

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -237,18 +237,29 @@ describe('TypeScriptConfiguration', () => {
             configuration = new TypescriptConfiguration();
             configPath    = configuration.filePath;
 
+            // NOTE: suppressOutputPathCheck can't be overridden by a config file
             createConfigFile({
                 compilerOptions: {
-                    experimentalDecorators:  false,
-                    emitDecoratorMetadata:   false,
-                    allowJs:                 false,
-                    pretty:                  false,
-                    inlineSourceMap:         false,
-                    noImplicitAny:           true,
-                    module:                  'esnext',
-                    moduleResolution:        'classic',
-                    target:                  'esnext',
-                    suppressOutputPathCheck: false
+                    experimentalDecorators: false,
+                    emitDecoratorMetadata:  false,
+                    allowJs:                false,
+                    pretty:                 false,
+                    inlineSourceMap:        false,
+                    noImplicitAny:          true,
+
+                    module:           'esnext',
+                    moduleResolution: 'classic',
+                    target:           'esnext',
+                    lib:              ['es2018', 'dom'],
+
+                    incremental:         true,
+                    tsBuildInfoFile:     'tsBuildInfo.txt',
+                    emitDeclarationOnly: true,
+                    declarationMap:      true,
+                    declarationDir:      'C:/',
+                    composite:           true,
+                    outFile:             'oufile.js',
+                    out:                 ''
                 }
             });
 
@@ -256,18 +267,31 @@ describe('TypeScriptConfiguration', () => {
                 .then(() => {
                     consoleWrapper.unwrap();
 
-                    expect(configuration.getOption('experimentalDecorators')).eql(false);
-                    expect(configuration.getOption('emitDecoratorMetadata')).eql(false);
-                    expect(configuration.getOption('allowJs')).eql(false);
-                    expect(configuration.getOption('pretty')).eql(false);
-                    expect(configuration.getOption('inlineSourceMap')).eql(false);
-                    expect(configuration.getOption('noImplicitAny')).eql(true);
-                    expect(configuration.getOption('suppressOutputPathCheck')).eql(false);
+                    const options = configuration.getOptions();
+
+                    expect(options['experimentalDecorators']).eql(false);
+                    expect(options['emitDecoratorMetadata']).eql(false);
+                    expect(options['allowJs']).eql(false);
+                    expect(options['pretty']).eql(false);
+                    expect(options['inlineSourceMap']).eql(false);
+                    expect(options['noImplicitAny']).eql(true);
+                    expect(options['suppressOutputPathCheck']).eql(true);
 
                     // NOTE: `module` and `target` default options can not be overridden by custom config
-                    expect(configuration.getOption('module')).eql(1);
-                    expect(configuration.getOption('moduleResolution')).eql(2);
-                    expect(configuration.getOption('target')).eql(3);
+                    expect(options['module']).eql(1);
+                    expect(options['moduleResolution']).eql(2);
+                    expect(options['target']).eql(3);
+
+                    expect(options['lib']).deep.eql(['lib.es2018.d.ts', 'lib.dom.d.ts']);
+
+                    expect(options).not.have.property('incremental');
+                    expect(options).not.have.property('tsBuildInfoFile');
+                    expect(options).not.have.property('emitDeclarationOnly');
+                    expect(options).not.have.property('declarationMap');
+                    expect(options).not.have.property('declarationDir');
+                    expect(options).not.have.property('composite');
+                    expect(options).not.have.property('outFile');
+                    expect(options).not.have.property('out');
 
                     expect(consoleWrapper.messages.log).contains('You cannot override the "module" compiler option in the TypeScript configuration file.');
                     expect(consoleWrapper.messages.log).contains('You cannot override the "moduleResolution" compiler option in the TypeScript configuration file.');
@@ -312,7 +336,7 @@ describe('TypeScriptConfiguration', () => {
 
             createConfigFile({
                 compilerOptions: {
-                    target: 'override-target'
+                    target: 'es5'
                 }
             });
 

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -245,8 +245,9 @@ describe('TypeScriptConfiguration', () => {
                     pretty:                  false,
                     inlineSourceMap:         false,
                     noImplicitAny:           true,
-                    module:                  2,
-                    target:                  3,
+                    module:                  'esnext',
+                    moduleResolution:        'classic',
+                    target:                  'esnext',
                     suppressOutputPathCheck: false
                 }
             });
@@ -265,10 +266,32 @@ describe('TypeScriptConfiguration', () => {
 
                     // NOTE: `module` and `target` default options can not be overridden by custom config
                     expect(configuration.getOption('module')).eql(1);
-                    expect(configuration.getOption('target')).eql(2);
+                    expect(configuration.getOption('moduleResolution')).eql(2);
+                    expect(configuration.getOption('target')).eql(3);
 
                     expect(consoleWrapper.messages.log).contains('You cannot override the "module" compiler option in the TypeScript configuration file.');
+                    expect(consoleWrapper.messages.log).contains('You cannot override the "moduleResolution" compiler option in the TypeScript configuration file.');
                     expect(consoleWrapper.messages.log).contains('You cannot override the "target" compiler option in the TypeScript configuration file.');
+                });
+        });
+
+        it('Should not display override messages if config values are the same as default values', () => {
+            configuration = new TypescriptConfiguration();
+            configPath    = configuration.filePath;
+
+            createConfigFile({
+                compilerOptions: {
+                    module:           'commonjs',
+                    moduleResolution: 'node',
+                    target:           'es2016'
+                }
+            });
+
+            return configuration.init()
+                .then(() => {
+                    consoleWrapper.unwrap();
+
+                    expect(consoleWrapper.messages.log).not.ok;
                 });
         });
 


### PR DESCRIPTION
Closes #3970. Closes #3976.

1. `moduleResolution` is hardcoded in our TS config.
2. Override warning for hardcoded options is not shown if the user's config sets the same values as hardcoded values.
3. TypeScript target set to ES2016. Node 8 support of ES2016 is 100% - https://node.green/#ES2016. 