### PR TITLE
docs: Fix simple typo, overriden -> overridden

### DIFF
--- a/docs/articles/blog/2017-1-19-testcafe-v0-12-0-released.md
+++ b/docs/articles/blog/2017-1-19-testcafe-v0-12-0-released.md
@@ -284,7 +284,7 @@ Get it to ensure that ESLint does not fail on TestCafe test code.
 * Onclick event handler is now executed correctly during click automation in specific cases ([#1138](https://github.com/DevExpress/testcafe/issues/1138))
 * The `application/pdf` mime type is no longer recognized as a page ([testcafe-hammerhead#1014](https://github.com/DevExpress/testcafe-hammerhead/issues/1014))
 * Limited support for the `frameset` tag is implemented ([testcafe-hammerhead#1009](https://github.com/DevExpress/testcafe-hammerhead/issues/1009))
-* `Function.prototype.toString` is now proxied correctly when it is overriden in a user script ([testcafe-hammerhead#999](https://github.com/DevExpress/testcafe-hammerhead/issues/999))
+* `Function.prototype.toString` is now proxied correctly when it is overridden in a user script ([testcafe-hammerhead#999](https://github.com/DevExpress/testcafe-hammerhead/issues/999))
 * Script processing no longer hangs on chained assignments ([testcafe-hammerhead#866](https://github.com/DevExpress/testcafe-hammerhead/issues/866))
 * `formaction` attribute is now processed ([testcafe-hammerhead#988](https://github.com/DevExpress/testcafe-hammerhead/issues/988))
 * `document.styleSheets` is now overrided ([testcafe-hammerhead#1000](https://github.com/DevExpress/testcafe-hammerhead/issues/1000))

--- a/docs/articles/documentation/test-api/intercepting-http-requests/creating-a-custom-http-request-hook.md
+++ b/docs/articles/documentation/test-api/intercepting-http-requests/creating-a-custom-http-request-hook.md
@@ -57,7 +57,7 @@ You can create your own request hook to handle HTTP requests. This topic describ
 
 * The `onRequest` asynchronous method is called before the request is sent. Use this method to handle sending the request. You can change the request parameters before it is sent.
 
-    This method is abstract in the base class and needs to be overriden in the subclass.
+    This method is abstract in the base class and needs to be overridden in the subclass.
 
     ```js
     async onRequest (/*RequestEvent event*/) {


### PR DESCRIPTION
There is a small typo in docs/articles/blog/2017-1-19-testcafe-v0-12-0-released.md, docs/articles/documentation/test-api/intercepting-http-requests/creating-a-custom-http-request-hook.md.

Should read `overridden` rather than `overriden`.

