### PR TITLE
Multiple windows api (part 2) - SwitchToParentWindow, SwitchToWindow (by predicate), SwitchToRecentWindow

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -51,7 +51,8 @@ ll
     ]);
 
 const ARGS          = minimist(process.argv.slice(2));
-const DEV_MODE      = 'dev' in ARGS;
+// const DEV_MODE      = 'dev' in ARGS;
+const DEV_MODE      = true;
 const QR_CODE       = 'qr-code' in ARGS;
 const SKIP_BUILD    = process.env.SKIP_BUILD || 'skip-build' in ARGS;
 const BROWSER_ALIAS = ARGS['browser-alias'];
@@ -383,9 +384,9 @@ gulp.step('test-server-run', () => {
         }));
 });
 
-gulp.step('test-server-bootstrap', gulp.series('prepare-tests', 'test-server-run'));
+gulp.step('test-server-bootstrap', gulp.series('test-server-run'));
 
-gulp.task('test-server', gulp.parallel('check-licenses', 'test-server-bootstrap'));
+gulp.task('test-server', gulp.parallel('test-server-bootstrap'));
 
 function testClient (tests, settings, envSettings, cliMode) {
     function runTests (env, runOpts) {
@@ -834,7 +835,8 @@ gulp.step('test-functional-local-multiple-windows-run', () => {
     return testFunctional(MULTIPLE_WINDOWS_TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localChrome, { allowMultipleWindows: true });
 });
 
-gulp.task('test-functional-local-multiple-windows', gulp.series('prepare-tests', 'test-functional-local-multiple-windows-run'));
+// gulp.task('test-functional-local-multiple-windows', gulp.series('prepare-tests', 'test-functional-local-multiple-windows-run'));
+gulp.task('test-functional-local-multiple-windows', gulp.series('test-functional-local-multiple-windows-run'));
 
 gulp.step('test-functional-local-compiler-service-run', () => {
     return testFunctional(COMPILER_SERVICE_TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localHeadlessChrome, { experimentalCompilerService: true });

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -51,8 +51,7 @@ ll
     ]);
 
 const ARGS          = minimist(process.argv.slice(2));
-// const DEV_MODE      = 'dev' in ARGS;
-const DEV_MODE      = true;
+const DEV_MODE      = 'dev' in ARGS;
 const QR_CODE       = 'qr-code' in ARGS;
 const SKIP_BUILD    = process.env.SKIP_BUILD || 'skip-build' in ARGS;
 const BROWSER_ALIAS = ARGS['browser-alias'];
@@ -384,9 +383,9 @@ gulp.step('test-server-run', () => {
         }));
 });
 
-gulp.step('test-server-bootstrap', gulp.series('test-server-run'));
+gulp.step('test-server-bootstrap', gulp.series('prepare-tests', 'test-server-run'));
 
