### PR TITLE
Add warning messages when trying to assert Selector/ClientFunction instances

### DIFF
--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -353,8 +353,7 @@ export default class TestController {
 
         if (isClientFunction(actual))
             this._addWarning(WARNING_MESSAGE.assertedClientFunctionInstance, callsite);
-
-        if (isSelector(actual))
+        else if (isSelector(actual))
             this._addWarning(WARNING_MESSAGE.assertedSelectorInstance, callsite);
 
         return new Assertion(actual, this, callsite);

--- a/src/client-functions/types.ts
+++ b/src/client-functions/types.ts
@@ -1,0 +1,17 @@
+import builderSymbol from './builder-symbol';
+import ClientFunctionBuilder from './client-function-builder';
+import SelectorBuilder from './selectors/selector-builder';
+
+export function isClientFunction (obj: any): boolean {
+    if (typeof obj === 'function')
+        return obj[builderSymbol] && obj[builderSymbol] instanceof ClientFunctionBuilder && !(obj[builderSymbol] instanceof SelectorBuilder);
+
+    return false;
+}
+
+export function isSelector (obj: any): boolean {
+    if (typeof obj === 'function')
+        return obj[builderSymbol] && obj[builderSymbol] instanceof SelectorBuilder;
+
+    return false;
+}

--- a/src/client-functions/types.ts
+++ b/src/client-functions/types.ts
@@ -3,15 +3,10 @@ import ClientFunctionBuilder from './client-function-builder';
 import SelectorBuilder from './selectors/selector-builder';
 
 export function isClientFunction (obj: any): boolean {
-    if (typeof obj === 'function')
-        return obj[builderSymbol] && obj[builderSymbol] instanceof ClientFunctionBuilder && !(obj[builderSymbol] instanceof SelectorBuilder);
-
-    return false;
+    return obj && obj[builderSymbol] && obj[builderSymbol] instanceof ClientFunctionBuilder &&
+        !(obj[builderSymbol] instanceof SelectorBuilder);
 }
 
 export function isSelector (obj: any): boolean {
-    if (typeof obj === 'function')
-        return obj[builderSymbol] && obj[builderSymbol] instanceof SelectorBuilder;
-
-    return false;
+    return obj && obj[builderSymbol] && obj[builderSymbol] instanceof SelectorBuilder;
 }

--- a/src/errors/create-stack-filter.js
+++ b/src/errors/create-stack-filter.js
@@ -11,6 +11,7 @@ const REGENERATOR_RUNTIME = BABEL_MODULES_DIR + 'regenerator-runtime' + sep;
 
 const TESTCAFE_LIB        = join(__dirname, '../');
 const TESTCAFE_BIN        = join(__dirname, '../../bin');
+const TESTCAFE_SRC        = join(__dirname, '../../src');
 const TESTCAFE_HAMMERHEAD = `${sep}testcafe-hammerhead${sep}`;
 
 const SOURCE_MAP_SUPPORT = `${sep}source-map-support${sep}`;
@@ -37,7 +38,8 @@ export default function createStackFilter (limit) {
                    filename.indexOf(BABYLON) !== 0 &&
                    filename.indexOf(CORE_JS) !== 0 &&
                    filename.indexOf(REGENERATOR_RUNTIME) !== 0 &&
-                   filename.indexOf(SOURCE_MAP_SUPPORT) < 0;
+                   filename.indexOf(SOURCE_MAP_SUPPORT) < 0 &&
+                   filename.indexOf(TESTCAFE_SRC) !== 0;
 
         if (pass)
             passedFramesCount++;

--- a/src/notifications/warning-message.js
+++ b/src/notifications/warning-message.js
@@ -32,6 +32,8 @@ export default {
                                                         'The placeholder{suffix} {verb} replaced with an empty string.',
 
     clientScriptsWithEmptyContent:      'The client script you tried to inject is empty.',
-    clientScriptsWithDuplicatedContent: 'You injected the following client script{suffix} several times:\n {duplicatedScripts}'
+    clientScriptsWithDuplicatedContent: 'You injected the following client script{suffix} several times:\n {duplicatedScripts}',
+    assertedSelectorInstance:           'You are trying to assert the Selector instance.\nIf you want to assert that the selected element exists, consider using yourSelector.exists in the .expect() statement.',
+    assertedClientFunctionInstance:     'You are trying to assert the ClientFunction instance.\nIf you want to assert the returned value, consider calling your ClientFunction (using yourClientFunction.call()) in the .expect() statement.'
 };
 

--- a/test/functional/fixtures/api/es-next/assertions/test.js
+++ b/test/functional/fixtures/api/es-next/assertions/test.js
@@ -182,7 +182,7 @@ describe('[API] Assertions', function () {
             shouldFail: true,
             only:       'chrome'
         })
-            .then(function () {
+            .catch(function () {
                 expect(testReport.warnings[0]).to.match(new RegExp(['You are trying to assert the Selector instance.\nIf you want to ',
                     'assert that the selected element exists, consider using yourSelector.exists in the .expect() statement.'].join('')));
             });
@@ -193,7 +193,7 @@ describe('[API] Assertions', function () {
             shouldFail: true,
             only:       'chrome'
         })
-            .then(function () {
+            .catch(function () {
                 expect(testReport.warnings[0]).to.match(new RegExp(['You are trying to assert the ClientFunction instance.\nIf you want to ',
                     'assert the returned value, consider calling your ClientFunction (using yourClientFunction.call()) in the .expect() statement.'].join('')));
             });

--- a/test/functional/fixtures/api/es-next/assertions/test.js
+++ b/test/functional/fixtures/api/es-next/assertions/test.js
@@ -177,6 +177,28 @@ describe('[API] Assertions', function () {
             });
     });
 
+    it('Should raise a warning when trying to assert Selector instance', function () {
+        return runTests('./testcafe-fixtures/assertions-test.js', 'Passing Selector instance into an assertion', {
+            shouldFail: true,
+            only:       'chrome'
+        })
+            .then(function () {
+                expect(testReport.warnings[0]).to.match(new RegExp(['You are trying to assert the Selector instance.\nIf you want to ',
+                    'assert that the selected element exists, consider using yourSelector.exists in the .expect() statement.'].join('')));
+            });
+    });
+
+    it('Should raise a warning when trying to assert ClientFunction instance', function () {
+        return runTests('./testcafe-fixtures/assertions-test.js', 'Passing ClientFunction instance into an assertion', {
+            shouldFail: true,
+            only:       'chrome'
+        })
+            .then(function () {
+                expect(testReport.warnings[0]).to.match(new RegExp(['You are trying to assert the ClientFunction instance.\nIf you want to ',
+                    'assert the returned value, consider calling your ClientFunction (using yourClientFunction.call()) in the .expect() statement.'].join('')));
+            });
+    });
+
     it('Should retry assertion for selector results', function () {
         return runTests('./testcafe-fixtures/assertions-test.js', 'Selector result assertion', { only: 'chrome' });
     });

--- a/test/functional/fixtures/api/es-next/assertions/test.js
+++ b/test/functional/fixtures/api/es-next/assertions/test.js
@@ -183,8 +183,8 @@ describe('[API] Assertions', function () {
             only:       'chrome'
         })
             .catch(function () {
-                expect(testReport.warnings[0]).to.match(new RegExp(['You are trying to assert the Selector instance.\nIf you want to ',
-                    'assert that the selected element exists, consider using yourSelector.exists in the .expect() statement.'].join('')));
+                expect(testReport.warnings[0]).to.match(new RegExp(['You are trying to assert the Selector instance\\.\nIf you want to ',
+                    'assert that the selected element exists, consider using yourSelector\\.exists in the \\.expect\\(\\) statement\\.'].join('')));
             });
     });
 
@@ -194,8 +194,8 @@ describe('[API] Assertions', function () {
             only:       'chrome'
         })
             .catch(function () {
-                expect(testReport.warnings[0]).to.match(new RegExp(['You are trying to assert the ClientFunction instance.\nIf you want to ',
-                    'assert the returned value, consider calling your ClientFunction (using yourClientFunction.call()) in the .expect() statement.'].join('')));
+                expect(testReport.warnings[0]).to.match(new RegExp(['You are trying to assert the ClientFunction instance\\.\nIf you want to ',
+                    'assert the returned value, consider calling your ClientFunction \\(using yourClientFunction\\.call\\(\\)\\) in the \\.expect\\(\\) statement\\.'].join('')));
             });
     });
 

