### PR TITLE
Add exception handling in Reporter

### DIFF
--- a/src/errors/runtime/index.js
+++ b/src/errors/runtime/index.js
@@ -120,6 +120,6 @@ export class ReporterPluginError extends GeneralError {
     constructor ({ name, method, originalError }) {
         const code = RUNTIME_ERRORS.uncaughtErrorInReporter;
 
-        super(code, method, name, originalError.stack);
+        super(code, name, method, originalError.stack);
     }
 }

--- a/src/errors/runtime/index.js
+++ b/src/errors/runtime/index.js
@@ -116,19 +116,10 @@ export class CompositeError extends Error {
     }
 }
 
-export class ReporterPluginError extends Error {
-    constructor (originalError) {
-        const template     = TEMPLATES[RUNTIME_ERRORS.uncaughtErrorInReporter];
-        const errorMessage = originalError.toString();
+export class ReporterPluginError extends GeneralError {
+    constructor ({ name, method, originalError }) {
+        const code = RUNTIME_ERRORS.uncaughtErrorInReporter;
 
-        super(renderTemplate(template, errorMessage));
-
-        Object.assign(this, {
-            code: RUNTIME_ERRORS.uncaughtErrorInReporter,
-            data: [errorMessage]
-        });
-
-        // NOTE: stack helps to identify broken reporter plugin
-        this.stack = renderTemplate(template, originalError.stack);
+        super(code, method, name, originalError.stack);
     }
 }

--- a/src/errors/runtime/index.js
+++ b/src/errors/runtime/index.js
@@ -115,3 +115,20 @@ export class CompositeError extends Error {
         this.code  = RUNTIME_ERRORS.compositeArgumentsError;
     }
 }
+
+export class ReporterPluginError extends Error {
+    constructor (originalError) {
+        const template     = TEMPLATES[RUNTIME_ERRORS.uncaughtErrorInReporter];
+        const errorMessage = originalError.toString();
+
+        super(renderTemplate(template, errorMessage));
+
+        Object.assign(this, {
+            code: RUNTIME_ERRORS.uncaughtErrorInReporter,
+            data: [errorMessage]
+        });
+
+        // NOTE: stack helps to identify broken reporter plugin
+        this.stack = renderTemplate(template, originalError.stack);
+    }
+}

--- a/src/errors/runtime/templates.js
+++ b/src/errors/runtime/templates.js
@@ -107,5 +107,6 @@ export default {
         'If you use a portable browser version, ' +
         'specify the browser alias before the path instead of the \'path\' prefix. ' +
         'For more information, see https://devexpress.github.io/testcafe/documentation/guides/concepts/browsers.html#test-in-headless-mode',
-    [RUNTIME_ERRORS.uncaughtErrorInReporter]: 'An uncaught error occured in a reporter:\n{error}',
+
+    [RUNTIME_ERRORS.uncaughtErrorInReporter]: 'An uncaught error occured in the \'{methodName}\' method of the \'{reporterName}\' reporter. Details:\n{originalError}',
 };

--- a/src/errors/runtime/templates.js
+++ b/src/errors/runtime/templates.js
@@ -107,4 +107,5 @@ export default {
         'If you use a portable browser version, ' +
         'specify the browser alias before the path instead of the \'path\' prefix. ' +
         'For more information, see https://devexpress.github.io/testcafe/documentation/guides/concepts/browsers.html#test-in-headless-mode',
+    [RUNTIME_ERRORS.uncaughtErrorInReporter]: 'An uncaught error occured in a reporter:\n{error}',
 };

--- a/src/errors/runtime/templates.js
+++ b/src/errors/runtime/templates.js
@@ -108,5 +108,5 @@ export default {
         'specify the browser alias before the path instead of the \'path\' prefix. ' +
         'For more information, see https://devexpress.github.io/testcafe/documentation/guides/concepts/browsers.html#test-in-headless-mode',
 
-    [RUNTIME_ERRORS.uncaughtErrorInReporter]: 'An uncaught error occured in the \'{methodName}\' method of the \'{reporterName}\' reporter. Details:\n{originalError}',
+    [RUNTIME_ERRORS.uncaughtErrorInReporter]: 'An uncaught error occurred in the "{reporterName}" reporter\'s "{methodName}" method. Error details:\n{originalError}',
 };

--- a/src/errors/types.js
+++ b/src/errors/types.js
@@ -141,4 +141,5 @@ export const RUNTIME_ERRORS = {
     unexpectedIPCBodyPacket:                            'E1053',
     unexpectedIPCTailPacket:                            'E1054',
     cannotRunLocalNonHeadlessBrowserWithoutDisplay:     'E1057',
+    uncaughtErrorInReporter:                            'E1058',
 };

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -103,7 +103,7 @@ export default class Reporter {
             nextReportItem = this.reportQueue[0];
 
             await this.dispatchToPlugin({
-                method: ReporterPluginMethod.TestDone,
+                method: ReporterPluginMethod.reportTestDone,
                 args:   [
                     reportItem.test.name,
                     reportItem.testRunInfo,
@@ -118,7 +118,7 @@ export default class Reporter {
                 continue;
 
             await this.dispatchToPlugin({
-                method: ReporterPluginMethod.FixtureStart,
+                method: ReporterPluginMethod.reportFixtureStart,
                 args:   [
                     nextReportItem.fixture.name,
                     nextReportItem.fixture.path,
@@ -214,7 +214,7 @@ export default class Reporter {
         };
 
         await this.dispatchToPlugin({
-            method: ReporterPluginMethod.TaskStart,
+            method: ReporterPluginMethod.reportTaskStart,
             args:   [
                 startTime,
                 userAgents,
@@ -225,7 +225,7 @@ export default class Reporter {
         });
 
         await this.dispatchToPlugin({
-            method: ReporterPluginMethod.FixtureStart,
+            method: ReporterPluginMethod.reportFixtureStart,
             args:   [
                 first.fixture.name,
                 first.fixture.path,
@@ -249,7 +249,7 @@ export default class Reporter {
                 const testStartInfo = { testRunIds: reportItem.testRunIds, testId: reportItem.test.id };
 
                 await this.dispatchToPlugin({
-                    method: ReporterPluginMethod.TestStart,
+                    method: ReporterPluginMethod.reportTestStart,
                     args:   [
                         reportItem.test.name,
                         reportItem.test.meta,
@@ -286,7 +286,7 @@ export default class Reporter {
             restArgs = this._prepareReportTestActionEventArgs(restArgs);
 
             await this.dispatchToPlugin({
-                method: ReporterPluginMethod.TestActionStart,
+                method: ReporterPluginMethod.reportTestActionStart,
                 args:   [
                     apiActionName,
                     restArgs
@@ -300,7 +300,7 @@ export default class Reporter {
             restArgs = this._prepareReportTestActionEventArgs(restArgs);
 
             await this.dispatchToPlugin({
-                method: ReporterPluginMethod.TestActionDone,
+                method: ReporterPluginMethod.reportTestActionDone,
                 args:   [
                     apiActionName,
                     restArgs
@@ -319,7 +319,7 @@ export default class Reporter {
         };
 
         await this.dispatchToPlugin({
-            method: ReporterPluginMethod.TaskDone,
+            method: ReporterPluginMethod.reportTaskDone,
             args:   [
                 endTime,
                 this.passed,

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -195,7 +195,7 @@ export default class Reporter {
         }
         catch (originalError) {
             const uncaughError = new ReporterPluginError({
-                name: typeof this.plugin.name === 'string' ? this.plugin.name : 'customReporter',
+                name: this.plugin.name,
                 method,
                 originalError
             });

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -188,10 +188,7 @@ export default class Reporter {
         });
     }
 
-    async dispatchToPlugin ({ method, args = [], optional = false }) {
-        if (!this.plugin[method] && optional)
-            return;
-
+    async dispatchToPlugin ({ method, args = [] }) {
         try {
             await this.plugin[method](...args);
         }
@@ -247,17 +244,18 @@ export default class Reporter {
         reportItem.pendingStarts--;
 
         if (!reportItem.pendingStarts) {
-            const testStartInfo = { testRunIds: reportItem.testRunIds, testId: reportItem.test.id };
+            if (this.plugin.reportTestStart) {
+                const testStartInfo = { testRunIds: reportItem.testRunIds, testId: reportItem.test.id };
 
-            await this.dispatchToPlugin({
-                method:   'reportTestStart',
-                optional: true,
-                args:     [
-                    reportItem.test.name,
-                    reportItem.test.meta,
-                    testStartInfo
-                ]
-            });
+                await this.dispatchToPlugin({
+                    method: 'reportTestStart',
+                    args:   [
+                        reportItem.test.name,
+                        reportItem.test.meta,
+                        testStartInfo
+                    ]
+                });
+            }
 
             reportItem.pendingTestRunStartPromise.resolve();
         }
@@ -283,29 +281,31 @@ export default class Reporter {
     }
 
     async _onTaskTestActionStart ({ apiActionName, ...restArgs }) {
-        restArgs = this._prepareReportTestActionEventArgs(restArgs);
+        if (this.plugin.reportTestActionStart) {
+            restArgs = this._prepareReportTestActionEventArgs(restArgs);
 
-        await this.dispatchToPlugin({
-            method:   'reportTestActionStart',
-            optional: true,
-            args:     [
-                apiActionName,
-                restArgs
-            ]
-        });
+            await this.dispatchToPlugin({
+                method: 'reportTestActionStart',
+                args:   [
+                    apiActionName,
+                    restArgs
+                ]
+            });
+        }
     }
 
     async _onTaskTestActionDone ({ apiActionName, ...restArgs }) {
-        restArgs = this._prepareReportTestActionEventArgs(restArgs);
+        if (this.plugin.reportTestActionDone) {
+            restArgs = this._prepareReportTestActionEventArgs(restArgs);
 
-        await this.dispatchToPlugin({
-            method:   'reportTestActionDone',
-            optional: true,
-            args:     [
-                apiActionName,
-                restArgs
-            ]
-        });
+            await this.dispatchToPlugin({
+                method: 'reportTestActionDone',
+                args:   [
+                    apiActionName,
+                    restArgs
+                ]
+            });
+        }
     }
 
     async _onceTaskDoneHandler () {

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -3,6 +3,7 @@ import { writable as isWritableStream } from 'is-stream';
 import ReporterPluginHost from './plugin-host';
 import formatCommand from './command/format-command';
 import getBrowser from '../utils/get-browser';
+import { ReporterPluginError } from '../errors/runtime';
 
 export default class Reporter {
     constructor (plugin, task, outStream, name) {
@@ -100,10 +101,25 @@ export default class Reporter {
             // fixture, we can report this fixture start.
             nextReportItem = this.reportQueue[0];
 
-            await this.plugin.reportTestDone(reportItem.test.name, reportItem.testRunInfo, reportItem.test.meta);
+            try {
+                await this.plugin.reportTestDone(reportItem.test.name, reportItem.testRunInfo, reportItem.test.meta);
+            }
+            catch (e) {
+                this.task.emit('error', new ReporterPluginError(e));
+            }
 
-            if (nextReportItem && nextReportItem.fixture !== currentFixture)
-                await this.plugin.reportFixtureStart(nextReportItem.fixture.name, nextReportItem.fixture.path, nextReportItem.fixture.meta);
+            if (nextReportItem && nextReportItem.fixture !== currentFixture) {
+                try {
+                    await this.plugin.reportFixtureStart(
+                        nextReportItem.fixture.name,
+                        nextReportItem.fixture.path,
+                        nextReportItem.fixture.meta
+                    );
+                }
+                catch (e) {
+                    this.task.emit('error', new ReporterPluginError(e));
+                }
+            }
         }
     }
 
@@ -168,90 +184,134 @@ export default class Reporter {
         });
     }
 
+    async _onceTaskStartHandler () {
+        const startTime  = new Date();
+        const userAgents = this.task.browserConnectionGroups.map(group => group[0].userAgent);
+        const first      = this.reportQueue[0];
+        const taskProperties = {
+            configuration: this.task.opts
+        };
+
+        try {
+            await this.plugin.reportTaskStart(
+                startTime,
+                userAgents,
+                this.testCount,
+                this.task.testStructure,
+                taskProperties
+            );
+
+            await this.plugin.reportFixtureStart(first.fixture.name, first.fixture.path, first.fixture.meta);
+        }
+        catch (e) {
+            this.task.emit('error', new ReporterPluginError(e));
+        }
+    }
+
+    async _onTaskTestRunStartHandler (testRun) {
+        const reportItem = this._getReportItemForTestRun(testRun);
+
+        reportItem.testRunIds.push(testRun.id);
+
+        if (!reportItem.startTime)
+            reportItem.startTime = new Date();
+
+        reportItem.pendingStarts--;
+
+        if (!reportItem.pendingStarts) {
+            if (this.plugin.reportTestStart) {
+                const testStartInfo = { testRunIds: reportItem.testRunIds, testId: reportItem.test.id };
+
+                try {
+                    await this.plugin.reportTestStart(reportItem.test.name, reportItem.test.meta, testStartInfo);
+                }
+                catch (e) {
+                    this.task.emit('error', new ReporterPluginError(e));
+                }
+            }
+
+            reportItem.pendingTestRunStartPromise.resolve();
+        }
+
+        return reportItem.pendingTestRunStartPromise;
+    }
+
+    async _onTaskTestRunDoneHandler (testRun) {
+        const reportItem                    = this._getReportItemForTestRun(testRun);
+        const isTestRunStoppedTaskExecution = !!testRun.errs.length && this.stopOnFirstFail;
+
+        reportItem.pendingRuns = isTestRunStoppedTaskExecution ? 0 : reportItem.pendingRuns - 1;
+        reportItem.unstable    = reportItem.unstable || testRun.unstable;
+        reportItem.errs        = reportItem.errs.concat(testRun.errs);
+        reportItem.warnings    = testRun.warningLog ? union(reportItem.warnings, testRun.warningLog.messages) : [];
+
+        reportItem.browsers.push(Object.assign({ testRunId: testRun.id }, getBrowser(testRun.browserConnection)));
+
+        if (!reportItem.pendingRuns)
+            await this._resolveReportItem(reportItem, testRun);
+
+        await reportItem.pendingTestRunDonePromise;
+    }
+
+    async _onTaskTestActionStart ({ apiActionName, ...args }) {
+        if (this.plugin.reportTestActionStart) {
+            args = this._prepareReportTestActionEventArgs(args);
+
+            try {
+                await this.plugin.reportTestActionStart(apiActionName, args);
+            }
+            catch (e) {
+                this.task.emit('error', new ReporterPluginError(e));
+            }
+        }
+    }
+
+    async _onTaskTestActionDone ({ apiActionName, ...args }) {
+        if (this.plugin.reportTestActionDone) {
+            args = this._prepareReportTestActionEventArgs(args);
+
+            try {
+                await this.plugin.reportTestActionDone(apiActionName, args);
+            }
+            catch (e) {
+                this.task.emit('error', new ReporterPluginError(e));
+            }
+        }
+    }
+
+    async _onceTaskDoneHandler () {
+        const endTime = new Date();
+
+        const result = {
+            passedCount:  this.passed,
+            failedCount:  this.failed,
+            skippedCount: this.skipped
+        };
+
+        try {
+            await this.plugin.reportTaskDone(endTime, this.passed, this.task.warningLog.messages, result);
+        }
+        catch (e) {
+            this.task.emit('error', new ReporterPluginError(e));
+        }
+
+        this.pendingTaskDonePromise.resolve();
+    }
+
     _assignTaskEventHandlers () {
         const task = this.task;
 
-        task.once('start', async () => {
-            const startTime  = new Date();
-            const userAgents = task.browserConnectionGroups.map(group => group[0].userAgent);
-            const first      = this.reportQueue[0];
-            const taskProperties = {
-                configuration: task.opts
-            };
+        task.once('start', async () => await this._onceTaskStartHandler());
 
-            await this.plugin.reportTaskStart(startTime, userAgents, this.testCount, task.testStructure, taskProperties);
-            await this.plugin.reportFixtureStart(first.fixture.name, first.fixture.path, first.fixture.meta);
-        });
+        task.on('test-run-start', async testRun => await this._onTaskTestRunStartHandler(testRun));
 
-        task.on('test-run-start', async testRun => {
-            const reportItem = this._getReportItemForTestRun(testRun);
+        task.on('test-run-done', async testRun => await this._onTaskTestRunDoneHandler(testRun));
 
-            reportItem.testRunIds.push(testRun.id);
+        task.on('test-action-start', async e => await this._onTaskTestActionStart(e));
 
-            if (!reportItem.startTime)
-                reportItem.startTime = new Date();
+        task.on('test-action-done', async e => await this._onTaskTestActionDone(e));
 
-            reportItem.pendingStarts--;
-
-            if (!reportItem.pendingStarts) {
-                if (this.plugin.reportTestStart) {
-                    const testStartInfo = { testRunIds: reportItem.testRunIds, testId: reportItem.test.id };
-
-                    await this.plugin.reportTestStart(reportItem.test.name, reportItem.test.meta, testStartInfo);
-                }
-
-                reportItem.pendingTestRunStartPromise.resolve();
-            }
-
-            return reportItem.pendingTestRunStartPromise;
-        });
-
-        task.on('test-run-done', async testRun => {
-            const reportItem                    = this._getReportItemForTestRun(testRun);
-            const isTestRunStoppedTaskExecution = !!testRun.errs.length && this.stopOnFirstFail;
-
-            reportItem.pendingRuns = isTestRunStoppedTaskExecution ? 0 : reportItem.pendingRuns - 1;
-            reportItem.unstable    = reportItem.unstable || testRun.unstable;
-            reportItem.errs        = reportItem.errs.concat(testRun.errs);
-            reportItem.warnings    = testRun.warningLog ? union(reportItem.warnings, testRun.warningLog.messages) : [];
-
-            reportItem.browsers.push(Object.assign({ testRunId: testRun.id }, getBrowser(testRun.browserConnection)));
-
-            if (!reportItem.pendingRuns)
-                await this._resolveReportItem(reportItem, testRun);
-
-            await reportItem.pendingTestRunDonePromise;
-        });
-
-        task.on('test-action-start', async ({ apiActionName, ...args }) => {
-            if (this.plugin.reportTestActionStart) {
-                args = this._prepareReportTestActionEventArgs(args);
-
-                await this.plugin.reportTestActionStart(apiActionName, args);
-            }
-        });
-
-        task.on('test-action-done', async ({ apiActionName, ...args }) => {
-            if (this.plugin.reportTestActionDone) {
-                args = this._prepareReportTestActionEventArgs(args);
-
-                await this.plugin.reportTestActionDone(apiActionName, args);
-            }
-        });
-
-        task.once('done', async () => {
-            const endTime = new Date();
-
-            const result = {
-                passedCount:  this.passed,
-                failedCount:  this.failed,
-                skippedCount: this.skipped
-            };
-
-            await this.plugin.reportTaskDone(endTime, this.passed, task.warningLog.messages, result);
-
-            this.pendingTaskDonePromise.resolve();
-        });
+        task.once('done', async () => await this._onceTaskDoneHandler());
     }
 
     async dispose () {

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -1,6 +1,7 @@
 import { find, sortBy, union } from 'lodash';
 import { writable as isWritableStream } from 'is-stream';
 import ReporterPluginHost from './plugin-host';
+import ReporterPluginMethod from './plugin-methods';
 import formatCommand from './command/format-command';
 import getBrowser from '../utils/get-browser';
 import { ReporterPluginError } from '../errors/runtime';
@@ -102,7 +103,7 @@ export default class Reporter {
             nextReportItem = this.reportQueue[0];
 
             await this.dispatchToPlugin({
-                method: 'reportTestDone',
+                method: ReporterPluginMethod.TestDone,
                 args:   [
                     reportItem.test.name,
                     reportItem.testRunInfo,
@@ -117,7 +118,7 @@ export default class Reporter {
                 continue;
 
             await this.dispatchToPlugin({
-                method: 'reportFixtureStart',
+                method: ReporterPluginMethod.FixtureStart,
                 args:   [
                     nextReportItem.fixture.name,
                     nextReportItem.fixture.path,
@@ -213,7 +214,7 @@ export default class Reporter {
         };
 
         await this.dispatchToPlugin({
-            method: 'reportTaskStart',
+            method: ReporterPluginMethod.TaskStart,
             args:   [
                 startTime,
                 userAgents,
@@ -224,7 +225,7 @@ export default class Reporter {
         });
 
         await this.dispatchToPlugin({
-            method: 'reportFixtureStart',
+            method: ReporterPluginMethod.FixtureStart,
             args:   [
                 first.fixture.name,
                 first.fixture.path,
@@ -248,7 +249,7 @@ export default class Reporter {
                 const testStartInfo = { testRunIds: reportItem.testRunIds, testId: reportItem.test.id };
 
                 await this.dispatchToPlugin({
-                    method: 'reportTestStart',
+                    method: ReporterPluginMethod.TestStart,
                     args:   [
                         reportItem.test.name,
                         reportItem.test.meta,
@@ -285,7 +286,7 @@ export default class Reporter {
             restArgs = this._prepareReportTestActionEventArgs(restArgs);
 
             await this.dispatchToPlugin({
-                method: 'reportTestActionStart',
+                method: ReporterPluginMethod.TestActionStart,
                 args:   [
                     apiActionName,
                     restArgs
@@ -299,7 +300,7 @@ export default class Reporter {
             restArgs = this._prepareReportTestActionEventArgs(restArgs);
 
             await this.dispatchToPlugin({
-                method: 'reportTestActionDone',
+                method: ReporterPluginMethod.TestActionDone,
                 args:   [
                     apiActionName,
                     restArgs
@@ -318,7 +319,7 @@ export default class Reporter {
         };
 
         await this.dispatchToPlugin({
-            method: 'reportTaskDone',
+            method: ReporterPluginMethod.TaskDone,
             args:   [
                 endTime,
                 this.passed,

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -188,7 +188,7 @@ export default class Reporter {
         });
     }
 
-    async dispatchToPlugin ({ method, args, optional = false }) {
+    async dispatchToPlugin ({ method, args = [], optional = false }) {
         if (!this.plugin[method] && optional)
             return;
 
@@ -282,28 +282,28 @@ export default class Reporter {
         await reportItem.pendingTestRunDonePromise;
     }
 
-    async _onTaskTestActionStart ({ apiActionName, ...args }) {
-        args = this._prepareReportTestActionEventArgs(args);
+    async _onTaskTestActionStart ({ apiActionName, ...restArgs }) {
+        restArgs = this._prepareReportTestActionEventArgs(restArgs);
 
         await this.dispatchToPlugin({
             method:   'reportTestActionStart',
             optional: true,
             args:     [
                 apiActionName,
-                args
+                restArgs
             ]
         });
     }
 
-    async _onTaskTestActionDone ({ apiActionName, ...args }) {
-        args = this._prepareReportTestActionEventArgs(args);
+    async _onTaskTestActionDone ({ apiActionName, ...restArgs }) {
+        restArgs = this._prepareReportTestActionEventArgs(restArgs);
 
         await this.dispatchToPlugin({
             method:   'reportTestActionDone',
             optional: true,
             args:     [
                 apiActionName,
-                args
+                restArgs
             ]
         });
     }

--- a/src/reporter/interfaces.ts
+++ b/src/reporter/interfaces.ts
@@ -1,6 +1,14 @@
 import { Writable as WritableStream } from 'stream';
 
-type ReporterPlugin = unknown;
+export interface ReporterPlugin {
+    reportTaskStart(): void;
+    reportFixtureStart(): void;
+    reportTestStart?(): void;
+    reportTestActionStart?(): void;
+    reportTestActionDone?(): void;
+    reportTestDone(): void;
+    reportTaskDone(): void;
+}
 
 export interface ReporterSource {
     name: string;

--- a/src/reporter/interfaces.ts
+++ b/src/reporter/interfaces.ts
@@ -1,0 +1,17 @@
+import { Writable as WritableStream } from 'stream';
+
+type ReporterPlugin = unknown;
+
+export interface ReporterSource {
+    name: string;
+    output?: string | WritableStream;
+}
+
+export interface ReporterPluginSource {
+    plugin: ReporterPlugin;
+    outStream?: WritableStream;
+}
+
+export interface ReporterPluginFactory {
+    (): ReporterPlugin;
+}

--- a/src/reporter/plugin-methods.ts
+++ b/src/reporter/plugin-methods.ts
@@ -1,11 +1,14 @@
-enum ReporterPluginMethod {
-    TaskStart = 'reportTaskStart',
-    FixtureStart = 'reportFixtureStart',
-    TestStart = 'reportTestStart',
-    TestActionStart = 'reportTestActionStart',
-    TestActionDone = 'reportTestActionDone',
-    TestDone = 'reportTestDone',
-    TaskDone = 'reportTaskDone'
-}
+import { ReporterPlugin } from './interfaces';
+import { EnumFromPropertiesOf } from '../utils/types';
+
+const ReporterPluginMethod: EnumFromPropertiesOf<ReporterPlugin> = {
+    reportTaskStart:       'reportTaskStart',
+    reportFixtureStart:    'reportFixtureStart',
+    reportTestStart:       'reportTestStart',
+    reportTestActionStart: 'reportTestActionStart',
+    reportTestActionDone:  'reportTestActionDone',
+    reportTestDone:        'reportTestDone',
+    reportTaskDone:        'reportTaskDone'
+};
 
 export default ReporterPluginMethod;

--- a/src/reporter/plugin-methods.ts
+++ b/src/reporter/plugin-methods.ts
@@ -1,0 +1,11 @@
+enum ReporterPluginMethod {
+    TaskStart = 'reportTaskStart',
+    FixtureStart = 'reportFixtureStart',
+    TestStart = 'reportTestStart',
+    TestActionStart = 'reportTestActionStart',
+    TestActionDone = 'reportTestActionDone',
+    TestDone = 'reportTestDone',
+    TaskDone = 'reportTaskDone'
+}
+
+export default ReporterPluginMethod;

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -118,6 +118,7 @@ export default class Runner extends EventEmitter {
         }
 
         const browserSetErrorPromise = promisifyEvent(browserSet, 'error');
+        const taskErrorPromise       = promisifyEvent(task, 'error');
         const streamController       = new ReporterStreamController(task, reporters);
 
         const taskDonePromise = task.once('done')
@@ -128,7 +129,8 @@ export default class Runner extends EventEmitter {
 
         const promises = [
             taskDonePromise,
-            browserSetErrorPromise
+            browserSetErrorPromise,
+            taskErrorPromise
         ];
 
         if (testedApp)
@@ -169,6 +171,8 @@ export default class Runner extends EventEmitter {
         }
 
         task.on('done', stopHandlingTestErrors);
+
+        task.on('error', stopHandlingTestErrors);
 
         const onTaskCompleted = () => {
             task.unRegisterClientScriptRouting();

--- a/src/runner/task.ts
+++ b/src/runner/task.ts
@@ -31,7 +31,7 @@ export default class Task extends AsyncEventEmitter {
     public readonly videos?: Videos;
 
     public constructor (tests: Test[], browserConnectionGroups: BrowserConnection[][], proxy: Proxy, opts: Dictionary<OptionValue>) {
-        super();
+        super({ captureRejections: true });
 
         this._timeStamp              = moment();
         this._running                = false;

--- a/src/utils/async-event-emitter.ts
+++ b/src/utils/async-event-emitter.ts
@@ -1,6 +1,14 @@
 import Emittery from 'emittery';
 
 export default class AsyncEventEmitter extends Emittery {
+    private readonly captureRejections: boolean;
+
+    public constructor ({ captureRejections = true } = {}) {
+        super();
+
+        this.captureRejections = captureRejections;
+    }
+
     public once (event: string, listener?: Function): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
         if (!listener)
             return super.once(event);
@@ -17,7 +25,7 @@ export default class AsyncEventEmitter extends Emittery {
     public emit (eventName: string, ...args: unknown[]): Promise<void> {
         const emitPromise = super.emit(eventName, ...args);
 
-        if (eventName !== 'error')
+        if (this.captureRejections && eventName !== 'error')
             emitPromise.catch(reason => this.emit('error', reason));
 
         return emitPromise;

--- a/src/utils/async-event-emitter.ts
+++ b/src/utils/async-event-emitter.ts
@@ -3,7 +3,7 @@ import Emittery from 'emittery';
 export default class AsyncEventEmitter extends Emittery {
     private readonly captureRejections: boolean;
 
-    public constructor ({ captureRejections = true } = {}) {
+    public constructor ({ captureRejections = false } = {}) {
         super();
 
         this.captureRejections = captureRejections;

--- a/src/utils/reporter.ts
+++ b/src/utils/reporter.ts
@@ -1,0 +1,30 @@
+import { ReporterPluginFactory } from '../reporter/interfaces';
+import { GeneralError } from '../errors/runtime';
+import { RUNTIME_ERRORS } from '../errors/types';
+
+export function requireReporterPluginFactory (reporterName: string): ReporterPluginFactory {
+    try {
+        return require('testcafe-reporter-' + reporterName);
+    }
+    catch (err) {
+        throw new GeneralError(RUNTIME_ERRORS.cannotFindReporterForAlias, reporterName);
+    }
+}
+
+export function getPluginFactory (reporterFactorySource: string | ReporterPluginFactory): ReporterPluginFactory {
+    if (!isReporterPluginFactory(reporterFactorySource))
+        return requireReporterPluginFactory(reporterFactorySource);
+
+    return reporterFactorySource;
+}
+
+export function isReporterPluginFactory (value: string | Function): value is ReporterPluginFactory {
+    return typeof value === 'function';
+}
+
+export function processReporterName (value: string | Function): string {
+    if (isReporterPluginFactory(value))
+        return (value as Function).name || 'function () {}';
+
+    return value as string;
+}

--- a/src/utils/reporter.ts
+++ b/src/utils/reporter.ts
@@ -22,9 +22,9 @@ export function isReporterPluginFactory (value: string | Function): value is Rep
     return typeof value === 'function';
 }
 
-export function processReporterName (value: string | Function): string {
+export function processReporterName (value: string | ReporterPluginFactory): string {
     if (isReporterPluginFactory(value))
-        return (value as Function).name || 'function () {}';
+        return value.name || 'function () {}';
 
-    return value as string;
+    return value;
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,3 @@
+export type EnumFromPropertiesOf<T> = {
+    [P in keyof T]: Extract<keyof T, P>
+}

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -740,7 +740,7 @@ describe('Reporter', () => {
                 throw new Error('Promise rejection expected');
             }
             catch (err) {
-                expect(err.message).startsWith(`An uncaught error occured in the '${method}' method of the 'customReporter' reporter. Details:\nError: oops`);
+                expect(err.message).startsWith(`An uncaught error occured in the '${method}' method of the 'function () {}' reporter. Details:\nError: oops`);
             }
         }
     });

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -1,6 +1,7 @@
-const expect           = require('chai').expect;
-const fs               = require('fs');
-const generateReporter = require('./reporter');
+const expect               = require('chai').expect;
+const fs                   = require('fs');
+const generateReporter     = require('./reporter');
+const ReporterPluginMethod = require('../../../../lib/reporter/plugin-methods');
 
 const {
     createSimpleTestStream,
@@ -710,16 +711,6 @@ describe('Reporter', () => {
     });
 
     it('Should raise an error when uncaught exception occured in any reporter method', async () => {
-        const reporterMethods = [
-            'reportTaskStart',
-            'reportFixtureStart',
-            'reportTestStart',
-            'reportTestActionStart',
-            'reportTestActionDone',
-            'reportTestDone',
-            'reportTaskDone'
-        ];
-
         function createReporterWithBrokenMethod (method) {
             const base = {
                 async reportTaskStart () {},
@@ -735,7 +726,7 @@ describe('Reporter', () => {
             return () => base;
         }
 
-        for (const method of reporterMethods) {
+        for (const method of Object.values(ReporterPluginMethod)) {
             try {
                 await runTests(
                     'testcafe-fixtures/index-test.js',

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -740,7 +740,7 @@ describe('Reporter', () => {
                 throw new Error('Promise rejection expected');
             }
             catch (err) {
-                expect(err.message).startsWith(`An uncaught error occured in the '${method}' method of the 'function () {}' reporter. Details:\nError: oops`);
+                expect(err.message).startsWith(`An uncaught error occurred in the "function () {}" reporter's "${method}" method. Error details:\nError: oops`);
             }
         }
     });

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -2,6 +2,7 @@ const chai                            = require('chai');
 const { expect }                      = chai;
 const { chunk, random, noop, sortBy } = require('lodash');
 const Reporter                        = require('../../lib/reporter');
+const ReporterPluginMethod            = require('../../lib/reporter/plugin-methods');
 const Task                            = require('../../lib/runner/task');
 const Videos                          = require('../../lib/video-recorder/videos');
 const delay                           = require('../../lib/utils/delay');
@@ -1220,20 +1221,10 @@ describe('Reporter', () => {
     });
 
     it('Should dispatch uncaught exception from any plugin method to Task `error` event', async () => {
-        const reporterMethods = [
-            'reportTaskStart',
-            'reportFixtureStart',
-            'reportTestStart',
-            'reportTestActionStart',
-            'reportTestActionDone',
-            'reportTestDone',
-            'reportTaskDone'
-        ];
-
         function createBrokenReporter (task) {
             const reporterObject = {};
 
-            for (const method of reporterMethods) {
+            for (const method of Object.values(ReporterPluginMethod)) {
                 reporterObject[method] = () => {
                     throw new Error(`oops`);
                 };
@@ -1248,7 +1239,7 @@ describe('Reporter', () => {
 
         const reporter = createBrokenReporter(taskMock);
 
-        for (const method of reporterMethods) {
+        for (const method of Object.values(ReporterPluginMethod)) {
             await reporter.dispatchToPlugin({ method });
 
             const lastErr = log.pop();

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -1245,7 +1245,7 @@ describe('Reporter', () => {
             const lastErr = log.pop();
 
             expect(lastErr).instanceOf(ReporterPluginError);
-            expect(lastErr.message).startsWith(`An uncaught error occured in the '${method}' method of the 'customReporter' reporter. Details:\nError: oops`);
+            expect(lastErr.message).startsWith(`An uncaught error occurred in the "customReporter" reporter's "${method}" method. Error details:\nError: oops`);
         }
     });
 });

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -1230,7 +1230,7 @@ describe('Reporter', () => {
                 };
             }
 
-            return new Reporter(reporterObject, task);
+            return new Reporter(reporterObject, task, null, 'customReporter');
         }
 
         const taskMock = new TaskMock();
@@ -1244,7 +1244,7 @@ describe('Reporter', () => {
 
             const lastErr = log.pop();
 
-            expect(lastErr instanceof ReporterPluginError).to.be.true;
+            expect(lastErr).instanceOf(ReporterPluginError);
             expect(lastErr.message).startsWith(`An uncaught error occured in the '${method}' method of the 'customReporter' reporter. Details:\nError: oops`);
         }
     });


### PR DESCRIPTION
## Purpose
The exceptions which may be thrown by the methods of a reporter plugin leads to hanging of TestCafe. Moreover, Task event listeners in `Reporter` don't have any exception handling.

## Approach
* `AsyncEventEmitter` refactored:
  - `once` method worked incorrectly: resolve of a rejected promise could happen;
   - uncatched promise rejections from async event listeners should lead to emitting an `error` event. We need to handle this in our code, because [this](https://nodejs.org/api/events.html#events_capture_rejections_of_promises) thing is still experimental and emittery doesn't provide it.
* `Task` listeners/handlers are placed in separate methods of `Reporter`. 

## References
#5135

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
