### PR TITLE
Remove navigation to idle page for non-persistent browser connections

### DIFF
--- a/@types/chrome-remote-interface/index.d.ts
+++ b/@types/chrome-remote-interface/index.d.ts
@@ -9,22 +9,22 @@ declare module 'chrome-remote-interface' {
         }
 
         export interface GenericConnectionOptions {
-            port: number
+            port: number;
         }
 
         export interface ConstructorOptions extends GenericConnectionOptions {
-            target: TargetInfo
+            target: TargetInfo;
         }
 
         export interface CloseTabOptions extends GenericConnectionOptions {
-            id: TargetInfo['id']
+            id: TargetInfo['id'];
         }
     }
 
     interface ChromeRemoteInterface {
         (options: chromeRemoteInterface.ConstructorOptions): Promise<chromeRemoteInterface.ProtocolApi>;
         listTabs (options: chromeRemoteInterface.GenericConnectionOptions): Promise<chromeRemoteInterface.TargetInfo[]>;
-        closeTab (options: chromeRemoteInterface.CloseTabOptions): Promise<void>
+        closeTab (options: chromeRemoteInterface.CloseTabOptions): Promise<void>;
     }
 
     const chromeRemoteInterface: ChromeRemoteInterface;

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -786,13 +786,13 @@ gulp.step('test-functional-local-run', () => {
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localBrowsers);
 });
 
-gulp.task('test-functional-local', gulp.series('prepare-tests', 'test-functional-local-run'));
+gulp.task('test-functional-local', gulp.series(/*'prepare-tests',*/ 'test-functional-local-run'));
 
 gulp.step('test-functional-local-ie-run', () => {
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localBrowsersIE);
 });
 
-gulp.task('test-functional-local-ie', gulp.series('prepare-tests', 'test-functional-local-ie-run'));
+gulp.task('test-functional-local-ie', gulp.series(/*'prepare-tests',*/ 'test-functional-local-ie-run'));
 
 gulp.step('test-functional-local-chrome-firefox-run', () => {
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localBrowsersChromeFirefox);

--- a/run-cli.js
+++ b/run-cli.js
@@ -1,0 +1,10 @@
+process.argv = [
+    process.argv0,
+    'testcafe',
+    'chrome',
+    'test.js',
+    '-r',
+    'list,json:report.json'
+];
+
+require('./lib/cli');

--- a/run-permanent-connection.js
+++ b/run-permanent-connection.js
@@ -1,0 +1,28 @@
+const createTestCafe = require('./lib');
+let runner           = null;
+let testcafe         = null;
+
+createTestCafe('localhost', 1337, 1338)
+    .then(tc => {
+        testcafe = tc;
+        runner   = testcafe.createRunner();
+
+        return testcafe.createBrowserConnection();
+    })
+    .then(remoteConnection => {
+
+        // Outputs remoteConnection.url so that it can be visited from the remote browser.
+        console.log(remoteConnection.url);
+
+        remoteConnection.once('ready', () => {
+            runner
+                .src('test.js')
+                .browsers(remoteConnection)
+                .run()
+                .then(failedCount => {
+                    console.log(failedCount);
+                    testcafe.close();
+                })
+                .catch(error => { /* ... */});
+        });
+    });

--- a/run-site.js
+++ b/run-site.js
@@ -1,0 +1,4 @@
+const config                     = require('./test/functional/config');
+const site                       = require('./test/functional/site');
+
+site.create(config.site.ports, config.site.viewsPath);

--- a/run.js
+++ b/run.js
@@ -1,0 +1,23 @@
+const createTestCafe = require('./lib');
+let testcafe         = null;
+
+createTestCafe('localhost', 1337, 1338, void 0, true)
+    .then(tc => {
+        testcafe     = tc;
+        const runner = testcafe.createRunner();
+
+        return runner
+            .src('test.js')
+            //.browsers('chrome --auto-open-devtools-for-tabs --disable-background-networking')
+            //.browsers('chrome')
+            .browsers('firefox')
+            //.browsers('firefox --devtools')
+            //.browsers('ie')
+            //.browsers('chrome:headless')
+            //.browsers('edge')
+            .run();
+    })
+    .then(failedCount => {
+        console.log('Tests failed: ' + failedCount);
+        testcafe.close();
+    });

--- a/run.js
+++ b/run.js
@@ -8,7 +8,8 @@ createTestCafe('localhost', 1337, 1338, void 0, true)
 
         return runner
             .src('test.js')
-            .browsers('chrome:emulation:device=iphone 6 --no-sandbox --auto-open-devtools-for-tabs')
+            //.browsers('chrome:emulation:device=iphone 6 --no-sandbox --auto-open-devtools-for-tabs')
+            .browsers('chrome:emulation:device=iphone 6 --no-sandbox')
             //.browsers('chrome --auto-open-devtools-for-tabs --disable-background-networking')
             //.browsers('chrome')
             //.browsers('firefox')

--- a/run.js
+++ b/run.js
@@ -8,9 +8,10 @@ createTestCafe('localhost', 1337, 1338, void 0, true)
 
         return runner
             .src('test.js')
+            .browsers('chrome:emulation:device=iphone 6 --no-sandbox --auto-open-devtools-for-tabs')
             //.browsers('chrome --auto-open-devtools-for-tabs --disable-background-networking')
             //.browsers('chrome')
-            .browsers('firefox')
+            //.browsers('firefox')
             //.browsers('firefox --devtools')
             //.browsers('ie')
             //.browsers('chrome:headless')

--- a/run.js
+++ b/run.js
@@ -9,7 +9,7 @@ createTestCafe('localhost', 1337, 1338, void 0, true)
         return runner
             .src('test.js')
             //.browsers('chrome:emulation:device=iphone 6 --no-sandbox --auto-open-devtools-for-tabs')
-            .browsers('chrome:emulation:device=iphone 6 --no-sandbox')
+            .browsers('chrome:headless:emulation:device=iphone 6 --no-sandbox')
             //.browsers('chrome --auto-open-devtools-for-tabs --disable-background-networking')
             //.browsers('chrome')
             //.browsers('firefox')

--- a/src/browser/connection/gateway.ts
+++ b/src/browser/connection/gateway.ts
@@ -5,6 +5,7 @@ import { Proxy } from 'testcafe-hammerhead';
 import { Dictionary } from '../../configuration/interfaces';
 import BrowserConnection from './index';
 import { IncomingMessage, ServerResponse } from 'http';
+import SetupWindowResult from './setup-window-result';
 
 const IDLE_PAGE_SCRIPT = read('../../client/browser/idle-page/index.js');
 const IDLE_PAGE_STYLE  = read('../../client/browser/idle-page/styles.css');
@@ -52,6 +53,7 @@ export default class BrowserConnectionGateway {
         this._dispatch('/browser/init-script/{id}', proxy, BrowserConnectionGateway._onInitScriptResponse, 'POST');
         this._dispatch('/browser/active-window-id/{id}', proxy, BrowserConnectionGateway._onGetActiveWindowIdRequest);
         this._dispatch('/browser/active-window-id/{id}', proxy, BrowserConnectionGateway._onSetActiveWindowIdRequest, 'POST');
+        this._dispatch('/browser/set-up-window/{id}', proxy, BrowserConnectionGateway._onSetupWindow, 'POST');
 
         proxy.GET('/browser/connect', (req: IncomingMessage, res: ServerResponse) => this._connectNextRemoteBrowser(req, res));
         proxy.GET('/browser/connect/', (req: IncomingMessage, res: ServerResponse) => this._connectNextRemoteBrowser(req, res));
@@ -84,7 +86,7 @@ export default class BrowserConnectionGateway {
     }
 
     // Route handlers
-    private static _onConnection (req: IncomingMessage, res: ServerResponse, connection: BrowserConnection): void {
+    private static async _onConnection (req: IncomingMessage, res: ServerResponse, connection: BrowserConnection): Promise<void> {
         if (connection.isReady())
             respond500(res, 'The connection is already established.');
 
@@ -92,7 +94,14 @@ export default class BrowserConnectionGateway {
             const userAgent = req.headers['user-agent'] as string;
 
             connection.establish(userAgent);
-            redirect(res, connection.idleUrl);
+
+            if (connection.permanent)
+                redirect(res, connection.idleUrl);
+            else {
+                const testRunUrl = await connection.getTestRunUrl(true) || connection.idleUrl;
+
+                redirect(res, testRunUrl);
+            }
         }
     }
 
@@ -168,6 +177,14 @@ export default class BrowserConnectionGateway {
 
                 respondWithJSON(res);
             });
+        }
+    }
+
+    private static async _onSetupWindow (req: IncomingMessage, res: ServerResponse, connection: BrowserConnection): Promise<void> {
+        if (BrowserConnectionGateway._ensureConnectionReady(res, connection)) {
+            await connection.setUpBrowserWindow();
+
+            respondWithJSON(res, { result: SetupWindowResult.ok });
         }
     }
 

