### PR TITLE
allow taking full page screenshots (closes #1520)

### DIFF
--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -211,7 +211,7 @@ export default class TestController {
     }
 
     _takeScreenshot$ (options) {
-        if (typeof options === 'string')
+        if (options && typeof options !== 'object')
             options = { path: options };
 
         return this._enqueueCommand('takeScreenshot', TakeScreenshotCommand, options);

--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -210,8 +210,8 @@ export default class TestController {
         return this._enqueueCommand('clearUpload', ClearUploadCommand, { selector });
     }
 
-    _takeScreenshot$ (path) {
-        return this._enqueueCommand('takeScreenshot', TakeScreenshotCommand, { path });
+    _takeScreenshot$ (path, options) {
+        return this._enqueueCommand('takeScreenshot', TakeScreenshotCommand, Object.assign({ path }, options));
     }
 
     _takeElementScreenshot$ (selector, ...args) {

--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -210,8 +210,11 @@ export default class TestController {
         return this._enqueueCommand('clearUpload', ClearUploadCommand, { selector });
     }
 
-    _takeScreenshot$ (path, options) {
-        return this._enqueueCommand('takeScreenshot', TakeScreenshotCommand, Object.assign({ path }, options));
+    _takeScreenshot$ (options) {
+        if (typeof options === 'string')
+            options = { path: options };
+
+        return this._enqueueCommand('takeScreenshot', TakeScreenshotCommand, options);
     }
 
     _takeElementScreenshot$ (selector, ...args) {

--- a/src/browser/provider/built-in/dedicated/base.js
+++ b/src/browser/provider/built-in/dedicated/base.js
@@ -56,7 +56,7 @@ export default {
         let pngImage = await readPng(binaryImage);
 
         if (!fullPage)
-            pngImage = await cropScreenshot(pngImage, { path, cropDimensions });
+            pngImage = await cropScreenshot(pngImage, { path, cropDimensions }) || pngImage;
 
         await writePng(path, pngImage);
     },

--- a/src/browser/provider/built-in/dedicated/base.js
+++ b/src/browser/provider/built-in/dedicated/base.js
@@ -47,15 +47,18 @@ export default {
         };
     },
 
-    async takeScreenshot (browserId, path, viewportWidth, viewportHeight) {
+    async takeScreenshot (browserId, path, viewportWidth, viewportHeight, fullPage) {
         const runtimeInfo    = this.openedBrowsers[browserId];
         const browserClient  = this._getBrowserProtocolClient(runtimeInfo);
-        const binaryImage    = await browserClient.getScreenshotData(runtimeInfo);
-        const pngImage       = await readPng(binaryImage);
+        const binaryImage    = await browserClient.getScreenshotData(runtimeInfo, fullPage);
         const cropDimensions = this._getCropDimensions(viewportWidth, viewportHeight);
-        const croppedImage   = await cropScreenshot(pngImage, { path, cropDimensions });
 
-        await writePng(path, croppedImage || pngImage);
+        let pngImage = await readPng(binaryImage);
+
+        if (!fullPage)
+            pngImage = await cropScreenshot(pngImage, { path, cropDimensions });
+
+        await writePng(path, pngImage);
     },
 
     async maximizeWindow (browserId) {

--- a/src/browser/provider/built-in/dedicated/firefox/marionette-client/index.js
+++ b/src/browser/provider/built-in/dedicated/firefox/marionette-client/index.js
@@ -142,7 +142,13 @@ module.exports = class MarionetteClient {
     }
 
     async _getScreenshotRawData () {
-        return await this._getResponse({ command: COMMANDS.takeScreenshot });
+        return await this._getResponse({
+            command:    COMMANDS.takeScreenshot,
+            parameters: {
+                full: true,
+                hash: false
+            }
+        });
     }
 
     async connect () {
@@ -170,8 +176,8 @@ module.exports = class MarionetteClient {
         });
     }
 
-    async getScreenshotData () {
-        const frameData = await this._getScreenshotRawData();
+    async getScreenshotData (_, fullPage) {
+        const frameData = await this._getScreenshotRawData(fullPage);
 
         return Buffer.from(frameData.value, 'base64');
     }

--- a/src/browser/provider/built-in/dedicated/firefox/marionette-client/index.js
+++ b/src/browser/provider/built-in/dedicated/firefox/marionette-client/index.js
@@ -141,11 +141,11 @@ module.exports = class MarionetteClient {
         return responsePacket.body[3];
     }
 
-    async _getScreenshotRawData () {
+    async _getScreenshotRawData (fullPage) {
         return await this._getResponse({
             command:    COMMANDS.takeScreenshot,
             parameters: {
-                full: true,
+                full: fullPage,
                 hash: false
             }
         });

--- a/src/browser/provider/index.js
+++ b/src/browser/provider/index.js
@@ -3,6 +3,7 @@ import OS from 'os-family';
 import BrowserConnection from '../connection';
 import delay from '../../utils/delay';
 import { GET_TITLE_SCRIPT, GET_WINDOW_DIMENSIONS_INFO_SCRIPT } from './utils/client-functions';
+import WARNING_MESSAGE from '../../notifications/warning-message';
 
 
 const BROWSER_OPENING_DELAY = 2000;
@@ -295,11 +296,16 @@ export default class BrowserProvider {
         const hasCustomTakeScreenshot    = customActionsInfo.hasTakeScreenshot;
 
         if (canUseDefaultWindowActions && !hasCustomTakeScreenshot) {
-            await this._takeLocalBrowserScreenshot(browserId, screenshotPath, pageWidth, pageHeight);
-            return;
-        }
+            if (fullPage) {
+                const connection = BrowserConnection.getById(browserId);
 
-        await this.plugin.takeScreenshot(browserId, screenshotPath, pageWidth, pageHeight, fullPage);
+                connection.addWarning(WARNING_MESSAGE.screenshotFullPageNotSupported, connection.browserInfo.browserName);
+            }
+            else
+                await this._takeLocalBrowserScreenshot(browserId, screenshotPath, pageWidth, pageHeight);
+        }
+        else
+            await this.plugin.takeScreenshot(browserId, screenshotPath, pageWidth, pageHeight, fullPage);
     }
 
     async getVideoFrameData (browserId) {

--- a/src/browser/provider/index.js
+++ b/src/browser/provider/index.js
@@ -299,7 +299,7 @@ export default class BrowserProvider {
             if (fullPage) {
                 const connection = BrowserConnection.getById(browserId);
 
-                connection.addWarning(WARNING_MESSAGE.screenshotFullPageNotSupported, connection.browserInfo.browserName);
+                connection.addWarning(WARNING_MESSAGE.screenshotsFullPageNotSupported, connection.browserInfo.browserName);
             }
             else
                 await this._takeLocalBrowserScreenshot(browserId, screenshotPath, pageWidth, pageHeight);

--- a/src/browser/provider/index.js
+++ b/src/browser/provider/index.js
@@ -299,7 +299,7 @@ export default class BrowserProvider {
             if (fullPage) {
                 const connection = BrowserConnection.getById(browserId);
 
-                connection.addWarning(WARNING_MESSAGE.screenshotsFullPageNotSupported, connection.browserInfo.browserName);
+                connection.addWarning(WARNING_MESSAGE.screenshotsFullPageNotSupported, connection.browserInfo.alias);
             }
             else
                 await this._takeLocalBrowserScreenshot(browserId, screenshotPath, pageWidth, pageHeight);

--- a/src/browser/provider/index.js
+++ b/src/browser/provider/index.js
@@ -289,7 +289,7 @@ export default class BrowserProvider {
         return await this.plugin.maximizeWindow(browserId);
     }
 
-    async takeScreenshot (browserId, screenshotPath, pageWidth, pageHeight) {
+    async takeScreenshot (browserId, screenshotPath, pageWidth, pageHeight, fullPage) {
         const canUseDefaultWindowActions = await this._canUseDefaultWindowActions(browserId);
         const customActionsInfo          = await this.hasCustomActionForBrowser(browserId);
         const hasCustomTakeScreenshot    = customActionsInfo.hasTakeScreenshot;
@@ -299,7 +299,7 @@ export default class BrowserProvider {
             return;
         }
 
-        await this.plugin.takeScreenshot(browserId, screenshotPath, pageWidth, pageHeight);
+        await this.plugin.takeScreenshot(browserId, screenshotPath, pageWidth, pageHeight, fullPage);
     }
 
     async getVideoFrameData (browserId) {

--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -126,7 +126,7 @@ export default class CLIArgumentParser {
             .option('--ts-config-path <path>', 'use a custom TypeScript configuration file and specify its location')
             .option('--cs, --client-scripts <paths>', 'inject scripts into tested pages', this._parseList, [])
             .option('--disable-page-caching', 'disable page caching during test execution')
-            .option('--screenshots-full-page', 'enable full page screenshots')
+            .option('--screenshot-full-page', 'enable full page screenshots')
 
             // NOTE: these options will be handled by chalk internally
             .option('--color', 'force colors in command line')

--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -126,7 +126,7 @@ export default class CLIArgumentParser {
             .option('--ts-config-path <path>', 'use a custom TypeScript configuration file and specify its location')
             .option('--cs, --client-scripts <paths>', 'inject scripts into tested pages', this._parseList, [])
             .option('--disable-page-caching', 'disable page caching during test execution')
-            .option('--screenshots-full-page', 'enable full page screenshots')
+            .option('--screenshots-full-page', 'enable full-page screenshots')
 
             // NOTE: these options will be handled by chalk internally
             .option('--color', 'force colors in command line')

--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -126,7 +126,7 @@ export default class CLIArgumentParser {
             .option('--ts-config-path <path>', 'use a custom TypeScript configuration file and specify its location')
             .option('--cs, --client-scripts <paths>', 'inject scripts into tested pages', this._parseList, [])
             .option('--disable-page-caching', 'disable page caching during test execution')
-            .option('--screenshot-full-page', 'enable full page screenshots')
+            .option('--screenshots-full-page', 'enable full page screenshots')
 
             // NOTE: these options will be handled by chalk internally
             .option('--color', 'force colors in command line')

--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -126,6 +126,7 @@ export default class CLIArgumentParser {
             .option('--ts-config-path <path>', 'use a custom TypeScript configuration file and specify its location')
             .option('--cs, --client-scripts <paths>', 'inject scripts into tested pages', this._parseList, [])
             .option('--disable-page-caching', 'disable page caching during test execution')
+            .option('--screenshots-full-page', 'enable full page screenshots')
 
             // NOTE: these options will be handled by chalk internally
             .option('--color', 'force colors in command line')

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -93,7 +93,7 @@ async function runTests (argParser) {
         .concurrency(argParser.opts.concurrency)
         .filter(argParser.opts.filter)
         .video(opts.video, opts.videoOptions, opts.videoEncodingOptions)
-        .screenshots(opts.screenshots, opts.screenshotsOnFails, opts.screenshotPathPattern)
+        .screenshots(opts.screenshots, opts.screenshotsOnFails, opts.screenshotPathPattern, opts.screenshotFullPage)
         .startApp(opts.app, opts.appInitDelay)
         .clientScripts(argParser.opts.clientScripts);
 

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -97,7 +97,7 @@ async function runTests (argParser) {
             path:        opts.screenshots,
             takeOnFails: opts.screenshotsOnFails,
             pathPattern: opts.screenshotPathPattern,
-            fullPage:    opts.screenshotFullPage
+            fullPage:    opts.screenshotsFullPage
         })
         .startApp(opts.app, opts.appInitDelay)
         .clientScripts(argParser.opts.clientScripts);

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -93,7 +93,12 @@ async function runTests (argParser) {
         .concurrency(argParser.opts.concurrency)
         .filter(argParser.opts.filter)
         .video(opts.video, opts.videoOptions, opts.videoEncodingOptions)
-        .screenshots(opts.screenshots, opts.screenshotsOnFails, opts.screenshotPathPattern, opts.screenshotFullPage)
+        .screenshots({
+            path:        opts.screenshots,
+            takeOnFails: opts.screenshotsOnFails,
+            pathPattern: opts.screenshotPathPattern,
+            fullPage:    opts.screenshotFullPage
+        })
         .startApp(opts.app, opts.appInitDelay)
         .clientScripts(argParser.opts.clientScripts);
 

--- a/src/configuration/option-names.js
+++ b/src/configuration/option-names.js
@@ -11,6 +11,7 @@ export default {
     screenshotPath:         'screenshotPath',
     screenshotPathPattern:  'screenshotPathPattern',
     takeScreenshotsOnFails: 'takeScreenshotsOnFails',
+    screenshotFullPage:     'screenshotFullPage',
     proxyBypass:            'proxyBypass',
     appCommand:             'appCommand',
     appInitDelay:           'appInitDelay',

--- a/src/configuration/option-names.js
+++ b/src/configuration/option-names.js
@@ -11,7 +11,7 @@ export default {
     screenshotPath:         'screenshotPath',
     screenshotPathPattern:  'screenshotPathPattern',
     takeScreenshotsOnFails: 'takeScreenshotsOnFails',
-    screenshotFullPage:     'screenshotFullPage',
+    screenshotsFullPage:    'screenshotsFullPage',
     proxyBypass:            'proxyBypass',
     appCommand:             'appCommand',
     appInitDelay:           'appInitDelay',

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -30,7 +30,7 @@ const OPTION_FLAG_NAMES = [
     OPTION_NAMES.skipUncaughtErrors,
     OPTION_NAMES.stopOnFirstFail,
     OPTION_NAMES.takeScreenshotsOnFails,
-    OPTION_NAMES.screenshotFullPage,
+    OPTION_NAMES.screenshotsFullPage,
     OPTION_NAMES.disablePageCaching,
     OPTION_NAMES.developmentMode,
     OPTION_NAMES.retryTestPages,

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -30,6 +30,7 @@ const OPTION_FLAG_NAMES = [
     OPTION_NAMES.skipUncaughtErrors,
     OPTION_NAMES.stopOnFirstFail,
     OPTION_NAMES.takeScreenshotsOnFails,
+    OPTION_NAMES.screenshotFullPage,
     OPTION_NAMES.disablePageCaching,
     OPTION_NAMES.developmentMode,
     OPTION_NAMES.retryTestPages,

--- a/src/notifications/warning-message.js
+++ b/src/notifications/warning-message.js
@@ -2,7 +2,7 @@ export default {
     screenshotsPathNotSpecified:             'Was unable to take screenshots because the screenshot directory is not specified. To specify it, use the "-s" or "--screenshots" command line option or the "screenshots" method of the test runner in case you are using API.',
     screenshotError:                         'Was unable to take a screenshot due to an error.\n\n{errMessage}',
     screenshotMarkNotFound:                  'Unable to locate the page area in the browser window screenshot at {screenshotPath}, because the page area mark with ID {markId} is not found in the screenshot.',
-    screenshotFullPageNotSupported:          'Full page screenshots are not supported by the "{providerName}" browser',
+    screenshotsFullPageNotSupported:         'Full page screenshots are not supported by the "{providerName}" browser',
     screenshotRewritingError:                'The file at "{screenshotPath}" already exists. It has just been rewritten with a recent screenshot. This situation can possibly cause issues. To avoid them, make sure that each screenshot has a unique path. If a test runs in multiple browsers, consider including the user agent in the screenshot path or generate a unique identifier in another way.',
     browserManipulationsOnRemoteBrowser:     'The screenshot and window resize functionalities are not supported in a remote browser. They can function only if the browser is running on the same machine and in the same environment as the TestCafe server.',
     screenshotNotSupportedByBrowserProvider: 'The screenshot functionality is not supported by the "{providerName}" browser provider.',

--- a/src/notifications/warning-message.js
+++ b/src/notifications/warning-message.js
@@ -2,6 +2,7 @@ export default {
     screenshotsPathNotSpecified:             'Was unable to take screenshots because the screenshot directory is not specified. To specify it, use the "-s" or "--screenshots" command line option or the "screenshots" method of the test runner in case you are using API.',
     screenshotError:                         'Was unable to take a screenshot due to an error.\n\n{errMessage}',
     screenshotMarkNotFound:                  'Unable to locate the page area in the browser window screenshot at {screenshotPath}, because the page area mark with ID {markId} is not found in the screenshot.',
+    screenshotFullPageNotSupported:          'Full page screenshots are not supported by the "{providerName}" browser',
     screenshotRewritingError:                'The file at "{screenshotPath}" already exists. It has just been rewritten with a recent screenshot. This situation can possibly cause issues. To avoid them, make sure that each screenshot has a unique path. If a test runs in multiple browsers, consider including the user agent in the screenshot path or generate a unique identifier in another way.',
     browserManipulationsOnRemoteBrowser:     'The screenshot and window resize functionalities are not supported in a remote browser. They can function only if the browser is running on the same machine and in the same environment as the TestCafe server.',
     screenshotNotSupportedByBrowserProvider: 'The screenshot functionality is not supported by the "{providerName}" browser provider.',

--- a/src/notifications/warning-message.js
+++ b/src/notifications/warning-message.js
@@ -2,7 +2,7 @@ export default {
     screenshotsPathNotSpecified:             'Was unable to take screenshots because the screenshot directory is not specified. To specify it, use the "-s" or "--screenshots" command line option or the "screenshots" method of the test runner in case you are using API.',
     screenshotError:                         'Was unable to take a screenshot due to an error.\n\n{errMessage}',
     screenshotMarkNotFound:                  'Unable to locate the page area in the browser window screenshot at {screenshotPath}, because the page area mark with ID {markId} is not found in the screenshot.',
-    screenshotsFullPageNotSupported:         'Full page screenshots are not supported by the "{providerName}" browser',
+    screenshotsFullPageNotSupported:         '{browserAlias} does not support full-page screenshots.',
     screenshotRewritingError:                'The file at "{screenshotPath}" already exists. It has just been rewritten with a recent screenshot. This situation can possibly cause issues. To avoid them, make sure that each screenshot has a unique path. If a test runs in multiple browsers, consider including the user agent in the screenshot path or generate a unique identifier in another way.',
     browserManipulationsOnRemoteBrowser:     'The screenshot and window resize functionalities are not supported in a remote browser. They can function only if the browser is running on the same machine and in the same environment as the TestCafe server.',
     screenshotNotSupportedByBrowserProvider: 'The screenshot functionality is not supported by the "{providerName}" browser provider.',

--- a/src/notifications/warning-message.js
+++ b/src/notifications/warning-message.js
@@ -2,7 +2,7 @@ export default {
     screenshotsPathNotSpecified:             'Was unable to take screenshots because the screenshot directory is not specified. To specify it, use the "-s" or "--screenshots" command line option or the "screenshots" method of the test runner in case you are using API.',
     screenshotError:                         'Was unable to take a screenshot due to an error.\n\n{errMessage}',
     screenshotMarkNotFound:                  'Unable to locate the page area in the browser window screenshot at {screenshotPath}, because the page area mark with ID {markId} is not found in the screenshot.',
-    screenshotsFullPageNotSupported:         '{browserAlias} does not support full-page screenshots.',
+    screenshotsFullPageNotSupported:         'TestCafe does not support full-page screenshots in {browserAlias}.',
     screenshotRewritingError:                'The file at "{screenshotPath}" already exists. It has just been rewritten with a recent screenshot. This situation can possibly cause issues. To avoid them, make sure that each screenshot has a unique path. If a test runs in multiple browsers, consider including the user agent in the screenshot path or generate a unique identifier in another way.',
     browserManipulationsOnRemoteBrowser:     'The screenshot and window resize functionalities are not supported in a remote browser. They can function only if the browser is running on the same machine and in the same environment as the TestCafe server.',
     screenshotNotSupportedByBrowserProvider: 'The screenshot functionality is not supported by the "{providerName}" browser provider.',

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -378,7 +378,8 @@ export default class Runner extends EventEmitter {
     }
 
     screenshots (...options) {
-        let [path, takeOnFails, pathPattern, fullPage] = options;
+        let fullPage;
+        let [path, takeOnFails, pathPattern] = options;
 
         if (options.length === 1 && options[0] && typeof options[0] === 'object')
             ({ path, takeOnFails, pathPattern, fullPage } = options[0]);
@@ -387,7 +388,7 @@ export default class Runner extends EventEmitter {
             [OPTION_NAMES.screenshotPath]:         path,
             [OPTION_NAMES.takeScreenshotsOnFails]: takeOnFails,
             [OPTION_NAMES.screenshotPathPattern]:  pathPattern,
-            [OPTION_NAMES.screenshotFullPage]:     fullPage
+            [OPTION_NAMES.screenshotsFullPage]:    fullPage
         });
 
         return this;

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -377,11 +377,11 @@ export default class Runner extends EventEmitter {
         return this;
     }
 
-    screenshots (options) {
-        if (typeof options === 'string')
-            options = { path: options };
+    screenshots (...options) {
+        let [path, takeOnFails, pathPattern, fullPage] = options;
 
-        const { path, takeOnFails, pathPattern, fullPage } = options;
+        if (options.length === 1 && options[0] && typeof options[0] === 'object')
+            ({ path, takeOnFails, pathPattern, fullPage } = options[0]);
 
         this.configuration.mergeOptions({
             [OPTION_NAMES.screenshotPath]:         path,

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -377,11 +377,12 @@ export default class Runner extends EventEmitter {
         return this;
     }
 
-    screenshots (path, takeOnFails, pattern) {
+    screenshots (path, takeOnFails, pattern, fullPage) {
         this.configuration.mergeOptions({
             [OPTION_NAMES.screenshotPath]:         path,
             [OPTION_NAMES.takeScreenshotsOnFails]: takeOnFails,
-            [OPTION_NAMES.screenshotPathPattern]:  pattern
+            [OPTION_NAMES.screenshotPathPattern]:  pattern,
+            [OPTION_NAMES.screenshotFullPage]:     fullPage
         });
 
         return this;

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -381,12 +381,12 @@ export default class Runner extends EventEmitter {
         if (typeof options === 'string')
             options = { path: options };
 
-        const { path, takeOnFails, pattern, fullPage } = options;
+        const { path, takeOnFails, pathPattern, fullPage } = options;
 
         this.configuration.mergeOptions({
             [OPTION_NAMES.screenshotPath]:         path,
             [OPTION_NAMES.takeScreenshotsOnFails]: takeOnFails,
-            [OPTION_NAMES.screenshotPathPattern]:  pattern,
+            [OPTION_NAMES.screenshotPathPattern]:  pathPattern,
             [OPTION_NAMES.screenshotFullPage]:     fullPage
         });
 

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -377,7 +377,12 @@ export default class Runner extends EventEmitter {
         return this;
     }
 
-    screenshots (path, takeOnFails, pattern, fullPage) {
+    screenshots (options) {
+        if (typeof options === 'string')
+            options = { path: options };
+
+        const { path, takeOnFails, pattern, fullPage } = options;
+
         this.configuration.mergeOptions({
             [OPTION_NAMES.screenshotPath]:         path,
             [OPTION_NAMES.takeScreenshotsOnFails]: takeOnFails,

--- a/src/runner/task.js
+++ b/src/runner/task.js
@@ -18,7 +18,7 @@ export default class Task extends AsyncEventEmitter {
         this.tests                   = tests;
         this.opts                    = opts;
         this.proxy                   = proxy;
-        this.screenshots             = new Screenshots(this.opts.screenshotPath, this.opts.screenshotPathPattern, this.opts.screenshotFullPage);
+        this.screenshots             = new Screenshots(this.opts.screenshotPath, this.opts.screenshotPathPattern, this.opts.screenshotsFullPage);
         this.warningLog              = new WarningLog();
 
         this.fixtureHookController = new FixtureHookController(tests, browserConnectionGroups.length);

--- a/src/runner/task.js
+++ b/src/runner/task.js
@@ -18,7 +18,7 @@ export default class Task extends AsyncEventEmitter {
         this.tests                   = tests;
         this.opts                    = opts;
         this.proxy                   = proxy;
-        this.screenshots             = new Screenshots(this.opts.screenshotPath, this.opts.screenshotPathPattern);
+        this.screenshots             = new Screenshots(this.opts.screenshotPath, this.opts.screenshotPathPattern, this.opts.screenshotFullPage);
         this.warningLog              = new WarningLog();
 
         this.fixtureHookController = new FixtureHookController(tests, browserConnectionGroups.length);

--- a/src/screenshots/capturer.js
+++ b/src/screenshots/capturer.js
@@ -121,10 +121,12 @@ export default class Capturer {
         await addToQueue(screenshotPath, async () => {
             const clientAreaDimensions = Capturer._getClientAreaDimensions(pageDimensions);
 
+            const { width: pageWidth, height: pageHeight } = clientAreaDimensions || {};
+
             const takeScreenshotOptions = {
                 filePath: screenshotPath,
-                width:    clientAreaDimensions.width,
-                height:   clientAreaDimensions.height,
+                pageWidth,
+                pageHeight,
                 fullPage
             };
 

--- a/src/screenshots/capturer.js
+++ b/src/screenshots/capturer.js
@@ -102,10 +102,8 @@ export default class Capturer {
         return joinPath(imageDir, 'thumbnails', imageName);
     }
 
-    async _takeScreenshot (filePath, pageWidth, pageHeight, fullPage) {
+    async _takeScreenshot ({ filePath, pageWidth, pageHeight, fullPage = this.fullPage }) {
         await makeDir(dirname(filePath));
-
-        fullPage = fullPage !== void 0 ? fullPage : this.fullPage;
 
         await this.provider.takeScreenshot(this.browserId, filePath, pageWidth, pageHeight, fullPage);
     }
@@ -123,7 +121,14 @@ export default class Capturer {
         await addToQueue(screenshotPath, async () => {
             const clientAreaDimensions = Capturer._getClientAreaDimensions(pageDimensions);
 
-            await this._takeScreenshot(screenshotPath, ...clientAreaDimensions ? [clientAreaDimensions.width, clientAreaDimensions.height] : [], fullPage);
+            const takeScreenshotOptions = {
+                filePath: screenshotPath,
+                width:    clientAreaDimensions.width,
+                height:   clientAreaDimensions.height,
+                fullPage
+            };
+
+            await this._takeScreenshot(takeScreenshotOptions);
 
             if (!await Capturer._isScreenshotCaptured(screenshotPath))
                 return;

--- a/src/screenshots/capturer.js
+++ b/src/screenshots/capturer.js
@@ -101,12 +101,12 @@ export default class Capturer {
         return joinPath(imageDir, 'thumbnails', imageName);
     }
 
-    async _takeScreenshot (filePath, pageWidth, pageHeight) {
+    async _takeScreenshot (filePath, pageWidth, pageHeight, fullPage) {
         await makeDir(dirname(filePath));
-        await this.provider.takeScreenshot(this.browserId, filePath, pageWidth, pageHeight);
+        await this.provider.takeScreenshot(this.browserId, filePath, pageWidth, pageHeight, fullPage);
     }
 
-    async _capture (forError, { pageDimensions, cropDimensions, markSeed, customPath } = {}) {
+    async _capture (forError, { pageDimensions, cropDimensions, markSeed, customPath, fullPage } = {}) {
         if (!this.enabled)
             return null;
 
@@ -119,7 +119,7 @@ export default class Capturer {
         await addToQueue(screenshotPath, async () => {
             const clientAreaDimensions = Capturer._getClientAreaDimensions(pageDimensions);
 
-            await this._takeScreenshot(screenshotPath, ...clientAreaDimensions ? [clientAreaDimensions.width, clientAreaDimensions.height] : []);
+            await this._takeScreenshot(screenshotPath, ...clientAreaDimensions ? [clientAreaDimensions.width, clientAreaDimensions.height] : [], fullPage);
 
             if (!await Capturer._isScreenshotCaptured(screenshotPath))
                 return;

--- a/src/screenshots/capturer.js
+++ b/src/screenshots/capturer.js
@@ -10,7 +10,7 @@ import { readPngFile, deleteFile, stat, writePng } from '../utils/promisified-fu
 
 
 export default class Capturer {
-    constructor (baseScreenshotsPath, testEntry, connection, pathPattern, warningLog) {
+    constructor (baseScreenshotsPath, testEntry, connection, pathPattern, fullPage, warningLog) {
         this.enabled             = !!baseScreenshotsPath;
         this.baseScreenshotsPath = baseScreenshotsPath;
         this.testEntry           = testEntry;
@@ -18,6 +18,7 @@ export default class Capturer {
         this.browserId           = connection.id;
         this.warningLog          = warningLog;
         this.pathPattern         = pathPattern;
+        this.fullPage            = fullPage;
     }
 
     static _getDimensionWithoutScrollbar (fullDimension, documentDimension, bodyDimension) {
@@ -103,6 +104,9 @@ export default class Capturer {
 
     async _takeScreenshot (filePath, pageWidth, pageHeight, fullPage) {
         await makeDir(dirname(filePath));
+
+        fullPage = fullPage !== void 0 ? fullPage : this.fullPage;
+
         await this.provider.takeScreenshot(this.browserId, filePath, pageWidth, pageHeight, fullPage);
     }
 

--- a/src/screenshots/index.js
+++ b/src/screenshots/index.js
@@ -8,10 +8,11 @@ import getCommonPath from '../utils/get-common-path';
 const SCREENSHOT_EXTENSION = 'png';
 
 export default class Screenshots {
-    constructor (path, pattern) {
+    constructor (path, pattern, fullPage) {
         this.enabled            = !!path;
         this.screenshotsPath    = path;
         this.screenshotsPattern = pattern;
+        this.fullPage           = fullPage;
         this.testEntries        = [];
         this.now                = moment();
     }
@@ -66,6 +67,6 @@ export default class Screenshots {
             parsedUserAgent:   connection.browserInfo.parsedUserAgent,
         });
 
-        return new Capturer(this.screenshotsPath, testEntry, connection, pathPattern, warningLog);
+        return new Capturer(this.screenshotsPath, testEntry, connection, pathPattern, this.fullPage, warningLog);
     }
 }

--- a/src/test-run/browser-manipulation-queue.js
+++ b/src/test-run/browser-manipulation-queue.js
@@ -77,13 +77,15 @@ export default class BrowserManipulationQueue {
                     customPath:     command.path,
                     pageDimensions: driverMsg.pageDimensions,
                     cropDimensions: driverMsg.cropDimensions,
-                    markSeed:       command.markSeed
+                    markSeed:       command.markSeed,
+                    fullPage:       command.fullPage
                 }));
 
             case COMMAND_TYPE.takeScreenshotOnFail:
                 return await this._takeScreenshot(() => this.screenshotCapturer.captureError({
                     pageDimensions: driverMsg.pageDimensions,
-                    markSeed:       command.markSeed
+                    markSeed:       command.markSeed,
+                    fullPage:       command.fullPage
                 }));
 
             case COMMAND_TYPE.resizeWindow:

--- a/src/test-run/browser-manipulation-queue.js
+++ b/src/test-run/browser-manipulation-queue.js
@@ -78,7 +78,7 @@ export default class BrowserManipulationQueue {
                     pageDimensions: driverMsg.pageDimensions,
                     cropDimensions: driverMsg.cropDimensions,
                     markSeed:       command.markSeed,
-                    fullPage:       command.fullPage || void 0
+                    fullPage:       command.fullPage
                 }));
 
             case COMMAND_TYPE.takeScreenshotOnFail:

--- a/src/test-run/browser-manipulation-queue.js
+++ b/src/test-run/browser-manipulation-queue.js
@@ -78,7 +78,7 @@ export default class BrowserManipulationQueue {
                     pageDimensions: driverMsg.pageDimensions,
                     cropDimensions: driverMsg.cropDimensions,
                     markSeed:       command.markSeed,
-                    fullPage:       command.fullPage
+                    fullPage:       command.fullPage || void 0
                 }));
 
             case COMMAND_TYPE.takeScreenshotOnFail:

--- a/src/test-run/commands/browser-manipulation.js
+++ b/src/test-run/commands/browser-manipulation.js
@@ -43,7 +43,7 @@ export class TakeScreenshotCommand extends TakeScreenshotBaseCommand {
     _getAssignableProperties () {
         return [
             { name: 'path', type: screenshotPathArgument, defaultValue: '' },
-            { name: 'fullPage', type: booleanArgument, defaultValue: false }
+            { name: 'fullPage', type: booleanArgument, defaultValue: void 0 }
         ];
     }
 }

--- a/src/test-run/commands/browser-manipulation.js
+++ b/src/test-run/commands/browser-manipulation.js
@@ -4,6 +4,7 @@ import { ElementScreenshotOptions, ResizeToFitDeviceOptions } from './options';
 import { initSelector } from './validations/initializers';
 
 import {
+    booleanArgument,
     positiveIntegerArgument,
     screenshotPathArgument,
     resizeWindowDeviceArgument,
@@ -41,7 +42,8 @@ export class TakeScreenshotCommand extends TakeScreenshotBaseCommand {
 
     _getAssignableProperties () {
         return [
-            { name: 'path', type: screenshotPathArgument, defaultValue: '' }
+            { name: 'path', type: screenshotPathArgument, defaultValue: '' },
+            { name: 'fullPage', type: booleanArgument, defaultValue: false }
         ];
     }
 }
@@ -66,7 +68,9 @@ export class TakeScreenshotOnFailCommand extends TakeScreenshotBaseCommand {
     }
 
     _getAssignableProperties () {
-        return [];
+        return [
+            { name: 'fullPage', type: booleanArgument, defaultValue: false }
+        ];
     }
 }
 

--- a/test/functional/assertion-helper.js
+++ b/test/functional/assertion-helper.js
@@ -65,6 +65,24 @@ function checkScreenshotFileCropped (filePath) {
         });
 }
 
+function checkScreenshotFileFullPage (filePath) {
+    return readPngFile(filePath)
+        .then(function (png) {
+            const width  = png.width;
+            const height = png.height;
+
+            const size = 5050;
+
+            if (width !== size || height !== size)
+                return false;
+
+            return hasPixel(png, RED_PIXEL, 0, 0) &&
+                   hasPixel(png, RED_PIXEL, size - 1, size - 1) &&
+                   hasPixel(png, GREEN_PIXEL, 0, size - 1) &&
+                   hasPixel(png, GREEN_PIXEL, size - 1, 0);
+        });
+}
+
 function checkScreenshotFileIsNotWhite (filePath) {
     return readPngFile(filePath)
         .then(function (png) {
@@ -283,6 +301,10 @@ exports.checkScreenshotsCropped = function (forError, customPath) {
 
 exports.checkScreenshotIsNotWhite = function (forError, customPath) {
     return checkScreenshotImages(forError, customPath, checkScreenshotFileIsNotWhite);
+};
+
+exports.checkScreenshotFileFullPage = function (forError, customPath) {
+    return checkScreenshotImages(forError, customPath, checkScreenshotFileFullPage);
 };
 
 exports.isScreenshotsEqual = function (customPath, referenceImagePathGetter) {

--- a/test/functional/assertion-helper.js
+++ b/test/functional/assertion-helper.js
@@ -71,15 +71,13 @@ function checkScreenshotFileFullPage (filePath) {
             const width  = png.width;
             const height = png.height;
 
-            const size = 5050;
+            const expectedHeight = 5000;
 
-            if (width !== size || height !== size)
-                return false;
-
-            return hasPixel(png, RED_PIXEL, 0, 0) &&
-                   hasPixel(png, RED_PIXEL, size - 1, size - 1) &&
-                   hasPixel(png, GREEN_PIXEL, 0, size - 1) &&
-                   hasPixel(png, GREEN_PIXEL, size - 1, 0);
+            return height === expectedHeight &&
+                hasPixel(png, RED_PIXEL, 0, 0) &&
+                hasPixel(png, RED_PIXEL, width - 1, height - 1) &&
+                hasPixel(png, GREEN_PIXEL, 0, height - 1) &&
+                hasPixel(png, GREEN_PIXEL, width - 1, 0);
         });
 }
 

--- a/test/functional/fixtures/api/es-next/take-screenshot/pages/full-page.html
+++ b/test/functional/fixtures/api/es-next/take-screenshot/pages/full-page.html
@@ -11,7 +11,7 @@
             }
             div.wrapper {
                 position: relative;
-                height: 4999px;
+                height: 5000px;
             }
             div.d {
                 width: 50px;

--- a/test/functional/fixtures/api/es-next/take-screenshot/pages/full-page.html
+++ b/test/functional/fixtures/api/es-next/take-screenshot/pages/full-page.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            * {
+                margin: 0;
+                padding: 0;
+            }
+            body {
+                background-color: black;
+            }
+
+            div.d {
+                width: 50px;
+                height: 50px;
+                position: absolute;
+            }
+            .left {
+                left: 0;
+            }
+            .right {
+                margin-left: 5000px;
+            }
+            .top {
+            }
+            .bottom {
+                margin-top: 5000px;
+            }
+            .red {
+                background-color: rgb(255, 0, 0);
+            }
+            .green {
+                background-color: rgb(0, 255, 0);
+            }
+        </style>
+    </head>
+    <body>
+        <div class="d left top red"></div>
+        <div class="d right top green"></div>
+        <div class="d left bottom green"></div>
+        <div class="d right bottom red"></div>
+    </body>
+</html>

--- a/test/functional/fixtures/api/es-next/take-screenshot/pages/full-page.html
+++ b/test/functional/fixtures/api/es-next/take-screenshot/pages/full-page.html
@@ -9,7 +9,10 @@
             body {
                 background-color: black;
             }
-
+            div.wrapper {
+                position: relative;
+                height: 4999px;
+            }
             div.d {
                 width: 50px;
                 height: 50px;
@@ -19,12 +22,13 @@
                 left: 0;
             }
             .right {
-                margin-left: 5000px;
+                right: 0;
             }
             .top {
+                top: 0;
             }
             .bottom {
-                margin-top: 5000px;
+                bottom: 0;
             }
             .red {
                 background-color: rgb(255, 0, 0);
@@ -35,9 +39,11 @@
         </style>
     </head>
     <body>
-        <div class="d left top red"></div>
-        <div class="d right top green"></div>
-        <div class="d left bottom green"></div>
-        <div class="d right bottom red"></div>
+        <div class="wrapper">
+            <div class="d left top red"></div>
+            <div class="d right top green"></div>
+            <div class="d left bottom green"></div>
+            <div class="d right bottom red"></div>
+        </div>
     </body>
 </html>

--- a/test/functional/fixtures/api/es-next/take-screenshot/test.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/test.js
@@ -597,7 +597,10 @@ describe('[API] Take full page screenshots', function () {
         });
 
         it('Should take a full page screenshot via Runner', function () {
-            return runTests('./testcafe-fixtures/take-full-page-screenshot.js', 'Runner', { setScreenshotPath: true, screenshotFullPage: true })
+            return runTests('./testcafe-fixtures/take-full-page-screenshot.js', 'Runner', {
+                setScreenshotPath:  true,
+                screenshotFullPage: true
+            })
                 .then(function () {
                     return assertionHelper.checkScreenshotFileFullPage(false, 'custom');
                 })
@@ -605,6 +608,19 @@ describe('[API] Take full page screenshots', function () {
                     expect(result).eql(true);
                 });
         });
+
+        it('Should take a screenshot on fail', function () {
+            return runTests('./testcafe-fixtures/take-full-page-screenshot.js', 'Screenshot on fail', {
+                shouldFail:         true,
+                setScreenshotPath:  true,
+                screenshotFullPage: true,
+                screenshotsOnFails: true
+            })
+                .catch(function (errs) {
+                    expect(errs[0]).to.contains('screenshot on fail');
+
+                    return assertionHelper.checkScreenshotFileFullPage(true);
+                });
+        });
     }
 });
-

--- a/test/functional/fixtures/api/es-next/take-screenshot/test.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/test.js
@@ -582,12 +582,22 @@ describe('[API] t.takeElementScreenshot()', function () {
     }
 });
 
-describe('[API] t.takeScreenshot({ fullPage: true })', function () {
+describe('[API] Take full page screenshots', function () {
     afterEach(assertionHelper.removeScreenshotDir);
 
     if (config.useLocalBrowsers && config.useHeadlessBrowsers) {
-        it('Should take a screenshot', function () {
+        it('Should take a full page screenshot via API', function () {
             return runTests('./testcafe-fixtures/take-full-page-screenshot.js', 'API', { setScreenshotPath: true })
+                .then(function () {
+                    return assertionHelper.checkScreenshotFileFullPage(false, 'custom');
+                })
+                .then(function (result) {
+                    expect(result).eql(true);
+                });
+        });
+
+        it('Should take a full page screenshot via Runner', function () {
+            return runTests('./testcafe-fixtures/take-full-page-screenshot.js', 'Runner', { setScreenshotPath: true, screenshotFullPage: true })
                 .then(function () {
                     return assertionHelper.checkScreenshotFileFullPage(false, 'custom');
                 })

--- a/test/functional/fixtures/api/es-next/take-screenshot/test.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/test.js
@@ -582,3 +582,19 @@ describe('[API] t.takeElementScreenshot()', function () {
     }
 });
 
+describe('[API] t.takeScreenshot({ fullPage: true })', function () {
+    afterEach(assertionHelper.removeScreenshotDir);
+
+    if (config.useLocalBrowsers && config.useHeadlessBrowsers) {
+        it('Should take a screenshot', function () {
+            return runTests('./testcafe-fixtures/take-full-page-screenshot.js', 'API', { setScreenshotPath: true })
+                .then(function () {
+                    return assertionHelper.checkScreenshotFileFullPage(false, 'custom');
+                })
+                .then(function (result) {
+                    expect(result).eql(true);
+                });
+        });
+    }
+});
+

--- a/test/functional/fixtures/api/es-next/take-screenshot/test.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/test.js
@@ -598,8 +598,8 @@ describe('[API] Take full page screenshots', function () {
 
         it('Should take a full page screenshot via Runner', function () {
             return runTests('./testcafe-fixtures/take-full-page-screenshot.js', 'Runner', {
-                setScreenshotPath:  true,
-                screenshotFullPage: true
+                setScreenshotPath:   true,
+                screenshotsFullPage: true
             })
                 .then(function () {
                     return assertionHelper.checkScreenshotFileFullPage(false, 'custom');
@@ -611,10 +611,10 @@ describe('[API] Take full page screenshots', function () {
 
         it('Should take a screenshot on fail', function () {
             return runTests('./testcafe-fixtures/take-full-page-screenshot.js', 'Screenshot on fail', {
-                shouldFail:         true,
-                setScreenshotPath:  true,
-                screenshotFullPage: true,
-                screenshotsOnFails: true
+                shouldFail:          true,
+                setScreenshotPath:   true,
+                screenshotsFullPage: true,
+                screenshotsOnFails:  true
             })
                 .catch(function (errs) {
                     expect(errs[0]).to.contains('screenshot on fail');

--- a/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-full-page-screenshot.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-full-page-screenshot.js
@@ -18,3 +18,9 @@ test('Runner', async t => {
     await t.takeScreenshot('custom/' + parse(ua).family + '.png');
 });
 
+test('Screenshot on fail', async () => {
+    const ua = await getUserAgent();
+
+    throw new Error('screenshot on fail' + parse(ua).family);
+});
+

--- a/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-full-page-screenshot.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-full-page-screenshot.js
@@ -12,3 +12,9 @@ test('API', async t => {
     await t.takeScreenshot('custom/' + parse(ua).family + '.png', { fullPage: true });
 });
 
+test('Runner', async t => {
+    const ua = await getUserAgent();
+
+    await t.takeScreenshot('custom/' + parse(ua).family + '.png');
+});
+

--- a/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-full-page-screenshot.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-full-page-screenshot.js
@@ -1,0 +1,14 @@
+import { ClientFunction } from 'testcafe';
+import { parse } from 'useragent';
+
+const getUserAgent = ClientFunction(() => navigator.userAgent.toString());
+
+fixture `Take a full-page screenshot`
+    .page `../pages/full-page.html`;
+
+test('API', async t => {
+    const ua = await getUserAgent();
+
+    await t.takeScreenshot('custom/' + parse(ua).family + '.png', { fullPage: true });
+});
+

--- a/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-full-page-screenshot.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-full-page-screenshot.js
@@ -9,13 +9,13 @@ fixture `Take a full-page screenshot`
 test('API', async t => {
     const ua = await getUserAgent();
 
-    await t.takeScreenshot('custom/' + parse(ua).family + '.png', { fullPage: true });
+    await t.takeScreenshot({ path: 'custom/' + parse(ua).family + '.png', fullPage: true });
 });
 
 test('Runner', async t => {
     const ua = await getUserAgent();
 
-    await t.takeScreenshot('custom/' + parse(ua).family + '.png');
+    await t.takeScreenshot({ path: 'custom/' + parse(ua).family + '.png', fullPage: true });
 });
 
 test('Screenshot on fail', async () => {

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -190,7 +190,7 @@ before(function () {
                     quarantineMode,
                     screenshotPathPattern,
                     screenshotsOnFails,
-                    screenshotFullPage,
+                    screenshotsFullPage,
                     videoOptions,
                     videoEncodingOptions,
                     speed,
@@ -247,7 +247,7 @@ before(function () {
                         return testName ? test === testName : true;
                     })
                     .src(fixturePath)
-                    .screenshots(screenshotPath, screenshotsOnFails, screenshotPathPattern, screenshotFullPage)
+                    .screenshots(screenshotPath, screenshotsOnFails, screenshotPathPattern, screenshotsFullPage)
                     .video(videoPath, videoOptions, videoEncodingOptions)
                     .startApp(appCommand, appInitDelay)
                     .clientScripts(clientScripts)

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -190,6 +190,7 @@ before(function () {
                     quarantineMode,
                     screenshotPathPattern,
                     screenshotsOnFails,
+                    screenshotFullPage,
                     videoOptions,
                     videoEncodingOptions,
                     speed,
@@ -246,7 +247,7 @@ before(function () {
                         return testName ? test === testName : true;
                     })
                     .src(fixturePath)
-                    .screenshots(screenshotPath, screenshotsOnFails, screenshotPathPattern)
+                    .screenshots(screenshotPath, screenshotsOnFails, screenshotPathPattern, screenshotFullPage)
                     .video(videoPath, videoOptions, videoEncodingOptions)
                     .startApp(appCommand, appInitDelay)
                     .clientScripts(clientScripts)

--- a/test/server/browser-provider-test.js
+++ b/test/server/browser-provider-test.js
@@ -278,7 +278,7 @@ describe('Browser provider', function () {
 
                 return provider.takeScreenshot(bc.id, '', 1, 1, true)
                     .then(() => {
-                        expect(bc.message).eql(WARNING_MESSAGE.screenshotFullPageNotSupported);
+                        expect(bc.message).eql(WARNING_MESSAGE.screenshotsFullPageNotSupported);
                     });
             });
         });

--- a/test/server/browser-provider-test.js
+++ b/test/server/browser-provider-test.js
@@ -1,8 +1,25 @@
-const expect                = require('chai').expect;
-const proxyquire            = require('proxyquire');
-const testcafeBrowserTools  = require('testcafe-browser-tools');
-const browserProviderPool   = require('../../lib/browser/provider/pool');
-const parseProviderName     = require('../../lib/browser/provider/parse-provider-name');
+const expect               = require('chai').expect;
+const proxyquire           = require('proxyquire');
+const testcafeBrowserTools = require('testcafe-browser-tools');
+const browserProviderPool  = require('../../lib/browser/provider/pool');
+const parseProviderName    = require('../../lib/browser/provider/parse-provider-name');
+const BrowserConnection    = require('../../lib/browser/connection');
+const WARNING_MESSAGE      = require('../../lib/notifications/warning-message');
+
+class BrowserConnectionMock extends BrowserConnection {
+    constructor () {
+        super({ startServingConnection: () => {} }, { openBrowser: () => {} });
+
+        this.ready = true;
+    }
+
+    _runBrowser () {
+    }
+
+    addWarning (...args) {
+        this.message = args[0];
+    }
+}
 
 
 describe('Browser provider', function () {
@@ -245,6 +262,23 @@ describe('Browser provider', function () {
                     .isValidBrowserName('browser')
                     .then(result => {
                         expect(result).to.be.true;
+                    });
+            });
+
+            it('Should add warning if provider does not support `fullPage` screenshots', () => {
+                const ProviderCtor = require('../../lib/browser/provider/');
+
+                const provider = new ProviderCtor({
+                    isLocalBrowser:            () => true,
+                    isHeadlessBrowser:         () => false,
+                    hasCustomActionForBrowser: () => false
+                });
+
+                const bc = new BrowserConnectionMock();
+
+                return provider.takeScreenshot(bc.id, '', 1, 1, true)
+                    .then(() => {
+                        expect(bc.message).eql(WARNING_MESSAGE.screenshotFullPageNotSupported);
                     });
             });
         });

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -586,6 +586,7 @@ describe('CLI argument parser', function () {
             { long: '--video-encoding-options' },
             { long: '--ts-config-path' },
             { long: '--client-scripts', short: '--cs' },
+            { long: '--screenshots-full-page' },
             { long: '--disable-page-caching' }
         ];
 

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -586,7 +586,7 @@ describe('CLI argument parser', function () {
             { long: '--video-encoding-options' },
             { long: '--ts-config-path' },
             { long: '--client-scripts', short: '--cs' },
-            { long: '--screenshots-full-page' },
+            { long: '--screenshot-full-page' },
             { long: '--disable-page-caching' }
         ];
 

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -586,7 +586,7 @@ describe('CLI argument parser', function () {
             { long: '--video-encoding-options' },
             { long: '--ts-config-path' },
             { long: '--client-scripts', short: '--cs' },
-            { long: '--screenshot-full-page' },
+            { long: '--screenshots-full-page' },
             { long: '--disable-page-caching' }
         ];
 

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -58,7 +58,7 @@ describe('TestCafeConfiguration', () => {
             'screenshotPath':         'screenshot-path',
             'screenshotPathPattern':  'screenshot-path-pattern',
             'takeScreenshotsOnFails': true,
-            'screenshotFullPage':     true
+            'screenshotsFullPage':    true
         });
     });
 
@@ -107,7 +107,7 @@ describe('TestCafeConfiguration', () => {
                         expect(testCafeConfiguration.getOption('screenshotPath')).eql('screenshot-path');
                         expect(testCafeConfiguration.getOption('screenshotPathPattern')).eql('screenshot-path-pattern');
                         expect(testCafeConfiguration.getOption('takeScreenshotsOnFails')).eql(true);
-                        expect(testCafeConfiguration.getOption('screenshotFullPage')).eql(true);
+                        expect(testCafeConfiguration.getOption('screenshotsFullPage')).eql(true);
                     });
             });
 

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -54,7 +54,11 @@ describe('TestCafeConfiguration', () => {
                 'testMeta':    { test: 'meta' },
                 'fixtureMeta': { fixture: 'meta' }
             },
-            'clientScripts': 'test-client-script.js'
+            'clientScripts':          'test-client-script.js',
+            'screenshotPath':         'screenshot-path',
+            'screenshotPathPattern':  'screenshot-path-pattern',
+            'takeScreenshotsOnFails': true,
+            'screenshotFullPage':     true
         });
     });
 
@@ -100,6 +104,10 @@ describe('TestCafeConfiguration', () => {
                         expect(testCafeConfiguration.getOption('filter').testMeta).to.be.deep.equal({ test: 'meta' });
                         expect(testCafeConfiguration.getOption('filter').fixtureMeta).to.be.deep.equal({ fixture: 'meta' });
                         expect(testCafeConfiguration.getOption('clientScripts')).eql([ 'test-client-script.js' ]);
+                        expect(testCafeConfiguration.getOption('screenshotPath')).eql('screenshot-path');
+                        expect(testCafeConfiguration.getOption('screenshotPathPattern')).eql('screenshot-path-pattern');
+                        expect(testCafeConfiguration.getOption('takeScreenshotsOnFails')).eql(true);
+                        expect(testCafeConfiguration.getOption('screenshotFullPage')).eql(true);
                     });
             });
 

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -305,7 +305,7 @@ describe('Runner', () => {
             expect(runner.configuration.getOption('screenshotPath')).eql('path');
             expect(runner.configuration.getOption('takeScreenshotsOnFails')).eql(true);
             expect(runner.configuration.getOption('screenshotPathPattern')).eql('pathPattern');
-            expect(runner.configuration.getOption('screenshotFullPage')).eql(true);
+            expect(runner.configuration.getOption('screenshotsFullPage')).eql(true);
         });
     });
 

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -292,6 +292,21 @@ describe('Runner', () => {
                     expect(consoleWrapper.messages.log).eql(null);
                 });
         });
+
+        it('should allow to set object as a `screenshots` method parameter', () => {
+            runner
+                .screenshots({
+                    path:        'path',
+                    takeOnFails: true,
+                    pathPattern: 'pathPattern',
+                    fullPage:    true
+                });
+
+            expect(runner.configuration.getOption('screenshotPath')).eql('path');
+            expect(runner.configuration.getOption('takeScreenshotsOnFails')).eql(true);
+            expect(runner.configuration.getOption('screenshotPathPattern')).eql('pathPattern');
+            expect(runner.configuration.getOption('screenshotFullPage')).eql(true);
+        });
     });
 
     describe('.video()', () => {

--- a/test/server/test-run-commands-test.js
+++ b/test/server/test-run-commands-test.js
@@ -847,6 +847,7 @@ describe('Test run commands', () => {
                 selector: '#yo',
                 path:     'custom',
                 dummy:    'test',
+                fullPage:  true,
 
                 options: {
                     dummy: 'yo'
@@ -859,7 +860,8 @@ describe('Test run commands', () => {
                 type:     TYPE.takeScreenshot,
                 markData: '',
                 markSeed: null,
-                path:     'custom'
+                path:     'custom',
+                fullPage: true
             });
 
             commandObj = {
@@ -878,7 +880,8 @@ describe('Test run commands', () => {
                 type:     TYPE.takeScreenshot,
                 markData: '',
                 markSeed: null,
-                path:     ''
+                path:     '',
+                fullPage: false
             });
         });
 

--- a/test/server/test-run-commands-test.js
+++ b/test/server/test-run-commands-test.js
@@ -868,6 +868,7 @@ describe('Test run commands', () => {
                 type:     TYPE.takeScreenshot,
                 selector: '#yo',
                 dummy:    'test',
+                fullPage: void 0,
 
                 options: {
                     dummy: 'yo'
@@ -880,8 +881,7 @@ describe('Test run commands', () => {
                 type:     TYPE.takeScreenshot,
                 markData: '',
                 markSeed: null,
-                path:     '',
-                fullPage: false
+                path:     ''
             });
         });
 

--- a/test/server/test-run-commands-test.js
+++ b/test/server/test-run-commands-test.js
@@ -847,7 +847,7 @@ describe('Test run commands', () => {
                 selector: '#yo',
                 path:     'custom',
                 dummy:    'test',
-                fullPage:  true,
+                fullPage: true,
 
                 options: {
                     dummy: 'yo'

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -759,16 +759,28 @@ interface ActionOptions {
 }
 
 interface BasicScreenshotsOptions {
+    /**
+     * Specifies the path to save the screenshot
+     */
     path?: string;
-
+    /**
+     * Allows to make full-page screenshots
+     */
     fullPage?: boolean;
 }
 
 interface ScreenshotsOptions extends BasicScreenshotsOptions {
+    /**
+     * Specifies the base directory where the the screenshots are saved.
+     */
     path: string;
-
+    /**
+     * Specifies that a screenshot should be taken whenever a test fails
+     */
     takeOnFails?: boolean;
-
+    /**
+     * Specifies a custom pattern to compose screenshot files' relative path and name.
+     */
     pathPattern?: string;
 }
 
@@ -1196,7 +1208,7 @@ interface TestController {
     /**
     * Takes a screenshot of the tested page.
     *
-    * @param options
+    * @param options - TakeScreenshot Options
     */
     takeScreenshot(options: TakeScreenshotOptions): TestControllerPromise;
     /**
@@ -1659,6 +1671,11 @@ interface Runner {
      */
     screenshots(path: string, takeOnFails?: boolean, pathPattern?: string): this;
 
+    /**
+     * Enables TestCafe to take screenshots of the tested webpages.
+     *
+     * @param options - Screenshots options
+     */
     screenshots(options: ScreenshotsOptions): this;
 
     /**

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -760,22 +760,22 @@ interface ActionOptions {
 
 interface BasicScreenshotsOptions {
     /**
-     * Specifies the path to save the screenshot
+     * Specifies the path where the screenshots are saved.
      */
     path?: string;
     /**
-     * Allows to make full-page screenshots
+     * Specifies that TestCafe should take full-page screenshots.
      */
     fullPage?: boolean;
 }
 
 interface ScreenshotsOptions extends BasicScreenshotsOptions {
     /**
-     * Specifies the base directory where the the screenshots are saved.
+     * Specifies the base directory where the screenshots are saved.
      */
     path: string;
     /**
-     * Specifies that a screenshot should be taken whenever a test fails
+     * Specifies that a screenshot should be taken whenever a test fails.
      */
     takeOnFails?: boolean;
     /**

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -758,6 +758,22 @@ interface ActionOptions {
     speed?: number;
 }
 
+interface ScreenshotsOptions {
+    path: string;
+
+    takeOnFails?: boolean;
+
+    pathPattern?: string;
+
+    fullPage?: boolean;
+}
+
+interface TakeScreenshotOptions {
+    path?: string;
+
+    fullPage?: boolean;
+}
+
 interface TakeElementScreenshotOptions extends ActionOptions {
     /**
      * Allows to crop the target element on the screenshot.
@@ -1176,6 +1192,12 @@ interface TestController {
      * If path doesn't have .png extension, it will be added automatically.
      */
     takeScreenshot(path?: string): TestControllerPromise;
+    /**
+    * Takes a screenshot of the tested page.
+    *
+    * @param options
+    */
+    takeScreenshot(options: TakeScreenshotOptions): TestControllerPromise;
     /**
      * Takes a screenshot of the specified element.
      *
@@ -1635,6 +1657,8 @@ interface Runner {
      * @param pathPattern - The pattern to compose screenshot files' relative path and name.
      */
     screenshots(path: string, takeOnFails?: boolean, pathPattern?: string): this;
+
+    screenshots(options: ScreenshotsOptions): this;
 
     /**
      * Configures TestCafe's reporting feature.

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -758,20 +758,21 @@ interface ActionOptions {
     speed?: number;
 }
 
-interface ScreenshotsOptions {
+interface BasicScreenshotsOptions {
+    path?: string;
+
+    fullPage?: boolean;
+}
+
+interface ScreenshotsOptions extends BasicScreenshotsOptions {
     path: string;
 
     takeOnFails?: boolean;
 
     pathPattern?: string;
-
-    fullPage?: boolean;
 }
 
-interface TakeScreenshotOptions {
-    path?: string;
-
-    fullPage?: boolean;
+interface TakeScreenshotOptions extends BasicScreenshotsOptions  {
 }
 
 interface TakeElementScreenshotOptions extends ActionOptions {


### PR DESCRIPTION
I found some issues while researching cdp and marionette.
Chrome headless works great
Chrome non-headless adds some paddings sometimes. Not great, but not terrible.
Firefox cuts screenshots sometimes, especially if there are positioned elements on the page.