### PR TITLE
Provide all structure objects info in reportTaskStart (closes #4807)

### DIFF
--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -167,7 +167,7 @@ export default class Reporter {
             const userAgents = task.browserConnectionGroups.map(group => group[0].userAgent);
             const first      = this.reportQueue[0];
 
-            await this.plugin.reportTaskStart(startTime, userAgents, this.testCount);
+            await this.plugin.reportTaskStart(startTime, userAgents, this.testCount, task.testStructure);
             await this.plugin.reportFixtureStart(first.fixture.name, first.fixture.path, first.fixture.meta);
         });
 

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -1,6 +1,7 @@
 const { expect }        = require('chai');
 const { chunk, random } = require('lodash');
 const Reporter          = require('../../lib/reporter');
+const Task              = require('../../lib/runner/task');
 const AsyncEventEmitter = require('../../lib/utils/async-event-emitter');
 const delay             = require('../../lib/utils/delay');
 
@@ -319,6 +320,8 @@ describe('Reporter', () => {
                     'warning3'
                 ]
             };
+
+            this.testStructure = Task.prototype._prepareTestStructure.call(this, testMocks);
         }
     }
 

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -2,7 +2,6 @@ const { expect }        = require('chai');
 const { chunk, random } = require('lodash');
 const Reporter          = require('../../lib/reporter');
 const Task              = require('../../lib/runner/task');
