### PR TITLE
fix `debugLogger` server test

### DIFF
--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -832,6 +832,11 @@ describe('Runner', () => {
             expect(runner.configuration.getOption('debugLogger')).to.deep.equal(defaultLogger);
 
             customLogger.showBreakpoint = () => {};
+
+            runner.configuration.mergeOptions({ debugLogger: null });
+
+            expect(runner.configuration.getOption('debugLogger')).is.null;
+
             runner.configuration.mergeOptions({ debugLogger: customLogger });
             runner._validateDebugLogger();
 


### PR DESCRIPTION
Currently if you want to do smth like this `.mergeOptions({ debugLogger: customLogger });` the configuration will **merge** the target object, but not rewrite it. Fortunately, this error only in test code, since @Dmitry-Ostashev  in TestCafe merges `debugLogger` with 'null'. The 'null' !== object, so configuration will not merge, but just reset the debugLogger value. Thus everything should work as expected, excepting the test code.
In the test it's enough just to reset the debugLogger value to null, as happens in real code.