### PR TITLE
Bump version (v1.6.1-rc.1)

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -8,7 +8,7 @@
     "gitTag": true
   },
   "confirm": true,
-  "publishTag": "alpha",
+  "publishTag": "rc",
   "prePublishScript": "gulp test-server",
   "postPublishScript": "gulp docker-publish"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.6.1-alpha.3",
+  "version": "1.6.1-rc.1",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"
@@ -114,7 +114,7 @@
     "sanitize-filename": "^1.6.0",
     "source-map-support": "^0.5.5",
     "strip-bom": "^2.0.0",
-    "testcafe-browser-tools": "1.7.1",
+    "testcafe-browser-tools": "2.0.0",
     "testcafe-hammerhead": "14.10.2",
     "testcafe-legacy-api": "3.1.11",
     "testcafe-reporter-json": "^2.1.0",


### PR DESCRIPTION
### Changes
1. Bump version.
2. Update `testcafe-browser-tools` to `v2.0.0`.