### PR TITLE
Fix imports in client scripts

### DIFF
--- a/src/client/automation/index.js
+++ b/src/client/automation/index.js
@@ -20,6 +20,8 @@ import {
 import AutomationSettings from './settings';
 import { getOffsetOptions } from './utils/offsets';
 import { getNextFocusableElement } from './playback/press/utils';
+import { getSelectionCoordinatesByPosition } from './playback/select/utils';
+import { fromPoint as getElementFromPoint } from './get-element';
 import calculateSelectTextArguments from './playback/select/calculate-select-text-arguments';
 import ERROR_TYPES from './errors';
 import cursor from './cursor';
@@ -49,7 +51,9 @@ exports.calculateSelectTextArguments = calculateSelectTextArguments;
 exports.cursor                       = cursor;
 exports.getNextFocusableElement      = getNextFocusableElement;
 
-exports.get = require;
+exports.getSelectionCoordinatesByPosition = getSelectionCoordinatesByPosition;
+
+exports.getElementFromPoint = getElementFromPoint;
 
 const nativeMethods    = hammerhead.nativeMethods;
 const evalIframeScript = hammerhead.EVENTS.evalIframeScript;

--- a/src/client/ui/index.js
+++ b/src/client/ui/index.js
@@ -34,6 +34,8 @@ messageSandbox.on(messageSandbox.SERVICE_MSG_RECEIVED_EVENT, e => {
     }
 });
 
+
+exports.uiRoot          = uiRoot;
 exports.cursorUI        = cursorUI;
 exports.iframeCursorUI  = iframeCursorUI;
 exports.selectElement   = selectElement;

--- a/test/client/fixtures/automation/automations-test.js
+++ b/test/client/fixtures/automation/automations-test.js
@@ -3,9 +3,9 @@ const browserUtils     = hammerhead.utils.browser;
 const featureDetection = hammerhead.utils.featureDetection;
 
 const testCafeCore  = window.getTestCafeModule('testCafeCore');
-const domUtils      = testCafeCore.get('./utils/dom');
-const textSelection = testCafeCore.get('./utils/text-selection');
-const position      = testCafeCore.get('./utils/position');
+const domUtils      = testCafeCore.domUtils;
+const textSelection = testCafeCore.textSelection;
+const position      = testCafeCore.positionUtils;
 
 testCafeCore.preventRealEvents();
 
@@ -17,11 +17,11 @@ const TypeAutomation         = testCafeAutomation.Type;
 const PressAutomation        = testCafeAutomation.Press;
 const DragToOffsetAutomation = testCafeAutomation.DragToOffset;
 
-const ClickOptions = testCafeAutomation.get('../../test-run/commands/options').ClickOptions;
-const TypeOptions  = testCafeAutomation.get('../../test-run/commands/options').TypeOptions;
-const MouseOptions = testCafeAutomation.get('../../test-run/commands/options').MouseOptions;
+const ClickOptions = testCafeAutomation.ClickOptions;
+const TypeOptions  = testCafeAutomation.TypeOptions;
+const MouseOptions = testCafeAutomation.MouseOptions;
 
-const parseKeySequence = testCafeCore.get('./utils/parse-key-sequence');
+const parseKeySequence = testCafeCore.parseKeySequence;
 const getOffsetOptions = testCafeAutomation.getOffsetOptions;
 
 

--- a/test/client/fixtures/automation/click-test.js
+++ b/test/client/fixtures/automation/click-test.js
@@ -3,12 +3,12 @@ const browserUtils     = hammerhead.utils.browser;
 const featureDetection = hammerhead.utils.featureDetection;
 
 const testCafeCore = window.getTestCafeModule('testCafeCore');
-const styleUtils   = testCafeCore.get('./utils/style');
+const styleUtils   = testCafeCore.styleUtils;
 
 const testCafeAutomation = window.getTestCafeModule('testCafeAutomation');
 const getOffsetOptions   = testCafeAutomation.getOffsetOptions;
 const ClickAutomation    = testCafeAutomation.Click;
-const ClickOptions       = testCafeAutomation.get('../../test-run/commands/options').ClickOptions;
+const ClickOptions       = testCafeAutomation.ClickOptions;
 
 testCafeCore.preventRealEvents();
 

