### PR TITLE
Add type definitions for RequestOptions and ResponseMock (closes #5108)

### DIFF
--- a/test/server/data/test-suites/typescript-defs/request-hooks.ts
+++ b/test/server/data/test-suites/typescript-defs/request-hooks.ts
@@ -33,7 +33,7 @@ const mock = RequestMock()
         return req.url === 'https://example.com';
     }).respond((req, res) => {
         if (req.url === 'https://example.com')
-            res.statusCode = '200';
+            res.statusCode = 200;
     });
 
 

--- a/test/server/data/test-suites/typescript-testcafe-scripts-defs/request-hooks.ts
+++ b/test/server/data/test-suites/typescript-testcafe-scripts-defs/request-hooks.ts
@@ -30,7 +30,7 @@ const mock = RequestMock()
         return req.url === 'https://example.com';
     }).respond((req, res) => {
         if (req.url === 'https://example.com')
-            res.statusCode = '200';
+            res.statusCode = 200;
     });
 
 

--- a/ts-defs-src/test-api/request-hook.d.ts
+++ b/ts-defs-src/test-api/request-hook.d.ts
@@ -151,16 +151,62 @@ interface RequestMock {
      * Specifies requests to intercept
      * @param filter - Specifies which requests should be mocked with a response that follows in the `respond` method.
      */
-    onRequestTo(filter: string | RegExp | object | ((req: any) => boolean)): RequestMock;
+    onRequestTo(filter: string | RegExp | object | ((req: RequestOptions) => boolean)): RequestMock;
     /**
      * Specifies the mocked response.
      * @param body - The mocked response body.
      * @param statusCode - The response status code.
      * @param headers - Custom headers added to the response in the property-value form.
      */
-    respond(body?: object | string | ((req: any, res: any) => any), statusCode?: number, headers?: object): RequestMock;
+    respond(body?: object | string | ((req: RequestOptions, res: ResponseMock) => any), statusCode?: number, headers?: object): RequestMock;
 }
 
 interface RequestMockFactory {
     (): RequestMock;
+}
+
+/**
+ * {@link https://devexpress.github.io/testcafe/documentation/reference/test-api/requestmock/respond.html#requestoptions See documentation}.
+ */
+interface RequestOptions {
+    /** The request headers in the property-value form. */
+    headers: Object;
+    /** The request body. */
+    body: Buffer;
+    /** The URL to which the request is sent. */
+    url: string;
+    /** The protocol to use. Default: http:. */
+    protocol: string;
+    /** The alias for the host. */
+    hostname: string;
+    /** The domain name or IP address of the server to issue the request to. Default: localhost. */
+    host: string;
+    /** The port of the remote server. Default: 80. */
+    port: number;
+    /**
+     * The request path. Should include query string if any. E.G. '/index.html?page=12'. An exception
+     * is thrown when the request path contains illegal characters. Currently, only spaces are
+     * rejected but that may change in the future. Default: '/'.
+     */
+    path: string;
+    /** The string specifying the HTTP request method. Default: 'GET'. */
+    method: string;
+    /**
+     * Credentials that were used for authentication in the current session using NTLM or Basic
+     * authentication. For HTTP Basic authentication, these are `username` and `password`. NTLM
+     * authentication additionally specifies `workstation` and `domain`.
+     * See {@link https://devexpress.github.io/testcafe/documentation/guides/advanced-guides/authentication.html#http-authentication HTTP Authentication}.
+     */
+    credentials: object;
+    /**
+     * If a proxy is used, the property contains information about its `host`, `hostname`, `port`,
+     * `proxyAuth`, `authHeader` and `bypassRules`.
+     */
+    proxy: object;
+}
+
+interface ResponseMock {
+    headers: object;
+    statusCode: number;
+    setBody(value: string): void;
 }


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Add type definitions for `RequestOptions` and `ResponseMock`, and update type definitions for `RequestMock.onRequestTo` and `RequestMock.respond` accordingly.

## Approach
- Copied text/types from https://devexpress.github.io/testcafe/documentation/reference/test-api/requestmock/respond.html#requestoptions
- Also took a look at the src:
   - RequestOptions: https://github.com/DevExpress/testcafe-hammerhead/blob/master/src/request-pipeline/request-options.ts
   - ResponseMock: https://github.com/DevExpress/testcafe-hammerhead/blob/master/src/request-pipeline/request-hooks/response-mock.ts
- Not entirely sure how to test these in any feasible way. I confirmed they worked by modifying the .d.ts in node_modules of an existing project with the above changes, and confirming that auto-completion works, but not sure if the existing tests will catch anything odd here.
- I use the type definitions for autocompletion in a non-typescript project, so not sure if there's something here that might cause problems for actual typescript users.

## References
Closes #5108

## Pre-Merge TODO
- [x] Write tests for your proposed changes
    - There were some existing tests here; not sure what tests to add for type checking except just normal tests?
- [x] Make sure that existing tests do not fail
