### PR TITLE
Disable background tabs timer throttling

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "sanitize-filename": "^1.6.0",
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
-    "testcafe-browser-tools": "2.0.9",
+    "testcafe-browser-tools": "2.0.10",
     "testcafe-hammerhead": "16.1.3",
     "testcafe-legacy-api": "3.1.11",
     "testcafe-reporter-json": "^2.1.0",

--- a/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
+++ b/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
@@ -47,8 +47,9 @@ async function generatePreferences (profileDir: string, { marionettePort, config
         'user_pref("devtools.toolbox.host", "window");',
         'user_pref("devtools.toolbox.previousHost", "bottom");',
         'user_pref("signon.rememberSignons", false);',
-        'user_pref("dom.min_background_timeout_value", 4);',
-        'user_pref("dom.timeout.throttling_delay", 4);'
+        'user_pref("dom.min_timeout_value", 0);',
+        'user_pref("dom.min_background_timeout_value", 0);',
+        'user_pref("dom.timeout.throttling_delay", 0);'
     ];
 
     if (marionettePort) {

--- a/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
+++ b/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
@@ -47,9 +47,13 @@ async function generatePreferences (profileDir: string, { marionettePort, config
         'user_pref("devtools.toolbox.host", "window");',
         'user_pref("devtools.toolbox.previousHost", "bottom");',
         'user_pref("signon.rememberSignons", false);',
-        'user_pref("dom.min_timeout_value", 0);',
-        'user_pref("dom.min_background_timeout_value", 0);',
-        'user_pref("dom.timeout.throttling_delay", 0);'
+        // NOTE: dom.min_background_timeout_value should be equal to dom.min_timeout_value
+        'user_pref("dom.min_background_timeout_value", 4);',
+        'user_pref("dom.timeout.throttling_delay", 0);',
+        'user_pref("dom.timeout.budget_throttling_max_delay", 0);',
+        // NOTE: We set the foreground configuration for the background budget throttling parameters
+        'user_pref("dom.timeout.background_throttling_max_budget", -1);',
+        'user_pref("dom.timeout.background_budget_regeneration_rate", 1);'
     ];
 
     if (marionettePort) {

--- a/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
+++ b/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
@@ -46,7 +46,9 @@ async function generatePreferences (profileDir: string, { marionettePort, config
         'user_pref("extensions.shield-recipe-client.startupExperimentPrefs.browser.newtabpage.activity-stream.enabled", false);',
         'user_pref("devtools.toolbox.host", "window");',
         'user_pref("devtools.toolbox.previousHost", "bottom");',
-        'user_pref("signon.rememberSignons", false);'
+        'user_pref("signon.rememberSignons", false);',
+        'user_pref("dom.min_background_timeout_value", 4);',
+        'user_pref("dom.timeout.throttling_delay", 4);'
     ];
 
     if (marionettePort) {


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Fix testing page freezing when Firefox window is hidden behind another window.

## Approach
Decrease `dom.min_background_timeout_value` and `dom.timeout.throttling_delay` options to 4ms in a Firefox profile. The default values are 10s and 30s respectively.

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
