### PR TITLE
Display unstable tests in the test reporter

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -758,8 +758,7 @@ function testFunctional (src, testingEnvironmentName, { allowMultipleWindows, ex
     tests.unshift(SETUP_TESTS_GLOB);
 
     const opts = {
-        ui:       'bdd',
-        reporter: 'spec',
+        reporter: 'mocha-reporter-spec-with-retries',
         timeout:  typeof v8debug === 'undefined' ? 3 * 60 * 1000 : Infinity // NOTE: disable timeouts in debug
     };
 

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "markdownlint": "^0.19.0",
     "merge-stream": "^1.0.1",
     "minimist": "^1.2.0",
-    "mocha-reporter-spec-with-retries": "0.0.4",
+    "mocha-reporter-spec-with-retries": "0.0.5",
     "multer": "^1.1.0",
     "npm-auditor": "^1.1.1",
     "open": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "markdownlint": "^0.19.0",
     "merge-stream": "^1.0.1",
     "minimist": "^1.2.0",
+    "mocha-reporter-spec-with-retries": "0.0.3",
     "multer": "^1.1.0",
     "npm-auditor": "^1.1.1",
     "open": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "markdownlint": "^0.19.0",
     "merge-stream": "^1.0.1",
     "minimist": "^1.2.0",
-    "mocha-reporter-spec-with-retries": "0.0.3",
+    "mocha-reporter-spec-with-retries": "0.0.4",
     "multer": "^1.1.0",
     "npm-auditor": "^1.1.1",
     "open": "^6.4.0",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "gulp-git": "^2.4.2",
     "gulp-less": "^4.0.0",
     "gulp-ll-next": "^2.1.0",
-    "gulp-mocha-simple": "^1.0.0",
+    "gulp-mocha-simple": "^1.1.0",
     "gulp-mustache": "^3.0.1",
     "gulp-prompt": "^1.0.1",
     "gulp-qunit-harness": "^1.0.2",

--- a/test/functional/fixtures/api/es-next/assertions/test.js
+++ b/test/functional/fixtures/api/es-next/assertions/test.js
@@ -1,17 +1,6 @@
 const expect = require('chai').expect;
 
 describe('[API] Assertions', function () {
-    let counter = 0;
-
-    it('!!!Unstable test', () => {
-        counter++;
-
-        if (counter === 2)
-            expect(true).eql(true);
-        else
-            expect(false).eql(true);
-    });
-
     it('Should perform .eql() assertion', function () {
         return runTests('./testcafe-fixtures/assertions-test.js', '.eql() assertion', {
             shouldFail: true,

--- a/test/functional/fixtures/api/es-next/assertions/test.js
+++ b/test/functional/fixtures/api/es-next/assertions/test.js
@@ -1,6 +1,17 @@
 const expect = require('chai').expect;
 
 describe('[API] Assertions', function () {
+    let counter = 0;
+
+    it('!!!Unstable test', () => {
+        counter++;
+
+        if (counter === 2)
+            expect(true).eql(true);
+        else
+            expect(false).eql(true);
+    });
+
     it('Should perform .eql() assertion', function () {
         return runTests('./testcafe-fixtures/assertions-test.js', '.eql() assertion', {
             shouldFail: true,


### PR DESCRIPTION
See the custom reporter description - https://github.com/miherlosev/mocha-reporter-spec-with-retries#mocha-reporter-spec-with-retries.

https://dev.azure.com/DevExpressTestCafe/testcafebuildbot-testcafe/_build/results?buildId=5747&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=35f53584-79fc-539f-463c-6471d0663a3a
![image](https://user-images.githubusercontent.com/4133518/83331003-c3fd2800-a29b-11ea-8a6b-c28073050763.png)



