### PR TITLE
[doc] Add  link to @testcafe-community/axe

### DIFF
--- a/docs/articles/documentation/recipes/README.md
+++ b/docs/articles/documentation/recipes/README.md
@@ -24,6 +24,7 @@ This section provides examples and recipes of how to use TestCafe in different s
 
 * [Import Third-Party Modules](integrations/import-third-party-modules.md)
 * [Testing Library API](integrations/use-testing-library-api.md)
+* [Axe-core](https://github.com/testcafe-community/axe)
 * [Angular CLI Builder](integrations/use-angular-cli-builder.md)
 * [Gulp](integrations/gulp.md)
 * [Grunt](integrations/grunt.md)


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Adding link to @testcafe-community/axe for integration with axe-core.

## Approach

The axe-testcafe project has been dormant on github for quite some time.  As such I decided to fork that library and modernize it, fixing some bugs and adding a more streamlined API that is based on modern testcafe. (using clientScripts for example)

## References
https://github.com/testcafe-community/axe

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
