### PR TITLE
`t.closeWindow` method makes parent window of target window active(closes #5296)

### DIFF
--- a/src/client/driver/driver-link/messages.js
+++ b/src/client/driver/driver-link/messages.js
@@ -45,10 +45,11 @@ export class SwitchToWindowValidationMessage extends InterDriverMessage {
 }
 
 export class CloseWindowCommandMessage extends InterDriverMessage {
-    constructor ({ windowId }) {
+    constructor ({ windowId, isCurrentWindow }) {
         super(TYPE.closeWindow);
 
-        this.windowId = windowId;
+        this.windowId        = windowId;
+        this.isCurrentWindow = isCurrentWindow;
     }
 }
 

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -290,10 +290,14 @@ export default class Driver extends serviceUtils.EventEmitter {
             if (!firstClosedChildWindowDriverLink)
                 return;
 
-            this.emit(CHILD_WINDOW_CLOSED_EVENT);
+            const childWindowClosedEventArgs = { setWindowAsMaster: true };
+
+            this.emit(CHILD_WINDOW_CLOSED_EVENT, childWindowClosedEventArgs);
 
             arrayUtils.remove(this.childWindowDriverLinks, firstClosedChildWindowDriverLink);
-            this._setCurrentWindowAsMaster();
+
+            if (childWindowClosedEventArgs.setWindowAsMaster)
+                this._setCurrentWindowAsMaster();
 
             if (!this.childWindowDriverLinks.length)
                 nativeMethods.clearInterval.call(window, this.checkClosedChildWindowIntervalId);
@@ -579,19 +583,24 @@ export default class Driver extends serviceUtils.EventEmitter {
             });
     }
 
+    _closeWindowAndWait (childWindowToClose, msg) {
+        const waitWindowForClose = this._createWaitForEventPromise(CHILD_WINDOW_CLOSED_EVENT, CHILD_WINDOW_CLOSED_EVENT_TIMEOUT, e => {
+            e.setWindowAsMaster = msg.isCurrentWindow;
+        });
+
+        childWindowToClose.driverWindow.close();
+
+        return waitWindowForClose;
+    }
+
     _closeWindow (msg) {
         if (!this.childWindowDriverLinks.length)
             return Promise.resolve();
 
         const childWindowToClose = this.childWindowDriverLinks.find(link => link.windowId === msg.windowId);
 
-        if (childWindowToClose) {
-            const result = this._createWaitForEventPromise(CHILD_WINDOW_CLOSED_EVENT, CHILD_WINDOW_CLOSED_EVENT_TIMEOUT);
-
-            childWindowToClose.driverWindow.close();
-
-            return result;
-        }
+        if (childWindowToClose)
+            return this._closeWindowAndWait(childWindowToClose, msg);
 
         const searchQueries = this.childWindowDriverLinks.map(childWindowDriverLink => {
             return childWindowDriverLink.findChildWindows(msg, CloseWindowCommandMessage);
@@ -769,7 +778,7 @@ export default class Driver extends serviceUtils.EventEmitter {
             });
     }
 
-    _createWaitForEventPromise (eventName, timeout) {
+    _createWaitForEventPromise (eventName, timeout, onSuccess) {
         let eventHandler = null;
 
         const timeoutPromise = new Promise(resolve => {
@@ -781,8 +790,11 @@ export default class Driver extends serviceUtils.EventEmitter {
         });
 
         const resultPromise = new Promise(resolve => {
-            eventHandler = function () {
+            eventHandler = function (...args) {
                 this.off(eventName, eventHandler);
+
+                if (typeof onSuccess === 'function')
+                    onSuccess.apply(this, args);
 
                 resolve();
             };
@@ -1009,9 +1021,9 @@ export default class Driver extends serviceUtils.EventEmitter {
     }
 
     _onWindowCloseCommand (command) {
-        const wnd                           = this.parentWindowDriverLink?.getTopOpenedWindow() || window;
-        const targetWindowIsFirstLevelChild = !!this.childWindowDriverLinks.find(link => link.windowId === command.windowId);
-        const windowId                      = command.windowId || this.windowId;
+        const wnd             = this.parentWindowDriverLink?.getTopOpenedWindow() || window;
+        const windowId        = command.windowId || this.windowId;
+        const isCurrentWindow = windowId === this.windowId;
 
         this._validateChildWindowCloseCommandExists(windowId, wnd)
             .then(response => {
@@ -1020,12 +1032,13 @@ export default class Driver extends serviceUtils.EventEmitter {
                 if (!result.success)
                     throw ChildWindowValidationErrorFactory.createError(result);
 
-                return sendMessageToDriver(new CloseWindowCommandMessage({ windowId }), wnd, WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT, CannotSwitchToWindowError);
+                return sendMessageToDriver(new CloseWindowCommandMessage({ windowId, isCurrentWindow }), wnd, WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT, CannotSwitchToWindowError);
             })
             .then(() => {
-                // NOTE: we need to send new Driver Status only if we close direct child window
-                // in any other case the new Driver Status will be sent from the `_setCurrentWindowAsMaster` method
-                if (targetWindowIsFirstLevelChild) {
+                // NOTE: we do not need to send a new Driver Status if we close the current window
+                // in this case the new Driver Status will be sent from the `_setCurrentWindowAsMaster` method
+                // in other cases we need to send a new Driver Status from here.
+                if (!isCurrentWindow) {
                     this._onReady(new DriverStatus({
                         isCommandResult: true
                     }));

--- a/test/functional/fixtures/run-options/allow-multiple-windows/test.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/test.js
@@ -164,6 +164,10 @@ describe('Allow multiple windows', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Close specific window from parent', { only: 'chrome', allowMultipleWindows: true });
         });
 
+        it('Close window and check master did not changed', () => {
+            return runTests('testcafe-fixtures/api/api-test.js', 'Close window and check master did not changed', { only: 'chrome', allowMultipleWindows: true });
+        });
+
         it('Close specific window from child', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Close specific window from child', { only: 'chrome', allowMultipleWindows: true, shouldFail: true })
                 .catch(errs => {

--- a/test/functional/fixtures/run-options/allow-multiple-windows/testcafe-fixtures/api/api-test.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/testcafe-fixtures/api/api-test.js
@@ -193,6 +193,16 @@ test('Close specific window from parent', async t => {
     await t.expect(Selector('h1').innerText).eql('parent');
 });
 
+test('Close window and check master did not changed', async t => {
+    const childWindow = await t.openWindow(child1Url);
+
+    await t
+        .switchToParentWindow()
+        .openWindow(child2Url)
+        .closeWindow(childWindow)
+        .expect(Selector('h1').innerText).eql('child-2');
+});
+
 test('Close specific window from child', async t => {
     const childWindow1 = await t.openWindow(child1Url);
 
@@ -200,7 +210,6 @@ test('Close specific window from child', async t => {
     await t.openWindow(child2Url);
     await t.expect(Selector('h1').innerText).eql('child-2');
     await t.closeWindow(childWindow1);
-    await t.expect(Selector('h1').innerText).eql('parent');
     await t.switchToWindow(childWindow1);
 });
 


### PR DESCRIPTION
We can be sure that window is closed only inside the `_ensureClosedChildWindowWatcher` method's interval.
However, in this method we do not know if the window was closed itself (not from TestCafe) or via the `closeWindow` method.
In the case of the `closeWindow` method we do not need to call `setCurrentWindowAsMaster` method. The only case when we need to change master in API call is only when we close the current window via API. In all other cases we need to leave the master window as is.
So I handle CHILD_WINDOW_CLOSED_EVENT inside API call and set flag childWindowClosedEventArgs.setWindowAsMaster to prevent the call to `_setCurrentWindowAsMaster` method