### PR TITLE
Do not wait for reporter is executed when concurrency is enabled (closes #4894)

### DIFF
--- a/src/runner/browser-job.js
+++ b/src/runner/browser-job.js
@@ -125,7 +125,7 @@ export default class BrowserJob extends AsyncEventEmitter {
             const hasIncompleteTestRuns     = this.completionQueue.some(controller => !controller.done);
             const needWaitLastTestInFixture = this.reportsPending.some(controller => controller.test.fixture !== testRunController.test.fixture);
 
-            if (isBlocked || needWaitLastTestInFixture || hasIncompleteTestRuns && !isConcurrency)
+            if (isBlocked || (hasIncompleteTestRuns || needWaitLastTestInFixture) && !isConcurrency)
                 break;
 
             this.reportsPending.push(testRunController);

--- a/test/functional/fixtures/regression/gh-4787/test.js
+++ b/test/functional/fixtures/regression/gh-4787/test.js
@@ -58,7 +58,6 @@ if (config.useLocalBrowsers && !config.useHeadlessBrowsers) {
                         .src(path.join(__dirname, './testcafe-fixtures/index.js'))
                         .browsers(['chrome', 'firefox'])
                         .reporter(customReporter)
-                        .concurrency(2)
                         .run();
                 })
                 .then(() => {


### PR DESCRIPTION
If we have multiple fixtures and every fixture contains small number of tests, the synchronization occurs too often. This leads to the situation when concurrent browsers wait for last test in fixture is done.
I remove the syncronization when the concurrency mode is enabled