-const AsyncEventEmitter = require('../../lib/utils/async-event-emitter');
 const delay             = require('../../lib/utils/delay');
 
 describe('Reporter', () => {
@@ -16,29 +15,37 @@ describe('Reporter', () => {
 
     const fixtureMocks = [
         {
-            name: 'fixture1',
-            path: './file1.js',
-            meta: {
+            id:      'fid1',
+            pageUrl: 'furl1',
+            name:    'fixture1',
+            path:    './file1.js',
+            meta:    {
                 run: 'run-001'
             }
         },
         {
-            name: 'fixture2',
-            path: './file1.js',
-            meta: {
+            id:      'fid2',
+            pageUrl: 'furl2',
+            name:    'fixture2',
+            path:    './file1.js',
+            meta:    {
                 run: 'run-002'
             }
         },
         {
-            name: 'fixture3',
-            path: './file2.js',
-            meta: null
+            id:      'fid3',
+            pageUrl: 'furl3',
+            name:    'fixture3',
+            path:    './file2.js',
+            meta:    null
         }
     ];
 
     const testMocks = [
         {
+            id:          'idf1t1',
             name:        'fixture1test1',
+            pageUrl:     'urlf1t1',
             fixture:     fixtureMocks[0],
             skip:        false,
             screenshots: [{
@@ -48,12 +55,15 @@ describe('Reporter', () => {
                 takenOnFail:       false,
                 quarantineAttempt: 2
             }],
-            meta: {
+            clientScripts: [],
+            meta:          {
                 run: 'run-001'
             }
         },
         {
+            id:          'idf1t2',
             name:        'fixture1test2',
+            pageUrl:     'urlf1t2',
             fixture:     fixtureMocks[0],
             skip:        false,
             screenshots: [{
@@ -69,55 +79,74 @@ describe('Reporter', () => {
                 takenOnFail:       true,
                 quarantineAttempt: null
             }],
-            meta: {
+            clientScripts: [],
+            meta:          {
                 run: 'run-001'
             }
         },
         {
-            name:    'fixture1test3',
-            skip:    false,
-            fixture: fixtureMocks[0],
-            meta:    {
+            id:            'idf1t3',
+            name:          'fixture1test3',
+            pageUrl:       'urlf1t3',
+            skip:          false,
+            fixture:       fixtureMocks[0],
+            clientScripts: [],
+            meta:          {
                 run: 'run-001'
             }
         },
         {
-            name:    'fixture2test1',
-            skip:    false,
-            fixture: fixtureMocks[1],
-            meta:    {
+            id:            'idf2t1',
+            name:          'fixture2test1',
+            pageUrl:       'urlf2t1',
+            skip:          false,
+            fixture:       fixtureMocks[1],
+            clientScripts: [],
+            meta:          {
                 run: 'run-001'
             }
         },
         {
-            name:    'fixture2test2',
-            skip:    false,
-            fixture: fixtureMocks[1],
-            meta:    {
+            id:            'idf2t2',
+            name:          'fixture2test2',
+            pageUrl:       'urlf2t2',
+            skip:          false,
+            fixture:       fixtureMocks[1],
+            clientScripts: [],
+            meta:          {
                 run: 'run-001'
             }
         },
         {
-            name:    'fixture3test1',
-            skip:    false,
-            fixture: fixtureMocks[2],
-            meta:    {
+            id:            'idf3t1',
+            name:          'fixture3test1',
+            pageUrl:       'urlf3t1',
+            skip:          false,
+            fixture:       fixtureMocks[2],
+            clientScripts: [],
+            meta:          {
                 run: 'run-001'
             }
         },
         {
-            name:    'fixture3test2',
-            skip:    true,
-            fixture: fixtureMocks[2],
-            meta:    {
+            id:            'idf3t2',
+            name:          'fixture3test2',
+            pageUrl:       'urlf3t2',
+            skip:          true,
+            fixture:       fixtureMocks[2],
+            clientScripts: [],
+            meta:          {
                 run: 'run-001'
             }
         },
         {
-            name:    'fixture3test3',
-            skip:    false,
-            fixture: fixtureMocks[2],
-            meta:    {
+            id:            'idf3t3',
+            name:          'fixture3test3',
+            pageUrl:       'urlf3t3',
+            skip:          false,
+            fixture:       fixtureMocks[2],
+            clientScripts: [],
+            meta:          {
                 run: 'run-001'
             }
         }
@@ -304,14 +333,11 @@ describe('Reporter', () => {
         }
     }
 
-    class TaskMock extends AsyncEventEmitter {
+    class TaskMock extends Task {
         constructor () {
-            super();
+            super(testMocks, chunk(browserConnectionMocks, 1), {}, { stopOnFirstFail: false });
 
-            this.tests                   = testMocks;
-            this.opts                    = { stopOnFirstFail: false };
-            this.browserConnectionGroups = chunk(browserConnectionMocks, 1);
-            this.screenshots             = new ScreenshotsMock();
+            this.screenshots = new ScreenshotsMock();
 
             this.warningLog = {
                 messages: [
@@ -320,8 +346,9 @@ describe('Reporter', () => {
                     'warning3'
                 ]
             };
+        }
 
-            this.testStructure = Task.prototype._prepareTestStructure.call(this, testMocks);
+        _createBrowserJobs () {
         }
     }
 
@@ -408,7 +435,87 @@ describe('Reporter', () => {
                         'Chrome',
                         'Firefox'
                     ],
-                    7
+                    7,
+                    [
+                        {
+                            fixture: {
+                                id:      'fid1',
+                                name:    'fixture1',
+                                pageUrl: 'furl1',
+                                path:    './file1.js',
+                                tests:   [
+                                    {
+                                        id:      'idf1t1',
+                                        name:    'fixture1test1',
+                                        pageUrl: 'urlf1t1',
+                                        skip:    false
+                                    },
+                                    {
+                                        id:      'idf1t2',
+                                        name:    'fixture1test2',
+                                        pageUrl: 'urlf1t2',
+                                        skip:    false,
+                                    },
+                                    {
+                                        id:      'idf1t3',
+                                        name:    'fixture1test3',
+                                        pageUrl: 'urlf1t3',
+                                        skip:    false
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            fixture: {
+                                id:      'fid2',
+                                name:    'fixture2',
+                                pageUrl: 'furl2',
+                                path:    './file1.js',
+                                tests:   [
+                                    {
+                                        id:      'idf2t1',
+                                        name:    'fixture2test1',
+                                        pageUrl: 'urlf2t1',
+                                        skip:    false
+                                    },
+                                    {
+                                        id:      'idf2t2',
+                                        name:    'fixture2test2',
+                                        pageUrl: 'urlf2t2',
+                                        skip:    false
+                                    }
+                                ]
+                            },
+                        },
+                        {
+                            fixture: {
+                                id:      'fid3',
+                                name:    'fixture3',
+                                pageUrl: 'furl3',
+                                path:    './file2.js',
+                                tests:   [
+                                    {
+                                        id:      'idf3t1',
+                                        name:    'fixture3test1',
+                                        pageUrl: 'urlf3t1',
+                                        skip:    false
+                                    },
+                                    {
+                                        id:      'idf3t2',
+                                        name:    'fixture3test2',
+                                        pageUrl: 'urlf3t2',
+                                        skip:    true
+                                    },
+                                    {
+                                        id:      'idf3t3',
+                                        name:    'fixture3test3',
+                                        pageUrl: 'urlf3t3',
+                                        skip:    false
+                                    }
+                                ]
+                            }
+                        }
+                    ]
                 ]
             },
             {


### PR DESCRIPTION
I propose the following format for testStructure:
```JS
            fixture: {
                id:      'fixtureId',
                name:    'fixtureName',
                pageUrl: 'pageUrl',
                path:    'path',
                tests:   [{
                        id:      'testId',
                        name:    'testName',
                        pageUrl: 'pageUrl',
                        skip:    true/false
                       },
                       { ... }, 
                       { ... }
                ]
            }
```
@aleks-pro please check if it fulfills your requirements.
At this moment in this PR the `testStructure` arg is the last argument of `reportTaskStart` method to prevent BC. However, I don't really like this approach. I think we can make one `options` object, or, at least, merge the `testCount` argument and `testStructure` argument, since both of the are about tests.

@miherlosev @AndreyBelym if you are agree with API please review this PR