### PR TITLE
[docs] Add description for request's timestamp parameters

### DIFF
--- a/docs/articles/documentation/test-api/assertions/assertion-api.md
+++ b/docs/articles/documentation/test-api/assertions/assertion-api.md
@@ -35,7 +35,7 @@ await t.expect( actual ).eql( expected, message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | Any Type &#124; Selector's Property &#124; ClientFunction Promise | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the comparison value is obtained.
+`actual`             | Any Type &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the comparison value is obtained.
 `expected`             | Any type | An expected value.
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
 `options`&#160;*(optional)* | Object   | See [Options](README.md#assertion-options).
@@ -68,7 +68,7 @@ await t.expect( actual ).notEql( unexpected, message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | Any Type &#124; Selector's Property &#124; ClientFunction Promise | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the comparison value is obtained.
+`actual`             | Any Type &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the comparison value is obtained.
 `expected`             | Any type | An unexpected value.
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
 `options`&#160;*(optional)* | Object   | See [Options](README.md#assertion-options).
@@ -101,7 +101,7 @@ await t.expect( actual ).ok( message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | Any Type &#124; Selector's Property &#124; ClientFunction Promise | A value that should be truthy. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
+`actual`             | Any Type &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise | A value that should be truthy. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
 `options`&#160;*(optional)* | Object   | See [Options](README.md#assertion-options).
 
@@ -133,7 +133,7 @@ await t.expect( actual ).notOk( message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | Any Type &#124; Selector's Property &#124; ClientFunction Promise | A value that should be falsy. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
+`actual`             | Any Type &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise | A value that should be falsy. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
 `options`&#160;*(optional)* | Object   | See [Options](README.md#assertion-options).
 
@@ -165,7 +165,7 @@ await t.expect( actual ).contains( expected, message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | String &#124; Array &#124; Object &#124; Selector's Property &#124; ClientFunction Promise | A string that contains the `expected` substring, an array that contains the `expected` value or an object that contains the `expected` property. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
+`actual`             | String &#124; Array &#124; Object &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise | A string that contains the `expected` substring, an array that contains the `expected` value or an object that contains the `expected` property. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
 `expected`             | Any type | The expected value.
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
 `options`&#160;*(optional)* | Object   | See [Options](README.md#assertion-options).
@@ -201,7 +201,7 @@ await t.expect( actual ).notContains( expected, message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | String &#124; Array &#124; Object &#124; Selector's Property &#124; ClientFunction Promise | A string that should not contain the `expected` substring, an array that should not contain the `expected` value or an object that should not contain the `expected` property. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
+`actual`             | String &#124; Array &#124; Object &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise | A string that should not contain the `expected` substring, an array that should not contain the `expected` value or an object that should not contain the `expected` property. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
 `expected`             | Any type | The expected value.
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
 `options`&#160;*(optional)* | Object   | See [Options](README.md#assertion-options).
@@ -237,7 +237,7 @@ await t.expect( actual ).typeOf( typeName, message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | Any Type &#124; Selector's Property &#124; ClientFunction Promise  | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
+`actual`             | Any Type &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise  | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
 `typeName`             | String | The expected type of an `actual` value.
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
 `options`&#160;*(optional)* | Object   | See [Options](README.md#assertion-options).
@@ -271,7 +271,7 @@ await t.expect( actual ).notTypeOf( typeName, message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | Any Type &#124; Selector's Property &#124; ClientFunction Promise | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
+`actual`             | Any Type &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
 `typeName`             | String | An unexpected type of `actual` value.
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
 `options`&#160;*(optional)* | Object   | See [Options](README.md#assertion-options).
@@ -302,7 +302,7 @@ await t.expect( actual ).gt( expected, message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | Number &#124; Selector's Property &#124; ClientFunction Promise  | A value that should be greater than `expected`. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
+`actual`             | Number &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise  | A value that should be greater than `expected`. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
 `expected`             | Any type | A comparison value.
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
 `options`&#160;*(optional)* | Object   | See [Options](README.md#assertion-options).
@@ -333,7 +333,7 @@ await t.expect( actual ).gte( expected, message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | Number &#124; Selector's Property &#124; ClientFunction Promise | A value that should be greater than or equal to `expected`. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
+`actual`             | Number &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise | A value that should be greater than or equal to `expected`. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
 `expected`             | Any type | A comparison value.
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
 `options`&#160;*(optional)* | Object   | See [Options](README.md#assertion-options).
@@ -366,7 +366,7 @@ await t.expect( actual ).lt( expected, message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | Number &#124; Selector's Property &#124; ClientFunction Promise | A value that should be less than `expected`. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
+`actual`             | Number &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise | A value that should be less than `expected`. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
 `expected`             | Any type | A comparison value.
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
 `options`&#160;*(optional)* | Object   | See [Options](README.md#assertion-options).
@@ -397,7 +397,7 @@ await t.expect( actual ).lte( expected, message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | Number &#124; Selector's Property &#124; ClientFunction Promise | A value that should be less than or equal to `expected`. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
+`actual`             | Number &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise | A value that should be less than or equal to `expected`. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
 `expected`             | Any type | A comparison value.
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
 `options`&#160;*(optional)* | Object   | See [Options](README.md#assertion-options).
@@ -430,7 +430,7 @@ await t.expect( actual ).within( start, finish, message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | Number &#124; Selector's Property &#124; ClientFunction Promise | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
+`actual`             | Number &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
 `start`             | Number | A lower bound of range (included).
 `finish`             | Number | An upper bound of range (included).
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
@@ -462,7 +462,7 @@ await t.expect( actual ).notWithin( start, finish, message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | Number &#124; Selector's Property &#124; ClientFunction Promise | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
+`actual`             | Number &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
 `start`             | Number | A lower bound of range (included).
 `finish`             | Number | An upper bound of range (included).
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
@@ -494,7 +494,7 @@ await t.expect( actual ).match( re, message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | String &#124; Selector's Property &#124; ClientFunction Promise | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
+`actual`             | String &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
 `re`             | RegExp | A regular expression that is expected to match `actual`.
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
 `options`&#160;*(optional)* | Object   | See [Options](README.md#assertion-options).
@@ -527,7 +527,7 @@ await t.expect( actual ).notMatch( re, message, options );
 
 Parameter              | Type                                              | Description
 ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------
-`actual`             | String &#124; Selector's Property &#124; ClientFunction Promise | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
+`actual`             | String &#124; Selector's&nbsp;Property &#124; ClientFunction&nbsp;Promise | A comparison value. If you pass a [selector's property](../selecting-page-elements/selectors/using-selectors.md#define-assertion-actual-value) or a [client function](../obtaining-data-from-the-client/README.md) promise, the [Smart Assertion Query Mechanism](README.md#smart-assertion-query-mechanism) is activated, and the assertion automatically waits until the `actual` value is obtained.
 `re`             | RegExp | A regular expression that is expected not to match `actual`.
 `message`&#160;*(optional)* | String   | An assertion message that is displayed in the report if the test fails.
 `options`&#160;*(optional)* | Object   | See [Options](README.md#assertion-options).

--- a/docs/articles/documentation/test-api/intercepting-http-requests/logging-http-requests.md
+++ b/docs/articles/documentation/test-api/intercepting-http-requests/logging-http-requests.md
@@ -87,9 +87,11 @@ Property | Type | Description
 `request.method`     | String | The request's HTTP method.
 `request.headers`    | Object | Request headers in the property-value form. Logged if the `logRequestHeaders` option is set to `true`.
 `request.body`    | [Buffer](https://nodejs.org/api/buffer.html) &#124; String | The request body. A [Buffer](https://nodejs.org/api/buffer.html) or string depending on the `stringifyRequestBody` option. Logged if the `logRequestBody` option is set to `true`.
+`request.timestamp` | Number | The timestamp that specifies when the request was intercepted.
 `response.statusCode` | Number | The status code received in the response.
 `response.headers`    | Object | Response headers in the property-value form. Logged if the `logResponseHeaders` option is set to `true`.
 `response.body`    | [Buffer](https://nodejs.org/api/buffer.html) &#124; String | The response body. A [Buffer](https://nodejs.org/api/buffer.html) or string depending on the `stringifyResponseBody` option. Logged if the `logResponseBody` option is set to `true`.
+`response.timestamp` | Number | The timestamp that specifies when the response was intercepted.
 
 **Example**
 


### PR DESCRIPTION
And one unrelated formatting change.