### PR TITLE
Fix docker tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,8 @@ jobs:
         chrome:  stable
       services:
         - xvfb
-    - env: GULP_TASK="docker-test"
+    - node_js: "stable"
+      env: GULP_TASK="docker-test-travis"
       services:
         - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ jobs:
         chrome:  stable
       services:
         - xvfb
+    - env: GULP_TASK="docker-test"
+      services:
+        - docker
+
   fast_finish: true
 
 cache:

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -972,6 +972,8 @@ gulp.step('docker-publish-run', done => {
 
 gulp.task('docker-test', gulp.series('docker-build', 'docker-test-run'));
 
+gulp.task('docker-test-travis', gulp.series('build', 'docker-test'));
+
 gulp.task('docker-publish', gulp.series('docker-test', 'docker-publish-run'));
 
 gulp.task('travis', process.env.GULP_TASK ? gulp.series(process.env.GULP_TASK) : () => {});

--- a/docker/is-docker-daemon-running.js
+++ b/docker/is-docker-daemon-running.js
@@ -1,0 +1,38 @@
+const { execSync } = require('child_process');
+const OS           = require('os-family');
+
+
+const DOCKER_DAEMON_DETECTION_OPTIONS = {
+    windows: {
+        detectCommand:    'wmic process get Name /format:list',
+        daemonNameRegExp: /Docker (for Windows|Desktop).exe/
+    },
+
+    linux: {
+        detectCommand:    'ps -ejf | grep dockerd',
+        daemonNameRegExp: /dockerd/
+    }
+};
+
+const OS_NOT_SUPPORTED_ERROR = 'Cannot run docker tests with this OS';
+
+function detectDockerDaemon ({ detectCommand, daemonNameRegExp }) {
+    try {
+        const processInfo = execSync(detectCommand).toString();
+
+        return processInfo.match(daemonNameRegExp);
+    }
+    catch (e) {
+        return false;
+    }
+}
+
+module.exports = function () {
+    if (OS.win)
+        return detectDockerDaemon(DOCKER_DAEMON_DETECTION_OPTIONS.windows);
+
+    if (OS.linux)
+        return detectDockerDaemon(DOCKER_DAEMON_DETECTION_OPTIONS.linux);
+
+    throw new Error(OS_NOT_SUPPORTED_ERROR);
+};

--- a/test/server/bootstrapper-test.js
+++ b/test/server/bootstrapper-test.js
@@ -8,7 +8,7 @@ const Test                    = require('../../lib/api/structure/test');
 const browserProviderPool     = require('../../lib/browser/provider/pool');
 
 
-const BROWSER_NAME = isAlpine ? 'chromium' : 'chrome';
+const BROWSER_NAME = isAlpine() ? 'chromium' : 'chrome';
 
 class BrowserConnectionMock extends BrowserConnection {
     constructor (...args) {

--- a/test/server/bootstrapper-test.js
+++ b/test/server/bootstrapper-test.js
@@ -1,10 +1,14 @@
 const proxyquire              = require('proxyquire');
 const { expect }              = require('chai');
 const { noop }                = require('lodash');
+const isAlpine                = require('./helpers/is-alpine');
 const BrowserConnectionStatus = require('../../lib/browser/connection/status');
 const BrowserConnection       = require('../../lib/browser/connection');
 const Test                    = require('../../lib/api/structure/test');
 const browserProviderPool     = require('../../lib/browser/provider/pool');
+
+
+const BROWSER_NAME = isAlpine ? 'chromium' : 'chrome';
 
 class BrowserConnectionMock extends BrowserConnection {
     constructor (...args) {
@@ -44,7 +48,7 @@ describe('Bootstrapper', () => {
             });
 
             it('Should raise an error when browser is specified as non-headless', async () => {
-                bootstrapper.browsers = [ 'chrome' ];
+                bootstrapper.browsers = [ BROWSER_NAME ];
 
                 try {
                     await bootstrapper.createRunnableConfiguration();
@@ -53,7 +57,7 @@ describe('Bootstrapper', () => {
                 }
                 catch (err) {
                     expect(err.message).eql(
-                        `Your Linux version does not have a graphic subsystem to run chrome with a GUI. ` +
+                        `Your Linux version does not have a graphic subsystem to run ${BROWSER_NAME} with a GUI. ` +
                         `You can launch the browser in headless mode. ` +
                         `If you use a portable browser version, ` +
                         `specify the browser alias before the path instead of the 'path' prefix. ` +
@@ -84,7 +88,7 @@ describe('Bootstrapper', () => {
             });
 
             it('Should not raise an error when browser is specified as headless', async () => {
-                bootstrapper.browsers = [ 'chrome:headless' ];
+                bootstrapper.browsers = [ `${BROWSER_NAME}:headless` ];
 
                 let isErrorThrown = false;
 

--- a/test/server/helpers/is-alpine.js
+++ b/test/server/helpers/is-alpine.js
@@ -5,4 +5,4 @@ const ALPINE_RELEASE_INFO_PATH = '/etc/alpine-release';
 
 module.exports = function () {
     return fs.existsSync(ALPINE_RELEASE_INFO_PATH);
-}
+};

--- a/test/server/helpers/is-alpine.js
+++ b/test/server/helpers/is-alpine.js
@@ -1,0 +1,8 @@
+const fs = require('fs');
+
+
+const ALPINE_RELEASE_INFO_PATH = '/etc/alpine-release';
+
+module.exports = function () {
+    return fs.existsSync(ALPINE_RELEASE_INFO_PATH);
+}

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -5,6 +5,8 @@ const chai                    = require('chai');
 const { expect }              = chai;
 const request                 = require('request');
 const { noop, times, uniqBy } = require('lodash');
+const consoleWrapper          = require('./helpers/console-wrapper');
+const isAlpine                = require('./helpers/is-alpine');
 const createTestCafe          = require('../../lib/');
 const COMMAND                 = require('../../lib/browser/connection/command');
 const Task                    = require('../../lib/runner/task');
@@ -12,7 +14,6 @@ const BrowserConnection       = require('../../lib/browser/connection');
 const BrowserSet              = require('../../lib/runner/browser-set');
 const browserProviderPool     = require('../../lib/browser/provider/pool');
 const delay                   = require('../../lib/utils/delay');
-const consoleWrapper          = require('./helpers/console-wrapper');
 
 chai.use(require('chai-string'));
 
@@ -21,6 +22,8 @@ describe('Runner', () => {
     let runner                    = null;
     let connection                = null;
     let origRemoteBrowserProvider = null;
+
+    const BROWSER_NAME = `${isAlpine ? 'chromium' : 'chrome'}:headless`;
 
     const remoteBrowserProviderMock = {
         openBrowser () {
@@ -31,8 +34,6 @@ describe('Runner', () => {
             return Promise.resolve();
         }
     };
-
-    const browserMock = 'chrome:headless';
 
     before(() => {
         return createTestCafe('127.0.0.1', 1335, 1336)
@@ -407,7 +408,7 @@ describe('Runner', () => {
             };
 
             return runner
-                .browsers(browserMock)
+                .browsers(BROWSER_NAME)
                 .src('test/server/data/test-suites/basic/testfile1.js',
                     [
                         'test/server/data/test-suites/basic/*.js',
@@ -866,7 +867,7 @@ describe('Runner', () => {
             });
 
             return runner
-                .browsers(browserMock)
+                .browsers(BROWSER_NAME)
                 .src([])
                 .run()
                 .then(() => {

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -23,7 +23,7 @@ describe('Runner', () => {
     let connection                = null;
     let origRemoteBrowserProvider = null;
 
-    const BROWSER_NAME = `${isAlpine ? 'chromium' : 'chrome'}:headless`;
+    const BROWSER_NAME = `${isAlpine() ? 'chromium' : 'chrome'}:headless`;
 
     const remoteBrowserProviderMock = {
         openBrowser () {


### PR DESCRIPTION
`chrome` is now required for some of our server tests. Since we use Alpine for our Docker image, we can't use Chrome here, only Chromium. Tried to mock this, but it was painful. So I added Alpine detection (looking with `fs` for a specific file), and now server tests should use Chromium for Alpine, Chrome otherwise.