### PR TITLE
create screenshot dir if plugin is used (closes #4477)

### DIFF
--- a/src/browser/provider/index.ts
+++ b/src/browser/provider/index.ts
@@ -1,5 +1,7 @@
 import browserTools from 'testcafe-browser-tools';
 import OS from 'os-family';
+import { dirname } from 'path';
+import makeDir from 'make-dir';
 import BrowserConnection from '../connection';
 import delay from '../../utils/delay';
 import { GET_TITLE_SCRIPT, GET_WINDOW_DIMENSIONS_INFO_SCRIPT } from './utils/client-functions';
@@ -317,8 +319,11 @@ export default class BrowserProvider {
             else
                 await this._takeLocalBrowserScreenshot(browserId, screenshotPath);
         }
-        else
+        else {
+            await makeDir(dirname(screenshotPath));
+
             await this.plugin.takeScreenshot(browserId, screenshotPath, pageWidth, pageHeight, fullPage);
+        }
     }
 
     public async getVideoFrameData (browserId: string): Promise<any> {

--- a/src/utils/promisified-functions.js
+++ b/src/utils/promisified-functions.js
@@ -3,8 +3,6 @@ import fs from 'graceful-fs';
 import { PNG } from 'pngjs';
 import promisifyEvent from 'promisify-event';
 import { promisify } from 'util';
-import makeDir from 'make-dir';
-import { dirname } from 'path';
 
 export const readDir    = promisify(fs.readdir);
 export const stat       = promisify(fs.stat);
@@ -36,9 +34,7 @@ export async function readPngFile (filePath) {
     return await readPng(buffer);
 }
 
-export async function writePng (filePath, png) {
-    await ensureDir(filePath);
-
+export function writePng (filePath, png) {
     const outStream = fs.createWriteStream(filePath);
     const pngStream = png.pack();
 
@@ -51,15 +47,4 @@ export async function writePng (filePath, png) {
     pngStream.pipe(outStream);
 
     return finishPromise;
-}
-
-async function ensureDir (filePath) {
-    const dirName = dirname(filePath);
-
-    try {
-        await stat(dirName);
-    }
-    catch (err) {
-        await makeDir(dirName);
-    }
 }

--- a/test/server/browser-provider-test.js
+++ b/test/server/browser-provider-test.js
@@ -1,10 +1,15 @@
-const expect               = require('chai').expect;
-const proxyquire           = require('proxyquire');
-const testcafeBrowserTools = require('testcafe-browser-tools');
-const browserProviderPool  = require('../../lib/browser/provider/pool');
-const parseProviderName    = require('../../lib/browser/provider/parse-provider-name');
-const BrowserConnection    = require('../../lib/browser/connection');
-const WARNING_MESSAGE      = require('../../lib/notifications/warning-message');
+const expect                  = require('chai').expect;
+const { noop, stubFalse }     = require('lodash');
+const nanoid                  = require('nanoid');
+const { rmdirSync, statSync } = require('fs');
+const { join, dirname }       = require('path');
+const proxyquire              = require('proxyquire');
+const testcafeBrowserTools    = require('testcafe-browser-tools');
+const browserProviderPool     = require('../../lib/browser/provider/pool');
+const parseProviderName       = require('../../lib/browser/provider/parse-provider-name');
+const BrowserConnection       = require('../../lib/browser/connection');
+const ProviderCtor            = require('../../lib/browser/provider/');
+const WARNING_MESSAGE         = require('../../lib/notifications/warning-message');
 
 class BrowserConnectionMock extends BrowserConnection {
     constructor () {
@@ -264,10 +269,12 @@ describe('Browser provider', function () {
                         expect(result).to.be.true;
                     });
             });
+        });
+    });
 