--- a/src/browser/connection/gateway.ts
+++ b/src/browser/connection/gateway.ts
@@ -94,24 +94,27 @@ export default class BrowserConnectionGateway {
         else {
             const userAgent = req.headers['user-agent'] as string;
 
-            connection.establish(userAgent);
-
             if (connection.permanent)
                 redirect(res, connection.idleUrl);
             else {
                 if (connection.provider.plugin.connectedWithDebugProtocol) {
+                    console.log('gateway.before promisify connected event');
                     promisifyEvent(connection.provider.plugin, connection.provider.plugin.CONNECTED_EVENT_NAME)
                         .then(async () => {
+                            connection.establish(userAgent);
+                            console.log('gateway.raise ready event');
                             const testRunUrl = await connection.getTestRunUrl(true) || connection.idleUrl;
 
+                            console.log('gateway.redirect to first tested page');
                             redirect(res, testRunUrl);
                         });
                 }
-                else {
-                    const testRunUrl = await connection.getTestRunUrl(true) || connection.idleUrl;
-
-                    redirect(res, testRunUrl);
-                }
+                // else {
+                // console.log('gateway.redirect to the first tested page');
+                // const testRunUrl = await connection.getTestRunUrl(true) || connection.idleUrl;
+                //
+                // redirect(res, testRunUrl);
+                //}
             }
         }
     }

--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -63,6 +63,7 @@ export default class BrowserConnection extends EventEmitter {
     public readonly idleUrl: string;
     private forcedIdleUrl: string;
     private readonly initScriptUrl: string;
+    private readonly setupWindowUrl: string;
     private readonly heartbeatRelativeUrl: string;
     private readonly statusRelativeUrl: string;
     private readonly statusDoneRelativeUrl: string;
@@ -101,10 +102,11 @@ export default class BrowserConnection extends EventEmitter {
         this.pendingTestRunUrl    = null;
         this.allowMultipleWindows = allowMultipleWindows;
 
-        this.url           = `${gateway.domain}/browser/connect/${this.id}`;
-        this.idleUrl       = `${gateway.domain}/browser/idle/${this.id}`;
-        this.forcedIdleUrl = `${gateway.domain}/browser/idle-forced/${this.id}`;
-        this.initScriptUrl = `${gateway.domain}/browser/init-script/${this.id}`;
+        this.url            = `${gateway.domain}/browser/connect/${this.id}`;
+        this.idleUrl        = `${gateway.domain}/browser/idle/${this.id}`;
+        this.forcedIdleUrl  = `${gateway.domain}/browser/idle-forced/${this.id}`;
+        this.initScriptUrl  = `${gateway.domain}/browser/init-script/${this.id}`;
+        this.setupWindowUrl = `${gateway.domain}/browser/set-up-window/${this.id}`;
 
         this.heartbeatRelativeUrl  = `/browser/heartbeat/${this.id}`;
         this.statusRelativeUrl     = `/browser/status/${this.id}`;
@@ -187,7 +189,7 @@ export default class BrowserConnection extends EventEmitter {
         }, this.HEARTBEAT_TIMEOUT);
     }
 
