### PR TITLE
Debug logger is able to be overriden

### DIFF
--- a/src/configuration/option-names.js
+++ b/src/configuration/option-names.js
@@ -36,5 +36,6 @@ export default {
     port1:                  'port1',
     port2:                  'port2',
     developmentMode:        'developmentMode',
-    disablePageCaching:     'disablePageCaching'
+    disablePageCaching:     'disablePageCaching',
+    debugLogger:            'debugLogger'
 };

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -187,7 +187,10 @@ export default class Runner extends EventEmitter {
     _validateDebugLogger () {
         const debugLogger = this.configuration.getOption(OPTION_NAMES.debugLogger);
 
-        if (debugLogger === void 0) {
+        const debugLoggerDefinedCorrectly = debugLogger && 
+            ["showBreakpoint", "hideBreakpoint"].every(method => method in debugLogger && debugLogger[method] instanceof Function);
+
+        if (debugLogger === void 0 || !debugLoggerDefinedCorrectly) {
             this.configuration.mergeOptions({
                 [OPTION_NAMES.debugLogger]: defaultDebugLogger
             });

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -7,6 +7,7 @@ import { flattenDeep as flatten, pull as remove } from 'lodash';
 import Bootstrapper from './bootstrapper';
 import Reporter from '../reporter';
 import Task from './task';
+import defaultDebugLogger from '../notifications/debug-logger/default';
 import { GeneralError } from '../errors/runtime';
 import { RUNTIME_ERRORS } from '../errors/types';
 import { assertType, is } from '../errors/runtime/type-assertions';
@@ -183,6 +184,16 @@ export default class Runner extends EventEmitter {
         assets.forEach(asset => this.proxy.GET(asset.path, asset.info));
     }
 
+    _validateDebugLogger () {
+        const debugLogger = this.configuration.getOption(OPTION_NAMES.debugLogger);
+
+        if (debugLogger !== void 0) {
+            this.configuration.mergeOptions({
+                [OPTION_NAMES.debugLogger]: defaultDebugLogger
+            })
+        }
+    }
+
     _validateSpeedOption () {
         const speed = this.configuration.getOption(OPTION_NAMES.speed);
 
@@ -271,6 +282,7 @@ export default class Runner extends EventEmitter {
     }
 
     async _validateRunOptions () {
+        this._validateDebugLogger();
         this._validateScreenshotOptions();
         await this._validateVideoOptions();
         this._validateSpeedOption();

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -187,8 +187,8 @@ export default class Runner extends EventEmitter {
     _validateDebugLogger () {
         const debugLogger = this.configuration.getOption(OPTION_NAMES.debugLogger);
 
-        const debugLoggerDefinedCorrectly = debugLogger && 
-            ["showBreakpoint", "hideBreakpoint"].every(method => method in debugLogger && debugLogger[method] instanceof Function);
+        const debugLoggerDefinedCorrectly = debugLogger &&
+            ['showBreakpoint', 'hideBreakpoint'].every(method => method in debugLogger && debugLogger[method] instanceof Function);
 
         if (debugLogger === void 0 || !debugLoggerDefinedCorrectly) {
             this.configuration.mergeOptions({

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -190,7 +190,7 @@ export default class Runner extends EventEmitter {
         if (debugLogger !== void 0) {
             this.configuration.mergeOptions({
                 [OPTION_NAMES.debugLogger]: defaultDebugLogger
-            })
+            });
         }
     }
 

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -3,7 +3,7 @@ import debug from 'debug';
 import promisifyEvent from 'promisify-event';
 import mapReverse from 'map-reverse';
 import { EventEmitter } from 'events';
-import { flattenDeep as flatten, pull as remove } from 'lodash';
+import { flattenDeep as flatten, pull as remove, isFunction } from 'lodash';
 import Bootstrapper from './bootstrapper';
 import Reporter from '../reporter';
 import Task from './task';
@@ -188,7 +188,7 @@ export default class Runner extends EventEmitter {
         const debugLogger = this.configuration.getOption(OPTION_NAMES.debugLogger);
 
         const debugLoggerDefinedCorrectly = debugLogger &&
-            ['showBreakpoint', 'hideBreakpoint'].every(method => method in debugLogger && debugLogger[method] instanceof Function);
+            ['showBreakpoint', 'hideBreakpoint'].every(method => method in debugLogger && isFunction(debugLogger[method]));
 
         if (debugLogger === void 0 || !debugLoggerDefinedCorrectly) {
             this.configuration.mergeOptions({

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -7,7 +7,7 @@ import { flattenDeep as flatten, pull as remove } from 'lodash';
 import Bootstrapper from './bootstrapper';
 import Reporter from '../reporter';
 import Task from './task';
-import defaultDebugLogger from '../notifications/debug-logger/default';
+import defaultDebugLogger from '../notifications/debug-logger';
 import { GeneralError } from '../errors/runtime';
 import { RUNTIME_ERRORS } from '../errors/types';
 import { assertType, is } from '../errors/runtime/type-assertions';

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -187,7 +187,7 @@ export default class Runner extends EventEmitter {
     _validateDebugLogger () {
         const debugLogger = this.configuration.getOption(OPTION_NAMES.debugLogger);
 
-        if (debugLogger !== void 0) {
+        if (debugLogger === void 0) {
             this.configuration.mergeOptions({
                 [OPTION_NAMES.debugLogger]: defaultDebugLogger
             });

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -3,7 +3,6 @@ import { readSync as read } from 'read-file-relative';
 import promisifyEvent from 'promisify-event';
 import Mustache from 'mustache';
 import AsyncEventEmitter from '../utils/async-event-emitter';
-import debugLogger from '../notifications/debug-logger';
 import TestRunDebugLog from './debug-log';
 import TestRunErrorFormattableAdapter from '../errors/test-run/formattable-adapter';
 import TestCafeErrorList from '../errors/error-list';
@@ -123,7 +122,8 @@ export default class TestRun extends AsyncEventEmitter {
         this.debugLog = new TestRunDebugLog(this.browserConnection.userAgent);
 
         this.quarantine  = null;
-        this.debugLogger = debugLogger;
+
+        this.debugLogger = this.opts.debugLogger;
 
         this._addInjectables();
         this._initRequestHooks();

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -122,7 +122,8 @@ export default class TestRun extends AsyncEventEmitter {
 
         this.debugLog = new TestRunDebugLog(this.browserConnection.userAgent);
 
-        this.quarantine = null;
+        this.quarantine  = null;
+        this.debugLogger = debugLogger;
 
         this._addInjectables();
         this._initRequestHooks();
@@ -435,7 +436,8 @@ export default class TestRun extends AsyncEventEmitter {
             return;
         }
 
-        debugLogger.showBreakpoint(this.session.id, this.browserConnection.userAgent, callsite, error);
+        if (this.debugLogger)
+            this.debugLogger.showBreakpoint(this.session.id, this.browserConnection.userAgent, callsite, error);
 
         this.debugging = await this.executeCommand(new serviceCommands.SetBreakpointCommand(!!error), callsite);
     }
@@ -562,7 +564,8 @@ export default class TestRun extends AsyncEventEmitter {
     _adjustConfigurationWithCommand (command) {
         if (command.type === COMMAND_TYPE.testDone) {
             this.testDoneCommandQueued = true;
-            debugLogger.hideBreakpoint(this.session.id);
+            if (this.debugLogger)
+                this.debugLogger.hideBreakpoint(this.session.id);
         }
 
         else if (command.type === COMMAND_TYPE.setNativeDialogHandler)

--- a/test/server/execute-async-expression-test.js
+++ b/test/server/execute-async-expression-test.js
@@ -6,6 +6,7 @@ const TestRun        = require('../../lib/test-run/index');
 const TestController = require('../../lib/api/test-controller');
 const COMMAND_TYPE   = require('../../lib/test-run/commands/type');
 const markerSymbol   = require('../../lib/test-run/marker-symbol');
+const debugLogger    = require('../../lib/notifications/debug-logger');
 
 const assertTestRunError = require('./helpers/assert-test-run-error');
 
@@ -19,6 +20,7 @@ function createTestRunMock () {
         this.controller      = new TestController(this);
         this.driverTaskQueue = [];
         this.emit            = noop;
+        this.debugLogger     = debugLogger;
 
         this[markerSymbol] = true;
 

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -760,7 +760,7 @@ describe('Runner', () => {
                 });
         });
 
-        it('Should use default debugLogger if need', () => {
+        it('Should use the default debugLogger if necessary', () => {
             const defaultLogger = require('../../lib/notifications/debug-logger');
 
             runner._validateDebugLogger();

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -759,6 +759,23 @@ describe('Runner', () => {
                     expect(consoleWrapper.messages.log).eql(null);
                 });
         });
+
+        it('Should use default debugLogger if need', () => {
+            const defaultLogger = require('../../lib/notifications/debug-logger');
+
+            runner._validateDebugLogger();
+
+            expect(runner.configuration.getOption('debugLogger')).to.deep.equal(defaultLogger);
+
+            const customLogger = {
+                showBreakpoint: () => {},
+                hideBreakpoint: () => {}
+            };
+
+            runner.configuration.mergeOptions({ debugLogger: customLogger });
+
+            expect(runner.configuration.getOption('debugLogger')).to.deep.equal(customLogger);
+        });
     });
 
     describe('.clientScripts', () => {

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -768,11 +768,18 @@ describe('Runner', () => {
             expect(runner.configuration.getOption('debugLogger')).to.deep.equal(defaultLogger);
 
             const customLogger = {
-                showBreakpoint: () => {},
+                showBreakpoint: 'foo',
                 hideBreakpoint: () => {}
             };
 
             runner.configuration.mergeOptions({ debugLogger: customLogger });
+            runner._validateDebugLogger();
+
+            expect(runner.configuration.getOption('debugLogger')).to.deep.equal(defaultLogger);
+
+            customLogger.showBreakpoint = () => {};
+            runner.configuration.mergeOptions({ debugLogger: customLogger });
+            runner._validateDebugLogger();
 
             expect(runner.configuration.getOption('debugLogger')).to.deep.equal(customLogger);
         });


### PR DESCRIPTION
This PR is needed for https://github.com/DevExpress/testcafe-studio/issues/2729 to hide console output in coded steps with debug action.