### PR TITLE
Fix argument name for .notEql

### DIFF
--- a/docs/articles/documentation/reference/test-api/testcontroller/expect/noteql.md
+++ b/docs/articles/documentation/reference/test-api/testcontroller/expect/noteql.md
@@ -8,7 +8,7 @@ permalink: /documentation/reference/test-api/testcontroller/expect/noteql.html
 Assert that `actual` is not equal to `unexpected`.
 
 ```text
-await t.expect( actual ).notEql( unexpected, message, options );
+await t.expect( actual ).notEql( expected, message, options );
 ```
 
 Parameter              | Type                                              | Description

--- a/docs/articles/documentation/reference/test-api/testcontroller/expect/noteql.md
+++ b/docs/articles/documentation/reference/test-api/testcontroller/expect/noteql.md
@@ -5,7 +5,7 @@ permalink: /documentation/reference/test-api/testcontroller/expect/noteql.html
 ---
 # t.expect.notEql Method
 
-Assert that `actual` is not equal to `unexpected`.
+Assert that `actual` is not equal to `expected`.
 
 ```text
 await t.expect( actual ).notEql( expected, message, options );


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Fix argument name for `.notEql`