### PR TITLE
update ts-defs clientscripts

### DIFF
--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -1948,7 +1948,7 @@ interface FixtureFn {
      */
     requestHooks(...hooks: object[]): this;
     /**
-     * Injects scripts into fixture run during the test execution.
+     * Injects scripts into pages visited during the fixture execution.
      *
      * @param scripts - Scripts that should be added to the tested pages.
     */
@@ -2019,7 +2019,7 @@ interface TestFn {
      */
     requestHooks(...hooks: object[]): this;
     /**
-     * Injects scripts into tests run during the test execution.
+     * Injects scripts into pages visited during the test execution.
      *
      * @param scripts - Scripts that should be added to the tested pages.
     */

--- a/ts-defs/index.d.ts
+++ b/ts-defs/index.d.ts
@@ -1947,6 +1947,12 @@ interface FixtureFn {
      * @param hooks - The set of the RequestHook subclasses
      */
     requestHooks(...hooks: object[]): this;
+    /**
+     * Injects scripts into fixture run during the test execution.
+     *
+     * @param scripts - Scripts that should be added to the tested pages.
+    */
+   clientScripts (scripts: ClientScript | ClientScript[]): this;
 }
 
 interface TestFn {
@@ -2012,6 +2018,12 @@ interface TestFn {
      * @param hooks - The set of the RequestHook subclasses
      */
     requestHooks(...hooks: object[]): this;
+    /**
+     * Injects scripts into tests run during the test execution.
+     *
+     * @param scripts - Scripts that should be added to the tested pages.
+    */
+   clientScripts (scripts: ClientScript | ClientScript[]): this;
 }
 
 declare var fixture: FixtureFn;


### PR DESCRIPTION
The documentation shows that clientScripts can be ran on fixture and test but the typescript definitions do not take this into account. This updates the definitions to allow for these functions to be called.