### PR TITLE
[GH4576] Add options to reporter config which will be passed down to reporter init function.

### DIFF
--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -5,7 +5,7 @@ import { CommandReportItem } from './command-report-item';
 import TestCafeErrorList from '../errors/error-list';
 
 export default class Reporter {
-    constructor (plugin, task, outStream) {
+    constructor (plugin, task, outStream, options) {
         this.plugin = new ReporterPluginHost(plugin, outStream);
         this.task   = task;
 
@@ -21,6 +21,9 @@ export default class Reporter {
         this.pendingTaskDonePromise = Reporter._createPendingPromise();
 
         this._assignTaskEventHandlers();
+
+        if (this.plugin.init)
+            this.plugin.init(options);
     }
 
     static _isSpecialStream (stream) {

--- a/src/reporter/plugin-host.js
+++ b/src/reporter/plugin-host.js
@@ -135,6 +135,12 @@ export default class ReporterPluginHost {
 
 
     // Abstract methods implemented in plugin
+
+    // NOTE: It's an optional method
+    // init (/* options */) {
+    //     throw new Error('Not implemented');
+    // }
+
     async reportTaskStart (/* startTime, userAgents, testCount */) {
         throw new Error('Not implemented');
     }

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -39,9 +39,15 @@ interface Metadata {
 
 type BrowserSource = BrowserConnection | string;
 
+type JSONPrimitive = string | number | boolean | null;
+type JSONValue = JSONPrimitive | JSONObject | JSONArray;
+type JSONArray = JSONValue[];
+interface JSONObject { [key: string]: JSONValue }
+
 interface ReporterSource {
     name: string;
     output?: string | WritableStream;
+    options?: JSONObject;
 }
 
 interface ReporterPluginSource {
@@ -311,13 +317,14 @@ export default class Bootstrapper {
         if (!this.reporters.length)
             Bootstrapper._addDefaultReporter(this.reporters);
 
-        return Promise.all(this.reporters.map(async ({ name, output }) => {
+        return Promise.all(this.reporters.map(async ({ name, output, options }) => {
             const pluginFactory = this._getPluginFactory(name);
             const outStream     = output ? await this._ensureOutStream(output) : void 0;
 
             return {
                 plugin: pluginFactory(),
-                outStream
+                outStream,
+                options
             };
         }));
     }

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -151,7 +151,7 @@ export default class Runner extends EventEmitter {
     _runTask (reporterPlugins, browserSet, tests, testedApp) {
         let completed           = false;
         const task              = this._createTask(tests, browserSet.browserConnectionGroups, this.proxy, this.configuration.getOptions());
-        const reporters         = reporterPlugins.map(reporter => new Reporter(reporter.plugin, task, reporter.outStream));
+        const reporters         = reporterPlugins.map(reporter => new Reporter(reporter.plugin, task, reporter.outStream, reporter.options));
         const completionPromise = this._getTaskResult(task, browserSet, reporters, testedApp);
 
         task.on('start', startHandlingTestErrors);
@@ -413,11 +413,11 @@ export default class Runner extends EventEmitter {
         return this;
     }
 
-    reporter (name, output) {
+    reporter (name, output, options) {
         if (this.apiMethodWasCalled.reporter)
             throw new GeneralError(RUNTIME_ERRORS.multipleAPIMethodCallForbidden, OPTION_NAMES.reporter);
 
-        let reporters = prepareReporters(name, output);
+        let reporters = prepareReporters(name, output, options);
 
         reporters = this._prepareArrayParameter(reporters);
 

--- a/src/utils/prepare-reporters.js
+++ b/src/utils/prepare-reporters.js
@@ -18,13 +18,13 @@ function validateReporterOutput (obj) {
         throw new GeneralError(RUNTIME_ERRORS.invalidReporterOutput);
 }
 
-export default function (name, output) {
+export default function (name, output, options) {
     let reporters = [];
 
     if (name instanceof Array)
         reporters = name.map(r => typeof r === 'string' || typeof r === 'function' ? { name: r } : r);
     else {
-        const reporter = { name, output };
+        const reporter = { name, output, options };
 
         reporters.push(reporter);
     }

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -343,6 +343,11 @@ describe('Reporter', () => {
 
     function createReporter (taskMock) {
         return new Reporter({
+            init: function (...args) {
+                return delay(1000)
+                    .then(() => log.push({ method: 'init', args: args }));
+            },
+
             reportTaskStart: function (...args) {
                 expect(args[0]).to.be.a('date');
 
@@ -384,7 +389,15 @@ describe('Reporter', () => {
                 return delay(1000)
                     .then(() => log.push({ method: 'reportTaskDone', args: args }));
             }
-        }, taskMock);
+        },
+        taskMock,
+        null,
+        {
+            foo: 'bar',
+            baz: {
+                foo: 'bar'
+            }
+        });
     }
 
     beforeEach(() => {
@@ -397,6 +410,17 @@ describe('Reporter', () => {
         const taskMock = new TaskMock();
 
         const expectedLog = [
+            {
+                method: 'init',
+                args:   [
+                    {
+                        foo: 'bar',
+                        baz: {
+                            foo: 'bar',
+                        }
+                    },
+                ]
+            },
             {
                 method: 'reportTaskStart',
                 args:   [

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -1116,6 +1116,6 @@ describe('Runner', () => {
 
         expect(runner.configuration.getOption('src')).eql(['/path-to-test']);
         expect(runner.configuration.getOption('browsers')).eql(['ie']);
-        expect(runner.configuration.getOption('reporter')).eql([ { name: 'json', output: void 0 } ]);
+        expect(runner.configuration.getOption('reporter')).eql([ { name: 'json', output: void 0, options: void 0 } ]);
     });
 });

--- a/test/server/util-test.js
+++ b/test/server/util-test.js
@@ -427,23 +427,26 @@ describe('Utils', () => {
             expect(result[1].name).eql(fn2);
         });
 
-        it('Name and output stream', () => {
-            const result = prepareReporters('minimal', 'path/to/file');
+        it('Name, output stream and options', () => {
+            const result = prepareReporters('minimal', 'path/to/file', { foo: 'bar' });
 
             expect(result.length).eql(1);
             expect(result[0].name).eql('minimal');
             expect(result[0].output).eql('path/to/file');
+            expect(result[0].options).eql({ foo: 'bar' });
         });
 
-        it('Array of names and output streams', () => {
+        it('Array of names, output streams and options', () => {
             const data = [
                 {
                     name:      'minimal',
-                    outStream: 'path/to/file/1'
+                    outStream: 'path/to/file/1',
+                    options:   { foo: 'bar' }
                 },
                 {
                     name:      'json',
-                    outStream: 'path/to/file/2'
+                    outStream: 'path/to/file/2',
+                    options:   { bar: 'baz' }
                 }
             ];
 


### PR DESCRIPTION
This PR introduces the `options` property under the [reporter](https://devexpress.github.io/testcafe/documentation/using-testcafe/configuration-file.html#reporter) config section.
The purpose of this new property is to pass down configuration to the custom reporter without using ENV variables.

fixes #4576