### PR TITLE
wait until reporter of last test in fixture is completed before new fixture starts (closes #4787)

### DIFF
--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -89,12 +89,12 @@ export default class Reporter {
             reportItem     = this.reportQueue.shift();
             currentFixture = reportItem.fixture;
 
-            await this.plugin.reportTestDone(reportItem.test.name, reportItem.testRunInfo, reportItem.test.meta);
-
             // NOTE: here we assume that tests are sorted by fixture.
             // Therefore, if the next report item has a different
             // fixture, we can report this fixture start.
             nextReportItem = this.reportQueue[0];
+
+            await this.plugin.reportTestDone(reportItem.test.name, reportItem.testRunInfo, reportItem.test.meta);
 
             if (nextReportItem && nextReportItem.fixture !== currentFixture)
                 await this.plugin.reportFixtureStart(nextReportItem.fixture.name, nextReportItem.fixture.path, nextReportItem.fixture.meta);

--- a/test/functional/fixtures/regression/gh-4787/pages/index.html
+++ b/test/functional/fixtures/regression/gh-4787/pages/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>gh-4787</title>
+</head>
+<body>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-4787/test.js
+++ b/test/functional/fixtures/regression/gh-4787/test.js
@@ -1,0 +1,72 @@
+const expect         = require('chai').expect;
+const path           = require('path');
+const createTestCafe = require('../../../../../lib');
+const config         = require('../../../config.js');
+const delay          = require('../../../../../lib/utils/delay');
+
+let cafe   = null;
+let runner = null;
+const log  = [];
+
+const expectedLog = [
+    'Fixture 1',
+    ...new Array(10).fill('Test 1'),
+    'Fixture 2',
+    ...new Array(10).fill('Test 2'),
+    'Fixture 3',
+    ...new Array(10).fill('Test 3'),
+];
+
+async function sleep () {
+    return delay(100);
+}
+
+function customReporter () {
+    return {
+        async reportTaskStart () {
+        },
+        async reportTaskDone () {
+        },
+        async reportFixtureStart (name) {
+            log.push(name);
+
+            await sleep();
+        },
+        async reportTestStart (name) {
+            log.push(name);
+
+            await sleep();
+        },
+        async reportTestDone (name) {
+            log.push(name);
+
+            await sleep();
+        }
+    };
+}
+
+if (config.useLocalBrowsers && !config.useHeadlessBrowsers) {
+    describe('[Regression](GH-4787) - Should wait for last report before new fixture starts', function () {
+        it('Should wait for last report before new fixture starts', function () {
+            return createTestCafe('127.0.0.1', 1335, 1336)
+                .then(testcafe => {
+                    runner = testcafe.createRunner();
+                    cafe   = testcafe;
+                })
+                .then(() => {
+                    return runner
+                        .src(path.join(__dirname, './testcafe-fixtures/index.js'))
+                        .browsers(['chrome', 'firefox'])
+                        .reporter(customReporter)
+                        .concurrency(2)
+                        .run();
+                })
+                .then(() => {
+                    return cafe.close();
+                })
+                .then(() => {
+                    expect(log).eql(expectedLog);
+                });
+        });
+    });
+}

--- a/test/functional/fixtures/regression/gh-4787/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-4787/testcafe-fixtures/index.js
@@ -1,0 +1,26 @@
+fixture `Fixture 1`
+    .page `http://localhost:3000/fixtures/regression/gh-4787/pages/index.html`;
+
+for (let i = 0; i < 5; i++) {
+    test('Test 1', async t => {
+        await t.wait(1000);
+    });
+}
+
+fixture `Fixture 2`
+    .page `http://localhost:3000/fixtures/regression/gh-4787/pages/index.html`;
+
+for (let i = 0; i < 5; i++) {
+    test('Test 2', async t => {
+        await t.wait(1000);
+    });
+}
+
+fixture `Fixture 3`
+    .page `http://localhost:3000/fixtures/regression/gh-4787/pages/index.html`;
+
+for (let i = 0; i < 5; i++) {
+    test('Test 3', async t => {
+        await t.wait(1000);
+    });
+}


### PR DESCRIPTION
The issue:
In general next test starts when the previous test executed the test body. The next test does not wait until the reporter of previous one is completed.
This leads to inconsistency, because the test from new fixture can start before the `reportTestDone` of previous test is completed. So, the new test emits the `test-run-start` event before the `fixture-start` event is raised.
