### PR TITLE
Only catch error if provider module itself does not exist

### DIFF
--- a/src/browser/provider/pool.js
+++ b/src/browser/provider/pool.js
@@ -69,14 +69,19 @@ export default {
 
     _getProviderModule (providerName, moduleName) {
         try {
-            const providerObject = require(moduleName);
-
-            this.addProvider(providerName, providerObject);
-            return this._getProviderFromCache(providerName);
+            // First, just check if the module exists
+            require.resolve(moduleName);
         }
         catch (e) {
+            // Module does not exist. Return null, and let the caller handle
             return null;
         }
+
+        // Load the module
+        const providerObject = require(moduleName);
+
+        this.addProvider(providerName, providerObject);
+        return this._getProviderFromCache(providerName);
     },
 
     _getProviderFromCache (providerName) {

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -72,7 +72,7 @@ testingEnvironments[testingEnvironmentNames.mobileBrowsers] = {
             alias:       'ipad'
         },
         {
-            browserName: 'browserstack:iPhone XS@12.0',
+            browserName: 'browserstack:iPhone 7 Plus@10',
             alias:       'iphone'
         }
     ]

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -72,7 +72,7 @@ testingEnvironments[testingEnvironmentNames.mobileBrowsers] = {
             alias:       'ipad'
         },
         {
-            browserName: 'browserstack:iPhone 7 Plus@10',
+            browserName: 'browserstack:iPhone XS@12.0',
             alias:       'iphone'
         }
     ]


### PR DESCRIPTION
Fixes https://github.com/DevExpress/testcafe/issues/4522 and https://github.com/DevExpress/testcafe/issues/4673.

First uses `require.resolve`, which will only throw an error if the provider module itself doesn't exist. If it does exist, we then use `require` to load the module, not catching errors. That way, any errors caused by a 3rd party dependency will show up.