### PR TITLE
Improve error handling in IPC utils

### DIFF
--- a/src/errors/error-list.js
+++ b/src/errors/error-list.js
@@ -4,6 +4,7 @@ import { UncaughtErrorInTestCode } from './test-run';
 export default class TestCafeErrorList {
     constructor () {
         this.items = [];
+        this.name  = TestCafeErrorList.name;
     }
 
     get hasErrors () {

--- a/src/services/utils/ipc/interfaces.ts
+++ b/src/services/utils/ipc/interfaces.ts
@@ -1,14 +1,9 @@
 import { UnsubscribeFn } from 'emittery';
 import EventEmitter from '../../../utils/async-event-emitter';
+import TestCafeErrorList from '../../../errors/error-list';
 
 
 export type ExternalError = Error | TestCafeErrorList;
-
-export interface TestCafeErrorList {
-    isTestCafeErrorList: boolean;
-
-    items: Error[];
-}
 
 /* eslint-disable @typescript-eslint/interface-name-prefix */
 export enum IPCPacketType {
@@ -63,7 +58,7 @@ export interface IPCTransport extends EventEmitter {
 
 
 export function isTestCafeErrorList (err: ExternalError): err is TestCafeErrorList {
-    return (err as TestCafeErrorList).isTestCafeErrorList;
+    return (err as TestCafeErrorList).name === TestCafeErrorList.name;
 }
 
 export function isIPCErrorResponse (response: IPCSuccessfulResponse | IPCErrorResponse): response is IPCErrorResponse {

--- a/src/services/utils/ipc/io.ts
+++ b/src/services/utils/ipc/io.ts
@@ -63,7 +63,7 @@ export class AsyncWriter {
         if (this.stream.write(buffer))
             return Promise.resolve();
 
-        return new Promise(r => this.stream.on('drain', r));
+        return new Promise(r => this.stream.once('drain', r));
     }
 
     private _writeBuffers (buffers: Buffer[]): Promise<void> {

--- a/src/services/utils/ipc/transport.ts
+++ b/src/services/utils/ipc/transport.ts
@@ -1,5 +1,5 @@
 import { AsyncReader, AsyncWriter, SyncReader, SyncWriter } from './io';
-import EventEmitter from '../../../../src/utils/async-event-emitter';
+import EventEmitter from '../../../utils/async-event-emitter';
 import { GeneralError } from '../../../errors/runtime';
 import { RUNTIME_ERRORS } from '../../../errors/types';
 import { IPCPacket, IPCResponsePacket, IPCTransport, isIPCResponsePacket } from './interfaces';
@@ -26,7 +26,10 @@ export class HostTransport extends EventEmitter implements IPCTransport {
     }
 
     public read (): void {
-        this.readers.forEach(reader => reader.on('data', data => this.emit('data', data)));
+        this.readers.forEach(reader => {
+            reader.on('data', data => this.emit('data', data));
+            reader.read();
+        });
     }
 
     public async write (message: IPCPacket): Promise<void> {
@@ -63,6 +66,7 @@ export class ServiceTransport extends EventEmitter implements IPCTransport {
 
     public read (): void {
         this.asyncReader.on('data', data => this.emit('data', data));
+        this.asyncReader.read();
     }
 
     public async write (message: IPCPacket): Promise<void> {

--- a/src/utils/prerender-callsite.js
+++ b/src/utils/prerender-callsite.js
@@ -1,0 +1,16 @@
+import { renderers } from 'callsite-record';
+import renderCallsiteSync from './render-callsite-sync';
+import createStackFilter from '../errors/create-stack-filter';
+
+
+export default function prerenderCallsite (callsite) {
+    const stackFilter = createStackFilter(Error.stackTraceLimit);
+
+    return {
+        prerendered: true,
+
+        default: renderCallsiteSync(callsite, { renderer: renderers.default, stackFilter }),
+        html:    renderCallsiteSync(callsite, { renderer: renderers.html, stackFilter }),
+        noColor: renderCallsiteSync(callsite, { renderer: renderers.noColor, stackFilter })
+    };
+}

--- a/src/utils/render-callsite-sync.js
+++ b/src/utils/render-callsite-sync.js
@@ -1,3 +1,6 @@
+import { renderers } from 'callsite-record';
+
+
 export default function renderCallsiteSync (callsite, options) {
     if (!callsite)
         return '';
@@ -5,6 +8,18 @@ export default function renderCallsiteSync (callsite, options) {
     // NOTE: for raw API callsites
     if (typeof callsite === 'string')
         return callsite;
+
+    if (callsite.prerendered) {
+        const renderer = options && options.renderer;
+
+        if (renderer === renderers.html)
+            return callsite.html;
+
+        if (renderer === renderers.noColor)
+            return callsite.noColor;
+
+        return callsite.default || '';
+    }
 
     if (!callsite.renderSync)
         return '';


### PR DESCRIPTION
What's changed:

- Improved `TestCafeErrorList` deserialization (by the `TestCafeErrorList` error name) for passing `TestCafeErrorList`'s between the host and compiler service processes

- Allow prerendered callsites in TestCafe errors. V8 stack frames (which are used to render callsites) don't serialize well, so it's easier to render a whole callsite to a string before transferring it from the compiler service to the host process. 