### PR TITLE
[docs] Exclude most scopes from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,2 @@
-/docs/ @VasilyStrelyaev
-/CHANGELOG.md @VasilyStrelyaev
-/CODE_OF_CONDUCT.md @VasilyStrelyaev
-/CONTRIBUTING.md @VasilyStrelyaev
-/README.md @VasilyStrelyaev
 /LICENSE @kirovboris @AndreyBelym
-/package.json @kirovboris @AndreyBelym
+/package.json @AndreyBelym


### PR DESCRIPTION
1. @VasilyStrelyaev is no longer a code owner of `docs` and related `*.md` files since @anthophobiac can handle this too.
2. @kirovboris is no longer a code owner of `package.json` since most changes there are very minor and only increase the number of clutter mentions.