### PR TITLE
The `onActionDone` method should take TestRunErrorFormattableAdapter instance instead of Error (closes #4867)

### DIFF
--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -2,7 +2,6 @@ import { find, sortBy, union } from 'lodash';
 import { writable as isWritableStream } from 'is-stream';
 import ReporterPluginHost from './plugin-host';
 import formatCommand from './command/format-command';
-import TestCafeErrorList from '../errors/error-list';
 
 export default class Reporter {
     constructor (plugin, task, outStream, name) {
@@ -135,14 +134,11 @@ export default class Reporter {
         reportItem.pendingTestRunDonePromise.resolve();
     }
 
-    _prepareReportTestActionEventArgs ({ command, result, testRun, errors }) {
+    _prepareReportTestActionEventArgs ({ command, result, testRun, err }) {
         const args = {};
 
-        if (errors) {
-            errors = errors instanceof TestCafeErrorList ? errors.items : [errors];
-
-            args.errors = errors;
-        }
+        if (err)
+            args.err = err;
 
         return Object.assign(args, {
             testRunId: testRun.id,
@@ -218,9 +214,9 @@ export default class Reporter {
             }
         });
 
-        task.on('test-action-done', async ({ apiActionName, command, result, testRun, errors }) => {
+        task.on('test-action-done', async ({ apiActionName, command, result, testRun, err }) => {
             if (this.plugin.reportTestActionDone) {
-                const args = this._prepareReportTestActionEventArgs({ command, result, testRun, errors });
+                const args = this._prepareReportTestActionEventArgs({ command, result, testRun, err });
 
                 await this.plugin.reportTestActionDone(apiActionName, args);
             }

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -301,6 +301,9 @@ export default class TestRun extends AsyncEventEmitter {
 
             return false;
         }
+        finally {
+            this.errScreenshotPath = null;
+        }
 
         return !this._addPendingPageErrorIfAny();
     }

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -861,9 +861,9 @@ export default class TestRun extends AsyncEventEmitter {
             await this.emit('action-start', { command, apiActionName });
     }
 
-    async emitActionDone (apiActionName, command, result, errors) {
+    async emitActionDone (apiActionName, command, result, err) {
         if (!this.preventEmitActionEvents)
-            await this.emit('action-done', { command, apiActionName, result, errors });
+            await this.emit('action-done', { command, apiActionName, result, err });
     }
 }
 

--- a/test/functional/fixtures/reporter/reporter.js
+++ b/test/functional/fixtures/reporter/reporter.js
@@ -48,7 +48,7 @@ function generateReporter (log, options = {}) {
                 log.push(item);
             },
 
-            async reportTestActionDone (name, { command, test, fixture, errors }) {
+            async reportTestActionDone (name, { command, test, fixture, err }) {
                 if (!emitOnDone)
                     return;
 
@@ -57,8 +57,8 @@ function generateReporter (log, options = {}) {
 
                 const item = { name, action: 'done', command };
 
-                if (errors && errors.length)
-                    item.errors = errors.map(err => err.code);
+                if (err)
+                    item.err = err.code;
 
                 if (includeTestInfo) {
                     if (test.id) {

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -553,8 +553,7 @@ describe('Reporter', () => {
                                     phase:     'initialized'
                                 },
                                 type: 'useRole'
-                            },
-                            errors: [ void 0 ] // TODO: investigate
+                            }
                         }
                     ]);
                 });

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -308,7 +308,7 @@ describe('Reporter', () => {
                                 options:  new ClickOptions(),
                                 selector: 'Selector(\'#non-existing-target\')'
                             },
-                            errors: ['E24']
+                            err: 'E24'
                         }
                     ]);
                 });
@@ -541,7 +541,7 @@ describe('Reporter', () => {
                                 selector: 'Selector(\'#non-existing-element\')',
                                 type:     'click'
                             },
-                            errors: ['E24']
+                            err: 'E24'
                         },
                         {
                             name:    'useRole',
@@ -676,13 +676,13 @@ describe('Reporter', () => {
 
     describe('Screenshot errors', () => {
         it('Screenshot on action error', () => {
-            let testDoneErrors  = null;
+            let testDoneErrors     = null;
             const actionDoneErrors = [];
 
             function screenshotReporter () {
                 return {
-                    async reportTestActionDone (name, { errors }) {
-                        actionDoneErrors.push(errors);
+                    async reportTestActionDone (name, { err }) {
+                        actionDoneErrors.push(err);
                     },
                     async reportTaskStart () {
                     },
@@ -703,7 +703,7 @@ describe('Reporter', () => {
             })
                 .then(() => {
                     expect(actionDoneErrors[0]).is.undefined;
-                    expect(actionDoneErrors[1][0].code).eql('E24');
+                    expect(actionDoneErrors[1].code).eql('E24');
                     expect(testDoneErrors.map(err => err.code)).eql(['E24', 'E8']);
                     expect(testDoneErrors[0].screenshotPath).is.not.empty;
                     expect(testDoneErrors[0].screenshotPath).eql(testDoneErrors[1].screenshotPath);

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -554,7 +554,7 @@ describe('Reporter', () => {
                                 },
                                 type: 'useRole'
                             },
-                            errors: ['E24']
+                            errors: [ void 0 ] // TODO: investigate
                         }
                     ]);
                 });
@@ -675,5 +675,40 @@ describe('Reporter', () => {
         });
     });
 
+    describe('Screenshot errors', () => {
+        it('Screenshot on action error', () => {
+            let testDoneErrors  = null;
+            const actionDoneErrors = [];
 
+            function screenshotReporter () {
+                return {
+                    async reportTestActionDone (name, { errors }) {
+                        actionDoneErrors.push(errors);
+                    },
+                    async reportTaskStart () {
+                    },
+                    async reportFixtureStart () {
+                    },
+                    async reportTestDone (name, testRunInfo) {
+                        testDoneErrors = testRunInfo.errs;
+                    },
+                    async reportTaskDone () {
+                    }
+                };
+            }
+
+            return runTests('testcafe-fixtures/index-test.js', 'Screenshot on action error', {
+                only:               'chrome',
+                reporter:           screenshotReporter,
+                screenshotsOnFails: true
+            })
+                .then(() => {
+                    expect(actionDoneErrors[0]).is.undefined;
+                    expect(actionDoneErrors[1][0].code).eql('E24');
+                    expect(testDoneErrors.map(err => err.code)).eql(['E24', 'E8']);
+                    expect(testDoneErrors[0].screenshotPath).is.not.empty;
+                    expect(testDoneErrors[0].screenshotPath).eql(testDoneErrors[1].screenshotPath);
+                });
+        });
+    });
 });

--- a/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
@@ -63,3 +63,9 @@ test('Client Function', async () => {
 test('Eval', async t => {
     await t.eval(() => document.getElementById('#target'));
 });
+
+test('Screenshot on action error', async t => {
+    t.hover('body');
+
+    await t.click('#unexisting-element');
+});

--- a/test/server/test-controller-events-test.js
+++ b/test/server/test-controller-events-test.js
@@ -179,9 +179,9 @@ describe('TestController action events', () => {
         let errorAdapter = null;
 
         initializeReporter({
-            async reportTestActionDone (name, { command, errors }) {
-                errorAdapter = errors[0];
-                actionResult = { name, command: command.type, err: errors[0].errMsg };
+            async reportTestActionDone (name, { command, err }) {
+                errorAdapter = err;
+                actionResult = { name, command: command.type, err: err.errMsg };
             }
         });
 


### PR DESCRIPTION
This is the third attempt to write clean code for adapters.
In this version logic in more linear than in the first one.
The important moment is that we create a separate adapter for the `action-done` methods. Thus `testRunInfo.errs[0]` from `test-run-done` !== `err` from 'action-done'.
I think it does not really matter, since adapter is only service wrapper above the real error.

In addition,  the `errors` array param on `action-done` became just `err` param, because action should have only one error. 