### PR TITLE
pull published image immediately after push (closes #4979)

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -920,6 +920,8 @@ gulp.task('docker-test', done => {
 gulp.step('docker-publish-run', done => {
     PUBLISH_TAGS.forEach(tag => {
         childProcess.execSync(`docker push ${PUBLISH_REPO}:${tag}`, { stdio: 'inherit', env: process.env });
+
+        childProcess.execSync(`docker pull ${PUBLISH_REPO}:${tag}`, { stdio: 'inherit', env: process.env });
     });
 
     done();


### PR DESCRIPTION
It's enough to pull the image immediately after publishing.
The `pull` command sends request to the server even when you have local image with same name and tag. If the image exists on server the `image is up to date` message will appear in console, otherwise, the `manifest` not found error will break the task execution.