### PR TITLE
[docs] fix ReactSelector import

### DIFF
--- a/docs/articles/documentation/guides/basic-guides/select-page-elements.md
+++ b/docs/articles/documentation/guides/basic-guides/select-page-elements.md
@@ -410,7 +410,7 @@ For this purpose, the TestCafe team and community have developed libraries of de
 The React selectors module provides the `ReactSelector` class that allows you to select DOM elements by the component name. You can get a root element or search through the nested components or elements. In addition, you can obtain the component props and state.
 
 ```js
-import ReactSelector from 'testcafe-react-selectors';
+import { ReactSelector } from 'testcafe-react-selectors';
 
 const TodoList         = ReactSelector('TodoApp TodoList');
 const itemsCountStatus = ReactSelector('TodoApp div');


### PR DESCRIPTION
Fixing the docs example of using `testcafe-react-selectors`.
The default export declaration [changed 2 years ago](https://github.com/DevExpress/testcafe-react-selectors/commit/1172b89ef079872eb2b8c70fc73409764a273fec#diff-b19910e06a80cee27943e3eb72d8d760L4) to named export, as reflected on the [library docs](https://github.com/DevExpress/testcafe-react-selectors/blob/master/README.md#selecting-elements-by-the-component-name).