--- a/test/functional/fixtures/api/es-next/assertions/testcafe-fixtures/assertions-test.js
+++ b/test/functional/fixtures/api/es-next/assertions/testcafe-fixtures/assertions-test.js
@@ -159,3 +159,11 @@ test('ClientFunction result assertion', async t => {
 test('Assertion without method call', async t => {
     await t.expect();
 });
+
+test('Passing Selector instance into an assertion', async t => {
+    await t.expect(Selector('#el1')).eql(true);
+});
+
+test('Passing ClientFunction instance into an assertion', async t => {
+    await t.expect(ClientFunction(() => true)).eql(true);
+});

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -24,10 +24,6 @@ require('source-map-support').install();
 describe('Compiler', function () {
     const testRunMock = { id: 'yo' };
 
-    const tsCompilerPath     = path.resolve('src/compiler/test-file/formats/typescript/compiler.ts');
-    const apiBasedPath       = path.resolve('src/compiler/test-file/api-based.js');
-    const esNextCompilerPath = path.resolve('src/compiler/test-file/formats/es-next/compiler.js');
-
     this.timeout(20000);
 
     // FIXME: Babel errors always contain POSIX-format file paths.
@@ -708,9 +704,6 @@ describe('Compiler', function () {
             const dep      = posixResolve('test/server/data/test-suites/syntax-error-in-dep/dep.js');
 
             const stack = [
-                esNextCompilerPath,
-                esNextCompilerPath,
-                apiBasedPath,
                 testfile
             ];
 
@@ -734,7 +727,6 @@ describe('Compiler', function () {
 
             const stack = [
                 dep,
-                apiBasedPath,
                 testfile
             ];
 
@@ -765,7 +757,6 @@ describe('Compiler', function () {
                     assertError(err, {
                         stackTop: [
                             dep,
-                            apiBasedPath,
                             testfile
                         ],
 
@@ -812,18 +803,13 @@ describe('Compiler', function () {
         it('Should raise an error if test file has a syntax error', function () {
             const testfile = posixResolve('test/server/data/test-suites/syntax-error-in-testfile/testfile.js');
 
-            const stack  = [
-                esNextCompilerPath,
-                apiBasedPath,
-            ];
-
             return compile(testfile)
                 .then(function () {
                     throw new Error('Promise rejection expected');
                 })
                 .catch(function (err) {
                     assertError(err, {
-                        stackTop: stack,
+                        stackTop: null,
 
                         message: 'Cannot prepare tests due to an error.\n\n' +
                                  'SyntaxError: ' + testfile + ': Unexpected token, expected { (1:7)'
@@ -837,18 +823,13 @@ describe('Compiler', function () {
                 posixResolve('test/server/data/test-suites/flow-type-declarations/flower-marker.js')
             ];
 
-            const stack  = [
-                esNextCompilerPath,
-                apiBasedPath,
-            ];
-
             return compile(testfiles[0])
                 .then(function () {
                     throw new Error('Promise rejection expected');
                 })
                 .catch(function (err) {
                     assertError(err, {
-                        stackTop: stack,
+                        stackTop: null,
 
 
                         message: 'Cannot prepare tests due to an error.\n\n' +
@@ -862,7 +843,7 @@ describe('Compiler', function () {
                 })
                 .catch(function (err) {
                     assertError(err, {
-                        stackTop: stack,
+                        stackTop: null,
 
                         message: 'Cannot prepare tests due to an error.\n\n' +
                                  'SyntaxError: ' + testfiles[1] + ': Unexpected token, expected ; (2:8)'
@@ -872,7 +853,6 @@ describe('Compiler', function () {
 
         it('Should raise an error if test file has a TypeScript error', function () {
             const testfile = posixResolve('test/server/data/test-suites/typescript-compile-errors/testfile.ts');
-            const stack    = tsCompilerPath;
 
             return compile(testfile)
                 .then(function () {
@@ -880,7 +860,7 @@ describe('Compiler', function () {
                 })
                 .catch(function (err) {
                     assertError(err, {
-                        stackTop: stack,
+                        stackTop: null,
 
                         message: 'Cannot prepare tests due to an error.\n\n' +
                                  'Error: TypeScript compilation failed.\n' +


### PR DESCRIPTION
## Purpose
Users often want to assert that the selected element exists or that the returned value of ClientFunction meets a specific criteria.

## Approach
I created an addAssertionWarning function that checks if the "actual" expected value is a function and if its builder object is SelectorBuilder/ClientFunctionBuilder. If this condition is met, I print a corresponding warning.

## References
Part of #5087

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
