### PR TITLE
Fix Selector.visible for complex selectors (closes #5002)

### DIFF
--- a/src/client-functions/selectors/add-api.js
+++ b/src/client-functions/selectors/add-api.js
@@ -68,9 +68,9 @@ const expandSelectorResults = (new ClientFunctionBuilder((selector, populateDeri
 
 })).getFunction();
 
-async function getSnapshot (getSelector, callsite, SelectorBuilder) {
+async function getSnapshot (getSelector, callsite, SelectorBuilder, getVisibleValueMode) {
     let node       = null;
-    const selector = new SelectorBuilder(getSelector(), { needError: true }, { instantiation: 'Selector' }).getFunction();
+    const selector = new SelectorBuilder(getSelector(), { getVisibleValueMode, needError: true }, { instantiation: 'Selector' }).getFunction();
 
     try {
         node = await selector();
@@ -126,11 +126,12 @@ function addSnapshotProperties (obj, getSelector, SelectorBuilder, properties) {
 function addVisibleProperty ({ obj, getSelector, SelectorBuilder }) {
     Object.defineProperty(obj, VISIBLE_PROP_NAME, {
         get: () => {
-            return ReExecutablePromise.fromFn(async () => {
-                const builder  = new SelectorBuilder(getSelector(), { getVisibleValueMode: true }, { instantiation: 'Selector' });
-                const resultFn = builder.getFunction();
+            const callsite = getCallsiteForMethod('get');
 
-                return resultFn();
+            return ReExecutablePromise.fromFn(async () => {
+                const snapshot = await getSnapshot(getSelector, callsite, SelectorBuilder, true);
+
+                return !!snapshot && snapshot[VISIBLE_PROP_NAME];
             });
         }
     });

--- a/src/client/driver/command-executors/client-functions/selector-executor/filter.js
+++ b/src/client/driver/command-executors/client-functions/selector-executor/filter.js
@@ -54,11 +54,6 @@ class SelectorFilter {
             else
                 filtered = filtered.length;
         }
-        else if (options.getVisibleValueMode) {
-            const el = node[0];
-
-            return !!el && visible(el);
-        }
         else {
             if (options.collectionMode) {
                 if (options.index !== null) {

--- a/test/functional/fixtures/api/es-next/selector/pages/visible.html
+++ b/test/functional/fixtures/api/es-next/selector/pages/visible.html
@@ -5,7 +5,7 @@
     <title>Title</title>
 </head>
 <body>
-    <div></div>
-    <div></div>
+    <div id="invisible"></div>
+    <div id="visible">text</div>
 </body>
 </html>

--- a/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-visible-test.js
+++ b/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-visible-test.js
@@ -1,7 +1,7 @@
 import { Selector } from 'testcafe';
 
 fixture `Selector.visible`
-    .page('http://localhost:3000/fixtures/api/es-next/selector/pages/visible.html');
+    .page('../pages/visible.html');
 
 test('test', async t => {
     const nonExistingElement = Selector('#wrong-selector');
@@ -10,10 +10,16 @@ test('test', async t => {
         .expect(nonExistingElement.exists).notOk()
         .expect(nonExistingElement.visible).notOk();
 
-    const existingElement = Selector('div');
+    const invisibleElement = Selector('#invisible');
 
     await t
-        .expect(existingElement.exists).ok()
-        .expect(existingElement.visible).notOk();
+        .expect(invisibleElement.exists).ok()
+        .expect(invisibleElement.visible).notOk();
+
+    const visibleElement = Selector('#invisible, #visible').filterVisible();
+
+    await t.expect(visibleElement.exists).ok();
+    await t.expect((await visibleElement()).visible).ok();
+    await t.expect(visibleElement.visible).ok();
 });
 


### PR DESCRIPTION
In https://github.com/DevExpress/testcafe/commit/90e7b04aac9316c9416cc8fd08791c688b92948a we allowed to execute `Selector.visible` even if the target element does not exist. It was done by calculating visibility at the element filtration stage in contrast to calculating a DOM snapshot stage after filtration and retrieving visibility from it. Unfortunately it broke compatibility with other filters like `filterVisible`.

This PR moves visibilty calculation back to the DOM snapshot but makes it avoiding raising exceptions when we cannot find the target element. 