### PR TITLE
The functional test for changing title into the first script after <title> tag

### DIFF
--- a/test/functional/fixtures/regression/hammerhead/gh-2350/pages/change-value.html
+++ b/test/functional/fixtures/regression/hammerhead/gh-2350/pages/change-value.html
@@ -1,0 +1,26 @@
+<html>
+<head>
+    <script>
+        var log = [];
+    </script>
+    <title>Test page title 1</title>
+    <script>
+        log.push('head:after-first-title: ' + String(document.title));
+
+        var titleElement = document.getElementsByTagName('title')[0];
+
+        titleElement.innerText = 'Test page title 2';
+
+        log.push('head:after-title-update: ' + String(document.title));
+    </script>
+</head>
+<body>
+    <script>
+        log.push('body: ' + String(document.title));
+
+        titleElement.innerText = 'Test page title 3';
+
+        log.push('body:after-title-update: ' + String(document.title));
+    </script>
+</body>
+</html>

--- a/test/functional/fixtures/regression/hammerhead/gh-2350/test.js
+++ b/test/functional/fixtures/regression/hammerhead/gh-2350/test.js
@@ -6,4 +6,8 @@ describe("Should provide a valid value for the 'document.title' property", () =>
     it('Empty value', () => {
         return runTests('./testcafe-fixtures/index.js', 'empty value');
     });
+
+    it('Change value', () => {
+        return runTests('./testcafe-fixtures/index.js', 'change value');
+    });
 });

--- a/test/functional/fixtures/regression/hammerhead/gh-2350/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/hammerhead/gh-2350/testcafe-fixtures/index.js
@@ -15,6 +15,13 @@ const EMPTY_VALUE_EXPECTED_LOG = [
     'body: '
 ];
 
+const CHANGE_VALUE_EXPECTED_LOG = [
+    'head:after-first-title: Test page title 1',
+    'head:after-title-update: Test page title 2',
+    'body: Test page title 2',
+    'body:after-title-update: Test page title 3'
+];
+
 test
     .page('http://localhost:3000/fixtures/regression/hammerhead/gh-2350/pages/initial-value.html')
     ('initial value', async t => {
@@ -25,4 +32,10 @@ test
     .page('http://localhost:3000/fixtures/regression/hammerhead/gh-2350/pages/empty-value.html')
     ('empty value', async t => {
         await t.expect(getLog()).eql(EMPTY_VALUE_EXPECTED_LOG);
+    });
+
+test
+    .page('http://localhost:3000/fixtures/regression/hammerhead/gh-2350/pages/change-value.html')
+    ('change value', async t => {
+        await t.expect(getLog()).eql(CHANGE_VALUE_EXPECTED_LOG);
     });


### PR DESCRIPTION
### Todo
- [ ] Check the following case:
```html
<head>
    <title>Test page title 1</title>
    <script>
        var log = [];

        log.push('head:after-first-title: ' + String(document.title));
```

Related to https://github.com/DevExpress/testcafe-hammerhead/issues/2374