### PR TITLE
fix module cache clearing in live mode for Node 12 (closes #4052)

### DIFF
--- a/src/live/file-watcher/modules-graph.js
+++ b/src/live/file-watcher/modules-graph.js
@@ -57,7 +57,7 @@ export default class ModulesGraph {
         if (!cache[node])
             return;
 
-        cache[node] = null;
+        cache[node] = void 0;
 
         const parentEdges = this.graph.inEdges(node);
 

--- a/src/live/file-watcher/modules-graph.js
+++ b/src/live/file-watcher/modules-graph.js
@@ -57,7 +57,7 @@ export default class ModulesGraph {
         if (!cache[node])
             return;
 
-        cache[node] = void 0;
+        delete cache[node];
 
         const parentEdges = this.graph.inEdges(node);
 

--- a/test/server/data/test-suites/live/commonjs-module.js
+++ b/test/server/data/test-suites/live/commonjs-module.js
@@ -1,0 +1,1 @@
+module.exports = 'Hello world';

--- a/test/server/data/test-suites/live/multiple-tests.js
+++ b/test/server/data/test-suites/live/multiple-tests.js
@@ -1,11 +1,11 @@
-fixture('Fixture2')
+fixture('multiple')
     .page('http://example.com');
 
-test('test2', async t => {
+test('multiple 1', async t => {
 
 });
 
-test('test3', async t => {
+test('multiple 2', async t => {
 
 });
 

--- a/test/server/data/test-suites/live/test-external-module-rerun.js
+++ b/test/server/data/test-suites/live/test-external-module-rerun.js
@@ -1,0 +1,9 @@
+import module from './commonjs-module';
+
+fixture('rerun with external module')
+    .page('http://example.com');
+
+test('rerun with external module', async t => {
+    console.log('test');
+});
+

--- a/test/server/data/test-suites/live/test-external-module.js
+++ b/test/server/data/test-suites/live/test-external-module.js
@@ -1,9 +1,9 @@
 import { url } from './module';
 
-fixture('Fixture4')
+fixture('external module')
     .page('http://example.com');
 
-test('test1', async t => {
+test('external module', async t => {
 
 });
 

--- a/test/server/data/test-suites/live/test-external-unexisting-module.js
+++ b/test/server/data/test-suites/live/test-external-unexisting-module.js
@@ -1,7 +1,7 @@
 require('./non-existing-module');
 
-fixture('Fixture5')
+fixture('non existing module')
     .page('http://example.com');
 
-test('test6', async t => {
+test('non existing module', async t => {
 });

--- a/test/server/data/test-suites/live/test-with-syntax-error.js
+++ b/test/server/data/test-suites/live/test-with-syntax-error.js
@@ -1,6 +1,6 @@
-fixture('Fixture3')
+fixture('syntax error')
     .page('http://example.com');
 
-test('test4', async t => {
+test('syntax error', async t => {
     // Syntax error
 }

--- a/test/server/data/test-suites/live/test.js
+++ b/test/server/data/test-suites/live/test.js
@@ -1,7 +1,7 @@
-fixture('Fixture1')
+fixture('basic')
     .page('http://example.com');
 
-test('test1', async t => {
+test('basic', async t => {
 
 });
 


### PR DESCRIPTION
the cause is here https://github.com/nodejs/node/blob/master/lib/internal/modules/cjs/loader.js#L617
and the pull is here https://github.com/nodejs/node/commit/0f190a5bed14bf9f7392af889f3f83306bedae97