### PR TITLE
Allow again using Node.js globals in TypeScript tests (closes #4437)

### DIFF
--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -1,15 +1,23 @@
-const expect              = require('chai').expect;
-const path                = require('path');
+const { exec }            = require('child_process');
 const fs                  = require('fs');
+const os                  = require('os');
+const path                = require('path');
+const { promisify }       = require('util');
+const expect              = require('chai').expect;
 const proxyquire          = require('proxyquire');
 const sinon               = require('sinon');
 const globby              = require('globby');
+const nanoid              = require('nanoid');
 const { TEST_RUN_ERRORS } = require('../../lib/errors/types');
 const exportableLib       = require('../../lib/api/exportable-lib');
 const createStackFilter   = require('../../lib/errors/create-stack-filter.js');
 const assertError         = require('./helpers/assert-runtime-error').assertError;
 const compile             = require('./helpers/compile');
-const { exec }            = require('child_process');
+
+
+const copy   = promisify(fs.copyFile);
+const remove = promisify(fs.unlink);
+
 
 require('source-map-support').install();
 
@@ -320,7 +328,7 @@ describe('Compiler', function () {
             expect(createProgram.callCount).eql(1);
         });
 
-        it('Should provide correct globals in TestCafe scripts', async () => {
+        it('Should provide correct globals in TestCafe scripts', async function () {
             this.timeout(60000);
 
             const tscPath     = path.resolve('node_modules/.bin/tsc');
@@ -338,7 +346,7 @@ describe('Compiler', function () {
             });
         });
 
-        it('Should provide correct globals for selector and client-functions only', async () => {
+        it('Should provide correct globals for selector and client-functions only', async function () {
             this.timeout(60000);
 
             const tscPath     = path.resolve('node_modules/.bin/tsc');
@@ -368,6 +376,28 @@ describe('Compiler', function () {
             }
             finally {
                 process.chdir(currentDir);
+            }
+        });
+
+        it('Should provide Node.js global when TestCafe is installed globally', async function () {
+            this.timeout(60000);
+
+            const tmpFileName = `testfile-${nanoid()}.ts`;
+            const tmpFileDir  = os.tmpdir();
+            const tmpFilePath = path.join(tmpFileDir, tmpFileName);
+            const currentDir  = process.cwd();
+
+            await copy(path.resolve('test/server/data/test-suites/typescript-nodejs-globals/testfile.ts'), tmpFilePath);
+
+            try {
+                process.chdir(tmpFileDir);
+
+                await compile(tmpFileName);
+            }
+            finally {
+                process.chdir(currentDir);
+
+                await remove(tmpFilePath);
             }
         });
     });

--- a/test/server/data/test-suites/typescript-nodejs-globals/testfile.ts
+++ b/test/server/data/test-suites/typescript-nodejs-globals/testfile.ts
@@ -1,0 +1,5 @@
+fixture `Node`;
+
+test('Globals', async t => {
+    console.log(process.env);
+});

--- a/ts-defs-src/index.d.ts.mustache
+++ b/ts-defs-src/index.d.ts.mustache
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 declare module 'testcafe' {
     global {
         {{#format}}

--- a/ts-defs-src/runner-api/runner-api.d.ts
+++ b/ts-defs-src/runner-api/runner-api.d.ts
@@ -1,7 +1,8 @@
 
+// {{#allowReferences}}
+// NOTE: Must be added manually to the top of the index.d.ts template
 /// <reference types="node" />
 
-// {{#allowReferences}}
 /// <reference path="../test-api/client-script.d.ts" />
 /// <reference path="../test-api/action-options.d.ts" />
 // {{/allowReferences}}


### PR DESCRIPTION
Closes #4437.