+    describe('API', () => {
+        describe('Screenshots', () => {
             it('Should add warning if provider does not support `fullPage` screenshots', () => {
-                const ProviderCtor = require('../../lib/browser/provider/');
-
                 const provider = new ProviderCtor({
                     isLocalBrowser:            () => true,
                     isHeadlessBrowser:         () => false,
@@ -279,6 +286,27 @@ describe('Browser provider', function () {
                 return provider.takeScreenshot(bc.id, '', 1, 1, true)
                     .then(() => {
                         expect(bc.message).eql(WARNING_MESSAGE.screenshotsFullPageNotSupported);
+                    });
+            });
+
+            it('Should create a directory in screenshot was made using the plugin', () => {
+                const provider = new ProviderCtor({
+                    isLocalBrowser:            stubFalse,
+                    isHeadlessBrowser:         stubFalse,
+                    hasCustomActionForBrowser: stubFalse,
+                    takeScreenshot:            noop
+                });
+
+                const dir            = `temp${nanoid(7)}`;
+                const screenshotPath = join(process.cwd(), dir, 'tmp.png');
+
+                return provider.takeScreenshot('', screenshotPath, 0, 0, false)
+                    .then(() => {
+                        const stats = statSync(dirname(screenshotPath));
+
+                        expect(stats.isDirectory()).to.be.true;
+
+                        rmdirSync(dirname(screenshotPath));
                     });
             });
         });

--- a/test/server/capturer-test.js
+++ b/test/server/capturer-test.js
@@ -1,11 +1,11 @@
-const expect                            = require('chai').expect;
-const { resolve, dirname }              = require('path');
-const { rmdirSync, statSync }           = require('fs');
-const { writePng, readPng, deleteFile } = require('../../lib/utils/promisified-functions');
-const Capturer                          = require('../../lib/screenshots/capturer');
+const nanoid               = require('nanoid');
+const expect               = require('chai').expect;
+const { resolve, dirname } = require('path');
+const { statSync }         = require('fs');
+const Capturer             = require('../../lib/screenshots/capturer');
 
-const image          = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAEBgIApD5fRAAAAABJRU5ErkJggg==', 'base64');
-const screenshotPath = resolve(process.cwd(), 'temp-screenshots', 'temp.png');
+
+const filePath = resolve(process.cwd(), `temp${nanoid(7)}`, 'temp.png');
 
 class CapturerMock extends Capturer {
     constructor (provider) {
@@ -20,42 +20,21 @@ const emptyProvider = {
     }
 };
 
-const writingProvider = {
-    takeScreenshot: async (browserId, filePath) => {
-        const png = await readPng(image);
-
-        await writePng(filePath, png);
-    }
-};
-
 describe('Capturer', () => {
     it('Taking screenshots does not create a directory if provider does not', async () => {
         let errCode = null;
 
         const capturer = new CapturerMock(emptyProvider);
 
-        await capturer._takeScreenshot(screenshotPath);
+        await capturer._takeScreenshot({ filePath });
 
         try {
-            statSync(dirname(screenshotPath));
+            statSync(dirname(filePath));
         }
         catch (err) {
             errCode = err.code;
         }
 
         expect(errCode).eql('ENOENT');
-    });
-
-    it('Write png util created directory', async () => {
-        const capturer = new CapturerMock(writingProvider);
-
-        await capturer._takeScreenshot({ filePath: screenshotPath });
-
-        statSync(dirname(screenshotPath));
-        statSync(dirname(screenshotPath));
-
-        await deleteFile(screenshotPath);
-
-        rmdirSync(dirname(screenshotPath));
     });
 });

--- a/test/server/crop-test.js
+++ b/test/server/crop-test.js
@@ -1,9 +1,11 @@
+const nanoid      = require('nanoid');
 const expect      = require('chai').expect;
 const { resolve } = require('path');
+
 const { writePng, readPng, deleteFile, readPngFile } = require('../../lib/utils/promisified-functions');
 
 const image          = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAEBgIApD5fRAAAAABJRU5ErkJggg==', 'base64');
-const screenshotPath = resolve(process.cwd(), 'temp-screenshots', 'temp.png');
+const screenshotPath = resolve(process.cwd(), `temp${nanoid(7)}.png`);
 
 const {
     cropScreenshot,


### PR DESCRIPTION
I reverted the fix of https://github.com/DevExpress/testcafe/issues/4303
Since it leaded to failure in custom browser provers
Now the dir will be created for all plugins but not for local browser.
For local browser the dir is created by `browser-tools`