### PR TITLE
Add warnings for missing await when trying to get a snapshot property value

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "cross-spawn": "^4.0.0",
     "devtools-protocol": "0.0.678506",
     "dom-walk": "^0.1.1",
+    "escape-string-regexp": "^4.0.0",
     "eslint-plugin-hammerhead": "0.3.1",
     "eslint-plugin-no-only-tests": "^2.0.1",
     "express": "^4.13.3",

--- a/src/api/test-run-tracker.d.ts
+++ b/src/api/test-run-tracker.d.ts
@@ -1,10 +1,12 @@
 import ObservedCallsitesStorage from '../test-run/observed-callsites-storage';
 import TestController from './test-controller';
+import WarningLog from '../notifications/warning-log';
 
 export interface TestRun {
     id: string;
     controller: TestController;
     observedCallsites: ObservedCallsitesStorage;
+    warningLog: WarningLog;
 
     executeAction(apiMethodName: string, command: unknown, callsite: unknown): Promise<unknown>;
 }

--- a/src/api/wrap-test-function.ts
+++ b/src/api/wrap-test-function.ts
@@ -3,7 +3,7 @@ import testRunTracker from './test-run-tracker';
 import { TestRun } from './test-run-tracker.d';
 import TestCafeErrorList from '../errors/error-list';
 import { MissingAwaitError } from '../errors/test-run';
-import addWarning from '../notifications/add-rendered-warning';
+import addRenderedWarning from '../notifications/add-rendered-warning';
 import WARNING_MESSAGES from '../notifications/warning-message';
 
 export default function wrapTestFunction (fn: Function): Function {
@@ -11,6 +11,20 @@ export default function wrapTestFunction (fn: Function): Function {
         let result       = null;
         const errList    = new TestCafeErrorList();
         const markeredfn = testRunTracker.addTrackingMarkerToFunction(testRun.id, fn);
+
+        function addWarnings (callsiteSet: Set<Record<string, any>>, message: string): void {
+            callsiteSet.forEach(callsite => {
+                addRenderedWarning(testRun.warningLog, message, callsite);
+                callsiteSet.delete(callsite);
+            });
+        }
+
+        function addErrors (callsiteSet: Set<Record<string, any>>, ErrorClass: any): void {
+            callsiteSet.forEach(callsite => {
+                errList.addError(new ErrorClass(callsite));
+                callsiteSet.delete(callsite);
+            });
+        }
 
         testRun.controller = new TestController(testRun);
 
@@ -26,16 +40,8 @@ export default function wrapTestFunction (fn: Function): Function {
         }
 
         if (!errList.hasUncaughtErrorsInTestCode) {
-            // These look very similar, should I extract them into a separate function?
-            for (const callsite of testRun.observedCallsites.callsitesWithoutAwait) {
-                errList.addError(new MissingAwaitError(callsite));
-                testRun.observedCallsites.callsitesWithoutAwait.delete(callsite);
-            }
-
-            for (const callsite of testRun.observedCallsites.unawaitedSnapshotCallsites) {
-                addWarning(testRun.warningLog, WARNING_MESSAGES.missingAwaitOnSnapshotProperty, callsite);
-                testRun.observedCallsites.unawaitedSnapshotCallsites.delete(callsite);
-            }
+            addWarnings(testRun.observedCallsites.unawaitedSnapshotCallsites, WARNING_MESSAGES.missingAwaitOnSnapshotProperty);
+            addErrors(testRun.observedCallsites.callsitesWithoutAwait, MissingAwaitError);
         }
 
         if (errList.hasErrors)

--- a/src/api/wrap-test-function.ts
+++ b/src/api/wrap-test-function.ts
@@ -30,12 +30,12 @@ export default function wrapTestFunction (fn: Function): Function {
             for (const callsite of testRun.observedCallsites.callsitesWithoutAwait) {
                 errList.addError(new MissingAwaitError(callsite));
                 testRun.observedCallsites.callsitesWithoutAwait.delete(callsite);
-            };
+            }
 
             for (const callsite of testRun.observedCallsites.unawaitedSnapshotCallsites) {
                 addWarning(testRun.warningLog, WARNING_MESSAGES.missingAwaitOnSnapshotProperty, callsite);
                 testRun.observedCallsites.unawaitedSnapshotCallsites.delete(callsite);
-            };
+            }
         }
 
         if (errList.hasErrors)

