### PR TITLE
Fix the Firefox 74 "resizeWindowToFitDevice" (portrait orientation) test. Bump version (v1.8.3-rc.1)

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -8,7 +8,7 @@
     "gitTag": true
   },
   "confirm": true,
-  "publishTag": "alpha",
+  "publishTag": "rc",
   "prePublishScript": "gulp test-server",
   "postPublishScript": "gulp docker-publish"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.8.3-alpha.3",
+  "version": "1.8.3-rc.1",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"

--- a/test/functional/fixtures/api/es-next/resize-window/test.js
+++ b/test/functional/fixtures/api/es-next/resize-window/test.js
@@ -27,7 +27,7 @@ describe('[API] Resize window actions', function () {
                     .catch(function (errs) {
                         errorInEachBrowserContains(errs, 'A JavaScript error occurred on "http://localhost:3000/fixtures/api/es-next/resize-window/pages/index.html"', 0);
                         errorInEachBrowserContains(errs, 'Resize error', 0);
-                        errorInEachBrowserContains(errs, '> 70 |    await t.resizeWindow(500, 500);', 0);
+                        errorInEachBrowserContains(errs, '> 73 |    await t.resizeWindow(500, 500);', 0);
                     });
             });
         });
@@ -48,7 +48,7 @@ describe('[API] Resize window actions', function () {
                 })
                     .catch(function (errs) {
                         expect(errs[0]).to.contains('The "device" argument specifies an unsupported "iPhone555" device. For a list of supported devices, refer to "http://viewportsizes.com"');
-                        expect(errs[0]).to.contains(' > 64 |    await t.resizeWindowToFitDevice(\'iPhone555\');');
+                        expect(errs[0]).to.contains(' > 67 |    await t.resizeWindowToFitDevice(\'iPhone555\');');
                     });
             });
 
@@ -57,7 +57,7 @@ describe('[API] Resize window actions', function () {
                     .catch(function (errs) {
                         errorInEachBrowserContains(errs, 'A JavaScript error occurred on "http://localhost:3000/fixtures/api/es-next/resize-window/pages/index.html"', 0);
                         errorInEachBrowserContains(errs, 'Resize error', 0);
-                        errorInEachBrowserContains(errs, '> 76 |    await t.resizeWindowToFitDevice(\'iPhone\');', 0);
+                        errorInEachBrowserContains(errs, '> 79 |    await t.resizeWindowToFitDevice(\'iPhone\');', 0);
                     });
             });
         });

--- a/test/functional/fixtures/api/es-next/resize-window/testcafe-fixtures/resize-window-test.js
+++ b/test/functional/fixtures/api/es-next/resize-window/testcafe-fixtures/resize-window-test.js
@@ -53,10 +53,13 @@ test('Resize the window to fit a device', async t => {
 });
 
 test('Resize the window to fit a device with portrait orientation', async t => {
-    await t.resizeWindowToFitDevice('iPhone', { portraitOrientation: true });
+    // NOTE: Firefox 74 cannot set its width less than ~450px in both the headless and non-headless modes.
+    const iPadSize = { width: 1024, height: 768 };
 
-    expect(await getWindowWidth()).equals(iPhoneSize.height);
-    expect(await getWindowHeight()).equals(iPhoneSize.width);
+    await t.resizeWindowToFitDevice('iPad', { portraitOrientation: true });
+
+    expect(await getWindowWidth()).equals(iPadSize.height);
+    expect(await getWindowHeight()).equals(iPadSize.width);
 });
 
 


### PR DESCRIPTION
Firefox 74 cannot set its width less than ~450px in both the headless and non-headless modes:
![Capture](https://user-images.githubusercontent.com/30019338/76503822-96040680-6457-11ea-91e7-4650e77d9826.PNG)
