### PR TITLE
Enable multiwindow only for Chromium-based and Firefox

### DIFF
--- a/src/browser/provider/built-in/locally-installed.js
+++ b/src/browser/provider/built-in/locally-installed.js
@@ -1,27 +1,11 @@
 import browserTools from 'testcafe-browser-tools';
 
 export default {
-    openedBrowsers: {},
-
     isMultiBrowser: true,
-
-    supportMultipleWindows: true,
 
     needCleanUpBrowserInfo: true,
 
-    getActiveWindowId (browserId) {
-        return this.openedBrowsers[browserId].activeWindowId;
-    },
-
-    setActiveWindowId (browserId, val) {
-        this.openedBrowsers[browserId].activeWindowId = val;
-    },
-
-    cleanUpBrowserInfo (browserId) {
-        delete this.openedBrowsers[browserId];
-    },
-
-    async openBrowser (browserId, pageUrl, browserName, disableMultipleWindows) {
+    async openBrowser (browserId, pageUrl, browserName,) {
         const args  = browserName.split(' ');
         const alias = args.shift();
 
@@ -32,13 +16,6 @@ export default {
             openParameters.cmd = args.join(' ') + (openParameters.cmd ? ' ' + openParameters.cmd : '');
 
         await browserTools.open(openParameters, pageUrl);
-
-        let activeWindowId = null;
-
-        if (!disableMultipleWindows)
-            activeWindowId = this.calculateWindowId();
-
-        this.openedBrowsers[browserId] = { activeWindowId };
     },
 
     async isLocalBrowser () {

--- a/src/browser/provider/built-in/locally-installed.js
+++ b/src/browser/provider/built-in/locally-installed.js
@@ -3,9 +3,7 @@ import browserTools from 'testcafe-browser-tools';
 export default {
     isMultiBrowser: true,
 
-    needCleanUpBrowserInfo: true,
-
-    async openBrowser (browserId, pageUrl, browserName,) {
+    async openBrowser (browserId, pageUrl, browserName) {
         const args  = browserName.split(' ');
         const alias = args.shift();
 

--- a/src/errors/test-run/templates.js
+++ b/src/errors/test-run/templates.js
@@ -367,7 +367,7 @@ export default {
 
     [TEST_RUN_ERRORS.switchToWindowPredicateError]: err => `
         An error occurred inside the "switchToWindow" argument function.
-        
+
         Error details:
         ${escapeHtml(err.errMsg)}
     `,
@@ -377,6 +377,6 @@ export default {
     `,
 
     [TEST_RUN_ERRORS.multipleWindowsModeIsNotSupportedInRemoteBrowserError]: err => `
-        Multi window mode is supported in local browsers only. Run tests locally to use the "${err.methodName}" method.
+        Multi window mode is supported in Chrome, Chromium, Edge 84+ and Firefox only. Run tests in these browsers to use the "${err.methodName}" method.
     `,
 };

--- a/test/functional/fixtures/api/es-next/multiple-windows/test.js
+++ b/test/functional/fixtures/api/es-next/multiple-windows/test.js
@@ -6,7 +6,7 @@ if (!config.useLocalBrowsers) {
         it('Should fail on remote', function () {
             return runTests('./testcafe-fixtures/multiple-windows-test.js', 'Should fail on remote', { shouldFail: true })
                 .catch(errs => {
-                    expect(errs[0]).to.contain('Multi window mode is supported in local browsers only. Run tests locally to use the "openWindow" method');
+                    expect(errs[0]).to.contain('Multi window mode is supported in Chrome, Chromium, Edge 84+ and Firefox only. Run tests in these browsers to use the "openWindow" method');
                 });
         });
     });

--- a/test/server/browser-provider-test.js
+++ b/test/server/browser-provider-test.js
@@ -1,19 +1,20 @@
-const expect                    = require('chai').expect;
-const { noop, stubFalse }       = require('lodash');
-const nanoid                    = require('nanoid');
-const { rmdirSync, statSync }   = require('fs');
-const { join, dirname }         = require('path');
-const proxyquire                = require('proxyquire');
-const sinon                     = require('sinon');
-const Module                    = require('module');
-const dedent                    = require('dedent');
-const browserProviderPool       = require('../../lib/browser/provider/pool');
-const parseProviderName         = require('../../lib/browser/provider/parse-provider-name');
-const BrowserConnection         = require('../../lib/browser/connection');
-const ProviderCtor              = require('../../lib/browser/provider/');
-const WARNING_MESSAGE           = require('../../lib/notifications/warning-message');
-const BrowserProviderPluginHost = require('../../lib/browser/provider/plugin-host');
-const WarningLog                = require('../../lib/notifications/warning-log');
+const expect                          = require('chai').expect;
+const { noop, stubFalse, pick, omit } = require('lodash');
+const nanoid                          = require('nanoid');
+const { rmdirSync, statSync }         = require('fs');
+const { join, dirname }               = require('path');
+const proxyquire                      = require('proxyquire');
+const sinon                           = require('sinon');
+const Module                          = require('module');
+const dedent                          = require('dedent');
+const browserProviderPool             = require('../../lib/browser/provider/pool');
+const BUILTIN_PROVIDERS               = require('../../lib/browser/provider/built-in');
+const parseProviderName               = require('../../lib/browser/provider/parse-provider-name');
+const BrowserConnection               = require('../../lib/browser/connection');
+const ProviderCtor                    = require('../../lib/browser/provider/');
+const WARNING_MESSAGE                 = require('../../lib/notifications/warning-message');
+const BrowserProviderPluginHost       = require('../../lib/browser/provider/plugin-host');
+const WarningLog                      = require('../../lib/notifications/warning-log');
 
 class BrowserConnectionMock extends BrowserConnection {
     constructor () {
@@ -423,6 +424,24 @@ describe('Browser provider', function () {
             await provider.openBrowser(bc.id);
 
             expect(debugMock.data['testcafe:browser:provider:built-in:remote']).eql('Error: SomeError');
+        });
+    });
+
+    describe('Features', () => {
+        const PROVIDERS_WITH_MULTIWINDOW_MODE = ['chrome', 'chromium', 'chrome-canary', 'edge', 'firefox'];
+
+        it('Should support multiwindow mode in some providers', async () => {
+            const providers = pick(BUILTIN_PROVIDERS, PROVIDERS_WITH_MULTIWINDOW_MODE);
+
+            for (const [name, plugin] of Object.entries(providers))
+                expect(plugin.supportMultipleWindows, `Provider ${name} should support multiple windows`).ok;
+        });
+
+        it('Should not support multiwindow mode in other providers', async () => {
+            const providers = omit(BUILTIN_PROVIDERS, PROVIDERS_WITH_MULTIWINDOW_MODE);
+
+            for (const [name, plugin] of Object.entries(providers))
+                expect(plugin.supportMultipleWindows, `Provider ${name} should not support multiple windows`).not.ok;
         });
     });
 

--- a/test/server/data/expected-test-run-errors/multiple-windows-mode-is-not-available-in-remote-browser-error
+++ b/test/server/data/expected-test-run-errors/multiple-windows-mode-is-not-available-in-remote-browser-error
@@ -1,5 +1,5 @@
-Multi window mode is supported in local browsers only. Run tests locally to
-use the "openWindow" method.
+Multi window mode is supported in Chrome, Chromium, Edge 84+ and Firefox
+only. Run tests in these browsers to use the "openWindow" method.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>


### PR DESCRIPTION
To disable multiwindow mode for all browsers except Chrome(Chromium, Edge 84+) and Firefox, we should disable multiwindow mode for all locally installed installed browsers, since Chrome and Firefox use separate providers and have separate implementations that enable the multiwindow functionality.