-    private async _getTestRunUrl (needPopNext: boolean): Promise<string> {
+    public async getTestRunUrl (needPopNext: boolean): Promise<string> {
         if (needPopNext || !this.pendingTestRunUrl)
             this.pendingTestRunUrl = await this._popNextTestRunUrl();
 
@@ -404,7 +406,7 @@ export default class BrowserConnection extends EventEmitter {
         }
 
         if (this.status === BrowserConnectionStatus.opened) {
-            const testRunUrl = await this._getTestRunUrl(isTestDone || this.testRunAborted);
+            const testRunUrl = await this.getTestRunUrl(isTestDone || this.testRunAborted);
 
             this.testRunAborted = false;
 
@@ -434,5 +436,9 @@ export default class BrowserConnection extends EventEmitter {
         return this.status === BrowserConnectionStatus.ready ||
             this.status === BrowserConnectionStatus.opened ||
             this.status === BrowserConnectionStatus.closing;
+    }
+
+    public async setUpBrowserWindow (): Promise<void> {
+        return this.provider.setUpBrowserWindow(this.id);
     }
 }

--- a/src/browser/connection/setup-window-result.ts
+++ b/src/browser/connection/setup-window-result.ts
@@ -1,0 +1,6 @@
+enum SetupWindowResult {
+    ok = 'ok',
+    failed = 'failed'
+}
+
+export default SetupWindowResult;

--- a/src/browser/provider/built-in/dedicated/base.js
+++ b/src/browser/provider/built-in/dedicated/base.js
@@ -2,13 +2,18 @@ import { getBrowserInfo } from 'testcafe-browser-tools';
 import getMaximizedHeadlessWindowSize from '../../utils/get-maximized-headless-window-size';
 import { cropScreenshot } from '../../../../screenshots/crop';
 import { readPng, writePng } from '../../../../utils/promisified-functions';
+import { EventEmitter } from 'events';
 
-export default {
+export default Object.assign(new EventEmitter(), {
     openedBrowsers: {},
 
     isMultiBrowser: false,
 
     supportMultipleWindows: true,
+
+    connectedWithDebugProtocol: true,
+
+    CONNECTED_EVENT_NAME: 'connected',
 
     getActiveWindowId (browserId) {
         return this.openedBrowsers[browserId].activeWindowId;
@@ -76,4 +81,4 @@ export default {
 
         await this.resizeWindow(browserId, maximumSize.width, maximumSize.height, maximumSize.width, maximumSize.height);
     }
-};
+});

--- a/src/browser/provider/built-in/dedicated/chrome/cdp.ts
+++ b/src/browser/provider/built-in/dedicated/chrome/cdp.ts
@@ -243,7 +243,10 @@ async function calculateEmulatedDevicePixelRatio (runtimeInfo: RuntimeInfo): Pro
 async function setEmulation1 (runtimeInfo: RuntimeInfo): Promise<void> {
     await setUserAgent(runtimeInfo);
     await setTouchBehavior(runtimeInfo);
-    await setEmulationBounds(runtimeInfo);
+    await resizeWindow({
+        width: runtimeInfo.config.width,
+        height: runtimeInfo.config.height
+    }, runtimeInfo);
 }
 
 export async function setEmulationAndResize (runtimeInfo: RuntimeInfo): Promise<void> {
@@ -281,10 +284,8 @@ export async function updateMobileViewportSize (runtimeInfo: RuntimeInfo): Promi
 export async function resizeWindow (newDimensions: Size, runtimeInfo: RuntimeInfo): Promise<void> {
     const { browserId, config, viewportSize, providerMethods } = runtimeInfo;
 
-    const currentWidth  = viewportSize.width;
-    const currentHeight = viewportSize.height;
-    const newWidth      = newDimensions.width || currentWidth;
-    const newHeight     = newDimensions.height || currentHeight;
+    const newWidth  = newDimensions.width;
+    const newHeight = newDimensions.height;
 
     if (!config.headless)
         await providerMethods.resizeLocalBrowserWindow(browserId, newWidth, newHeight, currentWidth, currentHeight);

--- a/src/browser/provider/built-in/dedicated/chrome/cdp.ts
+++ b/src/browser/provider/built-in/dedicated/chrome/cdp.ts
@@ -74,6 +74,8 @@ async function setEmulation (runtimeInfo: RuntimeInfo): Promise<void> {
 
         if (client.Emulation.setTouchEmulationEnabled)
             await client.Emulation.setTouchEmulationEnabled(touchConfig);
+
+        await resizeWindow({ width: config.width, height: config.height }, runtimeInfo);
     }
 }
 
@@ -156,6 +158,21 @@ export async function createClient (runtimeInfo: RuntimeInfo): Promise<void> {
     await client.Network.enable({});
     await client.Runtime.enable();
 
+    /*const devicePixelRatioQueryResult = await client.Runtime.evaluate({ expression: 'window.devicePixelRatio' });
+
+    runtimeInfo.originalDevicePixelRatio = devicePixelRatioQueryResult.result.value;
+    runtimeInfo.emulatedDevicePixelRatio = config.scaleFactor || runtimeInfo.originalDevicePixelRatio;
+
+    if (config.emulation)
+        await setEmulation(runtimeInfo);*/
+
+    if (config.headless)
+        await enableDownloads(runtimeInfo);
+}
+
+export async function setEmulationAndResize (runtimeInfo: RuntimeInfo): Promise<void> {
+    const { client, config } = runtimeInfo;
+
     const devicePixelRatioQueryResult = await client.Runtime.evaluate({ expression: 'window.devicePixelRatio' });
 
     runtimeInfo.originalDevicePixelRatio = devicePixelRatioQueryResult.result.value;
@@ -163,9 +180,6 @@ export async function createClient (runtimeInfo: RuntimeInfo): Promise<void> {
 
     if (config.emulation)
         await setEmulation(runtimeInfo);
-
-    if (config.headless)
-        await enableDownloads(runtimeInfo);
 }
 
 export function isHeadlessTab ({ tab, config }: RuntimeInfo): boolean {

--- a/src/browser/provider/built-in/dedicated/chrome/cdp.ts
+++ b/src/browser/provider/built-in/dedicated/chrome/cdp.ts
@@ -75,8 +75,6 @@ async function setEmulation (runtimeInfo: RuntimeInfo): Promise<void> {
         if (client.Emulation.setTouchEmulationEnabled)
             await client.Emulation.setTouchEmulationEnabled(touchConfig);
     }
-
-    await resizeWindow({ width: config.width, height: config.height }, runtimeInfo);
 }
 
 async function enableDownloads ({ client }: RuntimeInfo): Promise<void> {

--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -71,11 +71,11 @@ export default {
 
         const { config, viewportSize } = runtimeInfo;
 
-        // emulation should be here??
         if (config.emulation)
-            await cdp.resizeWindow({ width: config.width, height: config.height }, runtimeInfo);
+            await cdp.setEmulationAndResize(runtimeInfo);
 
-        await this._ensureWindowIsExpanded(browserId, viewportSize);
+        else
+            await this._ensureWindowIsExpanded(browserId, viewportSize);
     },
 
     async closeBrowser (browserId) {

--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -59,9 +59,9 @@ export default {
         if (allowMultipleWindows)
             runtimeInfo.activeWindowId = this.calculateWindowId();
 
-        await cdp.createClient(runtimeInfo);
-
         this._setUserAgentMetaInfoForEmulatingDevice(browserId, runtimeInfo.config);
+
+        await cdp.createClient(runtimeInfo);
     },
 
     async resizeWindowAfterOpeningBrowser (browserId) {
@@ -71,6 +71,7 @@ export default {
 
         const { config, viewportSize } = runtimeInfo;
 
+        // emulation should be here??
         if (config.emulation)
             await cdp.resizeWindow({ width: config.width, height: config.height }, runtimeInfo);
 

--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -52,28 +52,32 @@ export default Object.assign(dedicatedProviderBase, {
         this._setUserAgentMetaInfoForEmulatingDevice(browserId, runtimeInfo.config);
 
         await startLocalChrome(pageUrl, runtimeInfo);
-        await cdp.createClient1(runtimeInfo);
+        console.log('provider.startLocalChrome');
+        await cdp.createClient(runtimeInfo);
+        console.log('provider.createClient');
 
         this.openedBrowsers[browserId] = runtimeInfo;
 
         await this.waitForConnectionReady(browserId);
+        console.log('provider.after waitForConnectionReady');
 
         if (allowMultipleWindows)
             runtimeInfo.activeWindowId = this.calculateWindowId();
-
-        //await cdp.createClient(runtimeInfo);
     },
 
     async resizeWindowAfterOpeningBrowser (browserId) {
+        console.log('provider.before resize');
         const runtimeInfo = this.openedBrowsers[browserId];
 
         runtimeInfo.viewportSize = await this.runInitScript(browserId, GET_WINDOW_DIMENSIONS_INFO_SCRIPT);
 
         const { config, viewportSize } = runtimeInfo;
 
-        if (config.emulation)
-            await cdp.setEmulationAndResize(runtimeInfo);
+        if (config.emulation) {
+            const { width, height } = runtimeInfo.config;
 
+            await cdp.resizeWindow({ width, height }, runtimeInfo);
+        }
         else
             await this._ensureWindowIsExpanded(browserId, viewportSize);
     },

--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -9,9 +9,7 @@ import { GET_WINDOW_DIMENSIONS_INFO_SCRIPT } from '../../../utils/client-functio
 
 const MIN_AVAILABLE_DIMENSION = 50;
 
-export default {
-    ...dedicatedProviderBase,
-
+export default Object.assign(dedicatedProviderBase, {
     _getConfig (name) {
         return getConfig(name);
     },
@@ -47,10 +45,14 @@ export default {
         runtimeInfo.browserId   = browserId;
 
         runtimeInfo.providerMethods = {
-            resizeLocalBrowserWindow: (...args) => this.resizeLocalBrowserWindow(...args)
+            resizeLocalBrowserWindow: (...args) => this.resizeLocalBrowserWindow(...args),
+            emitConnectedEvent:       () => this.emit(this.CONNECTED_EVENT_NAME)
         };
 
+        this._setUserAgentMetaInfoForEmulatingDevice(browserId, runtimeInfo.config);
+
         await startLocalChrome(pageUrl, runtimeInfo);
+        await cdp.createClient1(runtimeInfo);
 
         this.openedBrowsers[browserId] = runtimeInfo;
 
@@ -59,9 +61,7 @@ export default {
         if (allowMultipleWindows)
             runtimeInfo.activeWindowId = this.calculateWindowId();
 
-        this._setUserAgentMetaInfoForEmulatingDevice(browserId, runtimeInfo.config);
-
-        await cdp.createClient(runtimeInfo);
+        //await cdp.createClient(runtimeInfo);
     },
 
     async resizeWindowAfterOpeningBrowser (browserId) {
@@ -134,4 +134,4 @@ export default {
             await this.resizeWindow(browserId, newWidth, newHeight, outerWidth, outerHeight);
         }
     }
-};
+});

--- a/src/browser/provider/built-in/dedicated/firefox/index.js
+++ b/src/browser/provider/built-in/dedicated/firefox/index.js
@@ -38,6 +38,8 @@ export default {
 
         await startLocalFirefox(pageUrl, runtimeInfo);
 
+        this.openedBrowsers[browserId] = runtimeInfo;
+
         await this.waitForConnectionReady(runtimeInfo.browserId);
 
         if (allowMultipleWindows)
@@ -45,8 +47,6 @@ export default {
 
         if (runtimeInfo.marionettePort)
             runtimeInfo.marionetteClient = await this._createMarionetteClient(runtimeInfo);
-
-        this.openedBrowsers[browserId] = runtimeInfo;
     },
 
     async closeBrowser (browserId) {

--- a/src/browser/provider/index.ts
+++ b/src/browser/provider/index.ts
@@ -3,13 +3,10 @@ import OS from 'os-family';
 import { dirname } from 'path';
 import makeDir from 'make-dir';
 import BrowserConnection from '../connection';
-import delay from '../../utils/delay';
 import { GET_TITLE_SCRIPT, GET_WINDOW_DIMENSIONS_INFO_SCRIPT } from './utils/client-functions';
 import WARNING_MESSAGE from '../../notifications/warning-message';
 import { Dictionary } from '../../configuration/interfaces';
 import { WindowDimentionsInfo } from '../interfaces';
-
-const BROWSER_OPENING_DELAY = 2000;
 
 const RESIZE_DIFF_SIZE = {
     width:  100,
@@ -135,10 +132,6 @@ export default class BrowserProvider {
 
         await this._ensureLocalBrowserInfo(browserId);
 
-        // NOTE: delay to ensure the window finished the opening
-        await this.plugin.waitForConnectionReady(browserId);
-        await delay(BROWSER_OPENING_DELAY);
-
         if (this.localBrowsersInfo[browserId])
             this.localBrowsersInfo[browserId].windowDescriptor = await browserTools.findWindow(browserId);
     }
@@ -246,9 +239,6 @@ export default class BrowserProvider {
 
     public async openBrowser (browserId: string, pageUrl: string, browserName: string, allowMultipleWindows: boolean): Promise<void> {
         await this.plugin.openBrowser(browserId, pageUrl, browserName, allowMultipleWindows);
-
-        if (await this.canUseDefaultWindowActions(browserId))
-            await this._ensureBrowserWindowParameters(browserId);
     }
 
     public async closeBrowser (browserId: string): Promise<void> {
@@ -354,5 +344,12 @@ export default class BrowserProvider {
 
     public setActiveWindowId (browserId: string, val: string): void {
         this.plugin.setActiveWindowId(browserId, val);
+    }
+
+    public async setUpBrowserWindow (browserId: string): Promise<void> {
+        if (this.plugin.resizeWindowAfterOpeningBrowser)
+            await this.plugin.resizeWindowAfterOpeningBrowser(browserId);
+
+        await this._ensureBrowserWindowParameters(browserId);
     }
 }

--- a/src/browser/provider/utils/client-functions.ts
+++ b/src/browser/provider/utils/client-functions.ts
@@ -2,7 +2,8 @@ import { WindowDimentionsInfo } from '../../interfaces';
 
 /*eslint-disable no-undef, no-var*/
 function getTitle (): string {
-    return document.title;
+    // @ts-ignore
+    return window['%testCafeCore%'].domUtils.getDocumentTitle(document);
 }
 
 function getWindowDimensionsInfo (): WindowDimentionsInfo {

--- a/src/client/core/utils/dom.js
+++ b/src/client/core/utils/dom.js
@@ -516,3 +516,11 @@ export function contains (element, target) {
 
     return !!findParent(target, true, node => node === element);
 }
+
+export function setDocumentTitle (document, title) {
+    hammerhead.nativeMethods.documentTitleSetter.call(document, title);
+}
+
+export function getDocumentTitle (document) {
+    return hammerhead.nativeMethods.documentTitleGetter.call(document);
+}

--- a/src/client/driver/iframe-driver.js
+++ b/src/client/driver/iframe-driver.js
@@ -9,8 +9,8 @@ import { TYPE as MESSAGE_TYPE } from './driver-link/messages';
 import IframeNativeDialogTracker from './native-dialog-tracker/iframe';
 
 export default class IframeDriver extends Driver {
-    constructor (testRunId, options) {
-        super(testRunId, {}, {}, options);
+    constructor (testRunId, browserId, options) {
+        super(testRunId, browserId, {}, {}, options);
 
         this.lastParentDriverMessageId = null;
         this.parentDriverLink          = new ParentIframeDriverLink(window.parent);

--- a/src/client/test-run/iframe.js.mustache
+++ b/src/client/test-run/iframe.js.mustache
@@ -1,6 +1,6 @@
 (function () {
     var IframeDriver = window['%testCafeIframeDriver%'];
-    var driver       = new IframeDriver({{{testRunId}}}, {
+    var driver       = new IframeDriver({{{testRunId}}}, {{{browserId}}} {
         selectorTimeout:     {{{selectorTimeout}}},
         pageLoadTimeout:     {{{pageLoadTimeout}}},
         dialogHandler:       {{{dialogHandler}}},

--- a/src/client/test-run/index.js.mustache
+++ b/src/client/test-run/index.js.mustache
@@ -19,6 +19,8 @@
     var browserStatusUrl           = origin + {{{browserStatusRelativeUrl}}};
     var browserStatusDoneUrl       = origin + {{{browserStatusDoneRelativeUrl}}};
     var browserActiveWindowIdUrl   = origin + {{{browserActiveWindowIdUrl}}};
+    var browserInitScriptUrl       = {{{browserInitScriptUrl}}};
+    var browserSetupWindowUrl      = {{{browserSetupWindowUrl}}};
     var skipJsErrors               = {{{skipJsErrors}}};
     var dialogHandler              = {{{dialogHandler}}};
     var userAgent                  = {{{userAgent}}};
@@ -27,8 +29,12 @@
     var canUseDefaultWindowActions = {{{canUseDefaultWindowActions}}};
 
     var ClientDriver = window['%testCafeDriver%'];
-    var driver       = new ClientDriver(testRunId,
-        { heartbeat: browserHeartbeatUrl, status: browserStatusUrl, statusDone: browserStatusDoneUrl, activeWindowId: browserActiveWindowIdUrl },
+    var driver       = new ClientDriver(testRunId, browserId,
+        {
+          heartbeat: browserHeartbeatUrl, status: browserStatusUrl, statusDone: browserStatusDoneUrl,
+          activeWindowId: browserActiveWindowIdUrl, initScriptUrl: browserInitScriptUrl,
+          setupWindowUrl: browserSetupWindowUrl
+        },
         { userAgent: userAgent, fixtureName: fixtureName, testName: testName },
         {
             selectorTimeout:            selectorTimeout,

--- a/src/configuration/default-values.ts
+++ b/src/configuration/default-values.ts
@@ -49,3 +49,9 @@ export const TYPESCRIPT_BLACKLISTED_OPTIONS = [
     'outFile',
     'out'
 ];
+
+export const DEFAULT_REPORTER = {
+    name:   'spec',
+    output: process.stdout
+};
+

--- a/src/configuration/option-names.js
+++ b/src/configuration/option-names.js
@@ -40,5 +40,7 @@ export default {
     disableScreenshots:          'disableScreenshots',
     debugLogger:                 'debugLogger',
     allowMultipleWindows:        'allowMultipleWindows',
-    experimentalCompilerService: 'experimentalCompilerService'
+    experimentalCompilerService: 'experimentalCompilerService',
+    TestRunCtor:                 'TestRunCtor',
+    live:                        'live'
 };

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -12,16 +12,30 @@ import resolvePathRelativelyCwd from '../utils/resolve-path-relatively-cwd';
 import {
     DEFAULT_APP_INIT_DELAY,
     DEFAULT_CONCURRENCY_VALUE,
+    DEFAULT_DEVELOPMENT_MODE,
+    DEFAULT_REPORTER,
+    DEFAULT_RETRY_TEST_PAGES,
+    DEFAULT_SOURCE_DIRECTORIES,
     DEFAULT_SPEED_VALUE,
     DEFAULT_TIMEOUT,
-    DEFAULT_SOURCE_DIRECTORIES,
-    DEFAULT_DEVELOPMENT_MODE,
-    DEFAULT_RETRY_TEST_PAGES,
     STATIC_CONTENT_CACHING_SETTINGS
 } from './default-values';
 
 import OptionSource from './option-source';
-import { Dictionary, FilterOption, ReporterOption, StaticContentCachingOptions } from './interfaces';
+import {
+    Dictionary,
+    FilterOption,
+    ReporterOption,
+    StaticContentCachingOptions
+} from './interfaces';
+
+import {
+    BrowserSource,
+    ClientScriptSource,
+    Filter,
+    ReporterSource,
+    TestSource
+} from '../runner/interfaces';
 
 const CONFIGURATION_FILENAME = '.testcaferc.json';
 
@@ -38,7 +52,8 @@ const OPTION_FLAG_NAMES = [
     OPTION_NAMES.disablePageCaching,
     OPTION_NAMES.disablePageReloads,
     OPTION_NAMES.disableScreenshots,
-    OPTION_NAMES.allowMultipleWindows
+    OPTION_NAMES.allowMultipleWindows,
+    OPTION_NAMES.live
 ];
 
 const OPTION_INIT_FLAG_NAMES = [
@@ -194,11 +209,105 @@ export default class TestCafeConfiguration extends Configuration {
         this._ensureOptionWithValue(OPTION_NAMES.src, DEFAULT_SOURCE_DIRECTORIES, OptionSource.Configuration);
         this._ensureOptionWithValue(OPTION_NAMES.developmentMode, DEFAULT_DEVELOPMENT_MODE, OptionSource.Configuration);
         this._ensureOptionWithValue(OPTION_NAMES.retryTestPages, DEFAULT_RETRY_TEST_PAGES, OptionSource.Configuration);
+        this._ensureOptionWithValue(OPTION_NAMES.reporter, [DEFAULT_REPORTER], OptionSource.Configuration);
+        this._ensureOptionWithValue(OPTION_NAMES.clientScripts, [], OptionSource.Configuration);
 
         this._ensureScreenshotPath();
     }
 
     public static get FILENAME (): string {
         return CONFIGURATION_FILENAME;
+    }
+
+    public getSrcOption (): TestSource[] {
+        return this.getOption(OPTION_NAMES.src) as TestSource[];
+    }
+
+    public getTsConfigPathOption (): string {
+        return this.getOption(OPTION_NAMES.tsConfigPath) as string;
+    }
+
+    public getFilterOption (): Filter {
+        return this.getOption(OPTION_NAMES.filter) as Filter;
+    }
+
+    public getBrowsersOption (): BrowserSource[] {
+        return this.getOption(OPTION_NAMES.browsers) as BrowserSource[];
+    }
+
+    public getAllowMultipleWindowsOption (): boolean {
+        return this.getOption(OPTION_NAMES.allowMultipleWindows) as boolean;
+    }
+
+    public getScreenshotsOption (): ScreenshotOptionValue {
+        return this.getOption(OPTION_NAMES.screenshots) as ScreenshotOptionValue;
+    }
+
+    public getDisableScreenshotsOption (): boolean {
+        return this.getOption(OPTION_NAMES.disableScreenshots) as boolean;
+    }
+
+    public getConcurrencyOption (): number {
+        return this.getOption(OPTION_NAMES.concurrency) as number;
+    }
+
+    public getReporterOption (): ReporterSource[] {
+        return this.getOption(OPTION_NAMES.reporter) as ReporterSource[];
+    }
+
+    public getAppCommandOption (): string {
+        return this.getOption(OPTION_NAMES.appCommand) as string;
+    }
+
+    public getAppInitDelayOption (): number {
+        return this.getOption(OPTION_NAMES.appInitDelay) as number;
+    }
+
+    public getClientScriptsOption (): ClientScriptSource[] {
+        return this.getOption(OPTION_NAMES.clientScripts) as ClientScriptSource[];
+    }
+
+    public getLiveOption (): boolean {
+        return this.getOption(OPTION_NAMES.live) as boolean;
+    }
+
+    public getVideoPathOption (): string {
+        return this.getOption(OPTION_NAMES.videoPath) as string;
+    }
+
+    public getVideoOption (): object {
+        return this.getOption(OPTION_NAMES.videoOptions) as object;
+    }
+
+    public getVideoEncodingOption (): object {
+        return this.getOption(OPTION_NAMES.videoEncodingOptions) as object;
+    }
+
+    public getStopOnFirstFailOption (): boolean {
+        return this.getOption(OPTION_NAMES.stopOnFirstFail) as boolean;
+    }
+
+    public getSpeedOption (): number {
+        return this.getOption(OPTION_NAMES.speed) as number;
+    }
+
+    public getProxyByPassOption (): unknown {
+        return this.getOption(OPTION_NAMES.proxyBypass) as unknown;
+    }
+
+    public getScreenshotPathOption (): string {
+        return this.getOption(OPTION_NAMES.screenshotPath) as string;
+    }
+
+    public getScreenshotPathPattern (): string {
+        return this.getOption(OPTION_NAMES.screenshotPathPattern) as string;
+    }
+
+    public getSkipUncaughtErrors (): boolean {
+        return this.getOption(OPTION_NAMES.skipUncaughtErrors) as boolean;
+    }
+
+    public getDebugLoggerOption (): unknown {
+        return this.getOption(OPTION_NAMES.debugLogger) as unknown;
     }
 }

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -94,12 +94,14 @@ export default class TestCafeConfiguration extends Configuration {
         this.mergeOptions(options);
     }
 
-    public prepare (): void {
+    public prepare (options: object): void {
+        this.mergeOptions(options);
         this._prepareFlags();
         this._setDefaultValues();
+        this._notifyAboutOverriddenOptions();
     }
 
-    public notifyAboutOverriddenOptions (): void {
+    private _notifyAboutOverriddenOptions (): void {
         if (!this._overriddenOptions.length)
             return;
 

--- a/src/runner/browser-set.ts
+++ b/src/runner/browser-set.ts
@@ -82,6 +82,7 @@ export default class BrowserSet extends EventEmitter {
     }
 
     private async _waitConnectionsOpened (): Promise<void> {
+        // TODO: split to waitRemoteConnectionsOpened, waitLocalConnectionsOpened
         const connectionsReadyPromise = Promise.all(
             this._browserConnections
                 .filter(bc => bc.status !== BrowserConnectionStatus.opened)
@@ -111,7 +112,9 @@ export default class BrowserSet extends EventEmitter {
         const prepareConnection = Promise.resolve()
             .then(() => {
                 browserSet._checkForDisconnections();
-                return browserSet._waitConnectionsOpened();
+
+                // Need to waitForRemoteConnectionsOpened here
+                //return browserSet._waitConnectionsOpened();
             })
             .then(() => browserSet);
 

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -493,12 +493,9 @@ export default class Runner extends EventEmitter {
 
     run (options = {}) {
         this.apiMethodWasCalled.reset();
-        this.configuration.mergeOptions(options);
-        this.configuration.prepare();
-        this.configuration.notifyAboutOverriddenOptions();
+        this.configuration.prepare(options);
 
-        const runTaskPromise = Promise.resolve()
-            .then(() => this._validateRunOptions())
+        const runTaskPromise = this._validateRunOptions()
             .then(() => this._createRunnableConfiguration())
             .then(async runnableConfiguration => {
                 const { tests, commonClientScripts, browserSet } = runnableConfiguration;

--- a/src/runner/interfaces.ts
+++ b/src/runner/interfaces.ts
@@ -1,5 +1,16 @@
 import CommandBase from '../test-run/commands/base';
 import TestRun from '../test-run';
+import BrowserConnection from '../browser/connection';
+import { Writable as WritableStream } from 'stream';
+import ClientScriptInit from '../custom-client-scripts/client-script-init';
+import { Metadata } from '../api/structure/interfaces';
+import BrowserSet from './browser-set';
+import BrowserJob from './browser-job';
+import WarningLog from '../notifications/warning-log';
+import Test from '../api/structure/test';
+import TestedApp from './tested-app';
+import ClientScript from '../custom-client-scripts/client-script';
+import Screenshots from '../screenshots';
 
 export interface ActionEventArg {
     apiActionName: string;
@@ -23,3 +34,42 @@ export interface ReportedTestStructureItem {
     fixture: ReportedFixtureItem;
 }
 
+export type BrowserSource = BrowserConnection | string;
+
+export type TestSource = string | string[];
+
+export interface ReporterSource {
+    name: string;
+    output?: string | WritableStream;
+}
+
+export type ClientScriptSource = string | ClientScriptInit;
+
+export interface Filter {
+    (testName: string, fixtureName: string, fixturePath: string, testMeta: Metadata, fixtureMeta: Metadata): boolean;
+}
+
+
+export type ReporterPlugin = unknown;
+
+export interface ReporterPluginSource {
+    plugin: ReporterPlugin;
+    outStream?: WritableStream;
+}
+
+export interface BrowserConnectionRelatedResources {
+    browserSet: BrowserSet;
+    browserJobs: BrowserJob[];
+    warningLog: WarningLog;
+    screenshots: Screenshots;
+}
+
+export interface BasicRuntimeResources extends BrowserConnectionRelatedResources {
+    tests: Test[];
+    testedApp?: TestedApp;
+}
+
+export interface RuntimeResources extends BasicRuntimeResources {
+    reporterPlugins: ReporterPluginSource[];
+    commonClientScripts: ClientScript[];
+}

--- a/src/services/compiler/host.ts
+++ b/src/services/compiler/host.ts
@@ -9,8 +9,7 @@ import TestCafeErrorList from '../../errors/error-list';
 
 import { CompilerProtocol, RunTestArguments, ExecuteCommandArguments, FunctionProperties } from './protocol';
 import { CompilerArguments } from '../../compiler/interfaces';
-import { Test } from '../../api/structure/interfaces';
-
+import Test from '../../api/structure/test';
 
 const SERVICE_PATH = require.resolve('./service');
 

--- a/src/services/compiler/test-structure.ts
+++ b/src/services/compiler/test-structure.ts
@@ -1,7 +1,9 @@
 import { uniq, keyBy } from 'lodash';
 import { TEST_FUNCTION_PROPERTIES } from './protocol';
 
-import { Fixture, Test, TestFile } from '../../api/structure/interfaces';
+import Test from '../../api/structure/test';
+import Fixture from '../../api/structure/fixture';
+import TestFile from '../../api/structure/test-file';
 import * as unitTypes from '../../api/structure/unit-types';
 
 
@@ -80,6 +82,7 @@ export function serialize (units: Units): Units {
     const result: Units = {};
 
     for (const unit of Object.values(units)) {
+        //@ts-ignore
         const copy: Unit = { ...unit };
 
         replaceTestFunctions(copy);

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -238,6 +238,8 @@ export default class TestRun extends AsyncEventEmitter {
             browserStatusRelativeUrl:     JSON.stringify(this.browserConnection.statusRelativeUrl),
             browserStatusDoneRelativeUrl: JSON.stringify(this.browserConnection.statusDoneRelativeUrl),
             browserActiveWindowIdUrl:     JSON.stringify(this.browserConnection.activeWindowIdUrl),
+            browserInitScriptUrl:         JSON.stringify(this.browserConnection.initScriptUrl),
+            browserSetupWindowUrl:        JSON.stringify(this.browserConnection.setupWindowUrl),
             userAgent:                    JSON.stringify(this.browserConnection.userAgent),
             testName:                     JSON.stringify(this.test.name),
             fixtureName:                  JSON.stringify(this.test.fixture.name),

--- a/test.js
+++ b/test.js
@@ -18,6 +18,8 @@ const getUserAgent = ClientFunction(() => {
 });
 
 test('Check presence of touch event handlers', async t => {
+    await ClientFunction(() => location.reload(true))();
+
     console.log(await getUserAgent());
 
     await t

--- a/test.js
+++ b/test.js
@@ -1,3 +1,21 @@
-fixture `Fixture`;
+import { ClientFunction } from 'testcafe';
 
-test('test', async t => {});
+fixture `Touch events`;
+
+const EVENT_HANDLERS = ['ontouchstart', 'ontouchend', 'ontouchmove', 'ontouchcancel'];
+
+const hasTouchEventHandlers = ClientFunction(() => {
+    setTimeout(() => {
+        var hasOnTouchStart = 'ontouchstart' in window;
+        debugger;
+    }, 2000);
+
+
+    //return EVENT_HANDLERS.every(handler => handler in window);
+}, {
+    dependencies: { EVENT_HANDLERS }
+});
+
+test('Check presence of touch event handlers', async t => {
+    await t.expect(hasTouchEventHandlers()).ok();
+});

--- a/test.js
+++ b/test.js
@@ -5,17 +5,24 @@ fixture `Touch events`;
 const EVENT_HANDLERS = ['ontouchstart', 'ontouchend', 'ontouchmove', 'ontouchcancel'];
 
 const hasTouchEventHandlers = ClientFunction(() => {
-    setTimeout(() => {
-        var hasOnTouchStart = 'ontouchstart' in window;
-        debugger;
-    }, 2000);
+    var hasOnTouchStart = 'ontouchstart' in window;
 
-
+    return hasOnTouchStart;
     //return EVENT_HANDLERS.every(handler => handler in window);
 }, {
     dependencies: { EVENT_HANDLERS }
 });
 
+const getUserAgent = ClientFunction(() => {
+    return navigator.userAgent;
+});
+
 test('Check presence of touch event handlers', async t => {
-    await t.expect(hasTouchEventHandlers()).ok();
+    console.log(await getUserAgent());
+
+    await t
+        .expect(hasTouchEventHandlers()).ok()
+        .wait(5000);
+
+
 });

--- a/test.js
+++ b/test.js
@@ -1,0 +1,3 @@
+fixture `Fixture`;
+
+test('test', async t => {});

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,3 @@
+fixture ('Fixture');
+
+test('test', async t => {});

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -86,7 +86,7 @@ testingEnvironments[testingEnvironmentNames.localBrowsers] = {
             platform:    'Windows 10',
             browserName: 'chrome',
             alias:       'chrome'
-        },
+        }/*,
         {
             platform:    'Windows 10',
             browserName: 'ie',
@@ -97,7 +97,7 @@ testingEnvironments[testingEnvironmentNames.localBrowsers] = {
             platform:    'Windows 10',
             browserName: 'firefox',
             alias:       'firefox'
-        }
+        }*/
     ]
 };
 

--- a/test/functional/fixtures/browser-provider/chrome-emulation/test.js
+++ b/test/functional/fixtures/browser-provider/chrome-emulation/test.js
@@ -15,7 +15,7 @@ if (config.useLocalBrowsers) {
                 .src(path.join(__dirname, './testcafe-fixtures/index-test.js'))
                 .filter(fixtureName => fixtureName === 'Check presence of touch event handlers')
                 .reporter('minimal', createNullStream())
-                //.browsers('chrome:headless:emulation:device=iphone 6 --no-sandbox')
+                .browsers('chrome:headless:emulation:device=iphone 6 --no-sandbox')
                 .run()
                 .then(failedCount => {
                     expect(failedCount).eql(0);

--- a/test/functional/fixtures/browser-provider/chrome-emulation/test.js
+++ b/test/functional/fixtures/browser-provider/chrome-emulation/test.js
@@ -9,13 +9,13 @@ chai.use(require('chai-string'));
 
 if (config.useLocalBrowsers) {
     describe('Browser Provider - Chrome Emulation Mode', () => {
-        it('Should emulate touch event handlers', () => {
+        it.only('Should emulate touch event handlers', () => {
             return testCafe
                 .createRunner()
                 .src(path.join(__dirname, './testcafe-fixtures/index-test.js'))
                 .filter(fixtureName => fixtureName === 'Check presence of touch event handlers')
                 .reporter('minimal', createNullStream())
-                .browsers('chrome:headless:emulation:device=iphone 6 --no-sandbox')
+                //.browsers('chrome:headless:emulation:device=iphone 6 --no-sandbox')
                 .run()
                 .then(failedCount => {
                     expect(failedCount).eql(0);

--- a/test/functional/fixtures/live/test.js
+++ b/test/functional/fixtures/live/test.js
@@ -1,9 +1,10 @@
-const { noop }       = require('lodash');
-const createTestCafe = require('../../../../lib');
-const config         = require('../../config');
-const path           = require('path');
-const { expect }     = require('chai');
-const helper         = require('./test-helper');
+const { noop }           = require('lodash');
+const createTestCafe     = require('../../../../lib');
+const config             = require('../../config');
+const path               = require('path');
+const { expect }         = require('chai');
+const helper             = require('./test-helper');
+const { createReporter } = require('../../utils/reporter');
 
 const DEFAULT_BROWSERS = ['chrome', 'firefox'];
 let cafe               = null;
@@ -52,14 +53,7 @@ function createLiveModeRunner (tc, src, browsers = DEFAULT_BROWSERS) {
     return runner
         .src(path.join(__dirname, src))
         .browsers(browsers)
-        .reporter(() => {
-            return {
-                reportTaskStart:    noop,
-                reportTaskDone:     noop,
-                reportTestDone:     noop,
-                reportFixtureStart: noop
-            };
-        });
+        .reporter(createReporter());
 }
 
 if (config.useLocalBrowsers && !config.useHeadlessBrowsers) {
@@ -121,7 +115,7 @@ if (config.useLocalBrowsers && !config.useHeadlessBrowsers) {
                 });
         });
 
-        it('Client scripts', () => {
+        it.only('Client scripts', () => {
             return createTestCafe('127.0.0.1', 1335, 1336)
                 .then(tc => {
                     cafe = tc;
@@ -147,7 +141,6 @@ if (config.useLocalBrowsers && !config.useHeadlessBrowsers) {
                     return cafe.close();
                 });
         });
-
 
         it('Same runner stops and then runs again with other settings', function () {
             let finishTest = null;

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -60,6 +60,7 @@ describe('Runner', () => {
         browserProviderPool.addProvider('remote', origRemoteBrowserProvider);
 
         connection.close();
+
         return testCafe.close();
     });
 
@@ -941,6 +942,11 @@ describe('Runner', () => {
             }
         };
 
+        const jobMock = {
+            popNextTestRunUrl: async () => 'first tested page url',
+            hasQueuedTestRuns: true
+        };
+
         function taskDone () {
             this._pendingBrowserJobs.forEach(job => {
                 this.emit('browser-job-done', job);
@@ -973,7 +979,11 @@ describe('Runner', () => {
                 setTimeout(taskActionCallback.bind(this), TASK_ACTION_DELAY);
 
                 return this.browserConnectionGroups.map(bcGroup => {
-                    return { browserConnections: bcGroup };
+                    bcGroup.map(bc => bc.addJob(jobMock));
+
+                    jobMock.browserConnections = bcGroup;
+
+                    return jobMock;
                 });
             };
 


### PR DESCRIPTION
Changes:
* set the same title `[BrowserConnection.id]` for each visited test page.
* in `BrowserConnectionGateway._onConnection` method redirect to the first tested page instead of the idle page (only for non-persistent browser connections)
* resize browser window on the first tested page during driver starting