### PR TITLE
[docs] Update Xvfb docs to latest Travis recommendation

### DIFF
--- a/docs/articles/documentation/continuous-integration/travis.md
+++ b/docs/articles/documentation/continuous-integration/travis.md
@@ -53,25 +53,23 @@ Install TestCafe [locally](../using-testcafe/installing-testcafe.md#local-instal
 
 Travis CI uses Ubuntu Server virtual machines that do not have regular graphical environment like Unity, GNOME or KDE installed, so you have to setup and use [Xvfb](https://www.x.org/archive/X11R7.6/doc/man/man1/Xvfb.1.xhtml) to run browsers headlessly.
 
-The following sections are required in your `.travis.yml` to start `Xvfb`:
+The following `.travis.yml` will run your `npm` tests using `Xvfb`:
 
 ```yaml
-dist: trusty
-sudo: required
+dist: bionic
 
 addons:
   firefox: latest
-  apt:
-    sources:
-     - google-chrome
-    packages:
-     - google-chrome-stable fluxbox
+  chrome: stable
 
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3
-  - fluxbox >/dev/null 2>&1 &
+services:
+  - xvfb
+
+language: node_js
+node_js: 'stable'
+
+script:
+  - xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" npm run test
 ```
 
 You can find more information about Travis and Xvfb in [this article](https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI).

--- a/docs/articles/documentation/continuous-integration/travis.md
+++ b/docs/articles/documentation/continuous-integration/travis.md
@@ -53,7 +53,7 @@ Install TestCafe [locally](../using-testcafe/installing-testcafe.md#local-instal
 
 Travis CI uses Ubuntu Server virtual machines that do not have regular graphical environment like Unity, GNOME or KDE installed, so you have to setup and use [Xvfb](https://www.x.org/archive/X11R7.6/doc/man/man1/Xvfb.1.xhtml) to run browsers headlessly.
 
-The following `.travis.yml` will run your `npm` tests using `Xvfb`:
+The following sections are required in your `.travis.yml` to start `Xvfb`:
 
 ```yaml
 dist: bionic
@@ -68,8 +68,9 @@ services:
 language: node_js
 node_js: 'stable'
 
-script:
-  - xvfb-run --auto-servernum --server-args="-screen 0 1024x768x24" npm run test
+before_script:
+  - fluxbox >/dev/null 2>&1 &
+  - sleep 3
 ```
 
 You can find more information about Travis and Xvfb in [this article](https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI).


### PR DESCRIPTION
## Purpose
xvfb docs are outdated; I tried the recommended docs but got errors; this config worked (https://github.com/internetarchive/bookreader/pull/208). Update to the recommended setup described in the [travis docs](https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui).

## Approach
- Use the xvfb service and chrome addon instead of manual install, as described in https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui
- Make .travis.yml snippet complete for optimal copypasta

## References
NA

## Pre-Merge TODO
- [NA] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