--- a/src/client-functions/selectors/add-api.js
+++ b/src/client-functions/selectors/add-api.js
@@ -113,6 +113,9 @@ function addSnapshotProperties (obj, getSelector, SelectorBuilder, properties, o
             get: () => {
                 const callsite = getCallsiteForMethod('get');
 
+                if (observedCallsites)
+                    observedCallsites.unawaitedSnapshotCallsites.add(callsite);
+
                 const propertyPromise = ReExecutablePromise.fromFn(async () => {
                     const snapshot = await getSnapshot(getSelector, callsite, SelectorBuilder);
 
@@ -120,8 +123,10 @@ function addSnapshotProperties (obj, getSelector, SelectorBuilder, properties, o
                 });
 
                 propertyPromise.then = function (onFulfilled, onRejected) {
-                    if (observedCallsites)
+                    if (observedCallsites) {
                         observedCallsites.snapshotPropertyCallsites.add(callsite);
+                        observedCallsites.unawaitedSnapshotCallsites.delete(callsite);
+                    }
 
                     this._ensureExecuting();
 

--- a/src/notifications/add-rendered-warning.ts
+++ b/src/notifications/add-rendered-warning.ts
@@ -1,0 +1,13 @@
+import renderCallsiteSync from '../utils/render-callsite-sync';
+import createStackFilter from '../errors/create-stack-filter';
+import { renderers } from 'callsite-record';
+import WarningLog from './warning-log';
+
+export default function addWarning (warningLog: WarningLog, message: string, callsite: any = void 0): void {
+    const renderedCallsite = renderCallsiteSync(callsite, {
+        renderer:    renderers.noColor,
+        stackFilter: createStackFilter(Error.stackTraceLimit)
+    });
+
+    warningLog.addWarning(message + `\n\n${renderedCallsite}`);
+}

--- a/src/notifications/warning-message.js
+++ b/src/notifications/warning-message.js
@@ -41,6 +41,7 @@ export default {
     assertedSelectorInstance:           'You passed a Selector object to \'t.expect()\'.\nIf you want to check that a matched element exists, pass the \'selector.exists\' value instead.',
     assertedClientFunctionInstance:     'You passed a ClientFunction object to \'t.expect()\'.\nIf you want to check the function\'s return value, use parentheses to call the function: fnName().',
     multipleWindowsFoundByPredicate:    'The predicate function passed to the \'switchToWindow\' method matched multiple windows. The first matching window was activated.',
-    excessiveAwaitInAssertion:          'You passed a DOM snapshot property to the assertion\'s \'t.expect()\' method. The property value is assigned when the snapshot is resolved and this value is no longer updated. To ensure that the assertion verifies an up-to-date value, pass the selector property without \'await\'.'
+    excessiveAwaitInAssertion:          'You passed a DOM snapshot property to the assertion\'s \'t.expect()\' method. The property value is assigned when the snapshot is resolved and this value is no longer updated. To ensure that the assertion verifies an up-to-date value, pass the selector property without \'await\'.',
+    missingAwaitOnSnapshotProperty:     'You used a DOM snapshot property without \'await\'. The property value is assigned when the snapshot is resolved. If you need to use the property value, use \'await\' to resolve the Promise.'
 };
 

--- a/src/services/compiler/test-run-proxy.ts
+++ b/src/services/compiler/test-run-proxy.ts
@@ -4,12 +4,14 @@ import prerenderCallsite from '../../utils/prerender-callsite';
 import { TestRunDispatcherProtocol } from './protocol';
 import TestController from '../../api/test-controller';
 import ObservedCallsitesStorage from '../../test-run/observed-callsites-storage';
+import WarningLog from '../../notifications/warning-log';
 
 
 class TestRunMock {
     public readonly id: string;
     public readonly controller: TestController;
     public readonly observedCallsites: ObservedCallsitesStorage;
+    public readonly warningLog: WarningLog;
 
     private readonly dispatcher: TestRunDispatcherProtocol;
     private readonly fixtureCtx: unknown;
@@ -27,6 +29,7 @@ class TestRunMock {
         // Postponed until (GH-3244). See details in (GH-5250).
         this.controller =        new TestController(this);
         this.observedCallsites = new ObservedCallsitesStorage();
+        this.warningLog =        new WarningLog();
 
         testRunTracker.activeTestRuns[id] = this;
     }

--- a/src/test-run/observed-callsites-storage.ts
+++ b/src/test-run/observed-callsites-storage.ts
@@ -1,14 +1,17 @@
 export default class ObservedCallsitesStorage {
     public callsitesWithoutAwait: Set<Record<string, any>>;
     public snapshotPropertyCallsites: Set<Record<string, any>>;
+    public unawaitedSnapshotCallsites: Set<Record<string, any>>;
 
     public constructor () {
-        this.callsitesWithoutAwait     = new Set();
-        this.snapshotPropertyCallsites = new Set();
+        this.callsitesWithoutAwait      = new Set();
+        this.snapshotPropertyCallsites  = new Set();
+        this.unawaitedSnapshotCallsites = new Set();
     }
 
     public clear (): void {
-        this.callsitesWithoutAwait     = new Set();
-        this.snapshotPropertyCallsites = new Set();
+        this.callsitesWithoutAwait      = new Set();
+        this.snapshotPropertyCallsites  = new Set();
+        this.unawaitedSnapshotCallsites = new Set();
     }
 }

--- a/test/functional/fixtures/api/es-next/assertions/data/expected-missing-await-on-snapshot-callsite
+++ b/test/functional/fixtures/api/es-next/assertions/data/expected-missing-await-on-snapshot-callsite
@@ -1,8 +1,5 @@
-   176 |});
-   177 |
-   178 |test('Snapshot property without await', async t => {
-   179 |    await t.expect(Selector('#el1').innerText).eql('');
-   180 |
- > 181 |    Selector('#el1').innerText;
-   182 |});
-   183 |
+   179 |test('Snapshot property without await', async t => {
+   180 |    await t.expect(Selector('#el1').innerText).eql('');
+   181 |
+ > 182 |    Selector('#el1').innerText;
+   183 |});

--- a/test/functional/fixtures/api/es-next/assertions/data/expected-missing-await-on-snapshot-callsite
+++ b/test/functional/fixtures/api/es-next/assertions/data/expected-missing-await-on-snapshot-callsite
@@ -1,0 +1,8 @@
+   176 |});
+   177 |
+   178 |test('Snapshot property without await', async t => {
+   179 |    await t.expect(Selector('#el1').innerText).eql('');
+   180 |
+ > 181 |    Selector('#el1').innerText;
+   182 |});
+   183 |

--- a/test/functional/fixtures/api/es-next/assertions/data/expected-selector-property-awaited-callsite
+++ b/test/functional/fixtures/api/es-next/assertions/data/expected-selector-property-awaited-callsite
@@ -1,8 +1,7 @@
-   170 |
    171 |test('Await Selector property', async t => {
    172 |    await t
    173 |        .expect(Selector('#el1')).ok()
    174 |        .expect(await Selector('#el1')).ok()
- > 175 |        .expect(await Selector('#el1').innerText).eql('');
-   176 |});
-   177 |
+   175 |        .expect(Selector('#el1').innerText).eql('')
+ > 176 |        .expect(await Selector('#el1').innerText).eql('');
+   177 |});