--- a/test/client/fixtures/automation/content-editable/api-actions-content-editable-test/index-test.js
+++ b/test/client/fixtures/automation/content-editable/api-actions-content-editable-test/index-test.js
@@ -8,13 +8,13 @@ const DblClickAutomation   = testCafeAutomation.DblClick;
 const SelectTextAutomation = testCafeAutomation.SelectText;
 const PressAutomation      = testCafeAutomation.Press;
 const TypeAutomation       = testCafeAutomation.Type;
-const ClickOptions         = testCafeAutomation.get('../../test-run/commands/options').ClickOptions;
-const TypeOptions          = testCafeAutomation.get('../../test-run/commands/options').TypeOptions;
+const ClickOptions         = testCafeAutomation.ClickOptions;
+const TypeOptions          = testCafeAutomation.TypeOptions;
 
 const testCafeCore      = window.getTestCafeModule('testCafeCore');
-const domUtils          = testCafeCore.get('./utils/dom');
-const textSelection     = testCafeCore.get('./utils/text-selection');
-const parseKeySequence  = testCafeCore.get('./utils/parse-key-sequence');
+const domUtils          = testCafeCore.domUtils;
+const textSelection     = testCafeCore.textSelection;
+const parseKeySequence  = testCafeCore.parseKeySequence;
 
 
 testCafeCore.preventRealEvents();

--- a/test/client/fixtures/automation/content-editable/regression-test/index-test.js
+++ b/test/client/fixtures/automation/content-editable/regression-test/index-test.js
@@ -2,10 +2,10 @@ const hammerhead   = window.getTestCafeModule('hammerhead');
 const browserUtils = hammerhead.utils.browser;
 
 const testCafeCore = window.getTestCafeModule('testCafeCore');
-const domUtils     = testCafeCore.get('./utils/dom');
+const domUtils     = testCafeCore.domUtils;
 
 const testCafeAutomation = window.getTestCafeModule('testCafeAutomation');
-const TypeOptions        = testCafeAutomation.get('../../test-run/commands/options').TypeOptions;
+const TypeOptions        = testCafeAutomation.TypeOptions;
 const TypeAutomation     = testCafeAutomation.Type;
 
 testCafeCore.preventRealEvents();

--- a/test/client/fixtures/automation/content-editable/select-and-type-content-editable-test/index-test.js
+++ b/test/client/fixtures/automation/content-editable/select-and-type-content-editable-test/index-test.js
@@ -2,17 +2,17 @@ const hammerhead   = window.getTestCafeModule('hammerhead');
 const browserUtils = hammerhead.utils.browser;
 
 const testCafeCore      = window.getTestCafeModule('testCafeCore');
-const textSelection     = testCafeCore.get('./utils/text-selection');
-const contentEditable   = testCafeCore.get('./utils/content-editable');
-const domUtils          = testCafeCore.get('./utils/dom');
-const parseKeySequence  = testCafeCore.get('./utils/parse-key-sequence');
+const textSelection     = testCafeCore.textSelection;
+const contentEditable   = testCafeCore.contentEditable;
+const domUtils          = testCafeCore.domUtils;
+const parseKeySequence  = testCafeCore.parseKeySequence;
 
 const testCafeAutomation   = window.getTestCafeModule('testCafeAutomation');
 const TypeAutomation       = testCafeAutomation.Type;
 const SelectTextAutomation = testCafeAutomation.SelectText;
 const PressAutomation      = testCafeAutomation.Press;
 
-const TypeOptions = testCafeAutomation.get('../../test-run/commands/options').TypeOptions;
+const TypeOptions = testCafeAutomation.TypeOptions;
 
 testCafeCore.preventRealEvents();
 

--- a/test/client/fixtures/automation/dblclick-test.js
+++ b/test/client/fixtures/automation/dblclick-test.js
@@ -1,6 +1,6 @@
 const testCafeAutomation = window.getTestCafeModule('testCafeAutomation');
 const DblClickAutomation = testCafeAutomation.DblClick;
-const ClickOptions       = testCafeAutomation.get('../../test-run/commands/options').ClickOptions;
+const ClickOptions       = testCafeAutomation.ClickOptions;
 
 const testCafeCore      = window.getTestCafeModule('testCafeCore');
 

--- a/test/client/fixtures/automation/detection-element-after-events-simulation-test.js
+++ b/test/client/fixtures/automation/detection-element-after-events-simulation-test.js
@@ -3,7 +3,7 @@ const browserUtils     = hammerhead.utils.browser;
 const featureDetection = hammerhead.utils.featureDetection;
 
 const testCafeCore     = window.getTestCafeModule('testCafeCore');
