### PR TITLE
wait new window page is loaded completely (closes #5303)

### DIFF
--- a/src/client/driver/driver-link/window/child.js
+++ b/src/client/driver/driver-link/window/child.js
@@ -9,8 +9,8 @@ export default class ChildWindowDriverLink {
         this.windowId     = windowId;
     }
 
-    setAsMaster () {
-        const msg = new SetAsMasterMessage();
+    setAsMaster (finalizePendingCommand) {
+        const msg = new SetAsMasterMessage(finalizePendingCommand);
 
         return sendMessageToDriver(msg, this.driverWindow, WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT, CannotSwitchToWindowError);
     }

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -823,7 +823,7 @@ export default class Driver extends serviceUtils.EventEmitter {
     _switchToChildWindow (selector) {
         this.contextStorage.setItem(this.PENDING_WINDOW_SWITCHING_FLAG, true);
 
-        const isApiCall = this.contextStorage.getItem(this.WINDOW_COMMAND_API_CALL_FLAG);
+        const isWindowOpenedViaAPI = this.contextStorage.getItem(this.WINDOW_COMMAND_API_CALL_FLAG);
 
         return executeChildWindowDriverLinkSelector(selector, this.childWindowDriverLinks)
             .then(childWindowDriverLink => {
@@ -835,13 +835,13 @@ export default class Driver extends serviceUtils.EventEmitter {
                 return this._waitForCurrentCommandCompletion();
             })
             .then(() => {
-                return !isApiCall ? this._waitForEmptyCommand() : void 0;
+                return isWindowOpenedViaAPI ? void 0 : this._waitForEmptyCommand();
             })
             .then(() => {
                 this._abortSwitchingToChildWindowIfItClosed();
                 this._stopInternal();
 
-                return this.activeChildWindowDriverLink.setAsMaster(isApiCall);
+                return this.activeChildWindowDriverLink.setAsMaster(isWindowOpenedViaAPI);
             })
             .then(() => {
                 this.contextStorage.setItem(this.PENDING_WINDOW_SWITCHING_FLAG, false);

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -137,6 +137,7 @@ export default class Driver extends serviceUtils.EventEmitter {
         this.COMMAND_EXECUTING_FLAG        = 'testcafe|driver|command-executing-flag';
         this.EXECUTING_IN_IFRAME_FLAG      = 'testcafe|driver|executing-in-iframe-flag';
         this.PENDING_WINDOW_SWITCHING_FLAG = 'testcafe|driver|pending-window-switching-flag';
+        this.WINDOW_COMMAND_API_CALL_FLAG  = 'testcafe|driver|window-command-api-flag';
 
         this.testRunId                  = testRunId;
         this.heartbeatUrl               = communicationUrls.heartbeat;
@@ -181,8 +182,6 @@ export default class Driver extends serviceUtils.EventEmitter {
         this.readyPromise = eventUtils
             .documentReady(this.pageLoadTimeout)
             .then(() => this.pageInitialRequestBarrier.wait(true));
-
-        this._openWindowPromiseResolveFn = () => {};
 
         this._initChildDriverListening();
 
@@ -335,7 +334,6 @@ export default class Driver extends serviceUtils.EventEmitter {
     _onChildWindowOpened (e) {
         this._addChildWindowDriverLink(e);
         this._switchToChildWindow(e.windowId);
-        this._openWindowPromiseResolveFn(e.windowId);
     }
 
     // HACK: For https://github.com/DevExpress/testcafe/issues/3560
@@ -654,6 +652,7 @@ export default class Driver extends serviceUtils.EventEmitter {
             .then(() => {
                 this._startInternal({
                     finalizePendingCommand: msg.finalizePendingCommand,
+                    result:                 { id: this.windowId }
                 });
 
                 this.setAsMasterInProgress = false;
@@ -824,6 +823,8 @@ export default class Driver extends serviceUtils.EventEmitter {
     _switchToChildWindow (selector) {
         this.contextStorage.setItem(this.PENDING_WINDOW_SWITCHING_FLAG, true);
 
+        const isApiCall = this.contextStorage.getItem(this.WINDOW_COMMAND_API_CALL_FLAG);
+
         return executeChildWindowDriverLinkSelector(selector, this.childWindowDriverLinks)
             .then(childWindowDriverLink => {
                 return this._ensureChildWindowDriverLink(childWindowDriverLink.driverWindow, ChildWindowIsNotLoadedError, this.childWindowReadyTimeout);
@@ -834,13 +835,13 @@ export default class Driver extends serviceUtils.EventEmitter {
                 return this._waitForCurrentCommandCompletion();
             })
             .then(() => {
-                return this._waitForEmptyCommand();
+                return !isApiCall ? this._waitForEmptyCommand() : void 0;
             })
             .then(() => {
                 this._abortSwitchingToChildWindowIfItClosed();
                 this._stopInternal();
 
-                return this.activeChildWindowDriverLink.setAsMaster();
+                return this.activeChildWindowDriverLink.setAsMaster(isApiCall);
             })
             .then(() => {
                 this.contextStorage.setItem(this.PENDING_WINDOW_SWITCHING_FLAG, false);
@@ -1000,19 +1001,9 @@ export default class Driver extends serviceUtils.EventEmitter {
     }
 
     _onWindowOpenCommand (command) {
-        const openWindowPromise = new Promise(resolve => {
-            this._openWindowPromiseResolveFn = resolve;
+        this.contextStorage.setItem(this.WINDOW_COMMAND_API_CALL_FLAG, true);
 
-            window.open(command.url);
-        });
-
-        return openWindowPromise
-            .then(windowId => {
-                this._onReady(new DriverStatus({
-                    isCommandResult: true,
-                    result:          { id: windowId }
-                }));
-            });
+        window.open(command.url);
     }
 
     _onWindowCloseCommand (command) {
@@ -1246,6 +1237,8 @@ export default class Driver extends serviceUtils.EventEmitter {
     }
 
     _executeCommand (command) {
+        this.contextStorage.setItem(this.WINDOW_COMMAND_API_CALL_FLAG, false);
+
         if (this.customCommandHandlers[command.type])
             this._onCustomCommand(command);
 
@@ -1394,7 +1387,7 @@ export default class Driver extends serviceUtils.EventEmitter {
 
     }
 
-    _startCommandsProcessing (opts = { finalizePendingCommand: false, isFirstRequestAfterWindowSwitching: false }) {
+    _startCommandsProcessing (opts = { finalizePendingCommand: false, isFirstRequestAfterWindowSwitching: false, result: void 0 }) {
         const pendingStatus = this.contextStorage.getItem(PENDING_STATUS);
 
         if (pendingStatus)
@@ -1418,7 +1411,8 @@ export default class Driver extends serviceUtils.EventEmitter {
 
         const status = pendingStatus || new DriverStatus({
             isCommandResult:                    finalizePendingCommand,
-            isFirstRequestAfterWindowSwitching: opts.isFirstRequestAfterWindowSwitching
+            isFirstRequestAfterWindowSwitching: opts.isFirstRequestAfterWindowSwitching,
+            result:                             opts.result
         });
 
         this.contextStorage.setItem(this.COMMAND_EXECUTING_FLAG, false);

--- a/test/functional/fixtures/run-options/allow-multiple-windows/pages/api/child-3.html
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/pages/api/child-3.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>child-3</title>
+    <script>
+        const DATE_NOW     = Date.now();
+        const LOCK_TIMEOUT = 10000;
+
+        while (Date.now() < DATE_NOW + LOCK_TIMEOUT) {
+        }
+    </script>
+</head>
+<body>
+    <h1>child-3</h1>
+</body>
+</html>

--- a/test/functional/fixtures/run-options/allow-multiple-windows/test.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/test.js
@@ -96,6 +96,10 @@ describe('Allow multiple windows', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Open child window', { only: 'chrome', allowMultipleWindows: true });
         });
 
+        it('Open slow child window ', () => {
+            return runTests('testcafe-fixtures/api/api-test.js', 'Open slow child window', { only: 'chrome', allowMultipleWindows: true });
+        });
+
         it('Close current window', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Close current window', { only: 'chrome', allowMultipleWindows: true });
         });

--- a/test/functional/fixtures/run-options/allow-multiple-windows/testcafe-fixtures/api/api-test.js
+++ b/test/functional/fixtures/run-options/allow-multiple-windows/testcafe-fixtures/api/api-test.js
@@ -3,6 +3,7 @@ import { Selector } from 'testcafe';
 const parentUrl = 'http://localhost:3000/fixtures/run-options/allow-multiple-windows/pages/api/parent.html';
 const child1Url = 'http://localhost:3000/fixtures/run-options/allow-multiple-windows/pages/api/child-1.html';
 const child2Url = 'http://localhost:3000/fixtures/run-options/allow-multiple-windows/pages/api/child-2.html';
+const child3Url = 'http://localhost:3000/fixtures/run-options/allow-multiple-windows/pages/api/child-3.html';
 
 fixture `API`
     .page(parentUrl);
@@ -12,6 +13,15 @@ test('Open child window', async t => {
         .expect(Selector('h1').innerText).eql('parent')
         .openWindow(child1Url)
         .expect(Selector('h1').innerText).eql('child-1');
+});
+
+test('Open slow child window', async t => {
+    await t
+        .expect(Selector('h1').innerText).eql('parent')
+        .openWindow(child3Url)
+        .openWindow(child1Url)
+        .switchToRecentWindow()
+        .expect(Selector('h1').innerText).eql('child-3');
 });
 
 test('Close current window', async t => {


### PR DESCRIPTION
1. We need to send command result for `openWindow` command only after the page is loaded and is set as master. In other case, the `switchToRecentWindow` method will not work as expected.
Since `openWindow` calls `setAsMaster`, we need to set result inside the `setAsMaster`.
2. The other problem is that we have special `_waitForEmptyCommand` method inside the `_switchToChildWindow` method. The `_waitForEmptyCommand` is not required when we use API, since here cannot be other executing commands