### PR TITLE
Turn off the vulnerable dependencies check

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -1,6 +1,6 @@
 {
   "validations": {
-    "vulnerableDependencies": true,
+    "vulnerableDependencies": false,
     "uncommittedChanges": true,
     "untrackedFiles": true,
     "sensitiveData": true,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.8.8-alpha.2",
+  "version": "1.8.8-alpha.3",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.8.8-alpha.3",
+  "version": "1.8.8-alpha.2",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"


### PR DESCRIPTION
### Changes
1. The vulnerable dependencies check is temporarly disabled (`lodash` vulnerability).