### PR TITLE
Compiler doesn't execute typescript declaration files anymore

### DIFF
--- a/src/compiler/test-file/api-based.js
+++ b/src/compiler/test-file/api-based.js
@@ -174,10 +174,13 @@ export default class APIBasedTestFileCompilerBase extends TestFileCompilerBase {
         return this._runCompiledCode(compiledCode, filename);
     }
 
-    compile (code, filename) {
-        const [compiledCode] = this.precompile([{ code, filename }]);
+    async compile (code, filename) {
+        const [compiledCode] = await this.precompile([{ code, filename }]);
 
-        return this.execute(compiledCode, filename);
+        if (compiledCode)
+            return this.execute(compiledCode, filename);
+
+        return Promise.resolve();
     }
 
     _hasTests (code) {

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -869,7 +869,7 @@ describe('Compiler', function () {
         });
 
         it('getTests method should not raise an error for typescript declaration files', function () {
-            return compile('test/server/data/test-suites/type-script-decription/fs.d.ts')
+            return compile('test/server/data/test-suites/typescript-description-file/fs.d.ts')
                 .then(res => {
                     expect(res).eql({ tests: [], fixtures: [] });
                 });

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -867,5 +867,12 @@ describe('Compiler', function () {
                     expect(stack[2].source).to.have.string('testfile.js');
                 });
         });
+
+        it('getTests method should not raise an error for typescript declaration files', function () {
+            return compile('test/server/data/test-suites/type-script-decription/fs.d.ts')
+                .then(res => {
+                    expect(res).eql({ tests: [], fixtures: [] });
+                });
+        });
     });
 });


### PR DESCRIPTION
## Problem
If you try to start test run for a folder that contains testcafe's test file and a typescript declaration file you get an error:
![image](https://user-images.githubusercontent.com/12034551/78788145-1153cc00-79b4-11ea-905b-3df9a670d78f.png)
Try it yourself - [surveyjsio-site-tests.zip](https://github.com/DevExpress/testcafe/files/4450681/surveyjsio-site-tests.zip)


## Solution
TypeScript compiler should not execute such files because they are don't produce any code.