### PR TITLE
Passing configuration options to reporter (closes #5088)

### DIFF
--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -172,7 +172,7 @@ export default class Reporter {
             const userAgents = task.browserConnectionGroups.map(group => group[0].userAgent);
             const first      = this.reportQueue[0];
 
-            await this.plugin.reportTaskStart(startTime, userAgents, this.testCount, task.testStructure);
+            await this.plugin.reportTaskStart(startTime, userAgents, this.testCount, task.testStructure, task.opts);
             await this.plugin.reportFixtureStart(first.fixture.name, first.fixture.path, first.fixture.meta);
         });
 

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -171,8 +171,11 @@ export default class Reporter {
             const startTime  = new Date();
             const userAgents = task.browserConnectionGroups.map(group => group[0].userAgent);
             const first      = this.reportQueue[0];
+            const taskProperties = {
+                configuration: task.opts
+            };
 
-            await this.plugin.reportTaskStart(startTime, userAgents, this.testCount, task.testStructure, task.opts);
+            await this.plugin.reportTaskStart(startTime, userAgents, this.testCount, task.testStructure, taskProperties);
             await this.plugin.reportFixtureStart(first.fixture.name, first.fixture.path, first.fixture.meta);
         });
 

--- a/src/reporter/plugin-host.js
+++ b/src/reporter/plugin-host.js
@@ -143,7 +143,7 @@ export default class ReporterPluginHost {
 
 
     // Abstract methods implemented in plugin
-    async reportTaskStart (/* startTime, userAgents, testCount, testStructure, options */) {
+    async reportTaskStart (/* startTime, userAgents, testCount, testStructure, taskProperties */) {
         throw new Error('Not implemented');
     }
 

--- a/src/reporter/plugin-host.js
+++ b/src/reporter/plugin-host.js
@@ -143,7 +143,7 @@ export default class ReporterPluginHost {
 
 
     // Abstract methods implemented in plugin
-    async reportTaskStart (/* startTime, userAgents, testCount */) {
+    async reportTaskStart (/* startTime, userAgents, testCount, testStructure, options */) {
         throw new Error('Not implemented');
     }
 

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -529,7 +529,10 @@ describe('Reporter', () => {
                                 ]
                             }
                         }
-                    ]
+                    ],
+                    {
+                        stopOnFirstFail: false
+                    }
                 ]
             },
             {

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -359,10 +359,38 @@ describe('Reporter', () => {
         }
     }
 
+    const configurationOptions = {
+        allowMultipleWindows:   false,
+        appInitDelay:           1000,
+        assertionTimeout:       3000,
+        browsers:               ['chrome', 'firefox'],
+        concurrency:            1,
+        debugMode:              false,
+        debugOnFail:            false,
+        developmentMode:        false,
+        disablePageCaching:     false,
+        disablePageReloads:     false,
+        disableScreenshots:     false,
+        hostname:               'localhost',
+        pageLoadTimeout:        3000,
+        port1:                  1337,
+        port2:                  1338,
+        quarantineMode:         false,
+        reporter:               [{ name: 'customReporter' }],
+        retryTestPages:         false,
+        screenshots:            { path: '/path/to/screenshots' },
+        selectorTimeout:        10000,
+        skipJsErrors:           false,
+        skipUncaughtErrors:     false,
+        speed:                  1,
+        src:                    ['test.js'],
+        stopOnFirstFail:        false,
+        takeScreenshotsOnFails: false
+    };
 
     class TaskMock extends Task {
         constructor () {
-            super(testMocks, chunk(browserConnectionMocks, 1), {}, { stopOnFirstFail: false });
+            super(testMocks, chunk(browserConnectionMocks, 1), {}, configurationOptions);
 
             this.screenshots = new ScreenshotsMock();
 
@@ -530,8 +558,34 @@ describe('Reporter', () => {
                             }
                         }
                     ],
+                    // NOTE: configuration options
                     {
-                        stopOnFirstFail: false
+                        allowMultipleWindows:   false,
+                        appInitDelay:           1000,
+                        assertionTimeout:       3000,
+                        browsers:               ['chrome', 'firefox'],
+                        concurrency:            1,
+                        debugMode:              false,
+                        debugOnFail:            false,
+                        developmentMode:        false,
+                        disablePageCaching:     false,
+                        disablePageReloads:     false,
+                        disableScreenshots:     false,
+                        hostname:               'localhost',
+                        pageLoadTimeout:        3000,
+                        port1:                  1337,
+                        port2:                  1338,
+                        quarantineMode:         false,
+                        reporter:               [{ name: 'customReporter' }],
+                        retryTestPages:         false,
+                        screenshots:            { path: '/path/to/screenshots' },
+                        selectorTimeout:        10000,
+                        skipJsErrors:           false,
+                        skipUncaughtErrors:     false,
+                        speed:                  1,
+                        src:                    ['test.js'],
+                        stopOnFirstFail:        false,
+                        takeScreenshotsOnFails: false
                     }
                 ]
             },

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -359,7 +359,7 @@ describe('Reporter', () => {
         }
     }
 
