### PR TITLE
Turn on rerun failed tests on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,36 +1,45 @@
 if: NOT (commit_message =~ /^\[docs\]/)
 
-addons:
- chrome:  stable
- firefox: latest
- apt:
-  packages:
-   - dbus
-
 language: node_js
-matrix:
- include:
-  - node_js: "10"
-    env: GULP_TASK="test-server"
-  - node_js: "stable"
-    env: GULP_TASK="test-server"
-  - node_js: "10"
-    env: GULP_TASK="test-client-travis"
-  - node_js: "10"
-    env: GULP_TASK="test-client-travis-mobile"
-  - node_js: "10"
-    env: GULP_TASK="test-functional-local-headless-chrome"
-  - node_js: "10"
-    env: GULP_TASK="test-functional-local-headless-firefox"
-  - node_js: "10"
-    env: GULP_TASK="test-functional-local-legacy"
-  - node_js: "10"
-    env: GULP_TASK="test-functional-local-compiler-service"
-  - node_js: "10"
-    env: GULP_TASK="test-functional-local-multiple-windows"
-    services:
-      - xvfb
- fast_finish: true
+os: linux
+dist: xenial
+jobs:
+  include:
+    - node_js: "10"
+      env: GULP_TASK="test-server"
+    - node_js: "stable"
+      env: GULP_TASK="test-server"
+    - node_js: "10"
+      env: GULP_TASK="test-client-travis"
+    - node_js: "10"
+      env: GULP_TASK="test-client-travis-mobile"
+    - node_js: "10"
+      env:
+        GULP_TASK="test-functional-local-headless-chrome"
+        RETRY_FAILED_TESTS="true"
+      addons:
+        chrome:  stable
+    - node_js: "10"
+      env:
+        GULP_TASK="test-functional-local-headless-firefox"
+        RETRY_FAILED_TESTS="true"
+      addons:
+        firefox:  latest
+    - node_js: "10"
+      env: GULP_TASK="test-functional-local-legacy"
+      addons:
+        chrome:  stable
+    - node_js: "10"
+      env: GULP_TASK="test-functional-local-compiler-service"
+      addons:
+        chrome:  stable
+    - node_js: "10"
+      env: GULP_TASK="test-functional-local-multiple-windows"
+      addons:
+        chrome:  stable
+      services:
+        - xvfb
+  fast_finish: true
 
 cache:
   directories:
@@ -45,4 +54,4 @@ branches:
     - new-docs
 
 notifications:
- email: false
+  email: false

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -733,7 +733,7 @@ gulp.task('publish-website', gulp.series('build-website-production', 'website-pu
 
 gulp.task('test-docs-travis', gulp.parallel('test-website-travis', 'lint'));
 
-function testFunctional (src, testingEnvironmentName, { allowMultipleWindows, experimentalCompilerService, retry } = {}) {
+function testFunctional (src, testingEnvironmentName, { allowMultipleWindows, experimentalCompilerService } = {}) {
     process.env.TESTING_ENVIRONMENT       = testingEnvironmentName;
     process.env.BROWSERSTACK_USE_AUTOMATE = 1;
 
@@ -763,8 +763,11 @@ function testFunctional (src, testingEnvironmentName, { allowMultipleWindows, ex
         timeout:  typeof v8debug === 'undefined' ? 3 * 60 * 1000 : Infinity // NOTE: disable timeouts in debug
     };
 
-    if (retry)
+    if (process.env.RETRY_FAILED_TESTS === 'true') {
         opts.retries = RETRY_TEST_RUN_COUNT;
+
+        console.log('!!!Retry filed tests'); //eslint-disable-line no-console
+    }
 
     return gulp
         .src(tests)
@@ -772,13 +775,13 @@ function testFunctional (src, testingEnvironmentName, { allowMultipleWindows, ex
 }
 
 gulp.step('test-functional-travis-desktop-osx-and-ms-edge-run', () => {
-    return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.osXDesktopAndMSEdgeBrowsers, { retry: true });
+    return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.osXDesktopAndMSEdgeBrowsers);
 });
 
 gulp.task('test-functional-travis-desktop-osx-and-ms-edge', gulp.series('prepare-tests', 'test-functional-travis-desktop-osx-and-ms-edge-run'));
 
 gulp.step('test-functional-travis-mobile-run', () => {
-    return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.mobileBrowsers, { retry: true });
+    return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.mobileBrowsers);
 });
 
 gulp.task('test-functional-travis-mobile', gulp.series('prepare-tests', 'test-functional-travis-mobile-run'));

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ branches:
 
 environment:
   NODEJS_VERSION: "10"
+  RETRY_FAILED_TESTS: "true"
 
   matrix:
     - GULP_TASK: "test-functional-local-ie"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,3 @@
-variables:
-    name: RETRY_FAILED_TESTS
-    value: true
-
 trigger:
   branches:
     exclude:
@@ -19,6 +15,10 @@ trigger:
     - /package.json
 
 pool: 'BrowserStack agents'
+
+variables:
+    name: RETRY_FAILED_TESTS
+    value: true
 
 steps:
 - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,6 +30,9 @@ steps:
   inputs:
     versionSpec: '10.x'
 
+  env:
+    RETRY_FAILED_TESTS: "true"
+
 - bash: |
     npm install --no-progress --loglevel error
     npm test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,10 +30,8 @@ steps:
   inputs:
     versionSpec: '10.x'
 
-  env:
-    RETRY_FAILED_TESTS: "true"
-
 - bash: |
+    export RETRY_FAILED_TESTS=true
     npm install --no-progress --loglevel error
     npm test
   displayName: 'Run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,8 +17,7 @@ trigger:
 pool: 'BrowserStack agents'
 
 variables:
-    name: RETRY_FAILED_TESTS
-    value: true
+  RETRY_FAILED_TESTS: "true"
 
 steps:
 - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,7 @@
+variables:
+    name: RETRY_FAILED_TESTS
+    value: true
+
 trigger:
   branches:
     exclude:
@@ -31,7 +35,6 @@ steps:
     versionSpec: '10.x'
 
 - bash: |
-    export RETRY_FAILED_TESTS=true
     npm install --no-progress --loglevel error
     npm test
   displayName: 'Run tests'


### PR DESCRIPTION
Changes:
* add `RETRY_FAILED_TESTS` environment variable to CI config files (Appveyor, Travis, Azure Pipelines) that turn on rerun of the failed tests. Locally, the tests don't rerun.
* Rewrite `travis.yml` according validator messages (https://config.travis-ci.com/explore). Now, chrome and firefox browsers are installed only for those tasks where they are necessary. 