-gulp.task('test-server', gulp.parallel('test-server-bootstrap'));
+gulp.task('test-server', gulp.parallel('check-licenses', 'test-server-bootstrap'));
 
 function testClient (tests, settings, envSettings, cliMode) {
     function runTests (env, runOpts) {
@@ -835,8 +834,7 @@ gulp.step('test-functional-local-multiple-windows-run', () => {
     return testFunctional(MULTIPLE_WINDOWS_TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localChrome, { allowMultipleWindows: true });
 });
 
-// gulp.task('test-functional-local-multiple-windows', gulp.series('prepare-tests', 'test-functional-local-multiple-windows-run'));
-gulp.task('test-functional-local-multiple-windows', gulp.series('test-functional-local-multiple-windows-run'));
+gulp.task('test-functional-local-multiple-windows', gulp.series('prepare-tests', 'test-functional-local-multiple-windows-run'));
 
 gulp.step('test-functional-local-compiler-service-run', () => {
     return testFunctional(COMPILER_SERVICE_TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localHeadlessChrome, { experimentalCompilerService: true });

--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -33,6 +33,7 @@ import {
     SwitchToWindowCommand,
     SwitchToWindowByPredicateCommand,
     SwitchToParentWindowCommand,
+    SwitchToRecentWindowCommand,
     SetNativeDialogHandlerCommand,
     GetNativeDialogHistoryCommand,
     GetBrowserConsoleMessagesCommand,
@@ -338,6 +339,14 @@ export default class TestController {
         this._validateMultipleWindowCommand(apiMethodName);
 
         return this._enqueueCommand(apiMethodName, SwitchToParentWindowCommand);
+    }
+
+    _switchToRecentWindow$ () {
+        const apiMethodName = 'switchToRecentWindow';
+
+        this._validateMultipleWindowCommand(apiMethodName);
+
+        return this._enqueueCommand(apiMethodName, SwitchToRecentWindowCommand);
     }
 
     _eval$ (fn, options) {

--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -31,6 +31,8 @@ import {
     CloseWindowCommand,
     GetCurrentWindowCommand,
     SwitchToWindowCommand,
+    SwitchToWindowByPredicateCommand,
+    SwitchToParentWindowCommand,
     SetNativeDialogHandlerCommand,
     GetNativeDialogHistoryCommand,
     GetBrowserConsoleMessagesCommand,
@@ -308,14 +310,34 @@ export default class TestController {
         return this._enqueueCommand(apiMethodName, GetCurrentWindowCommand);
     }
 
-    _switchToWindow$ (window) {
+    _switchToWindow$ (windowSelector, options = {}) {
         const apiMethodName = 'switchToWindow';
 
         this._validateMultipleWindowCommand(apiMethodName);
 
-        const windowId = window?.id;
+        let command;
+        let args;
 
-        return this._enqueueCommand(apiMethodName, SwitchToWindowCommand, { windowId });
+        if (typeof windowSelector === 'function') {
+            command = SwitchToWindowByPredicateCommand;
+
+            args = { findWindow: { fn: windowSelector, options } };
+        }
+        else {
+            command = SwitchToWindowCommand;
+
+            args = { windowId: windowSelector?.id };
+        }
+
+        return this._enqueueCommand(apiMethodName, command, args);
+    }
+
+    _switchToParentWindow$ () {
+        const apiMethodName = 'switchToParentWindow';
+
+        this._validateMultipleWindowCommand(apiMethodName);
+
+        return this._enqueueCommand(apiMethodName, SwitchToParentWindowCommand);
     }
 
     _eval$ (fn, options) {

--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -47,6 +47,7 @@ interface ProviderMetaInfoOptions {
 
 export default class BrowserConnection extends EventEmitter {
     public permanent: boolean;
+    public recentActiveWindowId: string | null;
     private readonly allowMultipleWindows: boolean;
     private readonly HEARTBEAT_TIMEOUT: number;
     private readonly BROWSER_RESTART_TIMEOUT: number;
@@ -121,6 +122,8 @@ export default class BrowserConnection extends EventEmitter {
         });
 
         connections[this.id] = this;
+
+        this.recentActiveWindowId = null;
 
         this.browserConnectionGateway.startServingConnection(this);
 
@@ -423,6 +426,8 @@ export default class BrowserConnection extends EventEmitter {
     }
 
     public set activeWindowId (val) {
+        this.recentActiveWindowId = this.activeWindowId;
+
         this.provider.setActiveWindowId(this.id, val);
     }
 

--- a/src/client/driver/driver-link/messages.js
+++ b/src/client/driver/driver-link/messages.js
@@ -28,7 +28,7 @@ export class EstablishConnectionMessage extends InterDriverMessage {
 }
 
 export class CloseWindowValidationMessage extends InterDriverMessage {
-    constructor (windowId) {
+    constructor ({ windowId }) {
         super(TYPE.closeWindowValidation);
 
         this.windowId = windowId;
@@ -36,15 +36,16 @@ export class CloseWindowValidationMessage extends InterDriverMessage {
 }
 
 export class SwitchToWindowValidationMessage extends InterDriverMessage {
-    constructor (windowId) {
+    constructor ({ windowId, fn }) {
         super(TYPE.switchToWindowValidation);
 
         this.windowId = windowId;
+        this.fn       = fn;
     }
 }
 
 export class CloseWindowCommandMessage extends InterDriverMessage {
-    constructor (windowId) {
+    constructor ({ windowId }) {
         super(TYPE.closeWindow);
 
         this.windowId = windowId;
@@ -52,10 +53,11 @@ export class CloseWindowCommandMessage extends InterDriverMessage {
 }
 
 export class SwitchToWindowCommandMessage extends InterDriverMessage {
-    constructor (windowId) {
+    constructor ({ windowId, fn }) {
         super(TYPE.switchToWindow);
 
         this.windowId = windowId;
+        this.fn       = fn;
     }
 }
 
@@ -94,8 +96,10 @@ export class SetNativeDialogHandlerMessage extends InterDriverMessage {
 }
 
 export class SetAsMasterMessage extends InterDriverMessage {
-    constructor () {
+    constructor (finalizePendingCommand) {
         super(TYPE.setAsMaster);
+
+        this.finalizePendingCommand = finalizePendingCommand;
     }
 }
 

--- a/src/client/driver/driver-link/window/child.js
+++ b/src/client/driver/driver-link/window/child.js
@@ -21,8 +21,8 @@ export default class ChildWindowDriverLink {
         return sendMessageToDriver(msg, this.driverWindow, WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT, CloseChildWindowError);
     }
 
-    findChildWindows ({ windowId }, MessageCtor) {
-        const msg = new MessageCtor(windowId);
+    findChildWindows (options, MessageCtor) {
+        const msg = new MessageCtor(options);
 
         return sendMessageToDriver(msg, this.driverWindow, WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT, CannotSwitchToWindowError);
     }

--- a/src/client/driver/driver-link/window/parent.js
+++ b/src/client/driver/driver-link/window/parent.js
@@ -17,8 +17,8 @@ export default class ParentWindowDriverLink {
         return topOpened;
     }
 
-    _setAsMaster (wnd) {
-        const msg = new SetAsMasterMessage();
+    _setAsMaster (wnd, finalizePendingCommand) {
+        const msg = new SetAsMasterMessage(finalizePendingCommand);
 
         return sendMessageToDriver(msg, wnd, WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT, CannotSwitchToWindowError);
     }
@@ -33,9 +33,9 @@ export default class ParentWindowDriverLink {
         return this._setAsMaster(wnd);
     }
 
-    setParentWindowAsMaster () {
+    setParentWindowAsMaster (opts = {}) {
         const wnd = this.currentDriverWindow.opener;
 
-        return this._setAsMaster(wnd);
+        return this._setAsMaster(wnd, opts.finalizePendingCommand);
     }
 }

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -1254,7 +1254,9 @@ export default class Driver extends serviceUtils.EventEmitter {
         else if (command.type === COMMAND_TYPE.getCurrentWindow)
             this._onGetCurrentWindowCommand(command);
 
-        else if (command.type === COMMAND_TYPE.switchToWindow || command.type === COMMAND_TYPE.switchToWindowByPredicate)
+        else if (command.type === COMMAND_TYPE.switchToWindow ||
+                 command.type === COMMAND_TYPE.switchToWindowByPredicate ||
+                 command.type === COMMAND_TYPE.switchToRecentWindow)
             this._onSwitchToWindow(command);
 
         else if (command.type === COMMAND_TYPE.switchToParentWindow)

--- a/src/errors/test-run/child-window-error-factory.js
+++ b/src/errors/test-run/child-window-error-factory.js
@@ -1,0 +1,19 @@
+import { TEST_RUN_ERRORS } from '../types';
+
+import {
+    CannotCloseWindowWithChildrenError,
+    SwitchToWindowPredicateError,
+    WindowNotFoundError
+} from './index';
+
+export default class ChildWindowValidationErrorFactory {
+    static createError ({ errCode, errMsg }) {
+        if (errCode === TEST_RUN_ERRORS.cannotCloseWindowWithChildrenError)
+            return new CannotCloseWindowWithChildrenError();
+
+        if (errCode === TEST_RUN_ERRORS.switchToWindowPredicateError)
+            return new SwitchToWindowPredicateError(errMsg);
+
+        return new WindowNotFoundError();
+    }
+}

--- a/src/errors/test-run/index.js
+++ b/src/errors/test-run/index.js
@@ -572,6 +572,12 @@ export class WindowNotFoundError extends ChildWindowValidationError {
     }
 }
 
+export class ParentWindowNotFoundError extends TestRunErrorBase {
+    constructor () {
+        super(TEST_RUN_ERRORS.parentWindowNotFoundError);
+    }
+}
+
 export class CannotCloseWindowWithChildrenError extends ChildWindowValidationError {
     constructor () {
         super(TEST_RUN_ERRORS.cannotCloseWindowWithChildrenError);

--- a/src/errors/test-run/index.js
+++ b/src/errors/test-run/index.js
@@ -561,8 +561,10 @@ export class CloseChildWindowError extends TestRunErrorBase {
 }
 
 export class ChildWindowValidationError extends TestRunErrorBase {
-    constructor (code) {
-        super(code);
+    constructor ({ errCode, errMsg }) {
+        super(errCode);
+
+        this.errMsg = errMsg;
     }
 }
 
@@ -572,15 +574,27 @@ export class WindowNotFoundError extends ChildWindowValidationError {
     }
 }
 
+export class CannotCloseWindowWithChildrenError extends ChildWindowValidationError {
+    constructor () {
+        super(TEST_RUN_ERRORS.cannotCloseWindowWithChildrenError);
+    }
+}
+
+export class SwitchToWindowPredicateError extends ChildWindowValidationError {
+    constructor () {
+        super(TEST_RUN_ERRORS.switchToWindowPredicateError);
+    }
+}
+
 export class ParentWindowNotFoundError extends TestRunErrorBase {
     constructor () {
         super(TEST_RUN_ERRORS.parentWindowNotFoundError);
     }
 }
 
-export class CannotCloseWindowWithChildrenError extends ChildWindowValidationError {
+export class RecentWindowNotFoundError extends TestRunErrorBase {
     constructor () {
-        super(TEST_RUN_ERRORS.cannotCloseWindowWithChildrenError);
+        super(TEST_RUN_ERRORS.recentWindowNotFoundError);
     }
 }
 

--- a/src/errors/test-run/index.js
+++ b/src/errors/test-run/index.js
@@ -560,29 +560,23 @@ export class CloseChildWindowError extends TestRunErrorBase {
     }
 }
 
-export class ChildWindowValidationError extends TestRunErrorBase {
-    constructor ({ errCode, errMsg }) {
-        super(errCode);
-
-        this.errMsg = errMsg;
-    }
-}
-
-export class WindowNotFoundError extends ChildWindowValidationError {
+export class WindowNotFoundError extends TestRunErrorBase {
     constructor () {
         super(TEST_RUN_ERRORS.targetWindowNotFoundError);
     }
 }
 
-export class CannotCloseWindowWithChildrenError extends ChildWindowValidationError {
+export class CannotCloseWindowWithChildrenError extends TestRunErrorBase {
     constructor () {
         super(TEST_RUN_ERRORS.cannotCloseWindowWithChildrenError);
     }
 }
 
-export class SwitchToWindowPredicateError extends ChildWindowValidationError {
-    constructor () {
+export class SwitchToWindowPredicateError extends TestRunErrorBase {
+    constructor (errMsg) {
         super(TEST_RUN_ERRORS.switchToWindowPredicateError);
+
+        this.errMsg = errMsg;
     }
 }
 

--- a/src/errors/test-run/templates.js
+++ b/src/errors/test-run/templates.js
@@ -354,15 +354,15 @@ export default {
     `,
 
     [TEST_RUN_ERRORS.parentWindowNotFoundError]: () => `
-        Cannot find the parent window. Make sure that the current window was opened from another window.
+        Cannot find the parent window. Make sure that the tested window was opened from another window.
     `,
 
     [TEST_RUN_ERRORS.recentWindowNotFoundError]: () => `
-        Cannot find the recent window. Make sure that the recent window is opened.
+        Cannot find the previous window. Make sure that the previous window is opened.
     `,
 
     [TEST_RUN_ERRORS.switchToWindowPredicateError]: err => `
-        The error occured inside the "switchToWindow" argument function:
+        An error occurred inside the "switchToWindow" argument function.
         
         Error details:
         ${escapeHtml(err.errMsg)}

--- a/src/errors/test-run/templates.js
+++ b/src/errors/test-run/templates.js
@@ -354,6 +354,17 @@ export default {
     `,
 
     [TEST_RUN_ERRORS.parentWindowNotFoundError]: () => `
-        Cannot find the parent window.
+        Cannot find the parent window. Make sure that the current window was opened from another window.
+    `,
+
+    [TEST_RUN_ERRORS.recentWindowNotFoundError]: () => `
+        Cannot find the recent window. Make sure that the recent window is opened.
+    `,
+
+    [TEST_RUN_ERRORS.switchToWindowPredicateError]: err => `
+        The error occured inside the "switchToWindow" argument function:
+        
+        Error details:
+        ${escapeHtml(err.errMsg)}
     `,
 };

--- a/src/errors/test-run/templates.js
+++ b/src/errors/test-run/templates.js
@@ -352,4 +352,8 @@ export default {
     [TEST_RUN_ERRORS.allowMultipleWindowsOptionIsNotSpecifiedError]: err => `
         You should activate multi window mode (enable the "allow-multiple-windows" run option) to use the "${err.methodName}" method.
     `,
+
+    [TEST_RUN_ERRORS.parentWindowNotFoundError]: () => `
+        Cannot find the parent window.
+    `,
 };

--- a/src/errors/types.js
+++ b/src/errors/types.js
@@ -77,7 +77,9 @@ export const TEST_RUN_ERRORS = {
     cannotCloseWindowWithChildrenError:                    'E73',
     targetWindowNotFoundError:                             'E74',
     allowMultipleWindowsOptionIsNotSpecifiedError:         'E75',
-    parentWindowNotFoundError:                             'E76'
+    parentWindowNotFoundError:                             'E76',
+    recentWindowNotFoundError:                             'E77',
+    switchToWindowPredicateError:                          'E78'
 };
 
 export const RUNTIME_ERRORS = {

--- a/src/errors/types.js
+++ b/src/errors/types.js
@@ -76,7 +76,8 @@ export const TEST_RUN_ERRORS = {
     childWindowClosedBeforeSwitchingError:                 'E72',
     cannotCloseWindowWithChildrenError:                    'E73',
     targetWindowNotFoundError:                             'E74',
-    allowMultipleWindowsOptionIsNotSpecifiedError:         'E75'
+    allowMultipleWindowsOptionIsNotSpecifiedError:         'E75',
+    parentWindowNotFoundError:                             'E76'
 };
 
 export const RUNTIME_ERRORS = {

--- a/src/test-run/commands/actions.js
+++ b/src/test-run/commands/actions.js
@@ -76,7 +76,16 @@ function initDialogHandler (name, val, { skipVisibilityCheck, testRun }) {
         builder = new ClientFunctionBuilder(fn, options, { instantiation: methodName, execution: methodName });
 
     return builder.getCommand([]);
+}
 
+function initSwitchToWindowHandler (name, val) {
+    const fn      = val.fn;
+    const options = val.options;
+
+    const methodName = 'switchToWindowHandler';
+    const builder    = new ClientFunctionBuilder(fn, options, { instantiation: methodName, execution: methodName });
+
+    return builder.getCommand([]);
 }
 
 // Commands
@@ -360,7 +369,31 @@ export class SwitchToWindowCommand extends CommandBase {
 
     _getAssignableProperties () {
         return [
-            { name: 'windowId', type: nonEmptyStringArgument, required: true },
+            { name: 'windowId', type: nonEmptyStringArgument, required: true }
+        ];
+    }
+}
+
+export class SwitchToWindowByPredicateCommand extends CommandBase {
+    constructor (obj, testRun) {
+        super(obj, testRun, TYPE.switchToWindowByPredicate);
+    }
+
+    _getAssignableProperties () {
+        return [
+            { name: 'findWindow', init: initSwitchToWindowHandler, required: true }
+        ];
+    }
+}
+
+
+export class SwitchToParentWindowCommand extends CommandBase {
+    constructor (obj, testRun) {
+        super(obj, testRun, TYPE.switchToParentWindow);
+    }
+
+    _getAssignableProperties () {
+        return [
         ];
     }
 }

--- a/src/test-run/commands/actions.js
+++ b/src/test-run/commands/actions.js
@@ -398,6 +398,16 @@ export class SwitchToParentWindowCommand extends CommandBase {
     }
 }
 
+export class SwitchToRecentWindowCommand extends CommandBase {
+    constructor (obj, testRun) {
+        super(obj, testRun, TYPE.switchToRecentWindow);
+    }
+
+    _getAssignableProperties () {
+        return [];
+    }
+}
+
 export class SetNativeDialogHandlerCommand extends CommandBase {
     constructor (obj, testRun) {
         super(obj, testRun, TYPE.setNativeDialogHandler);

--- a/src/test-run/commands/type.js
+++ b/src/test-run/commands/type.js
@@ -37,6 +37,7 @@ export default {
     closeWindow:                'close-window',
     getCurrentWindow:           'get-current-window',
     switchToWindow:             'switch-to-window',
+    switchToWindowByPredicate:  'switch-to-window-by-predicate',
     switchToParentWindow:       'switch-to-parent-window',
     setNativeDialogHandler:     'set-native-dialog-handler',
     getNativeDialogHistory:     'get-native-dialog-history',

--- a/src/test-run/commands/type.js
+++ b/src/test-run/commands/type.js
@@ -39,6 +39,7 @@ export default {
     switchToWindow:             'switch-to-window',
     switchToWindowByPredicate:  'switch-to-window-by-predicate',
     switchToParentWindow:       'switch-to-parent-window',
+    switchToRecentWindow:       'switch-to-recent-window',
     setNativeDialogHandler:     'set-native-dialog-handler',
     getNativeDialogHistory:     'get-native-dialog-history',
     getBrowserConsoleMessages:  'get-browser-console-messages',

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -737,6 +737,9 @@ export default class TestRun extends AsyncEventEmitter {
         if (command.type === COMMAND_TYPE.getBrowserConsoleMessages)
             return await this._enqueueBrowserConsoleMessagesCommand(command, callsite);
 
+        if (command.type === COMMAND_TYPE.switchToRecentWindow)
+            command.windowId = this.browserConnection.recentActiveWindowId;
+
         return this._enqueueCommand(command, callsite);
     }
 

--- a/test/functional/fixtures/run-options/allow-multiple-windows/pages/api/child-1.html
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/pages/api/child-1.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>child-1</title>
 </head>
 <body>
     <h1>child-1</h1>

--- a/test/functional/fixtures/run-options/allow-multiple-windows/pages/api/child-2.html
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/pages/api/child-2.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>child-2</title>
 </head>
 <body>
     <h1>child-2</h1>

--- a/test/functional/fixtures/run-options/allow-multiple-windows/pages/api/parent.html
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/pages/api/parent.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>parent</title>
 </head>
 <body>
     <a href="child-1.html" target="_blank">link</a>

--- a/test/functional/fixtures/run-options/allow-multiple-windows/test.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/test.js
@@ -134,6 +134,17 @@ describe('Allow multiple windows', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Switch to window by title', { only: 'chrome', allowMultipleWindows: true });
         });
 
+        it('Switch to recent window', () => {
+            return runTests('testcafe-fixtures/api/api-test.js', 'Switch to recent window', { only: 'chrome', allowMultipleWindows: true });
+        });
+
+        it('Switch to recent closed window', () => {
+            return runTests('testcafe-fixtures/api/api-test.js', 'Switch to recent closed window', { only: 'chrome', allowMultipleWindows: true, shouldFail: true })
+                .catch(errs => {
+                    expect(errs[0]).to.contain('Cannot find the window specified in the action parameters.');
+                });
+        });
+
         it('Switch to other child', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Switch to other child', { only: 'chrome', allowMultipleWindows: true });
         });

--- a/test/functional/fixtures/run-options/allow-multiple-windows/test.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/test.js
@@ -111,7 +111,7 @@ describe('Allow multiple windows', () => {
         it('Switch to unexisting parent window', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Switch to unexisting parent window', { only: 'chrome', allowMultipleWindows: true, shouldFail: true })
                 .catch(errs => {
-                    expect(errs[0]).to.contain('Cannot find the parent window.');
+                    expect(errs[0]).to.contain('Cannot find the parent window. Make sure that the current window was opened from another window.');
                 });
         });
 
@@ -134,6 +134,13 @@ describe('Allow multiple windows', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Switch to window by title', { only: 'chrome', allowMultipleWindows: true });
         });
 
+        it('Switch to window by predicate with error', () => {
+            return runTests('testcafe-fixtures/api/api-test.js', 'Switch to window by predicate with error', { only: 'chrome', allowMultipleWindows: true, shouldFail: true })
+                .catch(errs => {
+                    expect(errs[0]).to.contain('The error occured inside the "switchToWindow" argument function:  Error details: Cannot read property \'field\' of undefined');
+                });
+        });
+
         it('Switch to recent window', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Switch to recent window', { only: 'chrome', allowMultipleWindows: true });
         });
@@ -141,7 +148,7 @@ describe('Allow multiple windows', () => {
         it('Switch to recent closed window', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Switch to recent closed window', { only: 'chrome', allowMultipleWindows: true, shouldFail: true })
                 .catch(errs => {
-                    expect(errs[0]).to.contain('Cannot find the window specified in the action parameters.');
+                    expect(errs[0]).to.contain('Cannot find the recent window. Make sure that the recent window is opened.');
                 });
         });
 

--- a/test/functional/fixtures/run-options/allow-multiple-windows/test.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/test.js
@@ -111,7 +111,7 @@ describe('Allow multiple windows', () => {
         it('Switch to unexisting parent window', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Switch to unexisting parent window', { only: 'chrome', allowMultipleWindows: true, shouldFail: true })
                 .catch(errs => {
-                    expect(errs[0]).to.contain('Cannot find the parent window. Make sure that the current window was opened from another window.');
+                    expect(errs[0]).to.contain('Cannot find the parent window. Make sure that the tested window was opened from another window.');
                 });
         });
 
@@ -137,7 +137,7 @@ describe('Allow multiple windows', () => {
         it('Switch to window by predicate with error', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Switch to window by predicate with error', { only: 'chrome', allowMultipleWindows: true, shouldFail: true })
                 .catch(errs => {
-                    expect(errs[0]).to.contain('The error occured inside the "switchToWindow" argument function:  Error details: Cannot read property \'field\' of undefined');
+                    expect(errs[0]).to.contain('An error occurred inside the "switchToWindow" argument function.  Error details: Cannot read property \'field\' of undefined');
                 });
         });
 
@@ -148,7 +148,7 @@ describe('Allow multiple windows', () => {
         it('Switch to recent closed window', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Switch to recent closed window', { only: 'chrome', allowMultipleWindows: true, shouldFail: true })
                 .catch(errs => {
-                    expect(errs[0]).to.contain('Cannot find the recent window. Make sure that the recent window is opened.');
+                    expect(errs[0]).to.contain('Cannot find the previous window. Make sure that the previous window is opened.');
                 });
         });
 

--- a/test/functional/fixtures/run-options/allow-multiple-windows/test.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/test.js
@@ -105,7 +105,14 @@ describe('Allow multiple windows', () => {
         });
 
         it('Switch to parent window', () => {
-            return runTests('testcafe-fixtures/api/api-test.js', 'Switch to parent window', { only: 'chrome', allowMultipleWindows: true });
+            return runTests('testcafe-fixtures/api/api-test.js', 'Switch to parent window', { only: 'chrome', allowMultipleWindows: true, speed: 0.01 });
+        });
+
+        it('Switch to unexisting parent window', () => {
+            return runTests('testcafe-fixtures/api/api-test.js', 'Switch to unexisting parent window', { only: 'chrome', allowMultipleWindows: true, shouldFail: true })
+                .catch(errs => {
+                    expect(errs[0]).to.contain('Cannot find the parent window.');
+                });
         });
 
         it('Switch to unexisting window', () => {
@@ -119,6 +126,13 @@ describe('Allow multiple windows', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Switch to child window', { only: 'chrome', allowMultipleWindows: true });
         });
 
+        it('Switch to window by url', () => {
+            return runTests('testcafe-fixtures/api/api-test.js', 'Switch to window by url', { only: 'chrome', allowMultipleWindows: true });
+        });
+
+        it('Switch to window by title', () => {
+            return runTests('testcafe-fixtures/api/api-test.js', 'Switch to window by title', { only: 'chrome', allowMultipleWindows: true });
+        });
 
         it('Switch to other child', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Switch to other child', { only: 'chrome', allowMultipleWindows: true });

--- a/test/functional/fixtures/run-options/allow-multiple-windows/testcafe-fixtures/api/api-test.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/testcafe-fixtures/api/api-test.js
@@ -93,6 +93,29 @@ test('Switch to window by title', async t => {
     await t.expect(Selector('h1').innerText).eql('child-2');
 });
 
+test('Switch to recent window', async t => {
+    await t
+        .openWindow(child1Url)
+        .openWindow(child2Url)
+        .expect(Selector('h1').innerText).eql('child-2')
+        .switchToRecentWindow()
+        .expect(Selector('h1').innerText).eql('child-1')
+        .switchToRecentWindow()
+        .expect(Selector('h1').innerText).eql('child-2');
+});
+
+test('Switch to recent closed window', async t => {
+    const child2Window = await t
+        .openWindow(child1Url)
+        .openWindow(child2Url);
+
+    await t.expect(Selector('h1').innerText).eql('child-2')
+        .switchToRecentWindow()
+        .expect(Selector('h1').innerText).eql('child-1')
+        .closeWindow(child2Window)
+        .switchToRecentWindow();
+});
+
 test('Switch to child window', async t => {
     let currentWindow = null;
 

--- a/test/functional/fixtures/run-options/allow-multiple-windows/testcafe-fixtures/api/api-test.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/testcafe-fixtures/api/api-test.js
@@ -93,6 +93,10 @@ test('Switch to window by title', async t => {
     await t.expect(Selector('h1').innerText).eql('child-2');
 });
 
+test('Switch to window by predicate with error', async t => {
+    await t.switchToWindow(w => w.nonExistingProperty.field === 'parent');
+});
+
 test('Switch to recent window', async t => {
     await t
         .openWindow(child1Url)

--- a/test/server/data/expected-test-run-errors/parent-window-not-found-error
+++ b/test/server/data/expected-test-run-errors/parent-window-not-found-error
@@ -1,0 +1,19 @@
+Cannot find the parent window.
+
+Browser: Chrome 15.0.874.120 / macOS 10.15
+Screenshot: /unix/path/with/<tag>
+
+   18 |function func1 () {
+   19 |    record = createCallsiteRecord({ byFunctionName: 'func1' });
+   20 |}
+   21 |
+   22 |(function func2 () {
+ > 23 |    func1();
+   24 |})();
+   25 |
+   26 |stackTrace.filter.deattach(stackFilter);
+   27 |
+   28 |module.exports = record;
+
+   at func2 (testfile.js:23:5)
+   at Object.<anonymous> (testfile.js:24:3)

--- a/test/server/data/expected-test-run-errors/recent-window-not-found-error
+++ b/test/server/data/expected-test-run-errors/recent-window-not-found-error
@@ -1,5 +1,5 @@
-Cannot find the parent window. Make sure that the tested window was opened
-from another window.
+Cannot find the previous window. Make sure that the previous window is
+opened.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/data/expected-test-run-errors/switch-to-window-predicate-error
+++ b/test/server/data/expected-test-run-errors/switch-to-window-predicate-error
@@ -1,5 +1,7 @@
-Cannot find the parent window. Make sure that the tested window was opened
-from another window.
+An error occurred inside the "switchToWindow" argument function.
+
+Error details:
+error message
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/data/test-controller-reporter-expected/index.js
+++ b/test/server/data/test-controller-reporter-expected/index.js
@@ -545,6 +545,23 @@ module.exports = [
     },
     {
         testRunId: 'test-run-id',
+        name:    'switchToRecentWindow',
+        command: {
+            type: 'switch-to-recent-window'
+        },
+        test:    {
+            id:    'test-id',
+            name:  'test-name',
+            phase: 'initial'
+        },
+        fixture: {
+            id:   'fixture-id',
+            name: 'fixture-name',
+        },
+        browser: { alias: 'test-browser', headless: false }
+    },
+    {
+        testRunId: 'test-run-id',
         name:    'setNativeDialogHandler',
         command: {
             dialogHandler: {

--- a/test/server/data/test-controller-reporter-expected/index.js
+++ b/test/server/data/test-controller-reporter-expected/index.js
@@ -528,6 +528,23 @@ module.exports = [
     },
     {
         testRunId: 'test-run-id',
+        name:    'switchToParentWindow',
+        command: {
+            type: 'switch-to-parent-window'
+        },
+        test:    {
+            id:    'test-id',
+            name:  'test-name',
+            phase: 'initial'
+        },
+        fixture: {
+            id:   'fixture-id',
+            name: 'fixture-name',
+        },
+        browser: { alias: 'test-browser', headless: false }
+    },
+    {
+        testRunId: 'test-run-id',
         name:    'setNativeDialogHandler',
         command: {
             dialogHandler: {

--- a/test/server/test-controller-events-test.js
+++ b/test/server/test-controller-events-test.js
@@ -120,6 +120,7 @@ const actions = {
     closeWindow:               [{ id: 'window-id' }],
     getCurrentWindow:          [],
     switchToParentWindow:      [],
+    switchToRecentWindow:      [],
     setNativeDialogHandler:    [() => true],
     getNativeDialogHistory:    [],
     getBrowserConsoleMessages: [],

--- a/test/server/test-controller-events-test.js
+++ b/test/server/test-controller-events-test.js
@@ -119,6 +119,7 @@ const actions = {
     switchToWindow:            [{ id: 'window-id' }],
     closeWindow:               [{ id: 'window-id' }],
     getCurrentWindow:          [],
+    switchToParentWindow:      [],
     setNativeDialogHandler:    [() => true],
     getNativeDialogHistory:    [],
     getBrowserConsoleMessages: [],

--- a/test/server/test-run-error-formatting-test.js
+++ b/test/server/test-run-error-formatting-test.js
@@ -80,6 +80,8 @@ const {
     ChildWindowClosedBeforeSwitchingError,
     WindowNotFoundError,
     ParentWindowNotFoundError,
+    RecentWindowNotFoundError,
+    SwitchToWindowPredicateError,
     CannotCloseWindowWithChildrenError,
     AllowMultipleWindowsOptionIsNotSpecifiedError
 } = require('../../lib/errors/test-run');
@@ -467,6 +469,14 @@ describe('Error formatting', () => {
 
         it('Should format "parentWindowNotFoundError"', () => {
             assertErrorMessage('parent-window-not-found-error', new ParentWindowNotFoundError());
+        });
+
+        it('Should format "recentWindowNotFoundError"', () => {
+            assertErrorMessage('recent-window-not-found-error', new RecentWindowNotFoundError());
+        });
+
+        it('Should format "switchToWindowPredicateError"', () => {
+            assertErrorMessage('switch-to-window-predicate-error', new SwitchToWindowPredicateError('error message'));
         });
 
         it('Should format "allowMultipleWindowsOptionIsNotSpecifiedError"', () => {

--- a/test/server/test-run-error-formatting-test.js
+++ b/test/server/test-run-error-formatting-test.js
@@ -79,6 +79,7 @@ const {
     CloseChildWindowError,
     ChildWindowClosedBeforeSwitchingError,
     WindowNotFoundError,
+    ParentWindowNotFoundError,
     CannotCloseWindowWithChildrenError,
     AllowMultipleWindowsOptionIsNotSpecifiedError
 } = require('../../lib/errors/test-run');
@@ -462,6 +463,10 @@ describe('Error formatting', () => {
 
         it('Should format "windowNotFoundError"', () => {
             assertErrorMessage('window-not-found-error', new WindowNotFoundError());
+        });
+
+        it('Should format "parentWindowNotFoundError"', () => {
+            assertErrorMessage('parent-window-not-found-error', new ParentWindowNotFoundError());
         });
 
         it('Should format "allowMultipleWindowsOptionIsNotSpecifiedError"', () => {


### PR DESCRIPTION
We need to resolve current driver task after the command is executed in one of the windows, so I pass the `finalizePendingCommand` arg in the `_switchToParentWindow` method. Otherwise, drivers of all windows will get duplicated command.

The predicate params:
```JS
(w => {
        return 
            w.title === 'Title'
            w.location.href === fullUrl &&
            w.location.protocol === 'http:' &&
            w.location.host === 'localhost:3000' &&
            w.location.port === '3000' &&
            w.location.query === '/fixtures/run-options/allow-multiple-windows/pages/api/parent.html';
    }, { dependencies: { fullUrl } });
```
