### PR TITLE
fix 'Should not finalize the "ExecuteSelectorCommand" command on driver starting' (close #4855) 

### DIFF
--- a/src/client/driver/status.js
+++ b/src/client/driver/status.js
@@ -6,14 +6,15 @@ export default class DriverStatus extends Assignable {
     constructor (obj) {
         super(obj);
 
-        this.id                       = generateId();
-        this.isCommandResult          = false;
-        this.executionError           = null;
-        this.pageError                = null;
-        this.resent                   = false;
-        this.result                   = null;
-        this.consoleMessages          = null;
-        this.isPendingWindowSwitching = false;
+        this.id                                 = generateId();
+        this.isCommandResult                    = false;
+        this.executionError                     = null;
+        this.pageError                          = null;
+        this.resent                             = false;
+        this.result                             = null;
+        this.consoleMessages                    = null;
+        this.isPendingWindowSwitching           = false;
+        this.isFirstRequestAfterWindowSwitching = false;
 
         this._assignFrom(obj, true);
     }
@@ -25,7 +26,8 @@ export default class DriverStatus extends Assignable {
             { name: 'pageError' },
             { name: 'result' },
             { name: 'consoleMessages' },
-            { name: 'isPendingWindowSwitching' }
+            { name: 'isPendingWindowSwitching' },
+            { name: 'isFirstRequestAfterWindowSwitching' }
         ];
     }
 }

--- a/test/functional/fixtures/run-options/allow-multiple-windows/pages/i4855/child.html
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/pages/i4855/child.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>i4855 - Child page</title>
+</head>
+<body>
+    <a href="http://localhost:3001/i4855">Open a self-closed page</a>
+</body>
+</html>

--- a/test/functional/fixtures/run-options/allow-multiple-windows/pages/i4855/index.html
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/pages/i4855/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>i4855 - Index page</title>
+</head>
+<body>
+    <!--
+        // NOTE: The problem is reproduced only for the following unstable scenario:
+        // - 'ExecuteSelectorCommand' is queried on the child page.
+        // - the child page is closed. At that moment, the result of the 'ExecuteSelectorCommand' was not sent to the server.
+        // - the parent page became a 'master' page and starts processing commands.
+        // - the initial command processing request on the new 'master' is interpreted as the 'ExecuteSelectorCommand'.
+        // This causes the crash down in the 'replicator' module.
+        // To create a stable reproducible example I am forced to guarantee that the result of the 'ExecuteSelectorCommand' isn't sent to the server.
+    -->
+    <a target="_blank" href="child.html">Open a new window</a><br/>
+    <span>Checked text</span>
+</body>
+</html>

--- a/test/functional/fixtures/run-options/allow-multiple-windows/test.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/test.js
@@ -72,4 +72,8 @@ describe('Allow multiple windows', () => {
                 return testCafe.close();
             });
     });
+
+    it("Should not finalize the 'ExecuteSelectorCommand' command on driver starting (GH-4855)", () => {
+        return runTests('testcafe-fixtures/i4855.js', null, { allowMultipleWindows: true });
+    });
 });

--- a/test/functional/fixtures/run-options/allow-multiple-windows/testcafe-fixtures/i4855.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/testcafe-fixtures/i4855.js
@@ -1,0 +1,11 @@
+import { Selector } from 'testcafe';
+
+fixture `Should not finalize the 'ExecuteSelectorCommand' command on driver starting (GH-4855)`
+    .page('http://localhost:3000/fixtures/run-options/allow-multiple-windows/pages/i4855/index.html');
+
+test('test', async t => {
+    await t
+        .click('a')
+        .click('a')
+        .expect(Selector('span').textContent).eql('Checked text');
+});

--- a/test/functional/site/server.js
+++ b/test/functional/site/server.js
@@ -69,6 +69,24 @@ Server.prototype._setupRoutes = function () {
         res.end(parsedUA.name);
     });
 
+    this.app.get('/i4855', (req, res) => {
+        res.send(`
+            <html>
+                <body>
+                    <script>
+                        var driver = window['%testCafeDriverInstance%'];
+
+                        driver._onExecuteSelectorCommand = function () {
+                            window.setTimeout(() =>{
+                                window.close();
+                            }, 1000);
+                        };
+                    </script>
+                </body>
+            </html>
+        `);
+    });
+
     this.app.get('*', function (req, res) {
         const reqPath      = req.params[0] || '';
         const resourcePath = path.join(server.basePath, reqPath);


### PR DESCRIPTION
The problem is reproduced only for the following unstable scenario:
 - 'ExecuteSelectorCommand' is queried on the child page.
 - the child page is closed. At that moment, the result of the 'ExecuteSelectorCommand' was not sent to the server.
 - the parent page became a 'master' page and starts processing commands.
 - the initial command processing request on the new 'master' is interpreted as the 'ExecuteSelectorCommand'.

This causes the crash down in the 'replicator' module.
To create a stable reproducible example I am forced to guarantee that the result of the 'ExecuteSelectorCommand' isn't sent to the server.