### PR TITLE
Bump version (v1.6.0)

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -8,7 +8,7 @@
     "gitTag": true
   },
   "confirm": true,
-  "publishTag": "rc",
+  "publishTag": "latest",
   "prePublishScript": "gulp test-server",
   "postPublishScript": "gulp docker-publish"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.6.0-rc.1",
+  "version": "1.6.0",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"
@@ -94,6 +94,7 @@
     "log-update-async-hook": "^2.0.2",
     "make-dir": "^1.3.0",
     "map-reverse": "^1.0.1",
+    "mime-db": "^1.41.0",
     "moment": "^2.10.3",
     "moment-duration-format-commonjs": "^1.0.0",
     "mustache": "^2.1.2",
@@ -174,7 +175,6 @@
     "license-checker": "^20.0.0",
     "markdownlint": ">=0.0.8",
     "merge-stream": "^1.0.1",
-    "mime-db": "^1.41.0",
     "minimist": "^1.2.0",
     "multer": "^1.1.0",
     "npm-auditor": "^1.1.1",


### PR DESCRIPTION
### Changes
1. Move `mime-db` from `devDependencies` to `dependencies`.
2. Bump version.