### PR TITLE
Provide test run IDs to reportTestStart (closes #4808)

### DIFF
--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -82,10 +82,6 @@ export default class Reporter {
         return find(this.reportQueue, i => i.test === testRun.test);
     }
 
-    _updateReportItem (reportItem, testRun) {
-        reportItem.testRunIds.push(testRun.id);
-    }
-
     async _shiftReportQueue (reportItem) {
         let currentFixture = null;
         let nextReportItem = null;
@@ -179,7 +175,7 @@ export default class Reporter {
         task.on('test-run-start', async testRun => {
             const reportItem = this._getReportItemForTestRun(testRun);
 
-            this._updateReportItem(reportItem, testRun);
+            reportItem.testRunIds.push(testRun.id);
 
             if (!reportItem.startTime)
                 reportItem.startTime = new Date();

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -186,7 +186,7 @@ export default class Reporter {
                 if (this.plugin.reportTestStart) {
                     const testStartInfo = { testRunIds: reportItem.testRunIds };
 
-                    await this.plugin.reportTestStart(reportItem.test.name, testStartInfo, reportItem.test.meta);
+                    await this.plugin.reportTestStart(reportItem.test.name, reportItem.test.meta, testStartInfo);
                 }
 
                 reportItem.pendingTestRunStartPromise.resolve();

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -440,13 +440,13 @@ describe('Reporter', () => {
                 args:   [
                     'fixture1test1',
                     {
+                        run: 'run-001'
+                    },
+                    {
                         testRunIds: [
                             'f1t1',
                             'f1t1'
                         ]
-                    },
-                    {
-                        run: 'run-001'
                     }
                 ]
             },
@@ -487,13 +487,13 @@ describe('Reporter', () => {
                 args:   [
                     'fixture1test2',
                     {
+                        run: 'run-001'
+                    },
+                    {
                         testRunIds: [
                             'f1t2',
                             'f1t2'
                         ]
-                    },
-                    {
-                        run: 'run-001'
                     }
                 ]
             },
@@ -551,13 +551,13 @@ describe('Reporter', () => {
                 args:   [
                     'fixture1test3',
                     {
+                        run: 'run-001'
+                    },
+                    {
                         testRunIds: [
                             'f1t3',
                             'f1t3'
                         ]
-                    },
-                    {
-                        run: 'run-001'
                     }
                 ]
             },
@@ -599,13 +599,13 @@ describe('Reporter', () => {
                 args:   [
                     'fixture2test1',
                     {
+                        run: 'run-001'
+                    },
+                    {
                         testRunIds: [
                             'f2t1',
                             'f2t1'
                         ]
-                    },
-                    {
-                        run: 'run-001'
                     }
                 ]
             },
@@ -637,13 +637,13 @@ describe('Reporter', () => {
                 args:   [
                     'fixture2test2',
                     {
+                        run: 'run-001'
+                    },
+                    {
                         testRunIds: [
                             'f2t2',
                             'f2t2'
                         ]
-                    },
-                    {
-                        run: 'run-001'
                     }
                 ]
             },
@@ -683,13 +683,13 @@ describe('Reporter', () => {
                 args:   [
                     'fixture3test1',
                     {
+                        run: 'run-001'
+                    },
+                    {
                         testRunIds: [
                             'f3t1',
                             'f3t1'
                         ]
-                    },
-                    {
-                        run: 'run-001'
                     }
                 ]
             },
@@ -727,13 +727,13 @@ describe('Reporter', () => {
                 args:   [
                     'fixture3test2',
                     {
+                        run: 'run-001'
+                    },
+                    {
                         testRunIds: [
                             'f3t2',
                             'f3t2'
                         ]
-                    },
-                    {
-                        run: 'run-001'
                     }
                 ]
             },
@@ -765,13 +765,13 @@ describe('Reporter', () => {
                 args:   [
                     'fixture3test3',
                     {
+                        run: 'run-001'
+                    },
+                    {
                         testRunIds: [
                             'f3t3',
                             'f3t3'
                         ]
-                    },
-                    {
-                        run: 'run-001'
                     }
                 ]
             },

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -126,6 +126,7 @@ describe('Reporter', () => {
     const chromeTestRunMocks = [
         //fixture1test1
         {
+            id:                'f1t1',
             test:              testMocks[0],
             unstable:          true,
             browserConnection: browserConnectionMocks[0],
@@ -138,6 +139,7 @@ describe('Reporter', () => {
 
         //fixture1test2
         {
+            id:                'f1t2',
             test:              testMocks[1],
             unstable:          false,
             browserConnection: browserConnectionMocks[0],
@@ -151,6 +153,7 @@ describe('Reporter', () => {
 
         //fixture1test3
         {
+            id:                'f1t3',
             test:              testMocks[2],
             unstable:          false,
             browserConnection: browserConnectionMocks[0],
@@ -160,6 +163,7 @@ describe('Reporter', () => {
 
         //fixture2test1
         {
+            id:                'f2t1',
             test:              testMocks[3],
             unstable:          false,
             browserConnection: browserConnectionMocks[0],
@@ -169,6 +173,7 @@ describe('Reporter', () => {
 
         //fixture2test2
         {
+            id:                'f2t2',
             test:              testMocks[4],
             unstable:          false,
             browserConnection: browserConnectionMocks[0],
@@ -178,6 +183,7 @@ describe('Reporter', () => {
 
         //fixture3test1
         {
+            id:                'f3t1',
             test:              testMocks[5],
             unstable:          false,
             browserConnection: browserConnectionMocks[0],
@@ -187,6 +193,7 @@ describe('Reporter', () => {
 
         //fixture3test2
         {
+            id:                'f3t2',
             test:              testMocks[6],
             unstable:          true,
             browserConnection: browserConnectionMocks[1],
@@ -196,6 +203,7 @@ describe('Reporter', () => {
 
         //fixture3test3
         {
+            id:                'f3t3',
             test:              testMocks[7],
             unstable:          true,
             browserConnection: browserConnectionMocks[1],
@@ -207,6 +215,7 @@ describe('Reporter', () => {
     const firefoxTestRunMocks = [
         //fixture1test1
         {
+            id:                'f1t1',
             test:              testMocks[0],
             unstable:          true,
             browserConnection: browserConnectionMocks[1],
@@ -219,6 +228,7 @@ describe('Reporter', () => {
 
         // 'fixture1test2
         {
+            id:                'f1t2',
             test:              testMocks[1],
             unstable:          false,
             browserConnection: browserConnectionMocks[1],
@@ -228,6 +238,7 @@ describe('Reporter', () => {
 
         //fixture1test3
         {
+            id:                'f1t3',
             test:              testMocks[2],
             unstable:          false,
             browserConnection: browserConnectionMocks[1],
@@ -237,6 +248,7 @@ describe('Reporter', () => {
 
         //fixture2test1
         {
+            id:                'f2t1',
             test:              testMocks[3],
             unstable:          false,
             browserConnection: browserConnectionMocks[1],
@@ -246,6 +258,7 @@ describe('Reporter', () => {
 
         //fixture2test2
         {
+            id:                'f2t2',
             test:              testMocks[4],
             unstable:          false,
             browserConnection: browserConnectionMocks[1],
@@ -255,6 +268,7 @@ describe('Reporter', () => {
 
         //fixture3test1
         {
+            id:                'f3t1',
             test:              testMocks[5],
             unstable:          true,
             browserConnection: browserConnectionMocks[1],
@@ -264,6 +278,7 @@ describe('Reporter', () => {
 
         //fixture3test2
         {
+            id:                'f3t2',
             test:              testMocks[6],
             unstable:          true,
             browserConnection: browserConnectionMocks[1],
@@ -273,6 +288,7 @@ describe('Reporter', () => {
 
         //fixture3test3
         {
+            id:                'f3t3',
             test:              testMocks[7],
             unstable:          true,
             browserConnection: browserConnectionMocks[1],
@@ -424,6 +440,12 @@ describe('Reporter', () => {
                 args:   [
                     'fixture1test1',
                     {
+                        testRunIds: [
+                            'f1t1',
+                            'f1t1'
+                        ]
+                    },
+                    {
                         run: 'run-001'
                     }
                 ]
@@ -464,6 +486,12 @@ describe('Reporter', () => {
                 method: 'reportTestStart',
                 args:   [
                     'fixture1test2',
+                    {
+                        testRunIds: [
+                            'f1t2',
+                            'f1t2'
+                        ]
+                    },
                     {
                         run: 'run-001'
                     }
@@ -523,6 +551,12 @@ describe('Reporter', () => {
                 args:   [
                     'fixture1test3',
                     {
+                        testRunIds: [
+                            'f1t3',
+                            'f1t3'
+                        ]
+                    },
+                    {
                         run: 'run-001'
                     }
                 ]
@@ -565,6 +599,12 @@ describe('Reporter', () => {
                 args:   [
                     'fixture2test1',
                     {
+                        testRunIds: [
+                            'f2t1',
+                            'f2t1'
+                        ]
+                    },
+                    {
                         run: 'run-001'
                     }
                 ]
@@ -596,6 +636,12 @@ describe('Reporter', () => {
                 method: 'reportTestStart',
                 args:   [
                     'fixture2test2',
+                    {
+                        testRunIds: [
+                            'f2t2',
+                            'f2t2'
+                        ]
+                    },
                     {
                         run: 'run-001'
                     }
@@ -637,6 +683,12 @@ describe('Reporter', () => {
                 args:   [
                     'fixture3test1',
                     {
+                        testRunIds: [
+                            'f3t1',
+                            'f3t1'
+                        ]
+                    },
+                    {
                         run: 'run-001'
                     }
                 ]
@@ -675,6 +727,12 @@ describe('Reporter', () => {
                 args:   [
                     'fixture3test2',
                     {
+                        testRunIds: [
+                            'f3t2',
+                            'f3t2'
+                        ]
+                    },
+                    {
                         run: 'run-001'
                     }
                 ]
@@ -706,6 +764,12 @@ describe('Reporter', () => {
                 method: 'reportTestStart',
                 args:   [
                     'fixture3test3',
+                    {
+                        testRunIds: [
+                            'f3t3',
+                            'f3t3'
+                        ]
+                    },
                     {
                         run: 'run-001'
                     }


### PR DESCRIPTION
The current signature of the `reportTestStart` method is following:
```JS
async reportTestStart (name, meta)
```
and the signature of the `reportTestDone` method is following: 
```JS
async reportTestDone (name, testRunInfo, meta)
```
I propose to make a BC and add the second argument to the `reportTestStart` method. It will be consistent to `reportTestDone`. We can call this argument as `testRunInfo` as well, because it will contain ids of all testRun which will be executed during the test execution.
```JS
async reportTestStart (name, testRunInfo, meta)
```
The `testRunInfo` object after this PR will look like the following:
```JS
{
    testRunIds: ['id1', 'id2']
}
```
We cannot name this field `ids` since it will be not clear enough, so it is `testRunIds`