### PR TITLE
report only modified options in reportActionDone(closes #4926)

### DIFF
--- a/src/reporter/command/command-formatter.ts
+++ b/src/reporter/command/command-formatter.ts
@@ -1,14 +1,16 @@
+import { isEmpty } from 'lodash';
 import { ExecuteSelectorCommand, ExecuteClientFunctionCommand } from '../../test-run/commands/observation';
 import { NavigateToCommand, SetNativeDialogHandlerCommand, UseRoleCommand } from '../../test-run/commands/actions';
 import { createReplicator, SelectorNodeTransform } from '../../client-functions/replicator';
 import { Command, FormattedCommand, SelectorInfo } from './interfaces';
+import diff from '../../utils/diff';
+
 import {
     ActionOptions,
     ResizeToFitDeviceOptions,
     AssertionOptions
 } from '../../test-run/commands/options';
-import { isEmpty } from 'lodash';
-import diff from '../../utils/diff';
+
 
 function isCommandOptions (obj: object): boolean {
     return obj instanceof ActionOptions || obj instanceof ResizeToFitDeviceOptions || obj instanceof AssertionOptions;
@@ -60,8 +62,9 @@ export class CommandFormatter {
 
     private _prepareSelector (command: Command, propertyName: string): SelectorInfo {
         const selectorChain = command.apiFnChain as string[];
+        const expression    = selectorChain.join('');
 
-        const expression = selectorChain.join('');
+        const result: SelectorInfo = { expression };
 
         let element = null;
 
@@ -69,9 +72,12 @@ export class CommandFormatter {
             element = this._getElementByPropertyName(propertyName);
 
         if (element)
-            return { expression, element };
+            result.element = element;
 
-        return { expression };
+        if (command.timeout)
+            result.timeout = command.timeout;
+
+        return result;
     }
 
     private _prepareClientFunction (command: Command): object {

--- a/src/reporter/command/command-formatter.ts
+++ b/src/reporter/command/command-formatter.ts
@@ -1,4 +1,3 @@
-import { isEmpty } from 'lodash';
 import { ExecuteSelectorCommand, ExecuteClientFunctionCommand } from '../../test-run/commands/observation';
 import { NavigateToCommand, SetNativeDialogHandlerCommand, UseRoleCommand } from '../../test-run/commands/actions';
 import { createReplicator, SelectorNodeTransform } from '../../client-functions/replicator';
@@ -115,10 +114,10 @@ export class CommandFormatter {
             else if (isCommandOptions(prop)) {
                 // @ts-ignore
                 const props = new prop.constructor();
-                const dif  = diff(props, prop);
+                const customOptions  = diff(props, prop);
 
-                if (!isEmpty(dif))
-                    formattedCommand[key] = dif;
+                if (customOptions)
+                    formattedCommand[key] = customOptions;
             }
             else
                 formattedCommand[key] = prop;

--- a/src/reporter/command/command-formatter.ts
+++ b/src/reporter/command/command-formatter.ts
@@ -1,3 +1,4 @@
+import { isEmpty } from 'lodash';
 import { ExecuteSelectorCommand, ExecuteClientFunctionCommand } from '../../test-run/commands/observation';
 import { NavigateToCommand, SetNativeDialogHandlerCommand, UseRoleCommand } from '../../test-run/commands/actions';
 import { createReplicator, SelectorNodeTransform } from '../../client-functions/replicator';
@@ -115,7 +116,7 @@ export class CommandFormatter {
             else if (isCommandOptions(property)) {
                 const modifiedOptions = CommandFormatter._getModifiedOptions(property);
 
-                if (modifiedOptions)
+                if (!isEmpty(modifiedOptions))
                     formattedCommand[key] = modifiedOptions;
             }
             else

--- a/src/reporter/command/command-formatter.ts
+++ b/src/reporter/command/command-formatter.ts
@@ -2,6 +2,8 @@ import { ExecuteSelectorCommand, ExecuteClientFunctionCommand } from '../../test
 import { NavigateToCommand, SetNativeDialogHandlerCommand, UseRoleCommand } from '../../test-run/commands/actions';
 import { createReplicator, SelectorNodeTransform } from '../../client-functions/replicator';
 import { Command, FormattedCommand, SelectorInfo } from './interfaces';
+import { ActionOptions } from '../../test-run/commands/options';
+import diff from '../../utils/diff';
 
 export class CommandFormatter {
     private _elements: HTMLElement[] = [];
@@ -95,6 +97,12 @@ export class CommandFormatter {
 
             if (prop instanceof ExecuteSelectorCommand)
                 formattedCommand[key] = this._prepareSelector(prop, key);
+            else if (prop instanceof ActionOptions) {
+                // @ts-ignore
+                const props = new prop.constructor();
+
+                formattedCommand[key] = diff(props, prop);
+            }
             else
                 formattedCommand[key] = prop;
         });

--- a/src/reporter/command/command-formatter.ts
+++ b/src/reporter/command/command-formatter.ts
@@ -2,8 +2,17 @@ import { ExecuteSelectorCommand, ExecuteClientFunctionCommand } from '../../test
 import { NavigateToCommand, SetNativeDialogHandlerCommand, UseRoleCommand } from '../../test-run/commands/actions';
 import { createReplicator, SelectorNodeTransform } from '../../client-functions/replicator';
 import { Command, FormattedCommand, SelectorInfo } from './interfaces';
-import { ActionOptions } from '../../test-run/commands/options';
+import {
+    ActionOptions,
+    ResizeToFitDeviceOptions,
+    AssertionOptions
+} from '../../test-run/commands/options';
+import { isEmpty } from 'lodash';
 import diff from '../../utils/diff';
+
+function isCommandOptions (obj: object): boolean {
+    return obj instanceof ActionOptions || obj instanceof ResizeToFitDeviceOptions || obj instanceof AssertionOptions;
+}
 
 export class CommandFormatter {
     private _elements: HTMLElement[] = [];
@@ -97,11 +106,13 @@ export class CommandFormatter {
 
             if (prop instanceof ExecuteSelectorCommand)
                 formattedCommand[key] = this._prepareSelector(prop, key);
-            else if (prop instanceof ActionOptions) {
+            else if (isCommandOptions(prop)) {
                 // @ts-ignore
                 const props = new prop.constructor();
+                const dif  = diff(props, prop);
 
-                formattedCommand[key] = diff(props, prop);
+                if (!isEmpty(dif))
+                    formattedCommand[key] = dif;
             }
             else
                 formattedCommand[key] = prop;

--- a/src/reporter/command/interfaces.ts
+++ b/src/reporter/command/interfaces.ts
@@ -12,5 +12,6 @@ export interface FormattedCommand {
 
 export interface SelectorInfo {
     expression: string;
+    timeout?: number;
     element?: HTMLElement;
 }

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,4 +1,4 @@
-import { set } from 'lodash';
+import { set, isEmpty } from 'lodash';
 import { Dictionary } from '../configuration/interfaces';
 
 function getFullPropertyPath (property: string, parentProperty: string): string {
@@ -8,23 +8,29 @@ function getFullPropertyPath (property: string, parentProperty: string): string 
     return property;
 }
 
-function diff (object1: Dictionary<any>, object2: Dictionary<any>, result: Dictionary<any> = {}, parentProperty: string = ''): Dictionary<any> {
-    for (const prop in object1) {
-        const fullPropertyPath = getFullPropertyPath(prop, parentProperty);
-        const value1 = object1[prop];
-        const value2 = object2[prop];
+function diff (source: Dictionary<object>, modified: Dictionary<object>, result: Dictionary<object>, parentProperty: string = ''): void {
+    for (const property in source) {
+        const fullPropertyPath = getFullPropertyPath(property, parentProperty);
 
-        if (value1 !== value2) {
-            if (typeof value1 === 'object' && typeof value2 === 'object')
-                diff(value1 as Dictionary<object>, value2 as Dictionary<object>, result, fullPropertyPath);
+        const sourceValue   = source[property] as Dictionary<object>;
+        const modifiedValue = modified[property] as Dictionary<object>;
+
+        if (sourceValue !== modifiedValue) {
+            if (typeof sourceValue === 'object' && typeof modifiedValue === 'object')
+                diff(sourceValue, modifiedValue, result, fullPropertyPath);
             else
-                set(result, fullPropertyPath, value2);
+                set(result, fullPropertyPath, modifiedValue);
         }
     }
-
-    return result;
 }
 
-export default (object1: Dictionary<any>, object2: Dictionary<any>) => {
-    return diff(object1, object2, {});
+export default (source: Dictionary<object>, modified: Dictionary<object>) => {
+    const result = {};
+
+    diff(source, modified, result);
+
+    if (isEmpty(result))
+        return null;
+
+    return result;
 };

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,8 +1,8 @@
 import { set, isEmpty, isEqual, isNil as isNullOrUndefined } from 'lodash';
 import { Dictionary } from '../configuration/interfaces';
 
-const OBJECTS_EMPTY_ERROR                = 'objects should be not empty';
-const OBJECTS_DIFFERENT_PROPERTIES_ERROR = 'objects should contain the same properties';
+const OBJECTS_EMPTY_ERROR                = 'Objects should be not empty';
+const OBJECTS_DIFFERENT_PROPERTIES_ERROR = 'Objects should contain the same properties';
 
 function getFullPropertyPath (property: string, parentProperty: string): string {
     if (parentProperty)

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,4 +1,4 @@
-import { set, isPlainObject } from 'lodash';
+import { set, isObjectLike } from 'lodash';
 import { Dictionary } from '../configuration/interfaces';
 
 function getFullPropertyPath (property: string, parentProperty: string): string {
@@ -19,7 +19,7 @@ function diff (source: Dictionary<object>, modified: Dictionary<object>, result:
         const modifiedValue = modified[property] as Dictionary<object>;
 
         if (sourceValue !== modifiedValue) {
-            if (isPlainObject(sourceValue) && isPlainObject(modifiedValue))
+            if (isObjectLike(sourceValue) && isObjectLike(modifiedValue))
                 diff(sourceValue, modifiedValue, result, fullPropertyPath);
             else
                 set(result, fullPropertyPath, modifiedValue);
@@ -30,7 +30,7 @@ function diff (source: Dictionary<object>, modified: Dictionary<object>, result:
 export default (source: Dictionary<object>, modified: Dictionary<object>) => {
     const result = {};
 
-    if (isPlainObject(source) && isPlainObject(modified))
+    if (isObjectLike(source) && isObjectLike(modified))
         diff(source, modified, result);
 
     return result;

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,0 +1,28 @@
+import { Dictionary } from '../configuration/interfaces';
+
+function diff (object1: Dictionary<any>, object2: Dictionary<any>, result: Dictionary<any> = {}): Dictionary<any> {
+    for (const prop in object1) {
+        const value1 = object1[prop];
+        const value2 = object2[prop];
+
+        if (value1 !== value2) {
+            if (typeof value1 === 'object' && typeof value2 === 'object') {
+                result[prop] = {};
+
+                diff(value1 as Dictionary<object>, value2 as Dictionary<object>, result[prop]);
+            }
+            else
+                result[prop] = value2;
+        }
+    }
+
+    return result;
+}
+
+export default (object1: Dictionary<any>, object2: Dictionary<any>) => {
+    const result = {};
+
+    diff(object1, object2, result);
+
+    return result;
+};

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,18 +1,24 @@
+import { set } from 'lodash';
 import { Dictionary } from '../configuration/interfaces';
 
-function diff (object1: Dictionary<any>, object2: Dictionary<any>, result: Dictionary<any> = {}): Dictionary<any> {
+function getFullPropertyPath (property: string, parentProperty: string): string {
+    if (parentProperty)
+        return `${parentProperty}.${property}`;
+
+    return property;
+}
+
+function diff (object1: Dictionary<any>, object2: Dictionary<any>, result: Dictionary<any> = {}, parentProperty: string): Dictionary<any> {
     for (const prop in object1) {
+        const fullPropertyPath = getFullPropertyPath(prop, parentProperty);
         const value1 = object1[prop];
         const value2 = object2[prop];
 
         if (value1 !== value2) {
-            if (typeof value1 === 'object' && typeof value2 === 'object') {
-                result[prop] = {};
-
-                diff(value1 as Dictionary<object>, value2 as Dictionary<object>, result[prop]);
-            }
+            if (typeof value1 === 'object' && typeof value2 === 'object')
+                diff(value1 as Dictionary<object>, value2 as Dictionary<object>, result, fullPropertyPath);
             else
-                result[prop] = value2;
+                set(result, fullPropertyPath, value2);
         }
     }
 
@@ -22,7 +28,5 @@ function diff (object1: Dictionary<any>, object2: Dictionary<any>, result: Dicti
 export default (object1: Dictionary<any>, object2: Dictionary<any>) => {
     const result = {};
 
-    diff(object1, object2, result);
-
-    return result;
+    return diff(object1, object2, result, '');
 };

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -1,8 +1,5 @@
-import { set, isEmpty, isEqual, isNil as isNullOrUndefined } from 'lodash';
+import { set, isPlainObject } from 'lodash';
 import { Dictionary } from '../configuration/interfaces';
-
-const OBJECTS_EMPTY_ERROR                = 'Objects should be not empty';
-const OBJECTS_DIFFERENT_PROPERTIES_ERROR = 'Objects should contain the same properties';
 
 function getFullPropertyPath (property: string, parentProperty: string): string {
     if (parentProperty)
@@ -11,25 +8,18 @@ function getFullPropertyPath (property: string, parentProperty: string): string 
     return property;
 }
 
-function validate (source: Dictionary<object>, modified: Dictionary<object>): void {
-    if (isEmpty(source) || isEmpty(modified))
-        throw new TypeError(OBJECTS_EMPTY_ERROR);
-
-    if (!isEqual(Object.keys(source), Object.keys(modified)))
-        throw new TypeError(OBJECTS_DIFFERENT_PROPERTIES_ERROR);
-}
-
 function diff (source: Dictionary<object>, modified: Dictionary<object>, result: Dictionary<object>, parentProperty: string = ''): void {
-    validate(source, modified);
-
     for (const property in source) {
         const fullPropertyPath = getFullPropertyPath(property, parentProperty);
+
+        if (!modified.hasOwnProperty(property))
+            continue;
 
         const sourceValue   = source[property] as Dictionary<object>;
         const modifiedValue = modified[property] as Dictionary<object>;
 
-        if (!isNullOrUndefined(modifiedValue) && sourceValue !== modifiedValue) {
-            if (typeof sourceValue === 'object' && typeof modifiedValue === 'object')
+        if (sourceValue !== modifiedValue) {
+            if (isPlainObject(sourceValue) && isPlainObject(modifiedValue))
                 diff(sourceValue, modifiedValue, result, fullPropertyPath);
             else
                 set(result, fullPropertyPath, modifiedValue);
@@ -40,15 +30,9 @@ function diff (source: Dictionary<object>, modified: Dictionary<object>, result:
 export default (source: Dictionary<object>, modified: Dictionary<object>) => {
     const result = {};
 
-    try {
+    if (isPlainObject(source) && isPlainObject(modified))
         diff(source, modified, result);
-    }
-    catch {
-        return null;
-    }
-
-    if (isEmpty(result))
-        return null;
 
     return result;
+
 };

--- a/src/utils/diff.ts
+++ b/src/utils/diff.ts
@@ -8,7 +8,7 @@ function getFullPropertyPath (property: string, parentProperty: string): string 
     return property;
 }
 
-function diff (object1: Dictionary<any>, object2: Dictionary<any>, result: Dictionary<any> = {}, parentProperty: string): Dictionary<any> {
+function diff (object1: Dictionary<any>, object2: Dictionary<any>, result: Dictionary<any> = {}, parentProperty: string = ''): Dictionary<any> {
     for (const prop in object1) {
         const fullPropertyPath = getFullPropertyPath(prop, parentProperty);
         const value1 = object1[prop];
@@ -26,7 +26,5 @@ function diff (object1: Dictionary<any>, object2: Dictionary<any>, result: Dicti
 }
 
 export default (object1: Dictionary<any>, object2: Dictionary<any>) => {
-    const result = {};
-
-    return diff(object1, object2, result, '');
+    return diff(object1, object2, {});
 };

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -8,8 +8,6 @@ const {
     createSyncTestStream
 } = require('../../utils/stream');
 
-const { ClickOptions, AssertionOptions } = require('../../../../lib/test-run/commands/options');
-
 describe('Reporter', () => {
     const stdoutWrite = process.stdout.write;
     const stderrWrite = process.stderr.write;
@@ -273,8 +271,10 @@ describe('Reporter', () => {
                             action:  'done',
                             command: {
                                 type:     'click',
-                                options:  new ClickOptions(),
-                                selector: 'Selector(\'#target\')'
+                                selector: 'Selector(\'#target\')',
+                                options:  {
+                                    offsetX: 10
+                                }
                             },
                             test: {
                                 id:    'test-id',
@@ -305,7 +305,6 @@ describe('Reporter', () => {
                             action:  'done',
                             command: {
                                 type:     'click',
-                                options:  new ClickOptions(),
                                 selector: 'Selector(\'#non-existing-target\')'
                             },
                             err: 'E24'
@@ -334,7 +333,9 @@ describe('Reporter', () => {
                                 expected:      true,
                                 expected2:     void 0,
                                 message:       'assertion message',
-                                options:       new AssertionOptions({ timeout: 100 })
+                                options:       {
+                                    timeout: 100
+                                }
                             }
                         },
                     ]);
@@ -360,8 +361,7 @@ describe('Reporter', () => {
                                 assertionType: 'eql',
                                 expected:      'target',
                                 expected2:     void 0,
-                                message:       null,
-                                options:       new AssertionOptions()
+                                message:       null
                             }
                         },
                     ]);
@@ -486,7 +486,6 @@ describe('Reporter', () => {
                             name:    'click',
                             action:  'done',
                             command: {
-                                options:  new ClickOptions(),
                                 selector: 'Selector(\'#target\')',
                                 type:     'click'
                             },
@@ -537,7 +536,6 @@ describe('Reporter', () => {
                             name:    'click',
                             action:  'done',
                             command: {
-                                options:  new ClickOptions(),
                                 selector: 'Selector(\'#non-existing-element\')',
                                 type:     'click'
                             },
@@ -585,7 +583,7 @@ describe('Reporter', () => {
     describe('Action snapshots', () => {
         it('Basic', () => {
             const expected = [
-                { expression: 'Selector(\'#input\')', element: { tagName: 'input', attributes: { value: '100', type: 'text', id: 'input' } } },
+                { expression: 'Selector(\'#input\')', timeout: 11000, element: { tagName: 'input', attributes: { value: '100', type: 'text', id: 'input' } } },
                 { expression: 'Selector(\'#obscuredInput\')', element: { tagName: 'div', attributes: { id: 'fixed' } } },
                 { expression: 'Selector(\'#obscuredInput\')', element: { tagName: 'div', attributes: { id: 'fixed' } } },
                 { expression: 'Selector(\'#obscuredDiv\')', element: { tagName: 'div', attributes: { id: 'obscuredDiv' } } },

--- a/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
@@ -23,7 +23,7 @@ test('Simple test', async t => {
 });
 
 test('Simple command test', async t => {
-    await t.click(Selector('#target'));
+    await t.click(Selector('#target'), { offsetX: 10 });
 });
 
 test('Simple command err test', async t => {

--- a/test/functional/fixtures/reporter/testcafe-fixtures/snapshots-test.js
+++ b/test/functional/fixtures/reporter/testcafe-fixtures/snapshots-test.js
@@ -4,7 +4,7 @@ fixture `Reporter snapshots`
     .page `http://localhost:3000/fixtures/reporter/pages/snapshots.html`;
 
 test('Basic', async t => {
-    await t.click('#input');
+    await t.click(Selector('#input', { timeout: 11000 }));
     await t.click('#obscuredInput');
     await t.dragToElement('#obscuredInput', '#obscuredDiv');
     await t.selectEditableContent('#p1', '#p2');

--- a/test/server/data/test-controller-reporter-expected/index.js
+++ b/test/server/data/test-controller-reporter-expected/index.js
@@ -6,7 +6,6 @@ const mouseOptions = Object.assign({
     modifiers: {
         alt:   true,
         ctrl:  true,
-        meta:  true,
         shift: true,
     },
     offsetX:   1,
@@ -16,8 +15,7 @@ const mouseOptions = Object.assign({
 const clickOptions = Object.assign({ caretPos: 1 }, mouseOptions);
 
 const dragToElementOptions = Object.assign({
-    destinationOffsetX: 3,
-    destinationOffsetY: 4
+    destinationOffsetX: 3
 }, mouseOptions);
 
 const typeTextOptions = Object.assign({
@@ -347,7 +345,12 @@ module.exports = [
             selector: { expression:'Selector(\'#target\')' },
             path:     'screenshotPath',
             type:     'take-element-screenshot',
-            options:  new ElementScreenshotOptions()
+            options:  {
+                includeMargins: true,
+                crop: {
+                    top: -100
+                }
+            }
         },
         test:    {
             id:    'test-id',

--- a/test/server/test-controller-events-test.js
+++ b/test/server/test-controller-events-test.js
@@ -242,14 +242,14 @@ describe('TestController action events', () => {
     });
 
     it('Default command options should not be passed to the `reportTestActionDone` method', async () => {
-        const doneLog  = [];
+        const log  = [];
 
         initializeReporter({
             async reportTestActionDone (name, { command }) {
-                doneLog.push(name);
+                log.push(name);
 
                 if (command.options)
-                    doneLog.push(command.options);
+                    log.push(command.options);
             }
         }, task);
 
@@ -258,7 +258,7 @@ describe('TestController action events', () => {
         for (let i = 0; i < actionsKeys.length; i++)
             await testController[actionsKeys[i]].apply(testController, actionsWithoutOptions[actionsKeys[i]]);
 
-        expect(doneLog).eql(actionsKeys);
+        expect(log).eql(actionsKeys);
     });
 
     it('Show only modified action options', async () => {

--- a/test/server/test-controller-events-test.js
+++ b/test/server/test-controller-events-test.js
@@ -64,16 +64,31 @@ const options = {
     modifiers: {
         alt:   true,
         ctrl:  true,
-        meta:  true,
         shift: true
     },
     offsetX:            1,
     offsetY:            2,
     destinationOffsetX: 3,
-    destinationOffsetY: 4,
     speed:              1,
     replace:            true,
-    paste:              true,
+    paste:              true
+};
+
+const actionsWithoutOptions = {
+    click:                   ['#target'],
+    rightClick:              ['#target'],
+    doubleClick:             ['#target'],
+    hover:                   ['#target'],
+    drag:                    ['#target', 100, 200],
+    dragToElement:           ['#target', '#target'],
+    typeText:                ['#input', 'test'],
+    selectText:              ['#input', 1, 3],
+    selectTextAreaContent:   ['#textarea', 1, 2, 3, 4],
+    selectEditableContent:   ['#contenteditable', '#contenteditable'],
+    pressKey:                ['enter'],
+    takeScreenshot:          [{ path: 'screenshotPath', fullPage: true }],
+    takeElementScreenshot:   ['#target', 'screenshotPath'],
+    resizeWindowToFitDevice: ['Sony Xperia Z']
 };
 
 const actions = {
@@ -93,7 +108,7 @@ const actions = {
     setFilesToUpload:          ['#file', '../test.js'],
     clearUpload:               ['#file'],
     takeScreenshot:            [{ path: 'screenshotPath', fullPage: true }],
-    takeElementScreenshot:     ['#target', 'screenshotPath'],
+    takeElementScreenshot:     ['#target', 'screenshotPath', { includeMargins: true, crop: { top: -100 } }],
     resizeWindow:              [200, 200],
     resizeWindowToFitDevice:   ['Sony Xperia Z', { portraitOrientation: true }],
     maximizeWindow:            [],
@@ -224,5 +239,78 @@ describe('TestController action events', () => {
             .then(() => {
                 expect(resultDuration).to.be.a('number').with.above(0);
             });
+    });
+
+    it('Default command options should not be passed to the `reportTestActionDone` method', async () => {
+        const doneLog  = [];
+
+        initializeReporter({
+            async reportTestActionDone (name, { command }) {
+                doneLog.push(name);
+
+                if (command.options)
+                    doneLog.push(command.options);
+            }
+        }, task);
+
+        const actionsKeys = Object.keys(actionsWithoutOptions);
+
+        for (let i = 0; i < actionsKeys.length; i++)
+            await testController[actionsKeys[i]].apply(testController, actionsWithoutOptions[actionsKeys[i]]);
+
+        expect(doneLog).eql(actionsKeys);
+    });
+
+    it('Show only modified action options', async () => {
+        const doneLog  = [];
+
+        initializeReporter({
+            async reportTestActionDone (name, { command }) {
+                const item = { name };
+
+                if (command.options)
+                    item.options = command.options;
+
+                doneLog.push(item);
+            }
+        }, task);
+
+        await testController.click('#target', { caretPos: 1, modifiers: { shift: true } });
+        await testController.click('#target', { modifiers: { ctrl: false } });
+
+        await testController.resizeWindowToFitDevice('iPhone 5', { portraitOrientation: true });
+        await testController.resizeWindowToFitDevice('iPhone 5', { portraitOrientation: false });
+
+        await testController.expect(true).eql(true, 'message', { timeout: 500 });
+        await testController.expect(true).eql(true);
+
+        const expectedLog = [
+            {
+                name:    'click',
+                options: {
+                    caretPos:  1,
+                    modifiers: {
+                        shift: true
+                    }
+                }
+            },
+            { name: 'click' },
+            {
+                name:    'resizeWindowToFitDevice',
+                options: {
+                    portraitOrientation: true
+                }
+            },
+            { name: 'resizeWindowToFitDevice' },
+            {
+                name:    'eql',
+                options: {
+                    timeout: 500
+                }
+            },
+            { name: 'eql' }
+        ];
+
+        expect(doneLog).eql(expectedLog);
     });
 });

--- a/test/server/util-test.js
+++ b/test/server/util-test.js
@@ -42,15 +42,25 @@ describe('Utils', () => {
     });
 
     it('Diff', () => {
+        expect(diff(null, null)).is.null;
+        expect(diff(void 0, void 0)).is.null;
+        expect(diff({ a: void 0 }, { b: void 0 })).is.null;
+        expect(diff({ a: null }, { b: null })).is.null;
         expect(diff({ a: 1 }, { a: 1 })).is.null;
-        expect(diff({ a: 1 }, { a: 2 })).eql({ a: 2 });
+        expect(diff({ a: 1 }, { a: 1 })).is.null;
+        expect(diff({ a: 1 }, { a: void 0 })).is.null;
+        expect(diff({ a: 1 }, { a: null })).is.null;
         expect(diff({ a: 1, b: 1 }, { a: 1, b: 1 })).is.null;
-        expect(diff({ a: 1, b: 1 }, { a: 1, b: 2 })).eql({ b: 2 });
         expect(diff({ a: 1, b: {} }, { a: 1, b: {} })).is.null;
         expect(diff({ a: 1, b: { c: 3 } }, { a: 1, b: { c: 3 } })).is.null;
+        expect(diff({ a: 1, b: { c: { d: 4 } } }, { a: 1, b: { c: { d: 4 } } })).is.null;
+
+        expect(diff({ a: 0 }, { a: 1 })).eql({ a: 1 });
+        expect(diff({ a: 1 }, { a: 0 })).eql({ a: 0 });
+        expect(diff({ a: 1 }, { a: 2 })).eql({ a: 2 });
+        expect(diff({ a: 1, b: 1 }, { a: 1, b: 2 })).eql({ b: 2 });
         expect(diff({ a: 1, b: { c: 3 } }, { a: 1, b: { c: 4 } })).eql({ b: { c: 4 } });
         expect(diff({ a: 1, b: { c: 3 } }, { a: 2, b: { c: 4 } })).eql({ a: 2, b: { c: 4 } });
-        expect(diff({ a: 1, b: { c: { d: 4 } } }, { a: 1, b: { c: { d: 4 } } })).is.null;
         expect(diff({ a: 1, b: { c: { d: 4 } } }, { a: 1, b: { c: { d: 5 } } })).eql({ b: { c: { d: 5 } } });
     });
 

--- a/test/server/util-test.js
+++ b/test/server/util-test.js
@@ -42,19 +42,19 @@ describe('Utils', () => {
     });
 
     it('Diff', () => {
-        expect(diff(null, null)).is.null;
-        expect(diff(void 0, void 0)).is.null;
-        expect(diff({ a: void 0 }, { b: void 0 })).is.null;
-        expect(diff({ a: null }, { b: null })).is.null;
-        expect(diff({ a: 1 }, { a: 1 })).is.null;
-        expect(diff({ a: 1 }, { a: 1 })).is.null;
-        expect(diff({ a: 1 }, { a: void 0 })).is.null;
-        expect(diff({ a: 1 }, { a: null })).is.null;
-        expect(diff({ a: 1, b: 1 }, { a: 1, b: 1 })).is.null;
-        expect(diff({ a: 1, b: {} }, { a: 1, b: {} })).is.null;
-        expect(diff({ a: 1, b: { c: 3 } }, { a: 1, b: { c: 3 } })).is.null;
-        expect(diff({ a: 1, b: { c: { d: 4 } } }, { a: 1, b: { c: { d: 4 } } })).is.null;
-
+        expect(diff(null, null)).eql({});
+        expect(diff(void 0, void 0)).eql({});
+        expect(diff(1, 2)).eql({});
+        expect(diff({ a: void 0 }, { b: void 0 })).eql({});
+        expect(diff({ a: null }, { b: null })).eql({});
+        expect(diff({ a: null }, { a: 1 })).eql({ a: 1 });
+        expect(diff({ a: 1 }, { a: 1 })).eql({});
+        expect(diff({ a: 1 }, { a: void 0 })).eql({ a: void 0 });
+        expect(diff({ a: 1 }, { a: null })).eql({ a: null });
+        expect(diff({ a: 1, b: 1 }, { a: 1, b: 1 })).eql({});
+        expect(diff({ a: 1, b: {} }, { a: 1, b: {} })).eql({});
+        expect(diff({ a: 1, b: { c: 3 } }, { a: 1, b: { c: 3 } })).eql({});
+        expect(diff({ a: 1, b: { c: { d: 4 } } }, { a: 1, b: { c: { d: 4 } } })).eql({});
         expect(diff({ a: 0 }, { a: 1 })).eql({ a: 1 });
         expect(diff({ a: 1 }, { a: 0 })).eql({ a: 0 });
         expect(diff({ a: 1 }, { a: 2 })).eql({ a: 2 });

--- a/test/server/util-test.js
+++ b/test/server/util-test.js
@@ -42,15 +42,15 @@ describe('Utils', () => {
     });
 
     it('Diff', () => {
-        expect(diff({ a: 1 }, { a: 1 })).eql({});
+        expect(diff({ a: 1 }, { a: 1 })).is.null;
         expect(diff({ a: 1 }, { a: 2 })).eql({ a: 2 });
-        expect(diff({ a: 1, b: 1 }, { a: 1, b: 1 })).eql({});
+        expect(diff({ a: 1, b: 1 }, { a: 1, b: 1 })).is.null;
         expect(diff({ a: 1, b: 1 }, { a: 1, b: 2 })).eql({ b: 2 });
-        expect(diff({ a: 1, b: {} }, { a: 1, b: {} })).eql({});
-        expect(diff({ a: 1, b: { c: 3 } }, { a: 1, b: { c: 3 } })).eql({});
+        expect(diff({ a: 1, b: {} }, { a: 1, b: {} })).is.null;
+        expect(diff({ a: 1, b: { c: 3 } }, { a: 1, b: { c: 3 } })).is.null;
         expect(diff({ a: 1, b: { c: 3 } }, { a: 1, b: { c: 4 } })).eql({ b: { c: 4 } });
         expect(diff({ a: 1, b: { c: 3 } }, { a: 2, b: { c: 4 } })).eql({ a: 2, b: { c: 4 } });
-        expect(diff({ a: 1, b: { c: { d: 4 } } }, { a: 1, b: { c: { d: 4 } } })).eql({});
+        expect(diff({ a: 1, b: { c: { d: 4 } } }, { a: 1, b: { c: { d: 4 } } })).is.null;
         expect(diff({ a: 1, b: { c: { d: 4 } } }, { a: 1, b: { c: { d: 5 } } })).eql({ b: { c: { d: 5 } } });
     });
 

--- a/test/server/util-test.js
+++ b/test/server/util-test.js
@@ -21,6 +21,8 @@ const prepareReporters                 = require('../../lib/utils/prepare-report
 const { replaceLeadingSpacesWithNbsp } = require('../../lib/errors/test-run/utils');
 const createTempProfile                = require('../../lib/browser/provider/built-in/dedicated/chrome/create-temp-profile');
 const parseUserAgent                   = require('../../lib/utils/parse-user-agent');
+const diff                             = require('../../lib/utils/diff');
+
 
 const {
     buildChromeArgs,
@@ -37,6 +39,19 @@ describe('Utils', () => {
 
     it('Escape user agent', () => {
         expect(escapeUserAgent('Chrome 67.0.3396 / Windows 8.1.0.0')).eql('Chrome_67.0.3396_Windows_8.1.0.0');
+    });
+
+    it('Diff', () => {
+        expect(diff({ a: 1 }, { a: 1 })).eql({});
+        expect(diff({ a: 1 }, { a: 2 })).eql({ a: 2 });
+        expect(diff({ a: 1, b: 1 }, { a: 1, b: 1 })).eql({});
+        expect(diff({ a: 1, b: 1 }, { a: 1, b: 2 })).eql({ b: 2 });
+        expect(diff({ a: 1, b: {} }, { a: 1, b: {} })).eql({});
+        expect(diff({ a: 1, b: { c: 3 } }, { a: 1, b: { c: 3 } })).eql({});
+        expect(diff({ a: 1, b: { c: 3 } }, { a: 1, b: { c: 4 } })).eql({ b: { c: 4 } });
+        expect(diff({ a: 1, b: { c: 3 } }, { a: 2, b: { c: 4 } })).eql({ a: 2, b: { c: 4 } });
+        expect(diff({ a: 1, b: { c: { d: 4 } } }, { a: 1, b: { c: { d: 4 } } })).eql({});
+        expect(diff({ a: 1, b: { c: { d: 4 } } }, { a: 1, b: { c: { d: 5 } } })).eql({ b: { c: { d: 5 } } });
     });
 
     it('Parse user agent', () => {


### PR DESCRIPTION
We pass the `command` object to the `action-start(done)` methods.
Some commands have `options`.
Options have default values.
User can pass options to action.

I.e. ClickCommand has ClickOptions:
```JS
{
    modifiers: {
        ctrl: Boolean,
        alt: Boolean,
        shift: Boolean,
        meta: Boolean
    },

    offsetX: Number,
    offsetY: Number,
    caretPos: Number,
    speed: Number
}
```
User executes action: `await t.click('#target'), { offsetX: 1, modifiers: { ctrl: true, alt: false } }`

The options will be the following:
```JS
{
    speed: null
    offsetX: 1
    offsetY: null
    modifiers: {
        ctrl: true
        alt: false
        shift: false
        meta: false
    }
    caretPos: null
}
```

We need to pass to reporter only NOT DEFAULT VALUES: `{ offsetX: 1, modifiers: { ctrl: true  } }`.

**P.S.**
I added the missing `timeout` option for selectors