### PR TITLE
Add capability to use 'allowMultipleWindows' option in headless browsers (close #4770)

### DIFF
--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -302,7 +302,7 @@ export default class BrowserConnection extends EventEmitter {
     }
 
     // API
-    public runInitScript (code: string): Promise<void> {
+    public async runInitScript (code: string): Promise<string | unknown> {
         return new Promise(resolve => this.initScriptsQueue.push({ code, resolve }));
     }
 

--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -302,7 +302,7 @@ export default class BrowserConnection extends EventEmitter {
     }
 
     // API
-    public async runInitScript (code: string): Promise<string | unknown> {
+    public runInitScript (code: string): Promise<string | unknown> {
         return new Promise(resolve => this.initScriptsQueue.push({ code, resolve }));
     }
 

--- a/src/browser/provider/built-in/dedicated/base.js
+++ b/src/browser/provider/built-in/dedicated/base.js
@@ -8,6 +8,16 @@ export default {
 
     isMultiBrowser: false,
 
+    supportMultipleWindows: true,
+
+    getActiveWindowId (browserId) {
+        return this.openedBrowsers[browserId].activeWindowId;
+    },
+
+    setActiveWindowId (browserId, val) {
+        this.openedBrowsers[browserId].activeWindowId = val;
+    },
+
     _getConfig () {
         throw new Error('Not implemented');
     },

--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -7,7 +7,6 @@ import { start as startLocalChrome, stop as stopLocalChrome } from './local-chro
 import * as cdp from './cdp';
 import { GET_WINDOW_DIMENSIONS_INFO_SCRIPT } from '../../../utils/client-functions';
 
-
 const MIN_AVAILABLE_DIMENSION = 50;
 
 export default {
@@ -40,7 +39,11 @@ export default {
 
         await this.waitForConnectionReady(browserId);
 
-        runtimeInfo.viewportSize = await this.runInitScript(browserId, GET_WINDOW_DIMENSIONS_INFO_SCRIPT);
+        runtimeInfo.viewportSize   = await this.runInitScript(browserId, GET_WINDOW_DIMENSIONS_INFO_SCRIPT);
+        runtimeInfo.activeWindowId = null;
+
+        if (allowMultipleWindows)
+            runtimeInfo.activeWindowId = await this.calculateWindowId(browserId);
 
         await cdp.createClient(runtimeInfo);
 

--- a/src/browser/provider/built-in/dedicated/firefox/index.js
+++ b/src/browser/provider/built-in/dedicated/firefox/index.js
@@ -30,7 +30,7 @@ export default {
         }
     },
 
-    async openBrowser (browserId, pageUrl, configString) {
+    async openBrowser (browserId, pageUrl, configString, allowMultipleWindows) {
         const runtimeInfo = await getRuntimeInfo(configString);
 
         runtimeInfo.browserName = this._getBrowserName();
@@ -39,6 +39,11 @@ export default {
         await startLocalFirefox(pageUrl, runtimeInfo);
 
         await this.waitForConnectionReady(runtimeInfo.browserId);
+
+        runtimeInfo.activeWindowId = null;
+
+        if (allowMultipleWindows)
+            runtimeInfo.activeWindowId = await this.calculateWindowId(browserId);
 
         if (runtimeInfo.marionettePort)
             runtimeInfo.marionetteClient = await this._createMarionetteClient(runtimeInfo);

--- a/src/browser/provider/built-in/locally-installed.js
+++ b/src/browser/provider/built-in/locally-installed.js
@@ -1,10 +1,27 @@
 import browserTools from 'testcafe-browser-tools';
 
-
 export default {
+    openedBrowsers: {},
+
     isMultiBrowser: true,
 
-    async openBrowser (browserId, pageUrl, browserName) {
+    supportMultipleWindows: true,
+
+    needCleanUpBrowserInfo: true,
+
+    getActiveWindowId (browserId) {
+        return this.openedBrowsers[browserId].activeWindowId;
+    },
+
+    setActiveWindowId (browserId, val) {
+        this.openedBrowsers[browserId].activeWindowId = val;
+    },
+
+    cleanUpBrowserInfo (browserId) {
+        delete this.openedBrowsers[browserId];
+    },
+
+    async openBrowser (browserId, pageUrl, browserName, allowMultipleWindows) {
         const args  = browserName.split(' ');
         const alias = args.shift();
 
@@ -15,6 +32,13 @@ export default {
             openParameters.cmd = args.join(' ') + (openParameters.cmd ? ' ' + openParameters.cmd : '');
 
         await browserTools.open(openParameters, pageUrl);
+
+        let activeWindowId = null;
+
+        if (allowMultipleWindows)
+            activeWindowId = await this.calculateWindowId(browserId);
+
+        this.openedBrowsers[browserId] = { activeWindowId };
     },
 
     async isLocalBrowser () {

--- a/src/browser/provider/plugin-host.js
+++ b/src/browser/provider/plugin-host.js
@@ -4,7 +4,7 @@ import promisifyEvent from 'promisify-event';
 import BROWSER_JOB_RESULT from '../../runner/browser-job-result';
 import BrowserConnection from '../connection';
 import WARNING_MESSAGE from '../../notifications/warning-message';
-
+import { GET_WINDOW_ID_SCRIPT } from '../provider/utils/client-functions';
 
 const name = Symbol();
 
@@ -23,10 +23,14 @@ export default class BrowserProviderPluginHost {
         return this[name];
     }
 
-    runInitScript (browserId, code) {
+    async runInitScript (browserId, code) {
         const connection = BrowserConnection.getById(browserId);
 
         return connection.runInitScript(`(${code})()`);
+    }
+
+    async calculateWindowId (browserId) {
+        return this.runInitScript(browserId, GET_WINDOW_ID_SCRIPT);
     }
 
     waitForConnectionReady (browserId) {

--- a/test/functional/fixtures/regression/gh-1875/pages/index.html
+++ b/test/functional/fixtures/regression/gh-1875/pages/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>GH-1875</title>>
+        <title>GH-1875</title>
     </head>
     <body>
         <h1>GH-1875</h1>

--- a/test/functional/fixtures/run-options/allow-multiple-windows/pages/headless/child.html
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/pages/headless/child.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Child page</title>
+</head>
+<body>
+    <h1>Child page</h1>
+</body>
+</html>

--- a/test/functional/fixtures/run-options/allow-multiple-windows/pages/headless/index.html
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/pages/headless/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Index page</title>
+</head>
+<body>
+    <h1>Index page</h1>
+    <a href="child.html" target="_blank">Open child page</a>
+</body>
+</html>

--- a/test/functional/fixtures/run-options/allow-multiple-windows/test.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/test.js
@@ -1,4 +1,6 @@
-const { expect } = require('chai');
+const { expect }     = require('chai');
+const createTestCafe = require('../../../../../lib');
+const path           = require('path');
 
 describe('Allow multiple windows', () => {
     describe('Switch to the child window', () => {
@@ -45,5 +47,23 @@ describe('Allow multiple windows', () => {
 
     it('Close the window immediately after opening (GH-3762)', () => {
         return runTests('testcafe-fixtures/close-window-immediately-after-opeping.js', null, { allowMultipleWindows: true });
+    });
+
+    it('headless', () => {
+        return createTestCafe('127.0.0.1', 1335, 1336)
+            .then(tc => {
+                testCafe = tc;
+            })
+            .then(() => {
+                const fullTestPath = path.join(__dirname, './testcafe-fixtures/headless.js');
+
+                return testCafe.createRunner()
+                    .browsers(`chrome:headless`)
+                    .src(fullTestPath)
+                    .run({ allowMultipleWindows: true });
+            })
+            .then(() => {
+                return testCafe.close();
+            });
     });
 });

--- a/test/functional/fixtures/run-options/allow-multiple-windows/testcafe-fixtures/headless.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/testcafe-fixtures/headless.js
@@ -1,0 +1,6 @@
+fixture `Fixture`
+    .page('http://localhost:3000/fixtures/run-options/allow-multiple-windows/pages/headless/index.html');
+
+test('test', async t => {
+    await t.click('a');
+});


### PR DESCRIPTION
I need to know the possibility of using the `allowMultipleWindows` option before running tests.
If this option is not supported for the used browser, we show a clear error message.

https://github.com/DevExpress/testcafe/blob/5b4979d60ced70c54e7e331847c60d90ec8be3cb/src/runner/index.js#L337

I'm forced to move calculation of the `windowId` parameter to the `plugin.openBrowser` method because of this parameter is calculated for headless browsers only after validation procedure.

I've run tests for `allowMultipleWindow` option with chrome, chrome:headless, firefox, firefox:headless, edge, edge:headless, ie, safari and all works fine.