--- a/test/functional/fixtures/api/es-next/assertions/testcafe-fixtures/assertions-test.js
+++ b/test/functional/fixtures/api/es-next/assertions/testcafe-fixtures/assertions-test.js
@@ -172,6 +172,7 @@ test('Await Selector property', async t => {
     await t
         .expect(Selector('#el1')).ok()
         .expect(await Selector('#el1')).ok()
+        .expect(Selector('#el1').innerText).eql('')
         .expect(await Selector('#el1').innerText).eql('');
 });
 

--- a/test/functional/fixtures/api/es-next/assertions/testcafe-fixtures/assertions-test.js
+++ b/test/functional/fixtures/api/es-next/assertions/testcafe-fixtures/assertions-test.js
@@ -174,3 +174,9 @@ test('Await Selector property', async t => {
         .expect(await Selector('#el1')).ok()
         .expect(await Selector('#el1').innerText).eql('');
 });
+
+test('Snapshot property without await', async t => {
+    await t.expect(Selector('#el1').innerText).eql('');
+
+    Selector('#el1').innerText;
+});


### PR DESCRIPTION
## Purpose
Add a warning message when trying to get a snapshot property value without calling await (which returns a Promise).

## Approach
Saving a callsite when accessing the snapshot property, deleting the callsite in `.then` (if the property is awaited). If there are callsites left after the test finishes, printing a warning

## References
Part of #5087

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
