### PR TITLE
Add tsConfigPath definition to Runner interface

### DIFF
--- a/ts-defs-src/runner-api/runner-api.d.ts
+++ b/ts-defs-src/runner-api/runner-api.d.ts
@@ -165,6 +165,11 @@ interface Runner {
      * Stops all the pending test tasks.
      */
     stop(): void;
+
+    /**
+     * The absolute or relative path to the TypeScript configuration file. Relative paths resolve from the current directory (the directory from which you run TestCafe).
+     */
+    tsConfigPath(path: string): this;
 }
 
 interface BrowserConnection {


### PR DESCRIPTION
Closes https://github.com/DevExpress/testcafe/issues/4387.

I've added the definition based on https://devexpress.github.io/testcafe/documentation/using-testcafe/programming-interface/runner.html#tsconfigpath.