### PR TITLE
fix mocha for functional tests

### DIFF
--- a/test/functional/fixtures/run-options/stop-on-first-fail/test.js
+++ b/test/functional/fixtures/run-options/stop-on-first-fail/test.js
@@ -13,7 +13,17 @@ const getTestRunCount = () => {
 
 describe('Stop test task on first failed test', () => {
     afterEach(() => {
-        fs.unlinkSync(TEST_RUN_COUNT_FILENAME);
+        try {
+            // NOTE: after mocha is updated to `^7.1.1` the `afterEach` hook is called if the test is skipped/pending
+            // before the update the `afterEach` hook was not called.
+            // When we run the test not in `chrome` the file will not exist, since we have the { only: 'chrome' } option,
+            // so we cannot unlink it.
+            fs.unlinkSync(TEST_RUN_COUNT_FILENAME);
+        }
+        /*eslint-disable no-empty */
+        catch (err) {
+        }
+        /*eslint-disable no-empty */
     });
 
     it('Basic', () => {

--- a/test/functional/fixtures/run-options/stop-on-first-fail/test.js
+++ b/test/functional/fixtures/run-options/stop-on-first-fail/test.js
@@ -13,17 +13,12 @@ const getTestRunCount = () => {
 
 describe('Stop test task on first failed test', () => {
     afterEach(() => {
-        try {
-            // NOTE: after mocha is updated to `^7.1.1` the `afterEach` hook is called if the test is skipped/pending
-            // before the update the `afterEach` hook was not called.
-            // When we run the test not in `chrome` the file will not exist, since we have the { only: 'chrome' } option,
-            // so we cannot unlink it.
+        // NOTE: after mocha is updated to `^7.1.1` the `afterEach` hook is called if the test is skipped/pending
+        // before the update the `afterEach` hook was not called.
+        // When we run the test not in `chrome` the file will not exist, since we have the { only: 'chrome' } option,
+        // so we cannot unlink it.
+        if (fs.existsSync(TEST_RUN_COUNT_FILENAME))
             fs.unlinkSync(TEST_RUN_COUNT_FILENAME);
-        }
-        /*eslint-disable no-empty */
-        catch (err) {
-        }
-        /*eslint-disable no-empty */
     });
 
     it('Basic', () => {

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -230,7 +230,8 @@ before(function () {
                 });
 
                 if (!actualBrowsers.length) {
-                    mocha.test.skip();
+                    global.currentTest.skip();
+
                     return Promise.resolve();
                 }
 
@@ -299,6 +300,10 @@ before(function () {
                     .catch(handleError);
             };
         });
+});
+
+beforeEach(function () {
+    global.currentTest = this.currentTest;
 });
 
 after(function () {


### PR DESCRIPTION
ISSUE 1
we need to add beforeEach mocha hook to get the current executing test
ISSUE 2
after mocha is updated to `^7.1.1` the `afterEach` hook is called if the test is skipped/pending before the update the `afterEach` hook was not called. When we run the test not in `chrome` the file will not exist, since we have the { only: 'chrome' } option, so we cannot unlink it.