### PR TITLE
[docs] Fix `filterHidden` docs example

### DIFF
--- a/docs/articles/documentation/test-api/selecting-page-elements/selectors/functional-style-selectors.md
+++ b/docs/articles/documentation/test-api/selecting-page-elements/selectors/functional-style-selectors.md
@@ -153,7 +153,7 @@ Method                              | Type     | Description
 
 ```js
 // Selects all hidden label elements.
-Selector('label').filterVisible();
+Selector('label').filterHidden();
 ```
 
 ### filter


### PR DESCRIPTION
From https://github.com/DevExpress/testcafe/issues/4610

> Current documentation for filterHidden uses filterVisible in the example code:
https://devexpress.github.io/testcafe/documentation/test-api/selecting-page-elements/selectors/functional-style-selectors.html#filterhidden