### PR TITLE
Change `requestHooks()` execution order back to how it was in `v1.3`

### DIFF
--- a/src/api/structure/test.js
+++ b/src/api/structure/test.js
@@ -64,7 +64,7 @@ export default class Test extends TestingUnit {
 
         assertRequestHookType(hooks);
 
-        this.requestHooks = union(this.requestHooks, hooks);
+        this.requestHooks = union(hooks, this.requestHooks);
 
         this.apiMethodWasCalled.requestHooks = true;
 

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -173,7 +173,7 @@ export default class TestRun extends AsyncEventEmitter {
         if (this.requestHooks.indexOf(hook) !== -1)
             return;
 
-        this.requestHooks.push(hook);
+        this.requestHooks.unshift(hook);
         this._initRequestHook(hook);
     }
 


### PR DESCRIPTION
This should fix #4680.

As I said in the issue you can close it if you don't want to change the order of the functions that `requestHooks()` executes.

As of now, the execution order of `requestHooks()` goes from the outermost defined hook (on `fixture`) to the innermost defined one (on `test` and then, eventually, on `t`).

This might not be the correct behaviour because prior to `v1.4.0` the hooks run the other way around, and the change of behaviour was not documented.

This behaviour might be correct for client scripts because you may want to override what was done in a `fixture`, but a request's response shouldn't be searched from the ones defined in `fixture`, then in `test`, then in `t`, but from the ones defined in `t`, then in `test`, then in `fixture`.


Please note that I didn't update any tests for now.