-const parseKeySequence = testCafeCore.get('./utils/parse-key-sequence');
+const parseKeySequence = testCafeCore.parseKeySequence;
 
 const testCafeAutomation   = window.getTestCafeModule('testCafeAutomation');
 const ClickAutomation      = testCafeAutomation.Click;
@@ -13,8 +13,8 @@ const SelectTextAutomation = testCafeAutomation.SelectText;
 const TypeAutomation       = testCafeAutomation.Type;
 const PressAutomation      = testCafeAutomation.Press;
 
-const ClickOptions = testCafeAutomation.get('../../test-run/commands/options').ClickOptions;
-const TypeOptions  = testCafeAutomation.get('../../test-run/commands/options').TypeOptions;
+const ClickOptions = testCafeAutomation.ClickOptions;
+const TypeOptions  = testCafeAutomation.TypeOptions;
 
 testCafeCore.preventRealEvents();
 

--- a/test/client/fixtures/automation/drag-test.js
+++ b/test/client/fixtures/automation/drag-test.js
@@ -1,10 +1,10 @@
 const testCafeAutomation      = window.getTestCafeModule('testCafeAutomation');
 const DragToOffsetAutomation  = testCafeAutomation.DragToOffset;
 const DragToElementAutomation = testCafeAutomation.DragToElement;
-const MouseOptions            = testCafeAutomation.get('../../test-run/commands/options').MouseOptions;
+const MouseOptions            = testCafeAutomation.MouseOptions;
 
 const testCafeCore = window.getTestCafeModule('testCafeCore');
-const position     = testCafeCore.get('./utils/position');
+const position     = testCafeCore.positionUtils;
 
 testCafeCore.preventRealEvents();
 

--- a/test/client/fixtures/automation/focus-blur-change-test.js
+++ b/test/client/fixtures/automation/focus-blur-change-test.js
@@ -7,14 +7,14 @@ const eventSimulator   = hammerhead.eventSandbox.eventSimulator;
 const testCafeCore       = window.getTestCafeModule('testCafeCore');
 const testCafeAutomation = window.getTestCafeModule('testCafeAutomation');
 
-const ClickOptions = testCafeAutomation.get('../../test-run/commands/options').ClickOptions;
-const TypeOptions  = testCafeAutomation.get('../../test-run/commands/options').TypeOptions;
+const ClickOptions = testCafeAutomation.ClickOptions;
+const TypeOptions  = testCafeAutomation.TypeOptions;
 
 const ClickAutomation = testCafeAutomation.Click;
 const TypeAutomation  = testCafeAutomation.Type;
 const PressAutomation = testCafeAutomation.Press;
 
-const parseKeySequence = testCafeCore.get('./utils/parse-key-sequence');
+const parseKeySequence = testCafeCore.parseKeySequence;
 const getOffsetOptions = testCafeAutomation.getOffsetOptions;
 
 testCafeCore.preventRealEvents();

--- a/test/client/fixtures/automation/get-element-test.js
+++ b/test/client/fixtures/automation/get-element-test.js
@@ -1,4 +1,4 @@
-const testCafeUIRoot = window.getTestCafeModule('testCafeUI').get('./ui-root');
+const testCafeUIRoot = window.getTestCafeModule('testCafeUI').uiRoot;
 
 let $rootDiv      = null;
 let $underRootDiv = null;
