### PR TITLE
Continue debugging when a child window closes (closes #4990)

### DIFF
--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -493,12 +493,17 @@ export default class TestRun extends AsyncEventEmitter {
 
     // Handle driver request
     _shouldResolveCurrentDriverTask (driverStatus) {
-        const isFirstReturnResultCommandAfterWindowSwitching =
-            driverStatus.isFirstRequestAfterWindowSwitching &&
-            (this.currentDriverTask.command instanceof observationCommands.ExecuteSelectorCommand ||
-            this.currentDriverTask.command instanceof observationCommands.ExecuteClientFunctionCommand);
+        const currentCommand = this.currentDriverTask.command;
 
-        return !isFirstReturnResultCommandAfterWindowSwitching;
+        const isExecutingObservationCommand = currentCommand instanceof observationCommands.ExecuteSelectorCommand ||
+            currentCommand instanceof observationCommands.ExecuteClientFunctionCommand;
+
+        const isDebugActive = currentCommand instanceof serviceCommands.SetBreakpointCommand;
+
+        const shouldExecuteCurrentCommand =
+            driverStatus.isFirstRequestAfterWindowSwitching && (isExecutingObservationCommand || isDebugActive);
+
+        return !shouldExecuteCurrentCommand;
     }
 
     _fulfillCurrentDriverTask (driverStatus) {

--- a/test/functional/fixtures/run-options/allow-multiple-windows/pages/debug-synchronization/child.html
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/pages/debug-synchronization/child.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Multiwindow debug test: child</title>
+    </head>
+    <body>
+        <button id="open" onclick="window.open('child.html')">Open</button>
+        <button id="close" onclick="window.close()">Close</button>
+    </body>
+</html>

--- a/test/functional/fixtures/run-options/allow-multiple-windows/pages/debug-synchronization/parent.html
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/pages/debug-synchronization/parent.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Multiwindow debug test: parent</title>
+    </head>
+    <body>
+        <button id="open" onclick="window.open('child.html')">Open</button>
+        <button id="close" onclick="window.close()">Close</button>
+    </body>
+</html>

--- a/test/functional/fixtures/run-options/allow-multiple-windows/test.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/test.js
@@ -86,4 +86,8 @@ describe('Allow multiple windows', () => {
     it('Should correctly synchronize a cookie from a new same-domain window', () => {
         return runTests('testcafe-fixtures/cookie-synchronization/same-domain.js', null, { allowMultipleWindows: true });
     });
+
+    it('Should continue debugging when a child window closes', () => {
+        return runTests('testcafe-fixtures/debug-synchronization.js', null, { only: 'chrome', allowMultipleWindows: true });
+    });
 });

--- a/test/functional/fixtures/run-options/allow-multiple-windows/testcafe-fixtures/debug-synchronization.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/testcafe-fixtures/debug-synchronization.js
@@ -1,0 +1,98 @@
+import cdp from 'chrome-remote-interface';
+
+
+fixture `Test`
+    .page `../pages/debug-synchronization/parent.html`;
+
+const TARGET_CHILD_WINDOW_TITLE  = 'Multiwindow debug test: child';
+
+async function getChildWindowTarget (port) {
+    const targets = await cdp.List({ port });
+
+    return targets.find(({ title }) => title === TARGET_CHILD_WINDOW_TITLE);
+}
+
+async function executeClientFunction (cdpClient, action) {
+    const { result: { value } } = await cdpClient.Runtime.evaluate({ expression: `(${action.toString()})()` });
+
+    return value;
+}
+
+function closeWindow () {
+    window.close();
+}
+
+function getDebuggingState () {
+    return window['%testCafeDriverInstance%'].statusBar.state.debugging;
+}
+
+function resumeDebugging () {
+    window['%testCafeDriverInstance%'].statusBar.resumeButton.dispatchEvent(new MouseEvent('mousedown'));
+}
+
+async function getRemoteDebuggingState (cdpClient) {
+    return executeClientFunction(cdpClient, getDebuggingState);
+}
+
+async function waitUntilDebuggingStarts (cdpClient) {
+    let debuggingState = await getRemoteDebuggingState(cdpClient);
+
+    while (!debuggingState)
+        debuggingState = await getRemoteDebuggingState(cdpClient);
+}
+
+async function getChildClient (port, target) {
+    const childClient = await cdp({ port, target });
+
+    await childClient.Runtime.enable;
+
+    return childClient;
+}
+
+async function waitUntilChildWindowOpens (port) {
+    let childTarget = await getChildWindowTarget(port);
+
+    while (!childTarget)
+        childTarget = await getChildWindowTarget(port);
+
+    return getChildClient(port, childTarget);
+}
+
+async function waitUntilChildWindowCloses (port) {
+    let childTarget = await getChildWindowTarget(port);
+
+    while (childTarget)
+        childTarget = await getChildWindowTarget(port);
+}
+
+async function closeRemoteWindow (cdpClient) {
+    await executeClientFunction(cdpClient, closeWindow);
+}
+
+async function resumeRemoteDebugging (cdpClient) {
+    await executeClientFunction(cdpClient, resumeDebugging);
+}
+
+test('test', async t => {
+    const browserInfo  = t.testRun.browserConnection.provider.plugin.openedBrowsers[t.testRun.browserConnection.id];
+    const browserPort  = browserInfo.cdpPort;
+    const parentClient = browserInfo.client;
+
+    await t.click('#open');
+
+    const childClient = await waitUntilChildWindowOpens(browserPort);
+
+    const debugPromise = t.debug();
+
+    await waitUntilDebuggingStarts(childClient);
+
+    await closeRemoteWindow(childClient);
+
+    await waitUntilChildWindowCloses(browserPort);
+
+    await waitUntilDebuggingStarts(parentClient);
+
+    await resumeRemoteDebugging(parentClient);
+
+    await debugPromise;
+});


### PR DESCRIPTION
Fixes a problem when TestCafe starts debugging in a child window, child window closes and test execution continues. If a child windows closes, we should reexecute the SetBreakpointCommand if it is the current command in the execution queue.

Includes a test that uses Chrome Devtools protocol to control the browser during debugging.