-    const configurationOptions = {
+    const taskOptions = {
         allowMultipleWindows:   false,
         appInitDelay:           1000,
         assertionTimeout:       3000,
@@ -390,7 +390,7 @@ describe('Reporter', () => {
 
     class TaskMock extends Task {
         constructor () {
-            super(testMocks, chunk(browserConnectionMocks, 1), {}, configurationOptions);
+            super(testMocks, chunk(browserConnectionMocks, 1), {}, taskOptions);
 
             this.screenshots = new ScreenshotsMock();
 
@@ -558,34 +558,36 @@ describe('Reporter', () => {
                             }
                         }
                     ],
-                    // NOTE: configuration options
+                    // NOTE: task properties
                     {
-                        allowMultipleWindows:   false,
-                        appInitDelay:           1000,
-                        assertionTimeout:       3000,
-                        browsers:               ['chrome', 'firefox'],
-                        concurrency:            1,
-                        debugMode:              false,
-                        debugOnFail:            false,
-                        developmentMode:        false,
-                        disablePageCaching:     false,
-                        disablePageReloads:     false,
-                        disableScreenshots:     false,
-                        hostname:               'localhost',
-                        pageLoadTimeout:        3000,
-                        port1:                  1337,
-                        port2:                  1338,
-                        quarantineMode:         false,
-                        reporter:               [{ name: 'customReporter' }],
-                        retryTestPages:         false,
-                        screenshots:            { path: '/path/to/screenshots' },
-                        selectorTimeout:        10000,
-                        skipJsErrors:           false,
-                        skipUncaughtErrors:     false,
-                        speed:                  1,
-                        src:                    ['test.js'],
-                        stopOnFirstFail:        false,
-                        takeScreenshotsOnFails: false
+                        configuration: {
+                            allowMultipleWindows:   false,
+                            appInitDelay:           1000,
+                            assertionTimeout:       3000,
+                            browsers:               ['chrome', 'firefox'],
+                            concurrency:            1,
+                            debugMode:              false,
+                            debugOnFail:            false,
+                            developmentMode:        false,
+                            disablePageCaching:     false,
+                            disablePageReloads:     false,
+                            disableScreenshots:     false,
+                            hostname:               'localhost',
+                            pageLoadTimeout:        3000,
+                            port1:                  1337,
+                            port2:                  1338,
+                            quarantineMode:         false,
+                            reporter:               [{ name: 'customReporter' }],
+                            retryTestPages:         false,
+                            screenshots:            { path: '/path/to/screenshots' },
+                            selectorTimeout:        10000,
+                            skipJsErrors:           false,
+                            skipUncaughtErrors:     false,
+                            speed:                  1,
+                            src:                    ['test.js'],
+                            stopOnFirstFail:        false,
+                            takeScreenshotsOnFails: false
+                        }
                     }
                 ]
             },


### PR DESCRIPTION
## Purpose
Having configuration options allows the reporter to provide additional info

## Approach
Feeding options as a param to `reportTaskStart` method

## References
#5088 (options have screenshot and video dir paths)
#3497 (screenshots/videos paths can be relativized)

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail