### PR TITLE
Protect form submit from pre-init use (close 4360)

### DIFF
--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -210,7 +210,7 @@ export default class Driver {
     // We have to cancel every form submit after a test is done
     // to prevent requests to a closed session
     _onFormSubmit (e) {
-        if (this.contextStorage !== null && this.contextStorage.getItem(TEST_DONE_SENT_FLAG))
+        if (this.contextStorage.getItem(TEST_DONE_SENT_FLAG))
             e.preventSubmit = true;
     }
 

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -210,7 +210,9 @@ export default class Driver {
     // We have to cancel every form submit after a test is done
     // to prevent requests to a closed session
     _onFormSubmit (e) {
-        if (this.contextStorage.getItem(TEST_DONE_SENT_FLAG))
+        // NOTE: We need to refactor this code to avoid the undefined value in contextStorage
+        // https://github.com/DevExpress/testcafe/issues/4360
+        if (this.contextStorage && this.contextStorage.getItem(TEST_DONE_SENT_FLAG))
             e.preventSubmit = true;
     }
 

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -210,7 +210,7 @@ export default class Driver {
     // We have to cancel every form submit after a test is done
     // to prevent requests to a closed session
     _onFormSubmit (e) {
-        if (this.contextStorage.getItem(TEST_DONE_SENT_FLAG))
+        if (this.contextStorage !== null && this.contextStorage.getItem(TEST_DONE_SENT_FLAG))
             e.preventSubmit = true;
     }
 

--- a/src/client/driver/iframe-driver.js
+++ b/src/client/driver/iframe-driver.js
@@ -74,14 +74,15 @@ export default class IframeDriver extends Driver {
 
     // API
     start () {
+        // TODO: refactor it to leave this in the base class only
+        this.contextStorage = new ContextStorage(window, id);
+
         this.nativeDialogsTracker = new IframeNativeDialogTracker(this.dialogHandler);
         this.statusBar            = new IframeStatusBar();
 
         const initializePromise = this.parentDriverLink
             .establishConnection()
             .then(id => {
-                this.contextStorage = new ContextStorage(window, id);
-
                 if (this._failIfClientCodeExecutionIsInterrupted())
                     return;
 

--- a/src/client/driver/iframe-driver.js
+++ b/src/client/driver/iframe-driver.js
@@ -74,15 +74,14 @@ export default class IframeDriver extends Driver {
 
     // API
     start () {
-        // TODO: refactor it to leave this in the base class only
-        this.contextStorage = new ContextStorage(window, id);
-
         this.nativeDialogsTracker = new IframeNativeDialogTracker(this.dialogHandler);
         this.statusBar            = new IframeStatusBar();
 
         const initializePromise = this.parentDriverLink
             .establishConnection()
             .then(id => {
+                this.contextStorage = new ContextStorage(window, id);
+
                 if (this._failIfClientCodeExecutionIsInterrupted())
                     return;
 

--- a/test/functional/fixtures/regression/gh-4360/pages/frame.html
+++ b/test/functional/fixtures/regression/gh-4360/pages/frame.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>gh-4360</title>
+</head>
+<body>
+<form></form>
+<div id="target"></div>
+
+<script type="text/javascript">
+    if (localStorage.getItem('preventReload'))
+        document.querySelector('#target').innerHTML = 'OK';
+    else {
+        localStorage.setItem('preventReload', true);
+
+        var form = document.querySelector('form');
+
+        form.submit();
+    }
+</script>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-4360/pages/index.html
+++ b/test/functional/fixtures/regression/gh-4360/pages/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>gh-4360</title>
+</head>
+<body>
+    <iframe src="./frame.html"></iframe>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-4360/test.js
+++ b/test/functional/fixtures/regression/gh-4360/test.js
@@ -1,6 +1,6 @@
 describe('[Regression](GH-4360) - Should not throw \'contextStorage is undefined\' error', function () {
     it('Submit form in iframe immediately after load', function () {
-        return runTests('testcafe-fixtures/index.js');
+        return runTests('testcafe-fixtures/index.js', null, { skip: ['chrome-osx', 'firefox-osx', 'ipad', 'iphone'] });
     });
 });
 

--- a/test/functional/fixtures/regression/gh-4360/test.js
+++ b/test/functional/fixtures/regression/gh-4360/test.js
@@ -1,0 +1,7 @@
+describe('[Regression](GH-4360) - Should not throw \'contextStorage is undefined\' error', function () {
+    it('Submit form in iframe immediately after load', function () {
+        return runTests('testcafe-fixtures/index.js');
+    });
+});
+
+

--- a/test/functional/fixtures/regression/gh-4360/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-4360/testcafe-fixtures/index.js
@@ -1,0 +1,9 @@
+import { Selector } from 'testcafe';
+
+fixture `GH-4360 - Should not throw 'contextStorage is undefined' error`
+    .page `http://localhost:3000/fixtures/regression/gh-4360/pages/index.html`;
+
+test(`Submit form in iframe immediately after load`, async t => {
+    await t.switchToIframe('iframe');
+    await t.expect(Selector('#target').innerText).eql('OK');
+});


### PR DESCRIPTION
The details of the requirement and the occurrence are contained in Issue #4360. This fix has been tested against the issue noted there and fixes it.

Simple addition to prevent use of contextStorage if not initialised. This is a valid check as it can't be already sent (therefore the flag check isn't required) if the storage isn't even initialised.

Other holes may exist with the same pattern but only the form submit is handled here. The other likely candidate is `_onJsError()` if the error is triggered prior to the driver start.