### PR TITLE
Handle errors when cannot find a browser window

### DIFF
--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -71,6 +71,7 @@ export default class BrowserConnection extends EventEmitter {
     private readonly statusUrl: string;
     private readonly activeWindowIdUrl: string;
     private statusDoneUrl: string;
+    private warningBuffer: any[];
 
     public idle: boolean;
 
@@ -89,6 +90,7 @@ export default class BrowserConnection extends EventEmitter {
         this.browserConnectionGateway = gateway;
         this.disconnectionPromise     = null;
         this.testRunAborted           = false;
+        this.warningBuffer            = [];
 
         this.browserInfo                           = browserInfo;
         this.browserInfo.userAgentProviderMetaInfo = '';
@@ -279,6 +281,8 @@ export default class BrowserConnection extends EventEmitter {
     public addWarning (...args: any[]): void {
         if (this.currentJob)
             this.currentJob.warningLog.addWarning(...args);
+        else
+            this.warningBuffer.push(args);
     }
 
     private _appendToPrettyUserAgent (str: string): void {
@@ -326,6 +330,8 @@ export default class BrowserConnection extends EventEmitter {
 
     public addJob (job: BrowserJob): void {
         this.jobQueue.push(job);
+        this.warningBuffer.forEach(warningArgs => job.warningLog.addWarning(...warningArgs));
+        this.warningBuffer = [];
     }
 
     public removeJob (job: BrowserJob): void {

--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -14,6 +14,7 @@ import { BROWSER_RESTART_TIMEOUT, HEARTBEAT_TIMEOUT } from '../../utils/browser-
 import { Dictionary } from '../../configuration/interfaces';
 import BrowserConnectionGateway from './gateway';
 import BrowserJob from '../../runner/browser-job';
+import WarningLog from '../../notifications/warning-log';
 
 const IDLE_PAGE_TEMPLATE                         = read('../../client/browser/idle-page/index.html.mustache');
 const connections: Dictionary<BrowserConnection> = {};
@@ -71,7 +72,7 @@ export default class BrowserConnection extends EventEmitter {
     private readonly statusUrl: string;
     private readonly activeWindowIdUrl: string;
     private statusDoneUrl: string;
-    private warningBuffer: any[];
+    private warningLog: WarningLog;
 
     public idle: boolean;
 
@@ -90,7 +91,7 @@ export default class BrowserConnection extends EventEmitter {
         this.browserConnectionGateway = gateway;
         this.disconnectionPromise     = null;
         this.testRunAborted           = false;
-        this.warningBuffer            = [];
+        this.warningLog               = new WarningLog();
 
         this.browserInfo                           = browserInfo;
         this.browserInfo.userAgentProviderMetaInfo = '';
@@ -282,11 +283,16 @@ export default class BrowserConnection extends EventEmitter {
         if (this.currentJob)
             this.currentJob.warningLog.addWarning(...args);
         else
-            this.warningBuffer.push(args);
+            this.warningLog.addWarning(...args);
     }
 
     private _appendToPrettyUserAgent (str: string): void {
         this.browserInfo.parsedUserAgent.prettyUserAgent += ` (${str})`;
+    }
+
+    private _moveWarningLogToJob (job: BrowserJob): void {
+        this.warningLog.copyTo(job.warningLog);
+        this.warningLog.clear();
     }
 
     public setProviderMetaInfo (str: string, options?: ProviderMetaInfoOptions): void {
@@ -330,8 +336,8 @@ export default class BrowserConnection extends EventEmitter {
 
     public addJob (job: BrowserJob): void {
         this.jobQueue.push(job);
-        this.warningBuffer.forEach(warningArgs => job.warningLog.addWarning(...warningArgs));
-        this.warningBuffer = [];
+
+        this._moveWarningLogToJob(job);
     }
 
     public removeJob (job: BrowserJob): void {

--- a/src/browser/provider/built-in/remote.js
+++ b/src/browser/provider/built-in/remote.js
@@ -1,6 +1,9 @@
+import debug from 'debug';
 import { findWindow } from 'testcafe-browser-tools';
 import WARNING_MESSAGE from '../../../notifications/warning-message';
 
+
+const DEBUG_LOGGER = debug('testcafe:browser:provider:built-in:remote');
 
 export default {
     canDetectLocalBrowsers: true,
@@ -13,7 +16,15 @@ export default {
 
         await this.waitForConnectionReady(browserId);
 
-        const localBrowserWindow = await findWindow(browserId);
+        let localBrowserWindow = null;
+
+        try {
+            localBrowserWindow = await findWindow(browserId);
+        }
+        catch (err) {
+            // NOTE: suppress the error, because finding of the local browser window was failed
+            DEBUG_LOGGER(err);
+        }
 
         this.localBrowsersFlags[browserId] = localBrowserWindow !== null;
     },

--- a/src/browser/provider/built-in/remote.js
+++ b/src/browser/provider/built-in/remote.js
@@ -22,7 +22,8 @@ export default {
             localBrowserWindow = await findWindow(browserId);
         }
         catch (err) {
-            // NOTE: suppress the error, because finding of the local browser window was failed
+            // NOTE: We can suppress the error here since we can just disable window manipulation functions
+            // when the browser is truly remote and we cannot find a local window descriptor
             DEBUG_LOGGER(err);
         }
 

--- a/src/browser/provider/index.ts
+++ b/src/browser/provider/index.ts
@@ -150,6 +150,8 @@ export default class BrowserProvider {
                 windowDescriptor = await browserTools.findWindow(browserId);
             }
             catch (err) {
+                // NOTE: We can suppress the error here since we can just disable window manipulation functions
+                // when we cannot find a local window descriptor
                 DEBUG_LOGGER(err);
                 connection.addWarning(WARNING_MESSAGE.cannotFindWindowDescriptorError, err.message);
             }

--- a/src/browser/provider/index.ts
+++ b/src/browser/provider/index.ts
@@ -153,7 +153,11 @@ export default class BrowserProvider {
                 // NOTE: We can suppress the error here since we can just disable window manipulation functions
                 // when we cannot find a local window descriptor
                 DEBUG_LOGGER(err);
-                connection.addWarning(WARNING_MESSAGE.cannotFindWindowDescriptorError, err.message);
+                connection.addWarning(
+                    WARNING_MESSAGE.cannotFindWindowDescriptorError,
+                    connection.browserInfo.alias,
+                    err.message
+                );
             }
 
             this.localBrowsersInfo[browserId].windowDescriptor = windowDescriptor;

--- a/src/browser/provider/index.ts
+++ b/src/browser/provider/index.ts
@@ -1,3 +1,4 @@
+import debug from 'debug';
 import browserTools from 'testcafe-browser-tools';
 import OS from 'os-family';
 import { dirname } from 'path';
@@ -8,6 +9,8 @@ import { GET_TITLE_SCRIPT, GET_WINDOW_DIMENSIONS_INFO_SCRIPT } from './utils/cli
 import WARNING_MESSAGE from '../../notifications/warning-message';
 import { Dictionary } from '../../configuration/interfaces';
 import { WindowDimentionsInfo } from '../interfaces';
+
+const DEBUG_LOGGER = debug('testcafe:browser:provider');
 
 const BROWSER_OPENING_DELAY = 2000;
 
@@ -139,8 +142,20 @@ export default class BrowserProvider {
         await this.plugin.waitForConnectionReady(browserId);
         await delay(BROWSER_OPENING_DELAY);
 
-        if (this.localBrowsersInfo[browserId])
-            this.localBrowsersInfo[browserId].windowDescriptor = await browserTools.findWindow(browserId);
+        if (this.localBrowsersInfo[browserId]) {
+            const connection     = BrowserConnection.getById(browserId) as BrowserConnection;
+            let windowDescriptor = null;
+
+            try {
+                windowDescriptor = await browserTools.findWindow(browserId);
+            }
+            catch (err) {
+                DEBUG_LOGGER(err);
+                connection.addWarning(WARNING_MESSAGE.cannotFindWindowDescriptorError, err.message);
+            }
+
+            this.localBrowsersInfo[browserId].windowDescriptor = windowDescriptor;
+        }
     }
 
     private async _ensureBrowserWindowParameters (browserId: string): Promise<void> {

--- a/src/notifications/warning-log.js
+++ b/src/notifications/warning-log.js
@@ -20,4 +20,12 @@ export default class WarningLog {
         if (this.globalLog)
             this.globalLog.addPlainMessage(msg);
     }
+
+    clear () {
+        this.messages = [];
+    }
+
+    copyTo (warningLog) {
+        this.messages.forEach(msg => warningLog.addWarning(msg));
+    }
 }

--- a/src/notifications/warning-message.js
+++ b/src/notifications/warning-message.js
@@ -14,7 +14,7 @@ export default {
     maximizeError:                           'Was unable to maximize the window due to an error.\n\n{errMessage}',
     requestMockCORSValidationFailed:         '{RequestHook}: CORS validation failed for a request specified as {requestFilterRule}',
     debugInHeadlessError:                    'You cannot debug in headless mode.',
-    cannotFindWindowDescriptorError:         'An error has occurred while searching for a window descriptor.\n\n{errMessage}',
+    cannotFindWindowDescriptorError:         'Cannot find the "{browserAlias}" window. The following error occurred:\n\n{errMessage}',
     cannotReadConfigFile:                    'An error has occurred while reading the configuration file.',
     cannotParseConfigFile:                   "Failed to parse the '{path}' file.\n\nThis file is not a well-formed JSON file.",
     configOptionsWereOverriden:              'The {optionsString} option{suffix} from the configuration file will be ignored.',

--- a/src/notifications/warning-message.js
+++ b/src/notifications/warning-message.js
@@ -14,11 +14,15 @@ export default {
     maximizeError:                           'Was unable to maximize the window due to an error.\n\n{errMessage}',
     requestMockCORSValidationFailed:         '{RequestHook}: CORS validation failed for a request specified as {requestFilterRule}',
     debugInHeadlessError:                    'You cannot debug in headless mode.',
-    cannotFindWindowDescriptorError:         'Cannot find the "{browserAlias}" window. The following error occurred:\n\n{errMessage}',
     cannotReadConfigFile:                    'An error has occurred while reading the configuration file.',
     cannotParseConfigFile:                   "Failed to parse the '{path}' file.\n\nThis file is not a well-formed JSON file.",
     configOptionsWereOverriden:              'The {optionsString} option{suffix} from the configuration file will be ignored.',
     cannotOverrideTypeScriptConfigOptions:   'You cannot override the "{optionName}" compiler option in the TypeScript configuration file.',
+
+    cannotFindWindowDescriptorError: 'Could not find the "{browserAlias}" window. ' +
+                                     'TestCafe is unable to resize the window or take screenshots.\n\n' +
+                                     'The following error occurred while TestCafe was searching ' +
+                                     'for the window descriptor:\n\n{errMessage}',
 
     cannotFindSSLCertFile: 'Unable to find the "{path}" file, specified by the "{option}" ssl option. Error details:\n' +
                            '\n' +

--- a/src/notifications/warning-message.js
+++ b/src/notifications/warning-message.js
@@ -14,7 +14,7 @@ export default {
     maximizeError:                           'Was unable to maximize the window due to an error.\n\n{errMessage}',
     requestMockCORSValidationFailed:         '{RequestHook}: CORS validation failed for a request specified as {requestFilterRule}',
     debugInHeadlessError:                    'You cannot debug in headless mode.',
-    cannotFindWindowDescriptorError:         'An error has occurred while finding the window descriptor.\n\n{errMessage}',
+    cannotFindWindowDescriptorError:         'An error has occurred while searching for a window descriptor.\n\n{errMessage}',
     cannotReadConfigFile:                    'An error has occurred while reading the configuration file.',
     cannotParseConfigFile:                   "Failed to parse the '{path}' file.\n\nThis file is not a well-formed JSON file.",
     configOptionsWereOverriden:              'The {optionsString} option{suffix} from the configuration file will be ignored.',

--- a/src/notifications/warning-message.js
+++ b/src/notifications/warning-message.js
@@ -14,6 +14,7 @@ export default {
     maximizeError:                           'Was unable to maximize the window due to an error.\n\n{errMessage}',
     requestMockCORSValidationFailed:         '{RequestHook}: CORS validation failed for a request specified as {requestFilterRule}',
     debugInHeadlessError:                    'You cannot debug in headless mode.',
+    cannotFindWindowDescriptorError:         'An error has occurred while finding the window descriptor.\n\n{errMessage}',
     cannotReadConfigFile:                    'An error has occurred while reading the configuration file.',
     cannotParseConfigFile:                   "Failed to parse the '{path}' file.\n\nThis file is not a well-formed JSON file.",
     configOptionsWereOverriden:              'The {optionsString} option{suffix} from the configuration file will be ignored.',

--- a/test/server/browser-provider-test.js
+++ b/test/server/browser-provider-test.js
@@ -28,19 +28,23 @@ class BrowserConnectionMock extends BrowserConnection {
     }
 }
 
-function debugMock (id) {
-    if (!debugMock.data)
-        debugMock.data = {};
-
-    if (!debugMock.data[id])
-        debugMock.data[id] = '';
-
-    return newData => {
-        debugMock.data[id] += newData;
-    };
-}
-
 describe('Browser provider', function () {
+    function debugMock (id) {
+        if (!debugMock.data)
+            debugMock.data = {};
+
+        if (!debugMock.data[id])
+            debugMock.data[id] = '';
+
+        return newData => {
+            debugMock.data[id] += newData;
+        };
+    }
+
+    beforeEach(() => {
+        debugMock.data = null;
+    });
+
     describe('Path and arguments handling', function () {
         it('Should parse the path: alias with arguments', async () => {
             const browserInfo = await browserProviderPool.getBrowserInfo('path:/usr/bin/chrome --arg1 --arg2');
@@ -399,7 +403,7 @@ describe('Browser provider', function () {
 
     describe('Remote provider', () => {
         it('Should log an error if a browser window was not found', async () => {
-            const bc   = new BrowserConnectionMock();
+            const bc = new BrowserConnectionMock();
 
             bc.isReady = () => true;
 
@@ -417,17 +421,16 @@ describe('Browser provider', function () {
             await provider.openBrowser(bc.id);
 
             expect(debugMock.data['testcafe:browser:provider:built-in:remote']).eql('Error: SomeError');
-
-            debugMock.data = {};
         });
     });
 
     it('Should raise a warning if a browser window was not found', async () => {
-        const bc      = new BrowserConnectionMock();
+        const bc = new BrowserConnectionMock();
 
-        bc.isReady    = () => true;
+        bc.isReady = () => true;
 
-        let warning; let errorMsg;
+        let warning  = null;
+        let errorMsg = null;
 
         bc.addWarning = (...args) => {
             warning  = args[0];
@@ -458,8 +461,6 @@ describe('Browser provider', function () {
         expect(debugMock.data['testcafe:browser:provider']).eql('Error: SomeError');
         expect(warning).eql(WARNING_MESSAGE.cannotFindWindowDescriptorError);
         expect(errorMsg).eql('SomeError');
-
-        debugMock.data = {};
     });
 });
 

--- a/test/server/browser-provider-test.js
+++ b/test/server/browser-provider-test.js
@@ -6,6 +6,7 @@ const { join, dirname }         = require('path');
 const proxyquire                = require('proxyquire');
 const sinon                     = require('sinon');
 const Module                    = require('module');
+const dedent                    = require('dedent');
 const browserProviderPool       = require('../../lib/browser/provider/pool');
 const parseProviderName         = require('../../lib/browser/provider/parse-provider-name');
 const BrowserConnection         = require('../../lib/browser/connection');
@@ -455,8 +456,12 @@ describe('Browser provider', function () {
         await provider.openBrowser(bc.id);
 
         expect(debugMock.data['testcafe:browser:provider']).eql('Error: SomeError');
-        expect(warningLog.messages).eql([
-            'Cannot find the "chromium" window. The following error occurred:\n\nSomeError'
+        expect(warningLog.messages).eql([dedent`
+            Could not find the "chromium" window. TestCafe is unable to resize the window or take screenshots.
+
+            The following error occurred while TestCafe was searching for the window descriptor:
+
+            SomeError`
         ]);
     });
 });

--- a/test/server/warning-log-test.js
+++ b/test/server/warning-log-test.js
@@ -46,4 +46,34 @@ describe('Warning log', () => {
             'Was unable to take a screenshot due to an error.\n\n' + TYPE_ERROR_TEXT
         ]);
     });
+
+    it('Should clear warning messages', () => {
+        const globalLog = new WarningLog();
+        const log       = new WarningLog(globalLog);
+
+        log.addWarning(WARNINGS.screenshotError, TYPE_ERROR_TEXT);
+        log.clear();
+
+        expect(log.messages).eql([]);
+
+        expect(globalLog.messages).eql([
+            'Was unable to take a screenshot due to an error.\n\n' + TYPE_ERROR_TEXT
+        ]);
+    });
+
+    it('Should copy messages to another instance', () => {
+        const firstLog  = new WarningLog();
+        const secondLog = new WarningLog();
+
+        firstLog.addWarning(WARNINGS.screenshotError, TYPE_ERROR_TEXT);
+        firstLog.copyTo(secondLog);
+
+        expect(firstLog.messages).eql([
+            'Was unable to take a screenshot due to an error.\n\n' + TYPE_ERROR_TEXT
+        ]);
+
+        expect(secondLog.messages).eql([
+            'Was unable to take a screenshot due to an error.\n\n' + TYPE_ERROR_TEXT
+        ]);
+    });
 });


### PR DESCRIPTION
## Purpose
When used WSL2 or connected browser as a remote to a headless Linux container (no X11, no Xvfb), TestCafe cannot handle errors thrown by `find-window`.

## References
DevExpress#4742

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
- [x] Make sure that works on WSL2
