### PR TITLE
Add --init option to the testcafe cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prepublishOnly": "publish-please guard"
   },
   "dependencies": {
+    "@types/inquirer": "^6.5.0",
     "@types/node": "^10.12.19",
     "async-exit-hook": "^1.1.2",
     "babel-core": "^6.22.1",
@@ -86,6 +87,7 @@
     "graphlib": "^2.1.5",
     "import-lazy": "^3.1.0",
     "indent-string": "^1.2.2",
+    "inquirer": "^7.1.0",
     "is-ci": "^1.0.10",
     "is-docker": "^2.0.0",
     "is-glob": "^2.0.1",

--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -95,6 +95,7 @@ export default class CLIArgumentParser {
             .usage('[options] <comma-separated-browser-list> <file-or-glob ...>')
             .description(CLIArgumentParser._getDescription())
 
+            .option('-i, --init', 'generate a configuration file')
             .option('-b, --list-browsers [provider]', 'output the aliases for local browsers or browsers available through the specified browser provider')
             .option('-r, --reporter <name[:outputFile][,...]>', 'specify the reporters and optionally files where reports are saved')
             .option('-s, --screenshots <option=value[,...]>', 'specify screenshot options')

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -9,7 +9,7 @@ import log from './log';
 import remotesWizard from './remotes-wizard';
 import correctBrowsersAndSources from './correct-browsers-and-sources';
 import createTestCafe from '../';
-import { generateConfigFile } from './generate-config-file';
+import generateConfigFile from './generate-config-file';
 
 // NOTE: Load the provider pool lazily to reduce startup time
 const lazyRequire         = require('import-lazy')(require);

--- a/src/cli/generate-config-file.ts
+++ b/src/cli/generate-config-file.ts
@@ -1,0 +1,213 @@
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+
+export async function generateConfigFile (configFile: File, browserNames = []): Promise<object> {
+    if (!await canGenerateConfigFile(configFile)) {
+        console.log('Goodbye! 👋');
+        process.exit(0);
+    }
+
+    console.log(
+        chalk.underline(
+            `The following questions will help Testcafe to create a suitable configuration for your project\n`,
+        )
+    );
+
+    let generatedConfig = {};
+
+    if (browserNames) {
+        const browsers = await inquirer
+            .prompt([
+                {
+                    type:    'checkbox',
+                    name:    'browsers',
+                    message: 'Browsers choices?',
+                    choices: browserNames,
+                }
+            ]);
+
+        generatedConfig = Object.assign(generatedConfig, browsers);
+    }
+
+    const src = await inquirer
+        .prompt([
+            {
+                type:    'text',
+                name:    'src',
+                message: 'Specifiy files or directories from which to run tests. (Specify multiple separated by commas.)',
+                filter:  function (value) {
+                    value = value.split(',');
+
+                    if (value.length === 1)
+                        value = value.join().trim();
+                    else if (value.length > 1)
+                        value = value.map((file: string) => file.trim());
+                    return value;
+                }
+            }
+        ]);
+
+    generatedConfig = Object.assign(generatedConfig, src);
+
+    const disableScreenshots = await inquirer
+        .prompt([
+            {
+                type:    'confirm',
+                name:    'disableScreenshots',
+                message: 'Do you want to disable screenshots?',
+                default: true
+            }
+        ]);
+
+    if (disableScreenshots.disableScreenshots)
+        generatedConfig = Object.assign(generatedConfig, disableScreenshots);
+    else {
+        let screenshots = {};
+        const screenshotsTakeOnFails = await inquirer
+            .prompt([
+                {
+                    type:    'confirm',
+                    name:    'takeOnFails',
+                    message: 'Screenshot should be taken whenever a test fails?',
+                    default: true
+                }
+            ]);
+
+        screenshots = Object.assign(screenshots, screenshotsTakeOnFails);
+
+        const screenshotsFullPage = await inquirer
+            .prompt([
+                {
+                    type:    'confirm',
+                    name:    'fullPage',
+                    message: 'The full page should be captured, including content that is not visible due to overflow?',
+                    default: true
+                }
+            ]);
+
+        screenshots = Object.assign(screenshots, screenshotsFullPage);
+        generatedConfig = Object.assign(generatedConfig, { screenshots });
+    }
+
+    const quarantineMode = await inquirer
+        .prompt([
+            {
+                type:    'confirm',
+                name:    'quarantineMode',
+                message: 'Do you want to enable quarantine mode?',
+                default: true
+            }
+        ]);
+
+    generatedConfig = Object.assign(generatedConfig, quarantineMode);
+
+    const debugMode = await inquirer
+        .prompt([
+            {
+                type:    'confirm',
+                name:    'debugMode',
+                message: 'Do you want to enable debug mode?',
+                default: true
+            }
+        ]);
+
+    generatedConfig = Object.assign(generatedConfig, debugMode);
+
+    const debugOnFail = await inquirer
+        .prompt([
+            {
+                type:    'confirm',
+                name:    'debugOnFail',
+                message: 'Do you want to enable debug mode only when a test fails?',
+                default: true
+            }
+        ]);
+
+    generatedConfig = Object.assign(generatedConfig, debugOnFail);
+
+    const skipJsErrors = await inquirer
+        .prompt([
+            {
+                type:    'confirm',
+                name:    'skipJsErrors',
+                message: 'Do you want to skip Javascript errors they occurs on a tested webpage?',
+                default: true
+            }
+        ]);
+
+    generatedConfig = Object.assign(generatedConfig, skipJsErrors);
+
+    const skipUncaughtErrors = await inquirer
+        .prompt([
+            {
+                type:    'confirm',
+                name:    'skipUncaughtErrors',
+                message: 'Do you want to skip uncaught errors on theserver during test execution?',
+                default: true
+            }
+        ]);
+
+    generatedConfig = Object.assign(generatedConfig, skipUncaughtErrors);
+
+    const appCommand = await inquirer
+        .prompt([
+            {
+                type:    'input',
+                name:    'appCommand',
+                message: 'Would you like to execute a specified shell command before running tests?',
+                default: false
+            }
+        ]);
+
+    if (appCommand.appCommand) {
+        generatedConfig = Object.assign(generatedConfig, appCommand);
+        const appInitDelay = await inquirer
+            .prompt([
+                {
+                    type:     'number',
+                    name:     'appInitDelay',
+                    message:  'Specify the time (in ms) allowed for your application launched using the appCommand option to initialize.',
+                    default:  1000,
+                    validate: function (value) {
+                        return !isNaN(parseFloat(value)) && isFinite(value) || 'Please enter a number';
+                    }
+                }
+            ]);
+
+        generatedConfig = Object.assign(generatedConfig, appInitDelay);
+    }
+
+    const concurrency = await inquirer
+        .prompt([
+            {
+                type:     'number',
+                name:     'concurrency',
+                message:  'Specify the number of browser instances that should run tests concurrently.',
+                default:  1,
+                validate: function (value) {
+                    return !isNaN(parseFloat(value)) && isFinite(value) || 'Please enter a number';
+                }
+            }
+        ]);
+
+    generatedConfig = Object.assign(generatedConfig, concurrency);
+
+    return generatedConfig;
+}
+
+async function canGenerateConfigFile (configFile: File): Promise<boolean> {
+    if (configFile) {
+        const overwriteAnswer = await inquirer
+            .prompt([
+                {
+                    type:    'confirm',
+                    name:    'overwrite',
+                    message: '.testcafe.json already exists! Would you like to overwrite it?',
+                    default: false
+                }
+            ]);
+
+        return overwriteAnswer.overwrite;
+    }
+    return true;
+}

--- a/src/cli/generate-config-file.ts
+++ b/src/cli/generate-config-file.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 
-export async function generateConfigFile (configFile: File, browserNames = []): Promise<object> {
+async function generateConfigFile (configFile: File, browserNames = []): Promise<object> {
     if (!await canGenerateConfigFile(configFile)) {
         console.log('Goodbye! 👋');
         process.exit(0);
@@ -34,7 +34,7 @@ export async function generateConfigFile (configFile: File, browserNames = []): 
             {
                 type:    'text',
                 name:    'src',
-                message: 'Specifiy files or directories from which to run tests. (Specify multiple separated by commas.)',
+                message: 'Specifiy files or directories from which to run tests. (Separated by commas.)',
                 filter:  function (value) {
                     value = value.split(',');
 
@@ -211,3 +211,5 @@ async function canGenerateConfigFile (configFile: File): Promise<boolean> {
     }
     return true;
 }
+
+export default generateConfigFile;


### PR DESCRIPTION
## Purpose
Add `--init` option to the `testcafe` cli to generate a configuration file.

## Approach
I followed [this documentation](https://devexpress.github.io/testcafe/documentation/using-testcafe/configuration-file.html) for possible questions to ask.
However, I just selected a few properties so as not to ask a lot of questions.
Here they are:

1. browsers
2. src
3. disableScreenshots
4. takeOnFails
5. fullPage
6. quarantineMode
7. debugMode
8. debugOnFail
9. skipJsErrors
10. skipUncaughtErrors
11. appCommand
12. appInitDelay


## References
I am targeting [this issue](https://github.com/DevExpress/testcafe/issues/3703) 

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