@@ -7,7 +7,7 @@ let $iframe       = null;
 function getElementFromPointMethod (window) {
     const testCafeAutomation = window.getTestCafeModule('testCafeAutomation');
 
-    return testCafeAutomation.get('./get-element').fromPoint;
+    return testCafeAutomation.getElementFromPoint;
 }
 
 function createRoot () {

--- a/test/client/fixtures/automation/hover-test.js
+++ b/test/client/fixtures/automation/hover-test.js
@@ -4,10 +4,10 @@ const featureDetection = hammerhead.utils.featureDetection;
 
 const testCafeAutomation = window.getTestCafeModule('testCafeAutomation');
 const HoverAutomation    = testCafeAutomation.Hover;
-const MouseOptions       = testCafeAutomation.get('../../test-run/commands/options').MouseOptions;
+const MouseOptions       = testCafeAutomation.MouseOptions;
 
 const testCafeCore = window.getTestCafeModule('testCafeCore');
-const position     = testCafeCore.get('./utils/position');
+const position     = testCafeCore.positionUtils;
 
 testCafeCore.preventRealEvents();
 

--- a/test/client/fixtures/automation/key-press-simulation-test.js
+++ b/test/client/fixtures/automation/key-press-simulation-test.js
@@ -2,9 +2,9 @@ const hammerhead   = window.getTestCafeModule('hammerhead');
 const browserUtils = hammerhead.utils.browser;
 
 const testCafeCore      = window.getTestCafeModule('testCafeCore');
-const eventUtils        = testCafeCore.get('./utils/event');
-const parseKeySequence  = testCafeCore.get('./utils/parse-key-sequence');
-const KEY_MAPS          = testCafeCore.get('./utils/key-maps');
+const eventUtils        = testCafeCore.eventUtils;
+const parseKeySequence  = testCafeCore.parseKeySequence;
+const KEY_MAPS          = testCafeCore.KEY_MAPS;
 
 testCafeCore.preventRealEvents();
 

--- a/test/client/fixtures/automation/out-of-bounds-test.js
+++ b/test/client/fixtures/automation/out-of-bounds-test.js
@@ -3,15 +3,15 @@ const browserUtils     = hammerhead.utils.browser;
 const featureDetection = hammerhead.utils.featureDetection;
 
 const testCafeCore  = window.getTestCafeModule('testCafeCore');
-const position      = testCafeCore.get('./utils/position');
-const textSelection = testCafeCore.get('./utils/text-selection');
+const position      = testCafeCore.positionUtils;
+const textSelection = testCafeCore.textSelection;
 
 testCafeCore.preventRealEvents();
 
 const testCafeAutomation     = window.getTestCafeModule('testCafeAutomation');
-const ClickOptions           = testCafeAutomation.get('../../test-run/commands/options').ClickOptions;
-const TypeOptions            = testCafeAutomation.get('../../test-run/commands/options').TypeOptions;
-const MouseOptions           = testCafeAutomation.get('../../test-run/commands/options').MouseOptions;
+const ClickOptions           = testCafeAutomation.ClickOptions;
+const TypeOptions            = testCafeAutomation.TypeOptions;
+const MouseOptions           = testCafeAutomation.MouseOptions;
 const ClickAutomation        = testCafeAutomation.Click;
 const RClickAutomation       = testCafeAutomation.RClick;
 const DblClickAutomation     = testCafeAutomation.DblClick;

--- a/test/client/fixtures/automation/press-shortcuts-test.js
+++ b/test/client/fixtures/automation/press-shortcuts-test.js
@@ -2,9 +2,9 @@ const hammerhead   = window.getTestCafeModule('hammerhead');
 const browserUtils = hammerhead.utils.browser;
 
 const testCafeCore     = window.getTestCafeModule('testCafeCore');
-const textSelection    = testCafeCore.get('./utils/text-selection');
-const domUtils         = testCafeCore.get('./utils/dom');
-const parseKeySequence = testCafeCore.get('./utils/parse-key-sequence');
+const textSelection    = testCafeCore.textSelection;
+const domUtils         = testCafeCore.domUtils;
+const parseKeySequence = testCafeCore.parseKeySequence;
 
 const testCafeAutomation = window.getTestCafeModule('testCafeAutomation');
 const PressAutomation    = testCafeAutomation.Press;

--- a/test/client/fixtures/automation/press-test.js
+++ b/test/client/fixtures/automation/press-test.js
@@ -1,7 +1,7 @@
 const testCafeCore      = window.getTestCafeModule('testCafeCore');
-const parseKeySequence  = testCafeCore.get('./utils/parse-key-sequence');
-const domUtils          = testCafeCore.get('./utils/dom');
-const textSelection     = testCafeCore.get('./utils/text-selection');
+const parseKeySequence  = testCafeCore.parseKeySequence;
+const domUtils          = testCafeCore.domUtils;
+const textSelection     = testCafeCore.textSelection;
 
 const testCafeAutomation = window.getTestCafeModule('testCafeAutomation');
 const PressAutomation    = testCafeAutomation.Press;

--- a/test/client/fixtures/automation/rclick-test.js
+++ b/test/client/fixtures/automation/rclick-test.js
@@ -1,6 +1,6 @@
 const testCafeAutomation = window.getTestCafeModule('testCafeAutomation');
 const RClickAutomation   = testCafeAutomation.RClick;
-const ClickOptions       = testCafeAutomation.get('../../test-run/commands/options').ClickOptions;
+const ClickOptions       = testCafeAutomation.ClickOptions;
 
 const testCafeCore = window.getTestCafeModule('testCafeCore');
 

--- a/test/client/fixtures/automation/real-actions-blocker-test.js
+++ b/test/client/fixtures/automation/real-actions-blocker-test.js
@@ -4,8 +4,8 @@ const nativeMethods = hammerhead.nativeMethods;
 const testCafeCore = window.getTestCafeModule('testCafeCore');
 
 const testCafeAutomation = window.getTestCafeModule('testCafeAutomation');
-const ClickOptions       = testCafeAutomation.get('../../test-run/commands/options').ClickOptions;
-const MouseOptions       = testCafeAutomation.get('../../test-run/commands/options').MouseOptions;
+const ClickOptions       = testCafeAutomation.ClickOptions;
+const MouseOptions       = testCafeAutomation.MouseOptions;
 const ClickAutomation    = testCafeAutomation.Click;
 const HoverAutomation    = testCafeAutomation.Hover;
 const getOffsetOptions   = testCafeAutomation.getOffsetOptions;

--- a/test/client/fixtures/automation/regression-test.js
+++ b/test/client/fixtures/automation/regression-test.js
@@ -5,16 +5,16 @@ const nativeMethods    = hammerhead.nativeMethods;
 const Promise          = hammerhead.Promise;
 
 const testCafeCore     = window.getTestCafeModule('testCafeCore');
-const eventUtils       = testCafeCore.get('./utils/event');
-const positionUtils    = testCafeCore.get('./utils/position');
-const textSelection    = testCafeCore.get('./utils/text-selection');
-const parseKeySequence = testCafeCore.get('./utils/parse-key-sequence');
+const eventUtils       = testCafeCore.eventUtils;
+const positionUtils    = testCafeCore.positionUtils;
+const textSelection    = testCafeCore.textSelection;
+const parseKeySequence = testCafeCore.parseKeySequence;
 
 const testCafeAutomation = window.getTestCafeModule('testCafeAutomation');
 
-const ClickOptions = testCafeAutomation.get('../../test-run/commands/options').ClickOptions;
-const TypeOptions  = testCafeAutomation.get('../../test-run/commands/options').TypeOptions;
-const MouseOptions = testCafeAutomation.get('../../test-run/commands/options').MouseOptions;
+const ClickOptions = testCafeAutomation.ClickOptions;
+const TypeOptions  = testCafeAutomation.TypeOptions;
+const MouseOptions = testCafeAutomation.MouseOptions;
 
 const ClickAutomation      = testCafeAutomation.Click;
 const RClickAutomation     = testCafeAutomation.RClick;

--- a/test/client/fixtures/automation/select-element-test.js
+++ b/test/client/fixtures/automation/select-element-test.js
@@ -4,12 +4,12 @@ const featureDetection = hammerhead.utils.featureDetection;
 const shadowUI         = hammerhead.shadowUI;
 
 const testCafeCore     = window.getTestCafeModule('testCafeCore');
-const parseKeySequence = testCafeCore.get('./utils/parse-key-sequence');
+const parseKeySequence = testCafeCore.parseKeySequence;
 
 testCafeCore.preventRealEvents();
 
 const testCafeAutomation         = window.getTestCafeModule('testCafeAutomation');
-const ClickOptions               = testCafeAutomation.get('../../test-run/commands/options').ClickOptions;
+const ClickOptions               = testCafeAutomation.ClickOptions;
 const PressAutomation            = testCafeAutomation.Press;
 const DblClickAutomation         = testCafeAutomation.DblClick;
 const ClickAutomation            = testCafeAutomation.Click;
@@ -17,7 +17,7 @@ const SelectChildClickAutomation = testCafeAutomation.SelectChildClick;
 const getOffsetOptions           = testCafeAutomation.getOffsetOptions;
 
 const testCafeUI    = window.getTestCafeModule('testCafeUI');
-const selectElement = testCafeUI.get('./select-element');
+const selectElement = testCafeUI.selectElement;
 
 $(document).ready(function () {
     //consts

--- a/test/client/fixtures/automation/select-test/index-test.js
+++ b/test/client/fixtures/automation/select-test/index-test.js
@@ -6,13 +6,13 @@ const testCafeCore = window.getTestCafeModule('testCafeCore');
 
 const testCafeAutomation                = window.getTestCafeModule('testCafeAutomation');
 const SelectTextAutomation              = testCafeAutomation.SelectText;
-const getSelectionCoordinatesByPosition = testCafeAutomation.get('./playback/select/utils').getSelectionCoordinatesByPosition;
+const getSelectionCoordinatesByPosition = testCafeAutomation.getSelectionCoordinatesByPosition;
 
 testCafeCore.preventRealEvents();
 
-const domUtils      = testCafeCore.get('./utils/dom');
-const style         = testCafeCore.get('./utils/style');
-const textSelection = testCafeCore.get('./utils/text-selection');
+const domUtils      = testCafeCore.domUtils;
+const style         = testCafeCore.styleUtils;
+const textSelection = testCafeCore.textSelection;
 
 
 $(document).ready(function () {

--- a/test/client/fixtures/automation/submit-on-enter-test.js
+++ b/test/client/fixtures/automation/submit-on-enter-test.js
@@ -2,7 +2,7 @@ const hammerhead   = window.getTestCafeModule('hammerhead');
 const browserUtils = hammerhead.utils.browser;
 
 const testCafeCore      = window.getTestCafeModule('testCafeCore');
-const parseKeySequence  = testCafeCore.get('./utils/parse-key-sequence');
+const parseKeySequence  = testCafeCore.parseKeySequence;
 
 const testCafeAutomation = window.getTestCafeModule('testCafeAutomation');
 const PressAutomation    = testCafeAutomation.Press;

--- a/test/client/fixtures/automation/tab-emulation-test.js
+++ b/test/client/fixtures/automation/tab-emulation-test.js
@@ -2,11 +2,11 @@ const hammerhead   = window.getTestCafeModule('hammerhead');
 const browserUtils = hammerhead.utils.browser;
 
 const testCafeCore = window.getTestCafeModule('testCafeCore');
-const domUtils     = testCafeCore.get('./utils/dom');
+const domUtils     = testCafeCore.domUtils;
 
 const testCafeAutomation = window.getTestCafeModule('testCafeAutomation');
 const PressAutomation    = testCafeAutomation.Press;
-const parseKeySequence   = testCafeCore.get('./utils/parse-key-sequence');
+const parseKeySequence   = testCafeCore.parseKeySequence;
 
 testCafeCore.preventRealEvents();
 

--- a/test/client/fixtures/automation/type-test.js
+++ b/test/client/fixtures/automation/type-test.js
@@ -3,12 +3,12 @@ const browserUtils  = hammerhead.utils.browser;
 const nativeMethods = hammerhead.nativeMethods;
 
 const testCafeCore      = window.getTestCafeModule('testCafeCore');
-const parseKeySequence  = testCafeCore.get('./utils/parse-key-sequence');
+const parseKeySequence  = testCafeCore.parseKeySequence;
 
 const testCafeAutomation = window.getTestCafeModule('testCafeAutomation');
 const TypeAutomation     = testCafeAutomation.Type;
 const PressAutomation    = testCafeAutomation.Press;
-const TypeOptions        = testCafeAutomation.get('../../test-run/commands/options').TypeOptions;
+const TypeOptions        = testCafeAutomation.TypeOptions;
 
 testCafeCore.preventRealEvents();
 

--- a/test/client/fixtures/core/dom-utils-test.js
+++ b/test/client/fixtures/core/dom-utils-test.js
@@ -1,7 +1,7 @@
 const hammerhead    = window.getTestCafeModule('hammerhead');
 const browserUtils  = hammerhead.utils.browser;
 const testCafeCore  = window.getTestCafeModule('testCafeCore');
-const domUtils      = testCafeCore.get('./utils/dom');
+const domUtils      = testCafeCore.domUtils;
 
 asyncTest('isIFrameWindowInDOM', function () {
     expect(browserUtils.isIE ? 2 : 1);

--- a/test/client/fixtures/core/style-utils-test.js
+++ b/test/client/fixtures/core/style-utils-test.js
@@ -1,5 +1,5 @@
 const testCafeCore = window.getTestCafeModule('testCafeCore');
-const styleUtils   = testCafeCore.get('./utils/style');
+const styleUtils   = testCafeCore.styleUtils;
 
 test('hasScroll (GH-2511)', function () {
     const div      = document.createElement('div');


### PR DESCRIPTION
Make client tests do not rely on the internal structures of client bundles. Tests have to use only exported symbols, since Rollup doesn't preserve the submodule structure inside a bundle.