### PR TITLE
Change event on prevented keypress (closes #4881)

### DIFF
--- a/src/client/automation/playback/type/index.js
+++ b/src/client/automation/playback/type/index.js
@@ -45,7 +45,7 @@ export default class TypeAutomation {
         this.currentKey           = null;
         this.currentKeyIdentifier = null;
 
-        this.changePrepared = false;
+        this.ignoreChangeEvent = true;
 
         this.eventArgs = {
             options: null,
@@ -182,7 +182,7 @@ export default class TypeAutomation {
         this.currentKey           = this.currentKeyCode === SPECIAL_KEYS['enter'] ? 'Enter' : char;
         this.currentKeyIdentifier = getKeyIdentifier(this.currentKey);
 
-        this.changePrepared = domUtils.getElementValue(this.element) !== elementEditingWatcher.getElementSavedValue(this.element);
+        this.ignoreChangeEvent = domUtils.getElementValue(this.element) === elementEditingWatcher.getElementSavedValue(this.element);
 
         this._keydown();
         this._keypress();
@@ -236,7 +236,7 @@ export default class TypeAutomation {
         if (this.eventState.simulateKeypress === false || this.eventState.simulateTypeChar === false) {
             // NOTE: change event should still be raised if element value
             // was changed before the prevented keypress or keydown (GH-4881)
-            if (this.changePrepared === false)
+            if (this.ignoreChangeEvent)
                 elementEditingWatcher.restartWatchingElementEditing(element);
 
             return delay(this.automationSettings.keyActionStepDelay);

--- a/src/client/automation/playback/type/index.js
+++ b/src/client/automation/playback/type/index.js
@@ -45,6 +45,8 @@ export default class TypeAutomation {
         this.currentKey           = null;
         this.currentKeyIdentifier = null;
 
+        this.changePrepared = false;
+
         this.eventArgs = {
             options: null,
             element: null
@@ -180,6 +182,8 @@ export default class TypeAutomation {
         this.currentKey           = this.currentKeyCode === SPECIAL_KEYS['enter'] ? 'Enter' : char;
         this.currentKeyIdentifier = getKeyIdentifier(this.currentKey);
 
+        this.changePrepared = domUtils.getElementValue(this.element) !== elementEditingWatcher.getElementSavedValue(this.element);
+
         this._keydown();
         this._keypress();
 
@@ -230,7 +234,10 @@ export default class TypeAutomation {
         // NOTE: change event must not be raised after prevented keydown
         // or keypress even if element value was changed (B253816)
         if (this.eventState.simulateKeypress === false || this.eventState.simulateTypeChar === false) {
-            elementEditingWatcher.restartWatchingElementEditing(element);
+            // NOTE: change event should still be raised if element value
+            // was changed before the prevented keypress or keydown
+            if (this.changePrepared === false)
+                elementEditingWatcher.restartWatchingElementEditing(element);
 
             return delay(this.automationSettings.keyActionStepDelay);
         }

--- a/src/client/automation/playback/type/index.js
+++ b/src/client/automation/playback/type/index.js
@@ -235,7 +235,7 @@ export default class TypeAutomation {
         // or keypress even if element value was changed (B253816)
         if (this.eventState.simulateKeypress === false || this.eventState.simulateTypeChar === false) {
             // NOTE: change event should still be raised if element value
-            // was changed before the prevented keypress or keydown
+            // was changed before the prevented keypress or keydown (GH-4881)
             if (this.changePrepared === false)
                 elementEditingWatcher.restartWatchingElementEditing(element);
 

--- a/test/client/fixtures/automation/type-test.js
+++ b/test/client/fixtures/automation/type-test.js
@@ -288,46 +288,48 @@ $(document).ready(function () {
         });
     }
 
-    asyncTest('change event can be raised after prevented keypress if there are unsaved changes', function () {
-        const $input = $('<input type="text" />').addClass(TEST_ELEMENT_CLASS).appendTo('body');
+    if (!browserUtils.isAndroid) {
+        asyncTest('change event can be raised after prevented keypress if there are unsaved changes', function () {
+            const $input = $('<input type="text" />').addClass(TEST_ELEMENT_CLASS).appendTo('body');
 
-        let changed = false;
+            let changed = false;
 
-        $input.bind('change', function () {
-            changed = true;
-        });
-
-        $input.bind('keypress', function (e) {
-            if (e.key === '-') {
-                e.target.value += String.fromCharCode(e.keyCode);
-                return false;
-            }
-
-            return true;
-        });
-
-        const firstType = new TypeAutomation($input[0], 'test-', new TypeOptions({ offsetX: 5, offsetY: 5 }));
-
-        firstType
-            .run()
-            .then(function () {
-                $input[0].blur();
-
-                ok(changed, 'change event raised on prevented keypress with unsaved data check');
-
-                changed = false;
-
-                const secondType = new TypeAutomation($input[0], '---', new TypeOptions({ offsetX: 5, offsetY: 5 }));
-
-                return secondType.run();
-            })
-            .then(function () {
-                $input[0].blur();
-
-                ok(!changed, 'change event not raised on prevented keypress with no unsaved data check');
-                start();
+            $input.bind('change', function () {
+                changed = true;
             });
-    });
+
+            $input.bind('keypress', function (e) {
+                if (e.key === '-') {
+                    e.target.value += String.fromCharCode(e.keyCode);
+                    return false;
+                }
+
+                return true;
+            });
+
+            const firstType = new TypeAutomation($input[0], 'test-', new TypeOptions({ offsetX: 5, offsetY: 5 }));
+
+            firstType
+                .run()
+                .then(function () {
+                    $input[0].blur();
+
+                    ok(changed, 'change event raised on prevented keypress with unsaved data check');
+
+                    changed = false;
+
+                    const secondType = new TypeAutomation($input[0], '---', new TypeOptions({ offsetX: 5, offsetY: 5 }));
+
+                    return secondType.run();
+                })
+                .then(function () {
+                    $input[0].blur();
+
+                    ok(!changed, 'change event not raised on prevented keypress with no unsaved data check');
+                    start();
+                });
+        });
+    }
 
     asyncTest('keypress args must contain charCode of the symbol, not keyCode', function () {
         const $input   = $('<input type="text" />').addClass(TEST_ELEMENT_CLASS).appendTo('body');

--- a/test/client/fixtures/automation/type-test.js
+++ b/test/client/fixtures/automation/type-test.js
@@ -286,10 +286,8 @@ $(document).ready(function () {
                     start();
                 });
         });
-    }
 
-    if (!browserUtils.isAndroid) {
-        asyncTest('change event can be raised after prevented keypress if there are unsaved changes', function () {
+        asyncTest('change event can be raised after prevented keypress if there are unsaved changes (GH-4881)', function () {
             const $input = $('<input type="text" />').addClass(TEST_ELEMENT_CLASS).appendTo('body');
 
             let changed = false;

--- a/test/client/fixtures/automation/type-test.js
+++ b/test/client/fixtures/automation/type-test.js
@@ -288,6 +288,47 @@ $(document).ready(function () {
         });
     }
 
+    asyncTest('change event can be raised after prevented keypress if there are unsaved changes', function () {
+        const $input = $('<input type="text" />').addClass(TEST_ELEMENT_CLASS).appendTo('body');
+
+        let changed = false;
+
+        $input.bind('change', function () {
+            changed = true;
+        });
+
+        $input.bind('keypress', function (e) {
+            if (e.key === '-') {
+                e.target.value += String.fromCharCode(e.keyCode);
+                return false;
+            }
+
+            return true;
+        });
+
+        const firstType = new TypeAutomation($input[0], 'test-', new TypeOptions({ offsetX: 5, offsetY: 5 }));
+
+        firstType
+            .run()
+            .then(function () {
+                $input[0].blur();
+
+                ok(changed, 'change event raised on prevented keypress with unsaved data check');
+
+                changed = false;
+
+                const secondType = new TypeAutomation($input[0], '---', new TypeOptions({ offsetX: 5, offsetY: 5 }));
+
+                return secondType.run();
+            })
+            .then(function () {
+                $input[0].blur();
+
+                ok(!changed, 'change event not raised on prevented keypress with no unsaved data check');
+                start();
+            });
+    });
+
     asyncTest('keypress args must contain charCode of the symbol, not keyCode', function () {
         const $input   = $('<input type="text" />').addClass(TEST_ELEMENT_CLASS).appendTo('body');
         const symbol   = '!';


### PR DESCRIPTION
## Purpose
As shown in #4881, 'change' events don't trigger if the last keypress was prevented, thus not saving the entire element value.

## Approach
Added changePrepared property that sets to true before calling _keypress() if element value changed but the 'change' event has not been called.
The value of changePrepared is then checked in _typeChar() and the elementEditingWatcher is reset if it's false.

## References
#4881

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
