### PR TITLE
[docs] Remove an obsolete paragraph about TS config

### DIFF
--- a/docs/articles/documentation/test-api/typescript-support.md
+++ b/docs/articles/documentation/test-api/typescript-support.md
@@ -86,8 +86,6 @@ See the available options in the [TypeScript Compiler Options](https://www.types
 
 > Important! You cannot override the `module` and `target` options.
 
-Save `tsconfig.json` to the directory from which you run TestCafe (usually the project's root directory), or specify the [tsConfigPath](../using-testcafe/configuration-file.md#tsconfigpath) option in the [configuration file](../using-testcafe/configuration-file.md) to use a different location.
-
 TestCafe passes the following options to the TypeScript compiler unless you override them in `tsconfig.json`:
 
 Option                    | Value


### PR DESCRIPTION
We now say about specifying the location at the beginning: https://github.com/DevExpress/testcafe/pull/4098/files#diff-faffa7cb8471bb25963ec2306a99c62aR48.

This paragraph is obsolete (as it says about the root project directory).