### PR TITLE
Implement compiler service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
   - node_js: "10"
     env: GULP_TASK="test-functional-local-legacy"
   - node_js: "10"
+    env: GULP_TASK="test-functional-local-compiler-service"
+  - node_js: "10"
     env: GULP_TASK="test-functional-local-multiple-windows"
     services:
       - xvfb

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "@types/mime-db": "^1.27.0",
     "@types/mustache": "^0.8.32",
     "@types/nanoid": "^2.1.0",
+    "@types/source-map-support": "^0.5.0",
     "@types/useragent": "^2.1.1",
     "@typescript-eslint/eslint-plugin": "1.13.0",
     "@typescript-eslint/parser": "1.13.0",

--- a/src/api/structure/base-unit.ts
+++ b/src/api/structure/base-unit.ts
@@ -1,0 +1,18 @@
+import { generateUniqueId } from 'testcafe-hammerhead';
+import * as unitTypes from './unit-types';
+
+
+type UnitTypes = typeof unitTypes;
+type UnitType = UnitTypes[keyof UnitTypes];
+
+const ID_LENGTH = 7;
+
+export default class BaseUnit {
+    public id: string;
+    public unitTypeName: UnitType;
+
+    public constructor (unitTypeName: UnitType) {
+        this.id           = generateUniqueId(ID_LENGTH);
+        this.unitTypeName = unitTypeName;
+    }
+}

--- a/src/api/structure/fixture.js
+++ b/src/api/structure/fixture.js
@@ -1,18 +1,24 @@
+import { flattenDeep as flatten } from 'lodash';
+import { SPECIAL_BLANK_PAGE } from 'testcafe-hammerhead';
+
+import TestingUnit from './testing-unit';
+import { FIXTURE as FIXTURE_TYPE } from './unit-types';
+
 import { assertType, is } from '../../errors/runtime/type-assertions';
 import handleTagArgs from '../../utils/handle-tag-args';
-import TestingUnit from './testing-unit';
 import wrapTestFunction from '../wrap-test-function';
 import assertRequestHookType from '../request-hooks/assert-type';
 import assertClientScriptType from '../../custom-client-scripts/assert-type';
-import { flattenDeep as flatten } from 'lodash';
-import { SPECIAL_BLANK_PAGE } from 'testcafe-hammerhead';
-import { APIError } from '../../errors/runtime';
+
 import OPTION_NAMES from '../../configuration/option-names';
+
+import { APIError } from '../../errors/runtime';
 import { RUNTIME_ERRORS } from '../../errors/types';
