### PR TITLE
The `onActionDone` method should take TestRunErrorFormattableAdapter instance instead of Error (closes #4867)

### DIFF
--- a/src/api/wrap-test-function.js
+++ b/src/api/wrap-test-function.js
@@ -2,12 +2,16 @@ import TestController from './test-controller';
 import testRunTracker from './test-run-tracker';
 import TestCafeErrorList from '../errors/error-list';
 import { MissingAwaitError } from '../errors/test-run';
+import TestRunErrorFormattableAdapter from '../errors/test-run/formattable-adapter';
+
 
 export default function wrapTestFunction (fn) {
     return async testRun => {
-        let result       = null;
-        const errList    = new TestCafeErrorList();
-        const markeredfn = testRunTracker.addTrackingMarkerToFunction(testRun.id, fn);
+        let result         = null;
+        let screenshotPath = null;
+        let executionError = null;
+        const errList      = new TestCafeErrorList();
+        const markeredfn   = testRunTracker.addTrackingMarkerToFunction(testRun.id, fn);
 
         testRun.controller = new TestController(testRun);
 
@@ -17,7 +21,10 @@ export default function wrapTestFunction (fn) {
             result = await markeredfn(testRun.controller);
         }
         catch (err) {
-            errList.addError(err);
+            if (err instanceof TestRunErrorFormattableAdapter)
+                executionError = err;
+            else
+                errList.addError(err);
         }
 
         if (!errList.hasUncaughtErrorsInTestCode) {
@@ -26,8 +33,14 @@ export default function wrapTestFunction (fn) {
             });
         }
 
-        if (errList.hasErrors)
-            throw errList;
+        if (errList.hasErrors) {
+            screenshotPath = executionError && executionError.screenshotPath;
+
+            await testRun.addErrorWithScreenshot(errList, screenshotPath);
+        }
+
+        if (testRun.errs.length)
+            throw testRun.errs;
 
         return result;
     };

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -134,11 +134,11 @@ export default class Reporter {
         reportItem.pendingTestRunDonePromise.resolve();
     }
 
-    _prepareReportTestActionEventArgs ({ command, result, testRun, errors }) {
+    _prepareReportTestActionEventArgs ({ command, result, testRun, err }) {
         const args = {};
 
-        if (errors)
-            args.errors = errors;
+        if (err)
+            args.err = err;
 
         return Object.assign(args, {
             testRunId: testRun.id,
@@ -214,9 +214,9 @@ export default class Reporter {
             }
         });
 
-        task.on('test-action-done', async ({ apiActionName, command, result, testRun, errors }) => {
+        task.on('test-action-done', async ({ apiActionName, command, result, testRun, err }) => {
             if (this.plugin.reportTestActionDone) {
-                const args = this._prepareReportTestActionEventArgs({ command, result, testRun, errors });
+                const args = this._prepareReportTestActionEventArgs({ command, result, testRun, err });
 
                 await this.plugin.reportTestActionDone(apiActionName, args);
             }

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -2,7 +2,6 @@ import { find, sortBy, union } from 'lodash';
 import { writable as isWritableStream } from 'is-stream';
 import ReporterPluginHost from './plugin-host';
 import formatCommand from './command/format-command';
-import TestCafeErrorList from '../errors/error-list';
 
 export default class Reporter {
     constructor (plugin, task, outStream, name) {
@@ -138,11 +137,8 @@ export default class Reporter {
     _prepareReportTestActionEventArgs ({ command, result, testRun, errors }) {
         const args = {};
 
-        if (errors) {
-            errors = errors instanceof TestCafeErrorList ? errors.items : [errors];
-
+        if (errors)
             args.errors = errors;
-        }
 
         return Object.assign(args, {
             testRunId: testRun.id,

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -695,5 +695,37 @@ describe('Reporter', () => {
         });
     });
 
+    it('Screenshot on action error', () => {
+        let testDoneErrors  = null;
+        let actionDoneError = null;
 
+        function screenshotReporter () {
+            return {
+                async reportTestActionDone (name, { err }) {
+                    actionDoneError = err;
+                },
+                async reportTaskStart () {
+                },
+                async reportFixtureStart () {
+                },
+                async reportTestDone (name, testRunInfo) {
+                    testDoneErrors = testRunInfo.errs;
+                },
+                async reportTaskDone () {
+                }
+            };
+        }
+
+        return runTests('testcafe-fixtures/index-test.js', 'Screenshot on action error', {
+            only:               'chrome',
+            reporter:           screenshotReporter,
+            screenshotsOnFails: true
+        })
+            .then(() => {
+                expect(actionDoneError.code).eql('E24');
+                expect(testDoneErrors.map(err => err.code)).eql(['E24', 'E8']);
+                expect(testDoneErrors[0].screenshotPath).is.not.empty;
+                expect(testDoneErrors[0].screenshotPath).eql(testDoneErrors[1].screenshotPath);
+            });
+    });
 });

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -528,11 +528,35 @@ describe('Reporter', () => {
         it('Complex nested command error', function () {
             const log = [];
 
-            return runTests('testcafe-fixtures/index-test.js', 'Complex nested command error', generateRunOptions(log))
+            return runTests('testcafe-fixtures/index-test.js', 'Complex nested command error', generateRunOptions(log, { includeTestInfo: true }))
                 .then(() => {
                     expect(log).eql([
-                        { name: 'useRole', action: 'start' },
-                        { name: 'click', action: 'start' },
+                        {
+                            name:    'useRole',
+                            action:  'start',
+                            fixture: {
+                                id:   'fixture-id',
+                                name: 'Reporter'
+                            },
+                            test: {
+                                id:    'test-id',
+                                name:  'Complex nested command error',
+                                phase: 'inTest'
+                            }
+                        },
+                        {
+                            name:    'click',
+                            action:  'start',
+                            fixture: {
+                                id:   'fixture-id',
+                                name: 'Reporter'
+                            },
+                            test: {
+                                id:    'test-id',
+                                name:  'Complex nested command error',
+                                phase: 'inRoleInitializer'
+                            }
+                        },
                         {
                             name:    'click',
                             action:  'done',
@@ -541,18 +565,14 @@ describe('Reporter', () => {
                                 selector: 'Selector(\'#non-existing-element\')',
                                 type:     'click'
                             },
-                            errors: ['E24']
-                        },
-                        {
-                            name:    'useRole',
-                            action:  'done',
-                            command: {
-                                role: {
-                                    loginPage: 'http://localhost:3000/fixtures/reporter/pages/index.html',
-                                    options:   {},
-                                    phase:     'initialized'
-                                },
-                                type: 'useRole'
+                            fixture: {
+                                id:   'fixture-id',
+                                name: 'Reporter'
+                            },
+                            test: {
+                                id:    'test-id',
+                                name:  'Complex nested command error',
+                                phase: 'inRoleInitializer'
                             },
                             errors: ['E24']
                         }

--- a/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
@@ -63,3 +63,9 @@ test('Client Function', async () => {
 test('Eval', async t => {
     await t.eval(() => document.getElementById('#target'));
 });
+
+test('Screenshot on action error', async t => {
+    t.click('body');
+
+    await t.click('#unexisting-element');
+});

--- a/test/server/data/test-controller-reporter-expected/index.js
+++ b/test/server/data/test-controller-reporter-expected/index.js
@@ -27,7 +27,7 @@ const typeTextOptions = Object.assign({
 
 module.exports = [
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'click',
         command: {
             options:  clickOptions,
@@ -35,18 +35,18 @@ module.exports = [
             type:     'click'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'rightClick',
         command: {
             options:  clickOptions,
@@ -54,18 +54,18 @@ module.exports = [
             type:     'right-click'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'doubleClick',
         command: {
             options:  clickOptions,
@@ -73,18 +73,18 @@ module.exports = [
             type:     'double-click'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'hover',
         command: {
             options:  mouseOptions,
@@ -92,18 +92,18 @@ module.exports = [
             type:     'hover'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'drag',
         command: {
             options:     mouseOptions,
@@ -113,18 +113,18 @@ module.exports = [
             type:        'drag'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'dragToElement',
         command: {
             options:             dragToElementOptions,
@@ -133,18 +133,18 @@ module.exports = [
             type:                'drag-to-element'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'typeText',
         command: {
             options:  typeTextOptions,
@@ -153,18 +153,18 @@ module.exports = [
             type:     'type-text'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'selectText',
         command: {
             options:  basicOptions,
@@ -174,18 +174,18 @@ module.exports = [
             type:     'select-text'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId:   'test-run-id',
+        testRunId:   'test_run_id',
         name: 'selectTextAreaContent',
 
         command: {
@@ -198,18 +198,18 @@ module.exports = [
             type:      'select-text-area-content'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'selectEditableContent',
         command: {
             options:       basicOptions,
@@ -218,18 +218,18 @@ module.exports = [
             type:          'select-editable-content'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'pressKey',
         command: {
             options: basicOptions,
@@ -237,18 +237,18 @@ module.exports = [
             type:    'press-key'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId:   'test-run-id',
+        testRunId:   'test_run_id',
         name: 'wait',
 
         command: {
@@ -256,36 +256,36 @@ module.exports = [
             timeout: 1
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'navigateTo',
         command: {
             type: 'navigate-to',
             url:  './index.html'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'setFilesToUpload',
         command: {
             selector: { expression:'Selector(\'#file\')' },
@@ -293,36 +293,36 @@ module.exports = [
             filePath: '../test.js'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'clearUpload',
         command: {
             selector: { expression:'Selector(\'#file\')' },
             type:     'clear-upload',
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'takeScreenshot',
         command: {
             path:     'screenshotPath',
@@ -330,18 +330,18 @@ module.exports = [
             type:     'take-screenshot',
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'takeElementScreenshot',
         command: {
             selector: { expression:'Selector(\'#target\')' },
@@ -350,18 +350,18 @@ module.exports = [
             options:  new ElementScreenshotOptions()
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'resizeWindow',
         command: {
             width:  200,
@@ -369,18 +369,18 @@ module.exports = [
             type:   'resize-window'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'resizeWindowToFitDevice',
         command: {
             device:  'Sony Xperia Z',
@@ -390,70 +390,70 @@ module.exports = [
             type:    'resize-window-to-fit-device'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'maximizeWindow',
         command: {
             type: 'maximize-window'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'switchToIframe',
         command: {
             selector: { expression:'Selector(\'#iframe\')' },
             type:     'switch-to-iframe'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'switchToMainWindow',
         command: {
             type: 'switch-to-main-window'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'setNativeDialogHandler',
         command: {
             dialogHandler: {
@@ -463,105 +463,105 @@ module.exports = [
             type: 'set-native-dialog-handler'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'getNativeDialogHistory',
         command: {
             type: 'get-native-dialog-history'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'getBrowserConsoleMessages',
         command: {
             type: 'get-browser-console-messages',
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'debug',
         command: {
             type: 'debug'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'setTestSpeed',
         command: {
             speed: 1,
             type:  'set-test-speed'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'setPageLoadTimeout',
         command: {
             duration: 1,
             type:     'set-page-load-timeout'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     },
     {
-        testRunId: 'test-run-id',
+        testRunId: 'test_run_id',
         name:    'useRole',
         command: {
             role: {
@@ -572,14 +572,14 @@ module.exports = [
             type: 'useRole'
         },
         test:    {
-            id:    'test-id',
-            name:  'test-name',
+            id:    'test_id',
+            name:  'test_name',
             phase: 'initial'
         },
         fixture: {
-            id:   'fixture-id',
-            name: 'fixture-name',
+            id:   'fixture_id',
+            name: 'fixture_name',
         },
-        browser: { alias: 'test-browser', headless: false }
+        browser: { alias: 'test_browser', headless: false }
     }
 ];

--- a/test/server/execute-async-expression-test.js
+++ b/test/server/execute-async-expression-test.js
@@ -20,6 +20,8 @@ function createTestRunMock () {
         this.controller      = new TestController(this);
         this.driverTaskQueue = [];
         this.emit            = noop;
+        this.once            = noop;
+        this.clearListeners  = noop;
         this.debugLogger     = debugLogger;
 
         this[markerSymbol] = true;

--- a/test/server/helpers/test-run-mock.js
+++ b/test/server/helpers/test-run-mock.js
@@ -1,0 +1,33 @@
+const TestRun = require('../../../lib/test-run');
+
+module.exports = class TestRunMock extends TestRun {
+    constructor (expectedError) {
+        super({ id: 'test_id', name: 'test_name', fixture: { path: 'dummy', id: 'fixture_id', name: 'fixture_name' } }, {}, {}, {}, {});
+
+        this.browserConnection = {
+            browserInfo: {
+                alias: 'test_browser'
+            },
+            isHeadlessBrowser: () => false
+        };
+
+        this.commands      = [];
+        this.expectedError = expectedError;
+    }
+
+    executeCommand (command) {
+        this.commands.push(command);
+
+        return this.expectedError ? Promise.reject(new Error(this.expectedError)) : Promise.resolve();
+    }
+
+    _addInjectables () {
+    }
+
+    _initRequestHooks () {
+    }
+
+    get id () {
+        return 'test_run_id';
+    }
+};

--- a/test/server/test-controller-events-test.js
+++ b/test/server/test-controller-events-test.js
@@ -1,6 +1,5 @@
 const expect                         = require('chai').expect;
 const AsyncEventEmitter              = require('../../lib/utils/async-event-emitter');
-const TestRun                        = require('../../lib/test-run');
 const TestController                 = require('../../lib/api/test-controller');
 const Task                           = require('../../lib/runner/task');
 const BrowserJob                     = require('../../lib/runner/browser-job');
@@ -8,34 +7,8 @@ const Reporter                       = require('../../lib/reporter');
 const { Role }                       = require('../../lib/api/exportable-lib');
 const wrapTestFunction               = require('../../lib/api/wrap-test-function');
 const TestRunErrorFormattableAdapter = require('../../lib/errors/test-run/formattable-adapter');
+const TestRunMock                    = require('./helpers/test-run-mock');
 
-class TestRunMock extends TestRun {
-    constructor () {
-        super({ id: 'test_id', name: 'test_name', fixture: { path: 'dummy', id: 'fixture_id', name: 'fixture_name' } }, {}, {}, {}, {});
-
-
-        this.browserConnection = {
-            browserInfo: {
-                alias: 'test_browser'
-            },
-            isHeadlessBrowser: () => false
-        };
-    }
-
-    _addInjectables () {
-    }
-
-    _initRequestHooks () {
-    }
-
-    get id () {
-        return 'test_run_id';
-    }
-
-    executeCommand () {
-        return Promise.resolve();
-    }
-}
 
 class TestControllerMock extends TestController {
     constructor (testRun) {
@@ -177,13 +150,13 @@ describe('TestController action events', () => {
 
     it('Error action', () => {
         let actionResult = null;
-        let err          = null;
+        let error        = null;
 
         initializeReporter({
-            async reportTestActionDone (name, { command, errors }) {
-                err = errors[0];
+            async reportTestActionDone (name, { command, err }) {
+                error = err;
 
-                actionResult = { name, command: command.type, err: errors[0].errMsg };
+                actionResult = { name, command: command.type, err: err.errMsg };
             }
         });
 
@@ -197,7 +170,7 @@ describe('TestController action events', () => {
 
         return testController.testRun._executeTestFn('', fn)
             .then(() => {
-                const isAdapter = err instanceof TestRunErrorFormattableAdapter;
+                const isAdapter = error instanceof TestRunErrorFormattableAdapter;
 
                 expect(isAdapter).to.be.true;
                 expect(actionResult).eql({ name: 'click', command: 'click', err: 'Error: test error' });

--- a/test/server/test-run-tracker-test.js
+++ b/test/server/test-run-tracker-test.js
@@ -8,7 +8,7 @@ describe('Test run tracker', function () {
     function runTest (testName) {
         const src         = 'test/server/data/test-run-tracking/' + testName;
         const compiler    = new Compiler([src]);
-        const testRunMock = { id: 'dB_J4h0H' };
+        const testRunMock = { id: 'dB_J4h0H', errs: [] };
         const expected    = fill(Array(3), testRunMock.id);
 
         return compiler.getTests()


### PR DESCRIPTION
The array of adapters is created when the `executeTestFn` function catches the error. When it happens we make the screenshot (if screenshot-on-fails is enabled), create adapters and store them into the `testRun.errs` property. After that we pass `testRun.errs` to the `reportTestDone` method.

Now we also need to pass the TestRunErrorFormattableAdapter to the `onActionDone`. So we need to create adapters on the `executeAction` method. In addition, we need to make screenshot on the `executeAction` method. So we need to catch the error on `executeAction`, create adapter and screenshot and rethrow the error to stop test execution. However, if we rethrow the error we will catch it again on `executeTestFn`. 
We know that some errors does not occur on the `executeAction` step, but occurs on `executeTestFn`, i.e. error in custom user's code. Thus we somehow need to detect if the error already was processed, and if it was not, we need to process it. I think it's a very bad idea to create adapters and screenshots in two places.
Moreover, we have one more layer of catching the errors - `wrapTestFunction`. Inside the `wrapTestFuncion` we catch execution errors and missing awaits, then create the `TestCafeErrorList` object and rethrow it.
Thus, inside the catch block of `executeTestFn` we catch the `TestCafeErrorList` object.

I think that it's better to leave creating adapters and making screenshots on fails as is, in one place: in the `executeTestFn`  catch block. So in this block I emit new `execution-error` event which can be handled inside the `executeAction` method.
