### PR TITLE
Update browser tools (v2.0.9), bump version (v1.8.3-rc.1)

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -8,7 +8,7 @@
     "gitTag": true
   },
   "confirm": true,
-  "publishTag": "latest",
+  "publishTag": "rc",
   "prePublishScript": "gulp test-server",
   "postPublishScript": "gulp docker-publish"
 }

--- a/.publishrc
+++ b/.publishrc
@@ -8,7 +8,7 @@
     "gitTag": true
   },
   "confirm": true,
-  "publishTag": "rc",
+  "publishTag": "alpha",
   "prePublishScript": "gulp test-server",
   "postPublishScript": "gulp docker-publish"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.8.3-rc.1",
+  "version": "1.8.3-alpha.1",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.8.2",
+  "version": "1.8.3-rc.1",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"
@@ -115,7 +115,7 @@
     "sanitize-filename": "^1.6.0",
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
-    "testcafe-browser-tools": "2.0.8",
+    "testcafe-browser-tools": "2.0.9",
     "testcafe-hammerhead": "16.1.2",
     "testcafe-legacy-api": "3.1.11",
     "testcafe-reporter-json": "^2.1.0",


### PR DESCRIPTION
We updated browser tool to run chrome with the following flags:
`--disable-background-networking`
`--disable-ipc-flooding-protection`