### PR TITLE
GH:2386 Visible should not fail if the selector does not exist/stops existing

### DIFF
--- a/src/client/driver/utils/element-utils.js
+++ b/src/client/driver/utils/element-utils.js
@@ -12,7 +12,7 @@ export function exists (el) {
 }
 
 export function visible (el) {
-    if (!domUtils.isDomElement(el) && !domUtils.isTextNode(el))
+    if (!exists(el) || !domUtils.isDomElement(el) && !domUtils.isTextNode(el))
         return false;
 
     if (domUtils.isOptionElement(el) || domUtils.getTagName(el) === 'optgroup')

--- a/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
+++ b/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
@@ -1085,3 +1085,10 @@ test('Selector `addCustomMethods` method - Selector mode', async t => {
     await t.expect(await nonExistingElement()).eql(null);
 });
 
+test('Inexistent element with exists/visible checks', async t => {
+    const selector = Selector('#idonotexist');
+
+    await t
+        .expect(selector.exists).notOk()
+        .expect(selector.visible).notOk();
+});


### PR DESCRIPTION
Previously, elements that did not exist threw errors if the `visible` property was accessed.
This PR fixes that by returning false if the element does not exist, which is in my opinion expected behaviour.

Fixes #2386 
