### PR TITLE
fire `beforeInput` (closes #4486 after hh is published)

### DIFF
--- a/src/client/automation/playback/type/type-text.js
+++ b/src/client/automation/playback/type/type-text.js
@@ -221,10 +221,24 @@ function _typeTextToContentEditable (element, text) {
 function _typeTextToTextEditable (element, text) {
     const elementValue      = domUtils.getElementValue(element);
     const textLength        = text.length;
-    let startSelection    = textSelection.getSelectionStart(element);
-    let endSelection      = textSelection.getSelectionEnd(element);
+    let startSelection      = textSelection.getSelectionStart(element);
+    let endSelection        = textSelection.getSelectionEnd(element);
     const isInputTypeNumber = domUtils.isInputElement(element) && element.type === 'number';
-    const needProcessInput  = simulateTextInput(element, text);
+
+    // NOTE: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/beforeinput_event
+    // The `beforeInput` event is supported only in Chrome-based browsers and Safari
+    // The order of events differs in Chrome and Safari:
+    // In Chrome: `beforeinput` occurs before `textInput`
+    // In Safari: `beforeinput` occurs after `textInput`
+    const needProcessTextInput = !browserUtils.isChrome || eventSimulator.beforeInput(element, text);
+
+    if (!needProcessTextInput)
+        return;
+
+    let needProcessInput = simulateTextInput(element, text);
+
+    if (needProcessInput && browserUtils.isSafari)
+        needProcessInput = eventSimulator.beforeInput(element, text);
 
     if (!needProcessInput)
         return;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/beforeinput_event

The `beforeInput` events fires only in Chrome and Safari.
However, the order of events is different.
In Chrome the order is `beforeinput - textInput - input`
In Safari - `textInput - beforeinput - input`

Any preceding event can prevent the next one. This behavior is shown in tests.
The `beforeinput` event handler has an argument of `InputEvent`. IE/Edge does not support `InputEvent`. Firefox supports `InputEvent` but does no support `beforeinput`
