### PR TITLE
[docs] Custom reporter documentation update

### DIFF
--- a/docs/articles/documentation/guides/extend-testcafe/reporter-plugin.md
+++ b/docs/articles/documentation/guides/extend-testcafe/reporter-plugin.md
@@ -65,7 +65,7 @@ Implement the following reporter methods (four mandatory and one optional):
 ```js
 export default function () {
     return {
-        async reportTaskStart (/* startTime, userAgents, testCount */) {
+        async reportTaskStart (/* startTime, userAgents, testCount, testStructure, taskProperties */) {
             throw new Error('Not implemented');
         },
 

--- a/docs/articles/documentation/reference/plugin-api/reporter.md
+++ b/docs/articles/documentation/reference/plugin-api/reporter.md
@@ -28,19 +28,21 @@ You can use the [helper methods and libraries](#helper-methods) within the repor
 Fires when a test task starts.
 
 ```text
-async reportTaskStart (startTime, userAgents, testCount)
+async reportTaskStart (startTime, userAgents, testCount, testStructure, taskProperties)
 ```
 
-Parameter    | Type             | Description
------------- | ---------------- | ---------------------------------------
-`startTime`  | Date             | The date and time when testing started.
-`userAgents` | Array of Strings | The list of browsers used for testing. Contains the formatted names and versions of the browsers and operating systems.
-`testCount`  | Number           | The total number of tests to run.
+Parameter        | Type              | Description
+---------------- | ----------------- | ---------------------------------------
+`startTime`      | Date              | The date and time when testing started.
+`userAgents`     | Array of Strings  | The list of browsers used for testing. Contains the formatted names and versions of the browsers and operating systems.
+`testCount`      | Number            | The total number of tests to run.
+`testStructure`  | Array of Objects  | An array of [testStructure](#teststructure-object) objects.
+`taskProperties` | Object            | A [taskProperties](#taskproperties-object) object.
 
 **Example**
 
 ```js
