### PR TITLE
Fix server tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@types/mime-db": "^1.27.0",
     "@types/mustache": "^0.8.32",
     "@types/nanoid": "^2.1.0",
-    "@types/source-map-support": "^0.5.0",
+    "@types/source-map-support": "0.5.1",
     "@types/useragent": "^2.1.1",
     "@typescript-eslint/eslint-plugin": "1.13.0",
     "@typescript-eslint/parser": "1.13.0",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "@types/mime-db": "^1.27.0",
     "@types/mustache": "^0.8.32",
     "@types/nanoid": "^2.1.0",
-    "@types/source-map-support": "0.5.1",
+    "@types/source-map-support": "^0.5.0",
     "@types/useragent": "^2.1.1",
     "@typescript-eslint/eslint-plugin": "1.13.0",
     "@typescript-eslint/parser": "1.13.0",

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -299,13 +299,13 @@ describe('Compiler', function () {
                 });
         });
 
-        it('Should complile ts-definitions successfully with the `--strict` option enabled', function () {
+        it('Should compile ts-definitions successfully with the `--strict` option enabled', function () {
             this.timeout(60000);
 
             const tscPath  = path.resolve('node_modules/.bin/tsc');
             const defsPath = path.resolve('ts-defs/index.d.ts');
             const args     = '--strict';
-            const command  = `${tscPath} ${defsPath} ${args} --target ES6 --noEmit`;
+            const command  = `${tscPath} ${defsPath} ${args} --target ES6 --noEmit --moduleResolution node`;
 
             return new Promise(resolve => {
                 exec(command, (error, stdout) => {
@@ -384,7 +384,7 @@ describe('Compiler', function () {
             const tscPath     = path.resolve('node_modules/.bin/tsc');
             const defsPath    = path.resolve('ts-defs/testcafe-scripts.d.ts');
             const scriptPaths = await globby('test/server/data/test-suites/typescript-testcafe-scripts-defs/*.ts');
-            const command     = `${tscPath} ${defsPath} ${scriptPaths.join(' ')} --target ES6 --noEmit`;
+            const command     = `${tscPath} ${defsPath} ${scriptPaths.join(' ')} --target ES6 --noEmit --moduleResolution node`;
 
             return new Promise(resolve => {
                 exec(command, (error, stdout) => {
@@ -402,7 +402,7 @@ describe('Compiler', function () {
             const tscPath     = path.resolve('node_modules/.bin/tsc');
             const defsPath    = path.resolve('ts-defs/selectors.d.ts');
             const scriptPaths = await globby('test/server/data/test-suites/typescript-selectors-defs/*.ts');
-            const command     = `${tscPath} ${defsPath} ${scriptPaths.join(' ')} --target ES6 --noEmit`;
+            const command     = `${tscPath} ${defsPath} ${scriptPaths.join(' ')} --target ES6 --noEmit --moduleResolution node`;
 
             return new Promise(resolve => {
                 exec(command, (error, stdout) => {


### PR DESCRIPTION
The latest version (`0.5.2`) of the `@types/source-map-support` module references the `@source-map@^0.6.0` module without exporting typings. The types export was added to `source-map` module from the `0.7.0` version (https://github.com/mozilla/source-map/commit/7cc0c9dad9c358e956258389436bdd95c50354af).

I fixed the `@types/source-map-support` module version until it will be fixed.

