### PR TITLE
Fix '`testcafe -b` returns the "The specified "true" browser provider was not found" error'

### DIFF
--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -219,7 +219,7 @@ export default class CLIArgumentParser {
         }
     }
 
-    private _parseBrowserList (): void {
+    private _parseBrowsersFromArgs (): void {
         const browsersArg = this.program.args[0] || '';
 
         this.opts.browsers = splitQuotedText(browsersArg, ',')
@@ -259,7 +259,7 @@ export default class CLIArgumentParser {
             this.opts.videoEncodingOptions = await getVideoOptions(this.opts.videoEncodingOptions as string);
     }
 
-    private _setProviderName (): void {
+    private _parseListBrowsers (): void {
         const listBrowserOption = this.opts.listBrowsers;
 
         this.opts.listBrowsers = !!this.opts.listBrowsers;
@@ -267,7 +267,7 @@ export default class CLIArgumentParser {
         if (!this.opts.listBrowsers)
             return;
 
-        // NOTE: If the "listBrowserOption" is not presented by "string" we set providerName to the default "locally-installed" value (GH-4294)
+        // NOTE: If the "listBrowserOption" is not presented by "string", we set "providerName" to the default "locally-installed" value (GH-4294)
         this.opts.providerName = typeof listBrowserOption === 'string' ? listBrowserOption : 'locally-installed';
     }
 
@@ -278,7 +278,7 @@ export default class CLIArgumentParser {
 
         this.opts = this.program.opts();
 
-        this._setProviderName();
+        this._parseListBrowsers();
 
         // NOTE: the '-list-browsers' option only lists browsers and immediately exits the app.
         // Therefore, we don't need to process other arguments.
@@ -291,7 +291,7 @@ export default class CLIArgumentParser {
         this._parseAppInitDelay();
         this._parseSpeed();
         this._parsePorts();
-        this._parseBrowserList();
+        this._parseBrowsersFromArgs();
         this._parseConcurrency();
         this._parseFileList();
 

--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -267,7 +267,6 @@ export default class CLIArgumentParser {
         if (!this.opts.listBrowsers)
             return;
 
-        // NOTE: If the "listBrowserOption" is not presented by "string", we set "providerName" to the default "locally-installed" value (GH-4294)
         this.opts.providerName = typeof listBrowserOption === 'string' ? listBrowserOption : 'locally-installed';
     }
 

--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -259,8 +259,16 @@ export default class CLIArgumentParser {
             this.opts.videoEncodingOptions = await getVideoOptions(this.opts.videoEncodingOptions as string);
     }
 
-    private _setUpProviderName (): void {
-        this.opts.providerName = (this.opts.listBrowsers === true ? void 0 : this.opts.listBrowsers) as string;
+    private _setProviderName (): void {
+        const listBrowserOption = this.opts.listBrowsers;
+
+        this.opts.listBrowsers = !!this.opts.listBrowsers;
+
+        if (!this.opts.listBrowsers)
+            return;
+
+        // NOTE: If the "listBrowserOption" is not presented by "string" we set providerName to the default "locally-installed" value (GH-4294)
+        this.opts.providerName = typeof listBrowserOption === 'string' ? listBrowserOption : 'locally-installed';
     }
 
     public async parse (argv: string[]): Promise<void> {
@@ -270,13 +278,12 @@ export default class CLIArgumentParser {
 
         this.opts = this.program.opts();
 
+        this._setProviderName();
+
         // NOTE: the '-list-browsers' option only lists browsers and immediately exits the app.
         // Therefore, we don't need to process other arguments.
-        if (this.opts.listBrowsers) {
-            this._setUpProviderName();
-
+        if (this.opts.listBrowsers)
             return;
-        }
 
         this._parseSelectorTimeout();
         this._parseAssertionTimeout();

--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -260,8 +260,7 @@ export default class CLIArgumentParser {
     }
 
     private _setUpProviderName (): void {
-        if (this.opts.listBrowsers)
-            this.opts.providerName = this.opts.listBrowsers as string;
+        this.opts.providerName = (this.opts.listBrowsers === true ? void 0 : this.opts.listBrowsers) as string;
     }
 
     public async parse (argv: string[]): Promise<void> {

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -113,7 +113,7 @@ async function runTests (argParser) {
     exit(failed);
 }
 
-async function listBrowsers (providerName = 'locally-installed') {
+async function listBrowsers (providerName) {
     const provider = await browserProviderPool.getProvider(providerName);
 
     if (!provider)

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -32,6 +32,40 @@ describe('CLI argument parser', function () {
             });
     }
 
+    describe('Set browser provider name', function () {
+        it('Should set the default provider name to "locally-installed" from "--list-browsers"', function () {
+            return parse('--list-browsers')
+                .then(function (parser) {
+                    expect(parser.opts.listBrowsers).eql(true);
+                    expect(parser.opts.providerName).eql('locally-installed');
+                });
+        });
+
+        it('Should parse the browser provider name from "--list-browsers saucelabs"', function () {
+            return parse('--list-browsers saucelabs')
+                .then(function (parser) {
+                    expect(parser.opts.listBrowsers).eql(true);
+                    expect(parser.opts.providerName).eql('saucelabs');
+                });
+        });
+
+        it('Should set the default provider name to "locally-installed" from "-b"', function () {
+            return parse('-b')
+                .then(function (parser) {
+                    expect(parser.opts.listBrowsers).eql(true);
+                    expect(parser.opts.providerName).eql('locally-installed');
+                });
+        });
+
+        it('Should parse "-b saucelabs" browser provider name from "-b saucelabs"', function () {
+            return parse('-b saucelabs')
+                .then(function (parser) {
+                    expect(parser.opts.listBrowsers).eql(true);
+                    expect(parser.opts.providerName).eql('saucelabs');
+                });
+        });
+    });
+
     describe('Browser list', function () {
         it('Should be parsed as array of aliases or paths', function () {
             return parse('path:"/Applications/Firefox.app",ie,chrome,firefox,')


### PR DESCRIPTION
### Todo
- [ ] Close https://github.com/DevExpress/testcafe/issues/4294 after merge
- [x] ~~`_setProviderName` naming~~
- [x] ~~Test provider name to parse: `saucelabs` --> `providerName`?~~

https://github.com/DevExpress/testcafe/issues/4294

### Changes
1. Set the default "locally-installed" provider name in the `CliArgumentParser.parse` function.