### PR TITLE
[docs] Fix misprint in the setNativeDailogHandler reference

### DIFF
--- a/docs/articles/documentation/reference/test-api/testcontroller/setnativedialoghandler.md
+++ b/docs/articles/documentation/reference/test-api/testcontroller/setnativedialoghandler.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-title: t.setNativeDialogueHandler Method
+title: t.setNativeDialogHandler Method
 permalink: /documentation/reference/test-api/testcontroller/setnativedialoghandler.html
 ---
 # t.setNativeDialogHandler Method

--- a/docs/articles/documentation/reference/test-api/testcontroller/setnativedialoghandler.md
+++ b/docs/articles/documentation/reference/test-api/testcontroller/setnativedialoghandler.md
@@ -3,7 +3,7 @@ layout: docs
 title: t.setNativeDialogueHandler Method
 permalink: /documentation/reference/test-api/testcontroller/setnativedialoghandler.html
 ---
-# t.setNativeDialogueHandler Method
+# t.setNativeDialogHandler Method
 
 To handle native dialogs invoked during the test run, specify a handler function
 using the `setNativeDialogHandler` method of the


### PR DESCRIPTION
The header should be `setNativeDailogHandler` instead of `setNativeDailogueHandler`. 
