### PR TITLE
Make pressKey to work for elements within shadowDOM (closes #2432)

### DIFF
--- a/src/client/automation/playback/press/utils.js
+++ b/src/client/automation/playback/press/utils.js
@@ -1,7 +1,7 @@
 import hammerhead from '../../deps/hammerhead';
 import { KEY_MAPS, domUtils } from '../../deps/testcafe-core';
 import isLetter from '../../utils/is-letter';
-import { findDocument, isRadioButtonElement } from '../../../core/utils/dom';
+import { findDocument, isRadioButtonElement, getActiveElement } from '../../../core/utils/dom';
 import * as arrayUtils from '../../../core/utils/array';
 
 const nativeMethods    = hammerhead.nativeMethods;
@@ -62,11 +62,9 @@ export function getChar (key, shiftModified) {
 
 export function getDeepActiveElement (currentDocument) {
     const doc                 = currentDocument || document;
+    const activeElement       = getActiveElement(doc);
     let activeElementInIframe = null;
-    let activeElement         = nativeMethods.documentActiveElementGetter.call(doc);
 
-    if (!activeElement || !domUtils.isDomElement(activeElement))
-        activeElement = doc.body;
 
     if (activeElement && domUtils.isIframeElement(activeElement) &&
         nativeMethods.contentDocumentGetter.call(activeElement)) {

--- a/test/client/fixtures/automation/press-test.js
+++ b/test/client/fixtures/automation/press-test.js
@@ -5,6 +5,7 @@ const textSelection     = testCafeCore.textSelection;
 
 const testCafeAutomation = window.getTestCafeModule('testCafeAutomation');
 const PressAutomation    = testCafeAutomation.Press;
+const ClickAutomation    = testCafeAutomation.Click;
 
 testCafeCore.preventRealEvents();
 
@@ -202,6 +203,34 @@ $(document).ready(function () {
                 start();
             });
     });
+
+    if (!browserUtils.isIE) {
+        asyncTest('GH-2432 - Incorrect active element detection inside shadow dom (press)', function () {
+            const shadowContainer = document.createElement('div');
+            const input           = document.createElement('input');
+
+            shadowContainer.className = TEST_ELEMENT_CLASS;
+            input.type                = 'text';
+            input.value               = '123';
+
+            document.body.appendChild(shadowContainer);
+            shadowContainer.attachShadow({ mode: 'open' }).appendChild(input);
+            input.focus();
+
+            const click = new ClickAutomation(input, {});
+            const press = new PressAutomation(parseKeySequence('backspace').combinations, {});
+
+            click.run()
+                .then(function () {
+                    return press.run();
+                })
+                .then(function () {
+                    equal(input.value, '12');
+
+                    start();
+                });
+        });
+    }
 
     if (browserUtils.isSafari) {
         asyncTest('T334620 - Wrong "keyIdentifier" property in keyEvent objects (press)', function () {


### PR DESCRIPTION
The `getActiveElement` method from `hammerhead` contains required code to work with shadowRoot