+
 
 export default class Fixture extends TestingUnit {
     constructor (testFile) {
-        super(testFile, 'fixture');
+        super(testFile, FIXTURE_TYPE);
 
         this.path = testFile.filename;
 

--- a/src/api/structure/interfaces.ts
+++ b/src/api/structure/interfaces.ts
@@ -1,0 +1,30 @@
+export interface Metadata {
+    [key: string]: string;
+}
+
+export interface TestFile {
+    collectedTests: Test[];
+    currentFixture: Fixture;
+}
+
+export interface Fixture {
+    name: string;
+    path: string;
+    testFile: TestFile;
+    meta: Metadata;
+    afterFn: Function | null;
+    beforeFn: Function | null;
+    afterEachFn: Function | null;
+    beforeEachFn: Function | null;
+}
+
+export interface Test {
+    only: boolean;
+    name: string;
+    fixture: Fixture;
+    testFile: TestFile;
+    meta: Metadata;
+    fn: Function | null;
+    afterFn: Function | null;
+    beforeFn: Function | null;
+}

--- a/src/api/structure/interfaces.ts
+++ b/src/api/structure/interfaces.ts
@@ -1,29 +1,31 @@
-export interface Metadata {
-    [key: string]: string;
-}
+import { Dictionary } from '../../configuration/interfaces';
+import BaseUnit from './base-unit';
 
-export interface TestFile {
+
+export type Metadata = Dictionary<string>;
+
+export interface TestFile extends BaseUnit {
     collectedTests: Test[];
     currentFixture: Fixture;
 }
 
-export interface Fixture {
+export interface TestingUnit extends BaseUnit {
     name: string;
-    path: string;
+    only: boolean;
     testFile: TestFile;
     meta: Metadata;
+}
+
+export interface Fixture extends TestingUnit {
+    path: string;
     afterFn: Function | null;
     beforeFn: Function | null;
     afterEachFn: Function | null;
     beforeEachFn: Function | null;
 }
 
-export interface Test {
-    only: boolean;
-    name: string;
+export interface Test extends TestingUnit {
     fixture: Fixture;
-    testFile: TestFile;
-    meta: Metadata;
     fn: Function | null;
     afterFn: Function | null;
     beforeFn: Function | null;

--- a/src/api/structure/test-file.js
+++ b/src/api/structure/test-file.js
@@ -1,7 +1,13 @@
+import BaseUnit from './base-unit';
+import { TEST_FILE as TEST_FILE_TYPE } from './unit-types';
+
+
 const BORROWED_TEST_PROPERTIES = ['skip', 'only', 'pageUrl', 'authCredentials'];
 
-export default class TestFile {
+export default class TestFile extends BaseUnit {
     constructor (filename) {
+        super(TEST_FILE_TYPE);
+
         this.filename       = filename;
         this.currentFixture = null;
         this.collectedTests = [];

--- a/src/api/structure/test.js
+++ b/src/api/structure/test.js
@@ -1,16 +1,17 @@
+import { flattenDeep as flatten, union } from 'lodash';
 import TestingUnit from './testing-unit';
+import { TEST as TEST_TYPE } from './unit-types';
 import { assertType, is } from '../../errors/runtime/type-assertions';
 import wrapTestFunction from '../wrap-test-function';
 import assertRequestHookType from '../request-hooks/assert-type';
 import assertClientScriptType from '../../custom-client-scripts/assert-type';
-import { flattenDeep as flatten, union } from 'lodash';
 import { RUNTIME_ERRORS } from '../../errors/types';
 import { APIError } from '../../errors/runtime';
 import OPTION_NAMES from '../../configuration/option-names';
 
 export default class Test extends TestingUnit {
     constructor (testFile) {
-        super(testFile, 'test');
+        super(testFile, TEST_TYPE);
 
         this.fixture = testFile.currentFixture;
 

--- a/src/api/structure/testing-unit.js
+++ b/src/api/structure/testing-unit.js
@@ -1,16 +1,17 @@
+import BaseUnit from './base-unit';
 import { assertUrl, resolvePageUrl } from '../test-page-url';
 import handleTagArgs from '../../utils/handle-tag-args';
 import { delegateAPI, getDelegatedAPIList } from '../../utils/delegated-api';
 import { assertType, is } from '../../errors/runtime/type-assertions';
 import FlagList from '../../utils/flag-list';
 import OPTION_NAMES from '../../configuration/option-names';
-import { generateUniqueId } from 'testcafe-hammerhead';
 
-export default class TestingUnit {
+
+export default class TestingUnit extends BaseUnit {
     constructor (testFile, unitTypeName) {
-        this.id           = generateUniqueId(7);
-        this.testFile     = testFile;
-        this.unitTypeName = unitTypeName;
+        super(unitTypeName);
+
+        this.testFile = testFile;
 
         this.name            = null;
         this.pageUrl         = null;

--- a/src/api/structure/unit-types.ts
+++ b/src/api/structure/unit-types.ts
@@ -1,0 +1,3 @@
+export const TEST      = 'test';
+export const FIXTURE   = 'fixture';
+export const TEST_FILE = 'testfile';

--- a/src/api/test-run-tracker.d.ts
+++ b/src/api/test-run-tracker.d.ts
@@ -1,0 +1,13 @@
+export interface TestRun {
+    id: string;
+    executeAction(apiMethodName: string, command: unknown, callsite: unknown): Promise<unknown>;
+}
+
+export interface TestRunTracker {
+    activeTestRuns: { [id: string]: TestRun };
+}
+
+declare const testRunTracker: TestRunTracker;
+
+export default testRunTracker;
+

--- a/src/compiler/interfaces.ts
+++ b/src/compiler/interfaces.ts
@@ -1,0 +1,11 @@
+import { Test } from '../api/structure/interfaces';
+
+export interface CompilerArguments {
+    sourceList: string[];
+    compilerOptions: object;
+}
+
+export interface CompilerProvider {
+    init(): Promise<void>;
+    getTests(args: CompilerArguments): Promise<Test[]>;
+}

--- a/src/compiler/interfaces.ts
+++ b/src/compiler/interfaces.ts
@@ -1,11 +1,4 @@
-import { Test } from '../api/structure/interfaces';
-
 export interface CompilerArguments {
     sourceList: string[];
     compilerOptions: object;
-}
-
-export interface CompilerProvider {
-    init(): Promise<void>;
-    getTests(args: CompilerArguments): Promise<Test[]>;
 }

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -23,19 +23,12 @@ import ClientScript from '../custom-client-scripts/client-script';
 import ClientScriptInit from '../custom-client-scripts/client-script-init';
 import BrowserProvider from '../browser/provider';
 import BrowserConnectionGateway from '../browser/connection/gateway';
+import { CompilerArguments, CompilerProvider } from '../compiler/interfaces';
+import { Metadata, Test } from '../api/structure/interfaces';
 
 type TestSource = unknown;
 
 type ReporterPlugin = unknown;
-
-interface CompilerArguments {
-    parsedFileList: string[];
-    compilerOptions: object;
-}
-
-interface Metadata {
-    [key: string]: string;
-}
 
 type BrowserSource = BrowserConnection | string;
 
@@ -68,19 +61,6 @@ interface BrowserInfo {
 }
 
 type BrowserInfoSource = BrowserInfo | BrowserConnection;
-
-
-interface Fixture {
-    name: string;
-    path: string;
-    meta: Metadata;
-}
-
-interface Test {
-    name: string;
-    fixture: Fixture;
-    meta: Metadata;
-}
 
 interface PromiseSuccess<T> {
     result: T;
@@ -132,7 +112,9 @@ export default class Bootstrapper {
     public clientScripts: ClientScriptInit[];
     public allowMultipleWindows: boolean;
 
-    public constructor (browserConnectionGateway: BrowserConnectionGateway) {
+    private readonly compilerService?: CompilerProvider;
+
+    public constructor (browserConnectionGateway: BrowserConnectionGateway, compilerService?: CompilerProvider) {
         this.browserConnectionGateway = browserConnectionGateway;
         this.concurrency              = 1;
         this.sources                  = [];
@@ -144,6 +126,8 @@ export default class Bootstrapper {
         this.tsConfigPath             = void 0;
         this.clientScripts            = [];
         this.allowMultipleWindows     = false;
+
+        this.compilerService = compilerService;
     }
 
     private static _getBrowserName (browser: BrowserInfoSource): string {
@@ -233,14 +217,25 @@ export default class Bootstrapper {
         return tests.filter(test => predicate(test.name, test.fixture.name, test.fixture.path, test.meta, test.fixture.meta));
     }
 
-    private async _getTests (): Promise<Test[]> {
-        const { parsedFileList, compilerOptions } = await this._getCompilerArguments();
+    private async _compileTests ({ sourceList, compilerOptions }: CompilerArguments): Promise<Test[]> {
+        if (!this.compilerService) {
+            const compiler = new Compiler(sourceList, compilerOptions);
 
-        if (!parsedFileList.length)
+            return compiler.getTests();
+        }
+
+        await this.compilerService.init();
+
+        return await this.compilerService.getTests({ sourceList, compilerOptions });
+    }
+
+    private async _getTests (): Promise<Test[]> {
+        const { sourceList, compilerOptions } = await this._getCompilerArguments();
+
+        if (!sourceList.length)
             throw new GeneralError(RUNTIME_ERRORS.testFilesNotFound);
 
-        const compiler = new Compiler(parsedFileList, compilerOptions);
-        let tests      = await compiler.getTests();
+        let tests = await this._compileTests({ sourceList, compilerOptions });
 
         const testsWithOnlyFlag = tests.filter(test => test.only);
 
@@ -257,7 +252,7 @@ export default class Bootstrapper {
     }
 
     private async _getCompilerArguments (): Promise<CompilerArguments> {
-        const parsedFileList = await parseFileList(this.sources, process.cwd());
+        const sourceList = await parseFileList(this.sources, process.cwd());
 
         const compilerOptions = {
             typeScriptOptions: {
@@ -265,7 +260,7 @@ export default class Bootstrapper {
             }
         };
 
-        return { parsedFileList, compilerOptions };
+        return { sourceList, compilerOptions };
     }
 
     private async _ensureOutStream (outStream: string | WritableStream): Promise<WritableStream> {

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -218,15 +218,15 @@ export default class Bootstrapper {
     }
 
     private async _compileTests ({ sourceList, compilerOptions }: CompilerArguments): Promise<Test[]> {
-        if (!this.compilerService) {
-            const compiler = new Compiler(sourceList, compilerOptions);
+        if (this.compilerService) {
+            await this.compilerService.init();
 
-            return compiler.getTests();
+            return this.compilerService.getTests({ sourceList, compilerOptions });
         }
 
-        await this.compilerService.init();
+        const compiler = new Compiler(sourceList, compilerOptions);
 
-        return await this.compilerService.getTests({ sourceList, compilerOptions });
+        return compiler.getTests();
     }
 
     private async _getTests (): Promise<Test[]> {

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -23,7 +23,8 @@ import ClientScript from '../custom-client-scripts/client-script';
 import ClientScriptInit from '../custom-client-scripts/client-script-init';
 import BrowserProvider from '../browser/provider';
 import BrowserConnectionGateway from '../browser/connection/gateway';
-import { CompilerArguments, CompilerProvider } from '../compiler/interfaces';
+import { CompilerArguments } from '../compiler/interfaces';
+import CompilerService from '../services/compiler/host';
 import { Metadata, Test } from '../api/structure/interfaces';
 
 type TestSource = unknown;
@@ -112,9 +113,9 @@ export default class Bootstrapper {
     public clientScripts: ClientScriptInit[];
     public allowMultipleWindows: boolean;
 
-    private readonly compilerService?: CompilerProvider;
+    private readonly compilerService?: CompilerService;
 
-    public constructor (browserConnectionGateway: BrowserConnectionGateway, compilerService?: CompilerProvider) {
+    public constructor (browserConnectionGateway: BrowserConnectionGateway, compilerService?: CompilerService) {
         this.browserConnectionGateway = browserConnectionGateway;
         this.concurrency              = 1;
         this.sources                  = [];

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -26,11 +26,11 @@ import ReporterStreamController from './reporter-stream-controller';
 const DEBUG_LOGGER = debug('testcafe:runner');
 
 export default class Runner extends EventEmitter {
-    constructor (proxy, browserConnectionGateway, configuration) {
+    constructor (proxy, browserConnectionGateway, configuration, compilerService) {
         super();
 
         this.proxy               = proxy;
-        this.bootstrapper        = this._createBootstrapper(browserConnectionGateway);
+        this.bootstrapper        = this._createBootstrapper(browserConnectionGateway, compilerService);
         this.pendingTaskPromises = [];
         this.configuration       = configuration;
         this.isCli               = false;
@@ -43,8 +43,8 @@ export default class Runner extends EventEmitter {
         ]);
     }
 
-    _createBootstrapper (browserConnectionGateway) {
-        return new Bootstrapper(browserConnectionGateway);
+    _createBootstrapper (browserConnectionGateway, compilerService) {
+        return new Bootstrapper(browserConnectionGateway, compilerService);
     }
 
     _disposeBrowserSet (browserSet) {
@@ -374,7 +374,7 @@ export default class Runner extends EventEmitter {
         this.bootstrapper.reporters            = this.configuration.getOption(OPTION_NAMES.reporter) || this.bootstrapper.reporters;
         this.bootstrapper.tsConfigPath         = this.configuration.getOption(OPTION_NAMES.tsConfigPath);
         this.bootstrapper.clientScripts        = this.configuration.getOption(OPTION_NAMES.clientScripts) || this.bootstrapper.clientScripts;
-        this.bootstrapper.allowMultipleWindows = this.configuration.getOption(OPTION_NAMES.allowMultipleWindows) || this.bootstrapper.allowMultipleWindows;
+        this.bootstrapper.allowMultipleWindows = this.configuration.getOption(OPTION_NAMES.allowMultipleWindows);
     }
 
     // API

--- a/src/services/compiler/host.ts
+++ b/src/services/compiler/host.ts
@@ -1,0 +1,136 @@
+import { spawn, ChildProcess } from 'child_process';
+import { HOST_INPUT_FD, HOST_OUTPUT_FD, HOST_SYNC_FD } from './io';
+import { restore as restoreTestStructure } from './test-structure';
+import { default as testRunTracker, TestRun } from '../../api/test-run-tracker';
+import { IPCProxy } from '../utils/ipc/proxy';
+import { HostTransport } from '../utils/ipc/transport';
+import EventEmitter from '../../utils/async-event-emitter';
+import TestCafeErrorList from '../../errors/error-list';
+
+import { CompilerProtocol, RunTestArguments, ExecuteCommandArguments, FunctionProperties } from './protocol';
+import { CompilerArguments } from '../../compiler/interfaces';
+import { Test } from '../../api/structure/interfaces';
+
+
+const SERVICE_PATH = require.resolve('./service');
+
+interface RuntimeResources {
+    service: ChildProcess;
+    proxy: IPCProxy;
+}
+
+interface TestFunction {
+    (testRun: TestRun): Promise<unknown>;
+}
+
+export default class CompilerHost extends EventEmitter implements CompilerProtocol {
+    private runtime: Promise<RuntimeResources|undefined>;
+
+    public constructor () {
+        super();
+
+        this.runtime = Promise.resolve(void 0);
+    }
+
+    private _setupRoutes (proxy: IPCProxy): void {
+        proxy.register(this.executeAction, this);
+        proxy.register(this.ready, this);
+    }
+
+
+    private async _init (runtime: Promise<RuntimeResources|undefined>): Promise<RuntimeResources|undefined> {
+        const resolvedRuntime = await runtime;
+
+        if (resolvedRuntime)
+            return resolvedRuntime;
+
+        try {
+            const service = spawn(process.argv0, [SERVICE_PATH], { stdio: [0, 1, 2, 'pipe', 'pipe', 'pipe'] });
+
+            // HACK: Node.js definition are not correct when additional I/O channels are sp
+            const stdio = service.stdio as any;
+            const proxy = new IPCProxy(new HostTransport(stdio[HOST_INPUT_FD], stdio[HOST_OUTPUT_FD], stdio[HOST_SYNC_FD]));
+
+            this._setupRoutes(proxy);
+
+            await this.once('ready');
+
+            return { proxy, service };
+        }
+        catch (e) {
+            return void 0;
+        }
+    }
+
+    private async _getRuntime (): Promise<RuntimeResources> {
+        const runtime = await this.runtime;
+
+        if (!runtime)
+            throw new Error();
+
+        return runtime;
+    }
+
+    public async init (): Promise<void> {
+        this.runtime = this._init(this.runtime);
+
+        await this.runtime;
+    }
+
+
+    public async stop (): Promise<void> {
+        const { service } = await this._getRuntime();
+
+        service.kill();
+    }
+
+
+    private _wrapTestFunction (id: string, functionName: FunctionProperties): TestFunction {
+        return async testRun => {
+            try {
+                return await this.runTest({ id, functionName, testRunId: testRun.id });
+            }
+            catch (err) {
+                const errList = new TestCafeErrorList();
+
+                errList.addError(err);
+
+                throw errList;
+            }
+        };
+    }
+
+    public async ready (): Promise<void> {
+        this.emit('ready');
+    }
+
+    public async executeAction (data: ExecuteCommandArguments): Promise<unknown> {
+        if (!testRunTracker.activeTestRuns[data.id])
+            return void 0;
+
+        return testRunTracker
+            .activeTestRuns[data.id]
+            .executeAction(data.apiMethodName, data.command, data.callsite);
+    }
+
+    public async getTests ({ sourceList, compilerOptions }: CompilerArguments): Promise<Test[]> {
+        const { proxy } = await this._getRuntime();
+
+        const units = await proxy.call(this.getTests, { sourceList, compilerOptions });
+
+        return restoreTestStructure(units, (...args) => this._wrapTestFunction(...args));
+    }
+
+    public async runTest ({ id, functionName, testRunId }: RunTestArguments): Promise<unknown> {
+        const { proxy } = await this._getRuntime();
+
+        return await proxy.call(this.runTest, { id, functionName, testRunId });
+    }
+
+    public async cleanUp (): Promise<void> {
+        const { proxy } = await this._getRuntime();
+
+        await proxy.call(this.cleanUp);
+    }
+
+}

--- a/src/services/compiler/io.ts
+++ b/src/services/compiler/io.ts
@@ -1,0 +1,6 @@
+export const SERVICE_INPUT_FD  = 3;
+export const SERVICE_OUTPUT_FD = 4;
+export const SERVICE_SYNC_FD   = 5;
+export const HOST_INPUT_FD     = SERVICE_OUTPUT_FD;
+export const HOST_OUTPUT_FD    = SERVICE_INPUT_FD;
+export const HOST_SYNC_FD      = SERVICE_SYNC_FD;

--- a/src/services/compiler/protocol.ts
+++ b/src/services/compiler/protocol.ts
@@ -1,0 +1,46 @@
+import { CompilerArguments } from '../../compiler/interfaces';
+
+export const BEFORE_AFTER_PROPERTIES  = ['beforeFn', 'afterFn'] as const;
+export const BEFORE_AFTER_EACH_PROPERTIES = ['beforeEachFn', 'afterEachFn'] as const;
+export const TEST_FUNCTION_PROPERTIES = ['fn', ...BEFORE_AFTER_PROPERTIES] as const;
+export const FUNCTION_PROPERTIES = [...TEST_FUNCTION_PROPERTIES, ...BEFORE_AFTER_EACH_PROPERTIES] as const;
+
+export type FunctionProperties = typeof FUNCTION_PROPERTIES[number];
+export type TestFunctionProperties = typeof TEST_FUNCTION_PROPERTIES[number];
+export type FixtureFunctionProperties = typeof BEFORE_AFTER_EACH_PROPERTIES[number];
+
+
+export function isTestFunctionProperty (value: FunctionProperties): value is TestFunctionProperties {
+    return TEST_FUNCTION_PROPERTIES.includes(value as TestFunctionProperties);
+}
+
+export function isFixtureFunctionProperty (value: FunctionProperties): value is FixtureFunctionProperties {
+    return BEFORE_AFTER_EACH_PROPERTIES.includes(value as FixtureFunctionProperties);
+}
+
+export interface RunTestArguments {
+    id: string;
+    functionName: FunctionProperties;
+    testRunId: string;
+}
+
+export interface ExecuteCommandArguments {
+    id: string;
+    apiMethodName: string;
+    command: unknown;
+    callsite: unknown;
+}
+
+export interface TestRunDispatcherProtocol {
+    executeAction ({ id, apiMethodName, command, callsite }: ExecuteCommandArguments): Promise<unknown>;
+}
+
+export interface CompilerProtocol extends TestRunDispatcherProtocol {
+    ready (): Promise<void>;
+
+    getTests ({ sourceList, compilerOptions }: CompilerArguments): Promise<unknown>;
+
+    runTest ({ id, functionName, testRunId }: RunTestArguments): Promise<unknown>;
+
+    cleanUp (): Promise<void>;
+}

--- a/src/services/compiler/service.ts
+++ b/src/services/compiler/service.ts
@@ -1,0 +1,134 @@
+import fs from 'fs';
+import Compiler from '../../compiler';
+import TestRunProxy from './test-run-proxy';
+
+import {
+    flatten as flattenTestStructure, isFixture,
+    isTest,
+    serialize as serializeTestStructure, Unit,
+    Units
+} from './test-structure';
+
+import { SERVICE_INPUT_FD, SERVICE_OUTPUT_FD, SERVICE_SYNC_FD } from './io';
+import { IPCProxy } from '../utils/ipc/proxy';
+import { ServiceTransport } from '../utils/ipc/transport';
+import sourceMapSupport from 'source-map-support';
+
+import {
+    CompilerProtocol,
+    ExecuteCommandArguments, FunctionProperties, isFixtureFunctionProperty,
+    isTestFunctionProperty,
+    RunTestArguments
+} from './protocol';
+import { CompilerArguments } from '../../compiler/interfaces';
+
+sourceMapSupport.install({
+    hookRequire:              true,
+    handleUncaughtExceptions: false,
+    environment:              'node'
+});
+
+interface ServiceState {
+    testRuns: { [id: string]: TestRunProxy };
+    fixtureCtxs: { [id: string]: object };
+    units: Units;
+}
+
+class CompilerService implements CompilerProtocol {
+    private readonly proxy: IPCProxy;
+    private readonly state: ServiceState;
+
+    public constructor () {
+        const input  = fs.createReadStream('', { fd: SERVICE_INPUT_FD });
+        const output = fs.createWriteStream('', { fd: SERVICE_OUTPUT_FD });
+
+        this.proxy    = new IPCProxy(new ServiceTransport(input, output, SERVICE_SYNC_FD));
+        this.state    = {
+            testRuns:    {},
+            fixtureCtxs: {},
+            units:       {}
+        };
+
+        this._setupRoutes();
+        this.ready();
+    }
+
+    private _getFixtureCtx ({ id }: RunTestArguments): unknown {
+        const unit = this.state.units[id];
+
+        const fixtureId = isTest(unit) ? unit.fixture.id : unit.id;
+
+        if (!this.state.fixtureCtxs[fixtureId])
+            this.state.fixtureCtxs[fixtureId] = Object.create(null);
+
+        return this.state.fixtureCtxs[fixtureId];
+    }
+
+    private _getContext (args: RunTestArguments): unknown {
+        const { testRunId } = args;
+        const fixtureCtx        = this._getFixtureCtx(args);
+
+        if (!testRunId)
+            return fixtureCtx;
+
+        if (!this.state.testRuns[testRunId])
+            this.state.testRuns[testRunId] = new TestRunProxy(this, testRunId, fixtureCtx);
+
+        return this.state.testRuns[testRunId];
+    }
+
+    private _setupRoutes (): void {
+        this.proxy.register(this.getTests, this);
+        this.proxy.register(this.runTest, this);
+        this.proxy.register(this.cleanUp, this);
+    }
+
+    private _getFunction (unit: Unit, functionName: FunctionProperties): Function|null {
+        if (isTest(unit) && isTestFunctionProperty(functionName))
+            return unit[functionName];
+
+        if (isFixture(unit) && isFixtureFunctionProperty(functionName))
+            return unit[functionName];
+
+        throw new Error();
+    }
+
+    public async ready (): Promise<void> {
+        this.proxy.call(this.ready);
+    }
+
+    public async cleanUp (): Promise<void> {
+        await Compiler.cleanUp();
+    }
+
+    public async getTests ({ sourceList, compilerOptions }: CompilerArguments): Promise<Units> {
+        const compiler = new Compiler(sourceList, compilerOptions);
+
+        const tests = await compiler.getTests();
+        const units = flattenTestStructure(tests);
+
+        Object.assign(this.state.units, units);
+
+        return serializeTestStructure(units);
+    }
+
+    public async runTest (args: RunTestArguments): Promise<unknown> {
+        const { id, functionName } = args;
+
+        const unit    = this.state.units[id];
+        const context = this._getContext(args);
+
+        const functionObject = this._getFunction(unit, functionName);
+
+        if (!functionObject)
+            throw new Error();
+
+        return await functionObject(context);
+    }
+
+    public async executeAction ({ id, apiMethodName, command, callsite }: ExecuteCommandArguments): Promise<unknown> {
+        return this.proxy.call(this.executeAction, { id, apiMethodName, command, callsite });
+    }
+}
+
+export default new CompilerService();

--- a/src/services/compiler/test-run-proxy.ts
+++ b/src/services/compiler/test-run-proxy.ts
@@ -1,0 +1,35 @@
+import testRunTracker from '../../api/test-run-tracker';
+import prerenderCallsite from '../../utils/prerender-callsite';
+
+import { TestRunDispatcherProtocol } from './protocol';
+
+
+class TestRunMock {
+    public readonly id: string;
+
+    private readonly dispatcher: TestRunDispatcherProtocol;
+    private readonly fixtureCtx: unknown;
+    private readonly ctx: unknown;
+
+    public constructor (dispatcher: TestRunDispatcherProtocol, id: string, fixtureCtx: unknown) {
+        this.dispatcher = dispatcher;
+
+        this.id = id;
+
+        this.ctx        = Object.create(null);
+        this.fixtureCtx = fixtureCtx;
+
+        testRunTracker.activeTestRuns[id] = this;
+    }
+
+    public async executeAction (apiMethodName: string, command: unknown, callsite: unknown): Promise<unknown> {
+        if (callsite)
+            callsite = prerenderCallsite(callsite);
+
+        return await this.dispatcher.executeAction({ apiMethodName, command, callsite, id: this.id });
+    }
+}
+
+export default TestRunMock;
+
+

--- a/src/services/compiler/test-structure.ts
+++ b/src/services/compiler/test-structure.ts
@@ -1,0 +1,150 @@
+import nanoid from 'nanoid';
+import { uniq } from 'lodash';
+import { TEST_FUNCTION_PROPERTIES } from './protocol';
+
+import { Fixture, Test, TestFile } from '../../api/structure/interfaces';
+
+const RECURSIVE_PROPERTIES = ['testFile', 'fixture', 'currentFixture', 'collectedTests'] as const;
+
+interface FunctionMapper {
+    (id: string, functionName: typeof TEST_FUNCTION_PROPERTIES[number]): Function;
+}
+
+interface MapperArguments<T, P> {
+    object: T;
+    property: P;
+    item: any;
+}
+
+interface Mapper<T, P> {
+    ({ item, property, object }: MapperArguments<T, P>): any;
+}
+
+interface TestData {
+    tests: Test[];
+    fixtures: Fixture[];
+    testFiles: TestFile[];
+}
+
+interface ExtendedProperties {
+    id: string;
+    group: keyof TestData;
+}
+
+interface ExtendedTest extends Test, ExtendedProperties {
+    fixture: ExtendedFixture;
+    testFile: ExtendedTestFile;
+}
+
+interface ExtendedFixture extends Fixture, ExtendedProperties {
+    testFile: ExtendedTestFile;
+}
+
+interface ExtendedTestFile extends TestFile, ExtendedProperties {
+    collectedTests: ExtendedTest[];
+    currentFixture: ExtendedFixture;
+}
+
+export type Unit = ExtendedTest | ExtendedFixture | ExtendedTestFile;
+
+export interface Units {
+    [id: string]: Unit;
+}
+
+function isProperty<T extends object> (object: T, property: string): property is Extract<keyof T, string> {
+    return object.hasOwnProperty(property);
+}
+
+export function isTest (value: ExtendedProperties): value is ExtendedTest {
+    return value.group === 'tests';
+}
+
+export function isFixture (value: ExtendedProperties): value is ExtendedFixture {
+    return value.group === 'fixtures';
+}
+
+function mapProperties<T extends Readonly<object>, P extends Readonly<string[]>> (object: T, properties: P, mapper: Mapper<T, P[number]>): void {
+    for (const property of properties) {
+        if (!isProperty(object, property))
+            continue;
+
+        const value = object[property];
+
+        if (Array.isArray(value))
+            object[property] = value.map(item => mapper({ item, property, object })) as any;
+        else
+            object[property] = mapper({ item: object[property], property, object });
+    }
+}
+
+function replaceTestFunctions (unit: Unit): void {
+    mapProperties(unit, TEST_FUNCTION_PROPERTIES, ({ item }) => !!item);
+}
+
+function restoreTestFunctions (unit: Unit, mapper: FunctionMapper): void {
+    mapProperties(unit, TEST_FUNCTION_PROPERTIES, ({ item, object, property }) => item ? mapper(object.id, property) : item);
+}
+
+function flattenRecursiveProperties (unit: Unit): void {
+    mapProperties(unit, RECURSIVE_PROPERTIES, ({ item }) => item.id);
+}
+
+function restoreRecursiveProperties (unit: Unit, units: Units): void {
+    mapProperties(unit, RECURSIVE_PROPERTIES, ({ item }) => units[item]);
+}
+
+export function flatten (tests: Test[]): Units {
+    const testFiles = uniq(tests.map(test => test.testFile));
+    const fixtures  = uniq(tests.map(test => test.fixture));
+    const testData  = { tests, testFiles, fixtures };
+    const units: Units = {};
+
+    for (const group in testData) {
+        if (!isProperty(testData, group))
+            continue;
+
+        for (const unit of testData[group]) {
+            const extendedProperties = {
+                id:    nanoid(),
+                group: group
+            };
+
+            units[extendedProperties.id] = Object.assign(unit, extendedProperties) as Unit;
+        }
+    }
+
+    return units;
+}
+
+export function serialize (units: Units): Units {
+    const result: Units = {};
+
+    for (const unit of Object.values(units)) {
+        const copy: Unit = { ...unit };
+
+        replaceTestFunctions(copy);
+        flattenRecursiveProperties(copy);
+
+        result[copy.id] = copy;
+    }
+
+    return result;
+}
+
+export function restore (units: Units, mapper: FunctionMapper): Test[] {
+    const list = Object.values(units);
+
+    const result: Test[] = [];
+
+    for (const unit of list) {
+        restoreRecursiveProperties(unit, units);
+        restoreTestFunctions(unit, mapper);
+    }
+
+    for (const unit of list) {
+        if (isTest(unit))
+            result.push(unit);
+    }
+
+    return result;
+}

--- a/src/testcafe.js
+++ b/src/testcafe.js
@@ -12,6 +12,7 @@ const errorHandlers            = lazyRequire('./utils/handle-errors');
 const BrowserConnectionGateway = lazyRequire('./browser/connection/gateway');
 const BrowserConnection        = lazyRequire('./browser/connection');
 const browserProviderPool      = lazyRequire('./browser/provider/pool');
+const CompilerHost             = lazyRequire('./services/compiler/host');
 const Runner                   = lazyRequire('./runner');
 const LiveModeRunner           = lazyRequire('./live/test-runner');
 
@@ -30,6 +31,8 @@ export default class TestCafe {
         this.browserConnectionGateway = new BrowserConnectionGateway(this.proxy, { retryTestPages: configuration.getOption(OPTION_NAMES.retryTestPages) });
         this.runners                  = [];
         this.configuration            = configuration;
+
+        this.compilerService = configuration.getOption('experimentalCompilerService') ? new CompilerHost() : void 0;
 
         this._registerAssets(options.developmentMode);
     }
@@ -69,7 +72,7 @@ export default class TestCafe {
 
     _createRunner (isLiveMode) {
         const Ctor      = isLiveMode ? LiveModeRunner : Runner;
-        const newRunner = new Ctor(this.proxy, this.browserConnectionGateway, this.configuration.clone());
+        const newRunner = new Ctor(this.proxy, this.browserConnectionGateway, this.configuration.clone(), this.compilerService);
 
         this.runners.push(newRunner);
 
@@ -103,6 +106,9 @@ export default class TestCafe {
         await Promise.all(this.runners.map(runner => runner.stop()));
 
         await browserProviderPool.dispose();
+
+        if (this.compilerService)
+            this.compilerService.stop();
 
         this.browserConnectionGateway.close();
         this.proxy.close();

--- a/src/testcafe.js
+++ b/src/testcafe.js
@@ -32,7 +32,7 @@ export default class TestCafe {
         this.runners                  = [];
         this.configuration            = configuration;
 
-        this.compilerService = configuration.getOption('experimentalCompilerService') ? new CompilerHost() : void 0;
+        this.compilerService = configuration.getOption(OPTION_NAMES.experimentalCompilerService) ? new CompilerHost() : void 0;
 
         this._registerAssets(options.developmentMode);
     }

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -25,7 +25,8 @@ const testingEnvironmentNames = {
 const testingEnvironments = {};
 
 testingEnvironments[testingEnvironmentNames.osXDesktopAndMSEdgeBrowsers] = {
-    jobName: 'functional tests - OS X desktop and MS edge browsers',
+    jobName:  'functional tests - OS X desktop and MS edge browsers',
+    provider: browserProviderNames.browserstack,
 
     browserstack: {
         username:  process.env.BROWSER_STACK_USERNAME,
@@ -55,7 +56,8 @@ testingEnvironments[testingEnvironmentNames.osXDesktopAndMSEdgeBrowsers] = {
 };
 
 testingEnvironments[testingEnvironmentNames.mobileBrowsers] = {
-    jobName: 'functional tests - mobile browsers',
+    jobName:  'functional tests - mobile browsers',
+    provider: browserProviderNames.browserstack,
 
     browserstack: {
         username:  process.env.BROWSER_STACK_USERNAME,
@@ -175,7 +177,8 @@ testingEnvironments[testingEnvironmentNames.localHeadlessFirefox] = {
 };
 
 testingEnvironments[testingEnvironmentNames.remote] = {
-    remote: true,
+    remote:   true,
+    provider: browserProviderNames.remote,
 
     browsers: [{
         get qrCode () {

--- a/test/functional/fixtures/compiler-service/test.js
+++ b/test/functional/fixtures/compiler-service/test.js
@@ -1,0 +1,38 @@
+const path       = require('path');
+const { expect } = require('chai');
+
+
+describe('Compiler service', () => {
+    before(() => {
+        process.env.TESTCAFE_PID = String(process.pid);
+    });
+
+    after(() => {
+        delete process.env.TESTCAFE_PID;
+    });
+
+    it('Should execute a basic test', async () => {
+        await runTests('testcafe-fixtures/basic-test.js', 'Basic test');
+    });
+
+    it('Should handle an error', async () => {
+        try {
+            await runTests('testcafe-fixtures/error-test.js', 'Throw an error', { shouldFail: true });
+        }
+        catch (err) {
+            expect(err).deep.equal([
+                `The specified selector does not match any element in the DOM tree. ` +
+                ` > | Selector('#not-exists') ` +
+                ` [[user-agent]] ` +
+                ` 1 |fixture \`Compiler service\`;` +
+                ` 2 |` +
+                ` 3 |test(\`Throw an error\`, async t => {` +
+                ` 4 |    await t.expect(String(process.ppid)).eql(process.env.TESTCAFE_PID);` +
+                ` 5 |` +
+                ` > 6 |    await t.click('#not-exists');` +
+                ` 7 |});` +
+                ` 8 |  at <anonymous> (${path.join(__dirname, 'testcafe-fixtures/error-test.js')}:6:13)`
+            ]);
+        }
+    });
+});

--- a/test/functional/fixtures/compiler-service/testcafe-fixtures/basic-test.js
+++ b/test/functional/fixtures/compiler-service/testcafe-fixtures/basic-test.js
@@ -1,0 +1,22 @@
+import { ClientFunction } from 'testcafe';
+
+
+fixture `Compiler service`;
+
+const getClickOffset = ClientFunction(() => window.clickOffset);
+
+test(`Basic test`, async t => {
+    await t.expect(String(process.ppid)).eql(process.env.TESTCAFE_PID);
+
+    await t.navigateTo('http://localhost:3000/fixtures/api/es-next/click/pages/index.html');
+
+    await t.click('#div');
+
+    const expectedClickOffset = { x: 50, y: 50 };
+    const actualClickOffset   = await getClickOffset();
+
+    await t.expect(actualClickOffset.x).eql(expectedClickOffset.x);
+    await t.expect(actualClickOffset.y).eql(expectedClickOffset.y);
+});
+
+

--- a/test/functional/fixtures/compiler-service/testcafe-fixtures/error-test.js
+++ b/test/functional/fixtures/compiler-service/testcafe-fixtures/error-test.js
@@ -1,0 +1,7 @@
+fixture `Compiler service`;
+
+test(`Throw an error`, async t => {
+    await t.expect(String(process.ppid)).eql(process.env.TESTCAFE_PID);
+
+    await t.click('#not-exists');
+});

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -28,7 +28,7 @@ const FUNCTIONAL_TESTS_ASSERTION_TIMEOUT = 1000;
 const FUNCTIONAL_TESTS_PAGE_LOAD_TIMEOUT = 0;
 
 const environment     = config.currentEnvironment;
-const browserProvider = process.env.BROWSER_PROVIDER;
+const browserProvider = config.currentEnvironment.provider;
 const isBrowserStack  = browserProvider === config.browserProviderNames.browserstack;
 
 config.browsers = environment.browsers;
@@ -141,7 +141,19 @@ before(function () {
 
     const { devMode, retryTestPages } = config;
 
-    return createTestCafe(config.testCafe.hostname, config.testCafe.port1, config.testCafe.port2, null, devMode, retryTestPages)
+    const testCafeOptions = {
+        hostname: config.testCafe.hostname,
+        port1:    config.testCafe.port1,
+        port2:    config.testCafe.port2,
+
+        developmentMode: devMode,
+
+        retryTestPages,
+
+        experimentalCompilerService: !!process.env.EXPERIMENTAL_COMPILER_SERVICE
+    };
+
+    return createTestCafe(testCafeOptions)
         .then(function (tc) {
             testCafe = tc;
 
@@ -304,10 +316,4 @@ after(function () {
 
     return closeLocalBrowsers();
 });
-
-// TODO: Run takeScreenshot tests first because other tests heavily impact them
-if (config.useLocalBrowsers && !config.isLegacyEnvironment && !process.env.ALLOW_MULTIPLE_WINDOWS) {
-    require('./fixtures/api/es-next/take-screenshot/test');
-    require('./fixtures/screenshots-on-fails/test');
-}
 


### PR DESCRIPTION
 - Implemented the compiler service (`/src/services/compiler`) - a process that starts alongside the main TestCafe process and compiles & runs tests. Commands to compile and run specific tests are passed via inter-process messages handled by the IPC Proxy (`/src/services/utils/ipc`).

 - Added IDs to test file objects (IDs for fixture and test objects were done in another PR) to simplify serializing and deserializing test structure (test, fixture, test file) objects.
 
- Added the "unitTypeName" property to test file objects and refactored it to use named constants for test and fixture objects.
 
- Added and enabled on Travis a new test task dedicated to the compiler service that will be used until we can run all existing functional tests with the compiler service enabled.

 - Moved the hack that forced the screenshot tests to run before all other tests from `/test/functional/setup.js` to `/Gulpfile.js`.