-async reportTaskStart (startTime, userAgents, testCount) {
+async reportTaskStart (startTime, userAgents, testCount, testStructure, taskProperties) {
     this.startTime = startTime;
     this.testCount = testCount;
 
@@ -49,12 +51,53 @@ async reportTaskStart (startTime, userAgents, testCount) {
     this.write(`Testing started: ${time}`)
         .newline()
         .write(`Running ${testCount} tests in: ${userAgents}`)
-        .newline();
+        .newline()
+        .write(`Test structure: ${JSON.stringify(testStructure)}`)
+        .newline()
+        .write(`Using configuration: ${JSON.stringify(taskProperties)}`);
 }
 
 //=> Testing started: 8/12/2016 3:00:00 am
 //=> Running 6 tests in: Chrome 41.0.2227 / Mac OS X 10.10.1,Firefox 47 / Mac OS X 10.10.1
+//=> Test structure: [{"fixture":{"id":"2zeHcQZ","name":"Fixture1","tests":[{"id":"PThvxSu","name":"Test1","skip":false}, {"id":"QRfgxvu","name":"Test2","skip":false}]}}]
+//=> Using configuration: {"configuration":{"hostname":"localhost","port1":65235,"port2":65236,"developmentMode":false,"retryTestPages":false,"src":["/home/user/tests/**/*.js"],"reporter":[{}],"browsers":["chrome"],"quarantineMode":true,"skipJsErrors":false,"debugMode":false,"debugOnFail":false,"skipUncaughtErrors":false,"stopOnFirstFail":false,"takeScreenshotsOnFails":false,"disablePageCaching":false,"disablePageReloads":false,"disableScreenshots":false,"allowMultipleWindows":false,"selectorTimeout":10000,"assertionTimeout":3000,"pageLoadTimeout":3000,"speed":1,"appInitDelay":1000,"concurrency":1,"screenshots":{"path":"/home/user/reports/screenshots/"},"debugLogger":{"messages":[],"debugLogging":false,"streamsOverridden":false}}}
 ```
+
+### testStructure Object
+
+The `testStructure` array provides definition of tests that wil be executed per fixture. The array contain objects with following properties:
+
+Property            | Type    | Description
+------------------- | ------- | --------------------------------------------------------
+`fixture`           | Object  | A [fixture](#fixture-object) object.
+
+### fixture Object
+
+The `fixture` object provides name, id and tests defined under it. The object has the following properties:
+
+Property       | Type             | Description
+-------------- | ---------------- | --------------------------------------------------------
+`id`           | String           | Randomly generated fixture id
+`name`         | String           | Fixture name
+`tests`        | Array of Objects | An array of [tests](#tests-object) objects.
+
+### tests Object
+
+The `tests` object provides name, id and information if test should be skipped. The object has the following properties:
+
+Property       | Type             | Description
+-------------- | ---------------- | --------------------------------------------------------
+`id`           | String           | Randomly generated test id
+`name`         | String           | Test name
+`skip`         | Boolean          | Specifies if the test should be skipped
+
+### taskProperties Object
+
+The `taskProperties` provides information about a configuration that was used to execute the test run. The object contain following properties:
+
+Property            | Type    | Description
+------------------- | ------- | --------------------------------------------------------
+`configuration`     | Object  | A [configuration](../configuration-file.md) object.
 
 ## reportFixtureStart
 

--- a/docs/articles/documentation/reference/testcafe-api/runner/README.md
+++ b/docs/articles/documentation/reference/testcafe-api/runner/README.md
@@ -58,3 +58,30 @@ createTestCafe('localhost', 1337, 1338)
         testcafe.close();
     });
 ```
+
+**Example with multiple test runners**
+
+```js
+const createTestCafe = require('testcafe');
+let testcafe         = null;
+
+createTestCafe('localhost')
+    .then(tc => {
+        testcafe     = tc;
+        const desktopRunner = testcafe
+                          .createRunner()
+                          .filter(/* isDesktopTest */)
+                          .browsers('chrome');
+        const mobileRunner = testcafe
+                          .createRunner()
+                          .filter(/* isMobileTest */)
+                          .browsers('chrome:emulation:device=iPad;mobile=true;touch=true');
+
+        return Promise.allSettled([desktopRunner, mobileRunner].map(testRunner => testRunner.run())); // Promise.allSettled requires Node >= 12.10.0
+    })
+    .then(([desktopFailed, mobileFailed]) => {
+        console.log('Desktop tests failed: ' + desktopFailed, 'Mobile tests failed: ' + mobileFailed);
+        testcafe.close();
+    })
+    .catch(error => { /* ... */ });
+```

--- a/docs/articles/documentation/reference/testcafe-api/runner/reporter.md
+++ b/docs/articles/documentation/reference/testcafe-api/runner/reporter.md
@@ -15,7 +15,7 @@ reporter([ name | { name, output } | fn ]) → this
 
 Parameter                | Type                        | Description                                     | Default
 ------------------------ | --------------------------- | ----------------------------------------------- | --------
-`name`                   | String      | The name of the [reporter](../../../guides/concepts/reporters.md).
+`name`                   | String &#124; Function     | The name of the [reporter](../../../guides/concepts/reporters.md) or function that [returns a custom reporter object](#specify-a-custom-reporter)
 `output`&#160;*(optional)* | String &#124; Writable Stream implementer | The file path where the report is written or the output stream. | `stdout`
 `fn` | A function that [returns a custom reporter object](#specify-a-custom-reporter).
 
@@ -59,8 +59,9 @@ import { createTestCafe } from 'testcafe';
 
 const customReporter = () => {
     return {
-        async reportTaskStart (startTime, userAgents, testCount) { /* ... */ },
+        async reportTaskStart (startTime, userAgents, testCount, testStructure, taskProperties) { /* ... */ },
         async reportFixtureStart (name, path, meta) { /* ... */ },
+        async reportTestStart (name, meta) { /* ... */ }, // This method is optional
         async reportTestDone (name, testRunInfo, meta) { /* ... */ },
         async reportTaskDone (endTime, passed, warnings, result) { /* ... */ }
     };
@@ -70,6 +71,15 @@ const testcafe = await createTestCafe(/* [...] */);
 const runner   = testcafe.createRunner();
 
 await runner.reporter(customReporter);
+```
+
+Custom reporter can also be combined with multiple reporters
+
+```js
+runner.reporter(['spec', {
+    name: customReporter,
+    output: 'reports/customReporter.json'
+}]);
 ```
 
 ## Implement a Custom Stream


### PR DESCRIPTION
Updates documentation for reportTaskStart function with testStructure and taskProperties
Adds an example reporter with multiple runners
Adds an example of using custom reporter with multiple reporters

## Purpose
Existing documentation is incomplete. It is missing relevant information about reportTaskStart arguments and ability to use custom reporter with multiple reporters.

Types has been already updated in another PR: https://github.com/DevExpress/testcafe/pull/5203

## Approach
Update documentation for custom reporter with testStructure and taskProperties objects available under reportTaskStart function.
Also add examples of using multiple tests runners for a single test cafe instance as well as example of using a custom reporter with multiple reporters.

## References
https://github.com/DevExpress/testcafe/issues/4543
