### PR TITLE
Gulpfile - Fix website build on macOS

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -609,7 +609,12 @@ gulp.step('prepare-website-content', gulp.series('clean-website', 'fetch-assets-
 gulp.step('prepare-website', gulp.parallel('lint-docs', 'prepare-website-content'));
 
 function buildWebsite (mode, cb) {
-    const options = mode ? { stdio: 'inherit', env: { JEKYLL_ENV: mode } } : { stdio: 'inherit' };
+    const spawnEnv = process.env;
+
+    if(mode)
+        spawnEnv.JEKYLL_ENV = mode;
+
+    const options = { stdio: 'inherit', env: spawnEnv };
 
     spawn('jekyll', ['build', '--source', 'site/src/', '--destination', 'site/deploy'], options)
         .on('exit', cb);

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -611,7 +611,7 @@ gulp.step('prepare-website', gulp.parallel('lint-docs', 'prepare-website-content
 function buildWebsite (mode, cb) {
     const spawnEnv = process.env;
 
-    if(mode)
+    if (mode)
         spawnEnv.JEKYLL_ENV = mode;
 
     const options = { stdio: 'inherit', env: spawnEnv };


### PR DESCRIPTION
A new `env` object without parent's `process.env` was passed to Jekyll and overrode its environment.
The build somehow worked on Windows all these years, but not on macOS.
This PR fixes it.