### PR TITLE
Should ensure AsyncEventEmitter from additional event subscriptions (closes #4725)

### DIFF
--- a/src/runner/browser-job.js
+++ b/src/runner/browser-job.js
@@ -50,10 +50,6 @@ export default class BrowserJob extends AsyncEventEmitter {
         });
         testRunController.on('test-run-done', async () => this._onTestRunDone(testRunController));
 
-        testRunController.on('test-run-start', async () => {
-            await this.emit('test-run-start', testRunController.testRun);
-        });
-
         testRunController.on('test-action-start', async args => {
             await this.emit('test-action-start', args);
         });

--- a/test/functional/fixtures/regression/gh-4725/pages/index.html
+++ b/test/functional/fixtures/regression/gh-4725/pages/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>gh-4725</title>
+</head>
+<body>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-4725/test.js
+++ b/test/functional/fixtures/regression/gh-4725/test.js
@@ -1,0 +1,35 @@
+const AsyncEventEmitter = require('../../../../../lib/utils/async-event-emitter');
+
+const on = AsyncEventEmitter.prototype.on;
+
+const MAX_LISTENERS = {
+    'Task': {
+        'done':           3,
+        'start':          2,
+        'test-run-start': 2,
+        'test-run-done':  2
+    }
+};
+
+describe('[Regression](GH-4725)', function () {
+    it('Should ensure AsyncEventEmitter from additional event subscriptions', function () {
+        AsyncEventEmitter.prototype.on = function (eventName, listener) {
+            let maxListenerCount = 1;
+
+            if (MAX_LISTENERS[this.constructor.name])
+                maxListenerCount = MAX_LISTENERS[this.constructor.name][eventName] || maxListenerCount;
+
+            const result = on.call(this, eventName, listener);
+
+            if (this.listenerCount(eventName) > maxListenerCount)
+                throw new Error(`Check listeners for ${this.constructor.name}.${eventName}`);
+
+            return result;
+        };
+
+        return runTests('testcafe-fixtures/index.js')
+            .then(() => {
+                AsyncEventEmitter.prototype.on = on;
+            });
+    });
+});

--- a/test/functional/fixtures/regression/gh-4725/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-4725/testcafe-fixtures/index.js
@@ -1,0 +1,5 @@
+fixture `GH-4725 - Should ensure AsyncEventEmitter from additional event subscriptions`
+    .page `http://localhost:3000/fixtures/regression/gh-4725/pages/index.html`;
+
+test(`Should ensure AsyncEventEmitter from additional event subscriptions`, async () => {
+});

--- a/test/functional/fixtures/regression/gh-4725/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-4725/testcafe-fixtures/index.js
@@ -1,5 +1,9 @@
 fixture `GH-4725 - Should ensure AsyncEventEmitter from additional event subscriptions`
     .page `http://localhost:3000/fixtures/regression/gh-4725/pages/index.html`;
 
-test(`Should ensure AsyncEventEmitter from additional event subscriptions`, async () => {
-});
+for (let i = 0; i < 2; i++) {
+    test(`test ${i}`, async t => {
+        if (t.browser.alias === 'Firefox')
+            await t.wait(5000);
+    });
+}

--- a/test/server/browser-job-test.js
+++ b/test/server/browser-job-test.js
@@ -1,0 +1,20 @@
+const expect     = require('chai').expect;
+const BrowserJob = require('../../lib/runner/browser-job');
+
+describe('Browser Job', function () {
+    it('TestRunController events', function () {
+        const tests             = [1];
+        const job               = new BrowserJob(tests, [], null, null, null, null, { TestRunCtor: function () { } });
+        const testRunController = job.testRunControllerQueue[0];
+
+        expect(testRunController.listenerCount()).eql(8);
+        expect(testRunController.listenerCount('test-run-create')).eql(1);
+        expect(testRunController.listenerCount('test-run-start')).eql(1);
+        expect(testRunController.listenerCount('test-run-ready')).eql(1);
+        expect(testRunController.listenerCount('test-run-restart')).eql(1);
+        expect(testRunController.listenerCount('test-run-before-done')).eql(1);
+        expect(testRunController.listenerCount('test-run-done')).eql(1);
+        expect(testRunController.listenerCount('test-action-start')).eql(1);
+        expect(testRunController.listenerCount('test-action-done')).eql(1);
+    });
+});


### PR DESCRIPTION
Accidentally I duplicated the assign to the `test-run-start` event. Test will prevent this