### PR TITLE
Emit an error when runned on Linux without GUI

### DIFF
--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import Mustache from 'mustache';
 import { pull as remove } from 'lodash';
-import parseUserAgent from '../../utils/parse-user-agent';
+import parseUserAgent, { ParsedUserAgent } from '../../utils/parse-user-agent';
 import { readSync as read } from 'read-file-relative';
 import promisifyEvent from 'promisify-event';
 import nanoid from 'nanoid';
@@ -15,6 +15,7 @@ import { Dictionary } from '../../configuration/interfaces';
 import BrowserConnectionGateway from './gateway';
 import BrowserJob from '../../runner/browser-job';
 import WarningLog from '../../notifications/warning-log';
+import BrowserProvider from '../provider';
 
 const IDLE_PAGE_TEMPLATE                         = read('../../client/browser/idle-page/index.html.mustache');
 const connections: Dictionary<BrowserConnection> = {};
@@ -44,6 +45,15 @@ interface InitScriptTask extends InitScript {
 
 interface ProviderMetaInfoOptions {
     appendToUserAgent?: boolean;
+}
+
+export interface BrowserInfo {
+    alias: string;
+    browserName: string;
+    providerName: string;
+    provider: BrowserProvider;
+    userAgentProviderMetaInfo: string;
+    parsedUserAgent: ParsedUserAgent;
 }
 
 export default class BrowserConnection extends EventEmitter {
@@ -76,10 +86,14 @@ export default class BrowserConnection extends EventEmitter {
 
     public idle: boolean;
 
-    public browserInfo: any;
+    public browserInfo: BrowserInfo;
     public provider: any;
 
-    public constructor (gateway: BrowserConnectionGateway, browserInfo: any, permanent: boolean, allowMultipleWindows = false) {
+    public constructor (
+        gateway: BrowserConnectionGateway,
+        browserInfo: BrowserInfo,
+        permanent: boolean,
+        allowMultipleWindows = false) {
         super();
 
         this.HEARTBEAT_TIMEOUT       = HEARTBEAT_TIMEOUT;

--- a/src/browser/provider/built-in/dedicated/base.js
+++ b/src/browser/provider/built-in/dedicated/base.js
@@ -41,8 +41,13 @@ export default {
         return true;
     },
 
-    isHeadlessBrowser (browserId) {
-        return this.openedBrowsers[browserId].config.headless;
+    isHeadlessBrowser (browserId, browserName) {
+        if (browserId)
+            return this.openedBrowsers[browserId].config.headless;
+
+        const config = this._getConfig(browserName);
+
+        return !!config.headless;
     },
 
     _getCropDimensions (viewportWidth, viewportHeight) {

--- a/src/browser/provider/built-in/remote.js
+++ b/src/browser/provider/built-in/remote.js
@@ -36,13 +36,10 @@ export default {
 
     async isLocalBrowser (browserId) {
         // NOTE:
-        // if browserId is not specified, then a browser is not yet started
+        // if browserId is not specified, then it means that a browser is not yet started
         // we may assume that it's not local, because
         // otherwise we'll just disable window manipulation function's after the browser will be started
-        if (!browserId)
-            return false;
-
-        return this.localBrowsersFlags[browserId];
+        return !!browserId && this.localBrowsersFlags[browserId];
     },
 
     // NOTE: we must try to do a local screenshot or resize, if browser is accessible, and emit warning otherwise

--- a/src/browser/provider/built-in/remote.js
+++ b/src/browser/provider/built-in/remote.js
@@ -35,6 +35,13 @@ export default {
     },
 
     async isLocalBrowser (browserId) {
+        // NOTE:
+        // if browserId is not specified, then a browser is not yet started
+        // we may assume that it's not local, because
+        // otherwise we'll just disable window manipulation function's after the browser will be started
+        if (!browserId)
+            return false;
+
         return this.localBrowsersFlags[browserId];
     },
 

--- a/src/browser/provider/index.ts
+++ b/src/browser/provider/index.ts
@@ -261,8 +261,8 @@ export default class BrowserProvider {
         return await this.plugin.isLocalBrowser(browserId, browserName);
     }
 
-    public isHeadlessBrowser (browserId: string): Promise<boolean> {
-        return this.plugin.isHeadlessBrowser(browserId);
+    public isHeadlessBrowser (browserId?: string, browserName?: string): Promise<boolean> {
+        return this.plugin.isHeadlessBrowser(browserId, browserName);
     }
 
     public async openBrowser (browserId: string, pageUrl: string, browserName: string, allowMultipleWindows: boolean): Promise<void> {

--- a/src/browser/provider/plugin-host.js
+++ b/src/browser/provider/plugin-host.js
@@ -98,12 +98,17 @@ export default class BrowserProviderPluginHost {
     }
 
     // Extra functions
-    // NOTE: The browserName argument is optional, and must be supplied if the browserId argument is not valid (browser is not opened)
+    // NOTE:
+    // The browserName argument is optional, and must be supplied if the browserId argument is not valid
+    // (browser is not opened)
     async isLocalBrowser (/* browserId[, browserName] */) {
         return false;
     }
 
-    isHeadlessBrowser (/* browserId */) {
+    // NOTE:
+    // The browserName argument is optional, and must be supplied if the browserId argument is not valid
+    // (browser is not opened)
+    isHeadlessBrowser (/* browserId[, browserName] */) {
         return false;
     }
 

--- a/src/browser/provider/pool.js
+++ b/src/browser/provider/pool.js
@@ -113,6 +113,9 @@ export default {
         if (!await provider.isValidBrowserName(browserName))
             throw new GeneralError(RUNTIME_ERRORS.cannotFindBrowser, alias);
 
+        if (typeof alias !== 'string')
+            alias = JSON.stringify(alias);
+
         return { alias, ...browserInfo };
     },
 

--- a/src/errors/runtime/templates.js
+++ b/src/errors/runtime/templates.js
@@ -103,8 +103,10 @@ export default {
     [RUNTIME_ERRORS.unexpectedIPCTailPacket]:                            'Cannot create an IPC message due to an unexpected IPC tail packet.',
     [RUNTIME_ERRORS.cannotUseAllowMultipleWindowsOptionForLegacyTests]:  'You cannot run Legacy API tests in multi-window mode.',
     [RUNTIME_ERRORS.cannotUseAllowMultipleWindowsOptionForSomeBrowsers]: 'You cannot use multi-window mode in {browsers}.',
-    [RUNTIME_ERRORS.cannotRunLocalNonHeadlessBrowserWithoutDisplay]:     'You run "{browserAlias}" browser with graphic interface in Linux without graphic subsystem. ' +
-                                                                         'Try to run in headless mode. ' +
-                                                                         'For more information see ' +
-                                                                         'https://devexpress.github.io/testcafe/documentation/guides/concepts/browsers.html#test-in-headless-mode',
+    [RUNTIME_ERRORS.cannotRunLocalNonHeadlessBrowserWithoutDisplay]:
+        'Your Linux version does not have a graphic subsystem to run {browserAlias} with a GUI. ' +
+        'You can launch the browser in headless mode. ' +
+        'If you use a portable browser version, ' +
+        'specify the browser alias before the path instead of the \'path\' prefix. ' +
+        'For more information, see https://devexpress.github.io/testcafe/documentation/guides/concepts/browsers.html#test-in-headless-mode',
 };

--- a/src/errors/runtime/templates.js
+++ b/src/errors/runtime/templates.js
@@ -103,8 +103,8 @@ export default {
     [RUNTIME_ERRORS.unexpectedIPCTailPacket]:                            'Cannot create an IPC message due to an unexpected IPC tail packet.',
     [RUNTIME_ERRORS.cannotUseAllowMultipleWindowsOptionForLegacyTests]:  'You cannot run Legacy API tests in multi-window mode.',
     [RUNTIME_ERRORS.cannotUseAllowMultipleWindowsOptionForSomeBrowsers]: 'You cannot use multi-window mode in {browsers}.',
-    [RUNTIME_ERRORS.cannotRunLocalNonHeadlessBrowserWithoutDisplay]:     'You run {browserAlias} browser with graphic interface in Linux without graphic subsystem. ' +
-                                                                         'Try to run {browserAlias} in headless mode. ' +
+    [RUNTIME_ERRORS.cannotRunLocalNonHeadlessBrowserWithoutDisplay]:     'You run "{browserAlias}" browser with graphic interface in Linux without graphic subsystem. ' +
+                                                                         'Try to run in headless mode. ' +
                                                                          'For more information see ' +
                                                                          'https://devexpress.github.io/testcafe/documentation/guides/concepts/browsers.html#test-in-headless-mode',
 };

--- a/src/errors/runtime/templates.js
+++ b/src/errors/runtime/templates.js
@@ -102,5 +102,9 @@ export default {
     [RUNTIME_ERRORS.unexpectedIPCBodyPacket]:                            'Cannot create an IPC message due to an unexpected IPC body packet.',
     [RUNTIME_ERRORS.unexpectedIPCTailPacket]:                            'Cannot create an IPC message due to an unexpected IPC tail packet.',
     [RUNTIME_ERRORS.cannotUseAllowMultipleWindowsOptionForLegacyTests]:  'You cannot run Legacy API tests in multi-window mode.',
-    [RUNTIME_ERRORS.cannotUseAllowMultipleWindowsOptionForSomeBrowsers]: 'You cannot use multi-window mode in {browsers}.'
+    [RUNTIME_ERRORS.cannotUseAllowMultipleWindowsOptionForSomeBrowsers]: 'You cannot use multi-window mode in {browsers}.',
+    [RUNTIME_ERRORS.cannotRunLocalNonHeadlessBrowserWithoutDisplay]:     'You run {browserAlias} browser with graphic interface in Linux without graphic subsystem. ' +
+                                                                         'Try to run {browserAlias} in headless mode. ' +
+                                                                         'For more information see ' +
+                                                                         'https://devexpress.github.io/testcafe/documentation/guides/concepts/browsers.html#test-in-headless-mode',
 };

--- a/src/errors/types.js
+++ b/src/errors/types.js
@@ -139,5 +139,6 @@ export const RUNTIME_ERRORS = {
     unexpectedIPCBodyPacket:                            'E1053',
     unexpectedIPCTailPacket:                            'E1054',
     cannotUseAllowMultipleWindowsOptionForLegacyTests:  'E1055',
-    cannotUseAllowMultipleWindowsOptionForSomeBrowsers: 'E1056'
+    cannotUseAllowMultipleWindowsOptionForSomeBrowsers: 'E1056',
+    cannotRunLocalNonHeadlessBrowserWithoutDisplay:     'E1057',
 };

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -193,8 +193,8 @@ export default class Bootstrapper {
             if (browserInfo instanceof BrowserConnection)
                 continue;
 
-            const isLocalBrowser    = browserInfo.provider.isLocalBrowser(void 0, browserInfo.browserName);
-            const isHeadLessBrowser = browserInfo.provider.isHeadlessBrowser(void 0, browserInfo.browserName);
+            const isLocalBrowser    = await browserInfo.provider.isLocalBrowser(void 0, browserInfo.browserName);
+            const isHeadLessBrowser = await browserInfo.provider.isHeadlessBrowser(void 0, browserInfo.browserName);
 
             if (isLocalBrowser && !isHeadLessBrowser) {
                 throw new GeneralError(

--- a/src/utils/detect-display.ts
+++ b/src/utils/detect-display.ts
@@ -1,0 +1,3 @@
+export default function (): boolean {
+    return !!process.env.DISPLAY;
+}

--- a/test/functional/fixtures/browser-provider/job-reporting/test.js
+++ b/test/functional/fixtures/browser-provider/job-reporting/test.js
@@ -39,6 +39,10 @@ if (config.useLocalBrowsers) {
                 return Promise.resolve(true);
             },
 
+            isHeadlessBrowser () {
+                return true;
+            },
+
             reportJobResult (browserId, result, data) {
                 const name = this.idNameMap[browserId];
 

--- a/test/functional/fixtures/runner/test.js
+++ b/test/functional/fixtures/runner/test.js
@@ -11,7 +11,7 @@ function run (browsers, testFile) {
         .run();
 }
 
-describe.only('Runner', () => {
+describe('Runner', () => {
     if (config.useLocalBrowsers && !config.useHeadlessBrowsers && os.linux) {
         let originalDisplay = null;
 
@@ -28,6 +28,8 @@ describe.only('Runner', () => {
         it('Should throw an error when tests are run on Linux without graphical subsystem', async () => {
             try {
                 await run('chromium', './testcafe-fixtures/basic-test.js');
+
+                throw new Error('Promise rejection expected');
             }
             catch (err) {
                 expect(err.message).eql(

--- a/test/functional/fixtures/runner/test.js
+++ b/test/functional/fixtures/runner/test.js
@@ -1,0 +1,42 @@
+const path       = require('path');
+const os         = require('os-family');
+const { expect } = require('chai');
+const config     = require('../../config');
+
+function run (browsers, testFile) {
+    return testCafe
+        .createRunner()
+        .src(path.join(__dirname, testFile))
+        .browsers(browsers)
+        .run();
+}
+
+describe.only('Runner', () => {
+    if (config.useLocalBrowsers && !config.useHeadlessBrowsers && os.linux) {
+        let originalDisplay = null;
+
+        before(() => {
+            originalDisplay = process.env.DISPLAY;
+
+            process.env.DISPLAY = '';
+        });
+
+        after(() => {
+            process.env.DISPLAY = originalDisplay;
+        });
+
+        it('Should throw an error when tests are run on Linux without graphical subsystem', async () => {
+            try {
+                await run('chromium', './testcafe-fixtures/basic-test.js');
+            }
+            catch (err) {
+                expect(err.message).eql(
+                    `You run "chromium" browser with graphic interface in Linux without graphic subsystem. ` +
+                    `Try to run in headless mode. For more information see ` +
+                    `https://devexpress.github.io/testcafe/documentation/` +
+                    `guides/concepts/browsers.html#test-in-headless-mode`
+                );
+            }
+        });
+    }
+});

--- a/test/functional/fixtures/runner/test.js
+++ b/test/functional/fixtures/runner/test.js
@@ -33,10 +33,12 @@ describe('Runner', () => {
             }
             catch (err) {
                 expect(err.message).eql(
-                    `You run "chromium" browser with graphic interface in Linux without graphic subsystem. ` +
-                    `Try to run in headless mode. For more information see ` +
-                    `https://devexpress.github.io/testcafe/documentation/` +
-                    `guides/concepts/browsers.html#test-in-headless-mode`
+                    `Your Linux version does not have a graphic subsystem to run chromium with a GUI. ` +
+                    `You can launch the browser in headless mode. ` +
+                    `If you use a portable browser version, ` +
+                    `specify the browser alias before the path instead of the 'path' prefix. ` +
+                    `For more information, see ` +
+                    `https://devexpress.github.io/testcafe/documentation/guides/concepts/browsers.html#test-in-headless-mode`
                 );
             }
         });

--- a/test/functional/fixtures/runner/testcafe-fixtures/basic-test.js
+++ b/test/functional/fixtures/runner/testcafe-fixtures/basic-test.js
@@ -1,0 +1,5 @@
+fixture `Runner`;
+
+test(`Basic test`, async t => {
+    await t.expect(true).ok();
+});

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -3,7 +3,6 @@ const SlConnector                = require('saucelabs-connector');
 const BsConnector                = require('browserstack-connector');
 const caller                     = require('caller');
 const promisifyEvent             = require('promisify-event');
-const os                         = require('os-family');
 const createTestCafe             = require('../../lib');
 const browserProviderPool        = require('../../lib/browser/provider/pool');
 const BrowserConnection          = require('../../lib/browser/connection');
@@ -13,7 +12,6 @@ const RemoteConnector            = require('./remote-connector');
 const getTestError               = require('./get-test-error.js');
 const { createSimpleTestStream } = require('./utils/stream');
 const BrowserConnectionStatus    = require('../../lib/browser/connection/status');
-const detectDisplay              = require('../../lib/utils/detect-display');
 
 let testCafe     = null;
 let browsersInfo = null;
@@ -183,12 +181,6 @@ before(function () {
             return openRemoteBrowsers();
         })
         .then(() => {
-            if (config.useLocalBrowsers && !config.useHeadlessBrowsers && os.linux && !detectDisplay())
-                // NOTE:
-                // We don't have to wait in this case,
-                // because browsers will not be able to start under this configuration
-                return Promise.resolve();
-
             return waitUntilBrowsersConnected();
         })
         .then(() => {

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -3,6 +3,7 @@ const SlConnector                = require('saucelabs-connector');
 const BsConnector                = require('browserstack-connector');
 const caller                     = require('caller');
 const promisifyEvent             = require('promisify-event');
+const os                         = require('os-family');
 const createTestCafe             = require('../../lib');
 const browserProviderPool        = require('../../lib/browser/provider/pool');
 const BrowserConnection          = require('../../lib/browser/connection');
@@ -12,6 +13,7 @@ const RemoteConnector            = require('./remote-connector');
 const getTestError               = require('./get-test-error.js');
 const { createSimpleTestStream } = require('./utils/stream');
 const BrowserConnectionStatus    = require('../../lib/browser/connection/status');
+const detectDisplay              = require('../../lib/utils/detect-display');
 
 let testCafe     = null;
 let browsersInfo = null;
@@ -181,6 +183,12 @@ before(function () {
             return openRemoteBrowsers();
         })
         .then(() => {
+            if (config.useLocalBrowsers && !config.useHeadlessBrowsers && os.linux && !detectDisplay())
+                // NOTE:
+                // We don't have to wait in this case,
+                // because browsers will not be able to start under this configuration
+                return Promise.resolve();
+
             return waitUntilBrowsersConnected();
         })
         .then(() => {

--- a/test/server/bootstrapper-test.js
+++ b/test/server/bootstrapper-test.js
@@ -1,0 +1,117 @@
+const proxyquire              = require('proxyquire');
+const chai                    = require('chai');
+const { expect }              = chai;
+const { noop }                = require('lodash');
+const BrowserConnectionStatus = require('../../lib/browser/connection/status');
+const BrowserConnection       = require('../../lib/browser/connection');
+const Test                    = require('../../lib/api/structure/test');
+
+chai.use(require('chai-string'));
+
+class BrowserConnectionMock extends BrowserConnection {
+    constructor (...args) {
+        super(...args);
+
+        this.status = BrowserConnectionStatus.opened;
+    }
+}
+
+function setupBootstrapper () {
+    const BootstrapperMock = proxyquire('../../lib/runner/bootstrapper', {
+        '../browser/connection':   BrowserConnectionMock,
+        '../utils/detect-display': () => false,
+        'os-family':               { linux: true, win: false, mac: false },
+    });
+
+    const browserConnectionGateway = {
+        startServingConnection: noop,
+        stopServingConnection:  noop
+    };
+
+    const compilerService = {
+        init:     noop,
+        getTests: () => [ new Test({ currentFixture: void 0 }) ]
+    };
+
+    return new BootstrapperMock(browserConnectionGateway, compilerService);
+}
+
+describe('Bootstrapper', () => {
+    describe('.createRunnableConfiguration()', () => {
+        describe('On Linux without a graphics subsystem', () => {
+            let bootstrapper = null;
+
+            beforeEach(() => {
+                bootstrapper = setupBootstrapper();
+            });
+
+            it('Should raise an error when browser is specified as non-headless', async () => {
+                bootstrapper.browsers = [ 'chrome' ];
+
+                try {
+                    await bootstrapper.createRunnableConfiguration();
+
+                    throw new Error('Promise rejection expected');
+                }
+                catch (err) {
+                    expect(err.message).startsWith(
+                        `You run chrome browser with graphic interface in Linux without graphic subsystem. ` +
+                        `Try to run chrome in headless mode. For more information see ` +
+                        `https://devexpress.github.io/testcafe/documentation/` +
+                        `guides/concepts/browsers.html#test-in-headless-mode`
+                    );
+                }
+            });
+
+            it('Should raise an error when browser is specified by a path', async () => {
+                bootstrapper.browsers = [ 'path:/non/exist' ];
+
+                try {
+                    await bootstrapper.createRunnableConfiguration();
+
+                    throw new Error('Promise rejection expected');
+                }
+                catch (err) {
+                    expect(err.message).startsWith(
+                        `You run path:/non/exist browser with graphic interface in Linux without graphic subsystem. ` +
+                        `Try to run path:/non/exist in headless mode. For more information see ` +
+                        `https://devexpress.github.io/testcafe/documentation/` +
+                        `guides/concepts/browsers.html#test-in-headless-mode`
+                    );
+                }
+            });
+
+            it('Should not raise an error when browser is specified as headless', async () => {
+                bootstrapper.browsers = [ 'chrome:headless' ];
+
+                let isErrorThrown = false;
+
+                try {
+                    await bootstrapper.createRunnableConfiguration();
+                }
+                catch (err) {
+                    isErrorThrown = true;
+                }
+                finally {
+                    expect(isErrorThrown).to.be.false;
+                }
+            });
+
+            it('Should not raise an error when browser is specified as non-local', async () => {
+                bootstrapper.browsers = [ 'remote' ];
+
+                let isErrorThrown = false;
+
+                try {
+                    await bootstrapper.createRunnableConfiguration();
+                }
+                catch (err) {
+                    isErrorThrown = true;
+                }
+                finally {
+                    expect(isErrorThrown).to.be.false;
+                }
+            });
+        });
+    });
+});

--- a/test/server/bootstrapper-test.js
+++ b/test/server/bootstrapper-test.js
@@ -53,10 +53,12 @@ describe('Bootstrapper', () => {
                 }
                 catch (err) {
                     expect(err.message).eql(
-                        `You run "chrome" browser with graphic interface in Linux without graphic subsystem. ` +
-                        `Try to run in headless mode. For more information see ` +
-                        `https://devexpress.github.io/testcafe/documentation/` +
-                        `guides/concepts/browsers.html#test-in-headless-mode`
+                        `Your Linux version does not have a graphic subsystem to run chrome with a GUI. ` +
+                        `You can launch the browser in headless mode. ` +
+                        `If you use a portable browser version, ` +
+                        `specify the browser alias before the path instead of the 'path' prefix. ` +
+                        `For more information, see ` +
+                        `https://devexpress.github.io/testcafe/documentation/guides/concepts/browsers.html#test-in-headless-mode`
                     );
                 }
             });
@@ -71,10 +73,12 @@ describe('Bootstrapper', () => {
                 }
                 catch (err) {
                     expect(err.message).eql(
-                        `You run "{"path":"/non/exist"}" browser with graphic interface ` +
-                        `in Linux without graphic subsystem. Try to run in headless mode. ` +
-                        `For more information see https://devexpress.github.io/testcafe/documentation/` +
-                        `guides/concepts/browsers.html#test-in-headless-mode`
+                        `Your Linux version does not have a graphic subsystem to run {"path":"/non/exist"} with a GUI. ` +
+                        `You can launch the browser in headless mode. ` +
+                        `If you use a portable browser version, ` +
+                        `specify the browser alias before the path instead of the 'path' prefix. ` +
+                        `For more information, see ` +
+                        `https://devexpress.github.io/testcafe/documentation/guides/concepts/browsers.html#test-in-headless-mode`
                     );
                 }
             });

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -13,7 +13,6 @@ const BrowserSet              = require('../../lib/runner/browser-set');
 const browserProviderPool     = require('../../lib/browser/provider/pool');
 const delay                   = require('../../lib/utils/delay');
 const consoleWrapper          = require('./helpers/console-wrapper');
-const Bootstrapper            = require('../../lib/runner/bootstrapper');
 
 chai.use(require('chai-string'));
 
@@ -33,7 +32,7 @@ describe('Runner', () => {
         }
     };
 
-    const browserMock = { path: '/non/exist' };
+    const browserMock = 'chrome:headless';
 
     before(() => {
         return createTestCafe('127.0.0.1', 1335, 1336)
@@ -66,9 +65,6 @@ describe('Runner', () => {
 
     beforeEach(() => {
         runner = testCafe.createRunner();
-        // NOTE:
-        // Disable checking for graphic system (Linux), because it's may cause non determenistic test
-        Bootstrapper._checkThatTestsCanRunWithoutDisplay = noop;
     });
 
     afterEach(() => {
@@ -942,6 +938,10 @@ describe('Runner', () => {
                         resolve();
                     }, BROWSER_CLOSING_DELAY);
                 });
+            },
+
+            isHeadlessBrowser () {
+                return true;
             }
         };
 

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -13,6 +13,7 @@ const BrowserSet              = require('../../lib/runner/browser-set');
 const browserProviderPool     = require('../../lib/browser/provider/pool');
 const delay                   = require('../../lib/utils/delay');
 const consoleWrapper          = require('./helpers/console-wrapper');
+const Bootstrapper            = require('../../lib/runner/bootstrapper');
 
 chai.use(require('chai-string'));
 
@@ -65,6 +66,9 @@ describe('Runner', () => {
 
     beforeEach(() => {
         runner = testCafe.createRunner();
+        // NOTE:
+        // Disable checking for graphic system (Linux), because it's may cause non determenistic test
+        Bootstrapper._checkThatTestsCanRunWithoutDisplay = noop;
     });
 
     afterEach(() => {


### PR DESCRIPTION
## Purpose
Emit an error when trying to run tests on Linux without the graphics subsystem.

## Approach
Check that ```DISPLAY``` environment variable is set. If it's not, then throw an error when trying to run tests on local and non-headless browser.

## References
DevExpress/testcafe#4461

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
