### PR TITLE
Fix FFmpeg detection in PATH

### DIFF
--- a/src/utils/detect-ffmpeg.js
+++ b/src/utils/detect-ffmpeg.js
@@ -10,7 +10,7 @@ async function findFFMPEGinPath () {
     try {
         const ffmpegPath = await exec(`${FFMPEG_SEARCH_COMMAND} ${FFMPEG_BINARY_NAME}`);
 
-        return ffmpegPath.trim();
+        return ffmpegPath.stdout.trim();
     }
     catch (e) {
         return '';


### PR DESCRIPTION
A change in TestCafe 1.4.2 (possibly #4147) broke FFmpeg detection in `PATH`, resulting in an `Unable to locate the FFmpeg executable required to record videos` error when not using the `FFMPEG_PATH` environment variable, `ffmpegPath` video option or `@ffmpeg-installer/ffmpeg` package.

The issue happens on the following lines:
https://github.com/DevExpress/testcafe/blob/070540f89457e93a9bd351211e06e4d4b16fca40/src/utils/detect-ffmpeg.js#L11-L13

While `ffmpegPath` was previously a string, now it's an object like

```js
{ stdout: '/usr/local/bin/ffmpeg\n', stderr: '' }
```

meaning `ffmpegPath.trim()` results in `TypeError: ffmpegPath.trim is not a function`. Since everything is inside a try/catch, TestCafe itself doesn't break, but FFmpeg is not found.

This PR does the `trim` on `ffmpegPath.stdout` instead, thus fixing FFmpeg detection in `PATH`.