### PR TITLE
Rephrase the assertion warning for ClientFunction; Bump version (v1.9.0-rc.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.9.0-rc.1",
+  "version": "1.9.0-rc.2",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"

--- a/src/notifications/warning-message.js
+++ b/src/notifications/warning-message.js
@@ -39,7 +39,7 @@ export default {
     clientScriptsWithEmptyContent:      'The client script you tried to inject is empty.',
     clientScriptsWithDuplicatedContent: 'You injected the following client script{suffix} several times:\n {duplicatedScripts}',
     assertedSelectorInstance:           'You passed a Selector object to \'t.expect()\'.\nIf you want to check that a matched element exists, pass the \'selector.exists\' value instead.',
-    assertedClientFunctionInstance:     'You passed a ClientFunction object to \'t.expect()\'.\nIf you want to check the function\'s return value, call the client function (\'clientFunction()\') instead.',
+    assertedClientFunctionInstance:     'You passed a ClientFunction object to \'t.expect()\'.\nIf you want to check the function\'s return value, use parentheses to call the function: fnName().',
     multipleWindowsFoundByPredicate:    'The predicate function passed to the \'switchToWindow\' method matched multiple windows. The first matching window was activated.',
     excessiveAwaitInAssertion:          'You passed a DOM snapshot property to the assertion\'s \'t.expect()\' method. The property value is assigned when the snapshot is resolved and this value is no longer updated. To ensure that the assertion verifies an up-to-date value, pass the selector property without \'await\'.'
 };

--- a/test/functional/fixtures/api/es-next/assertions/test.js
+++ b/test/functional/fixtures/api/es-next/assertions/test.js
@@ -198,8 +198,10 @@ describe('[API] Assertions', function () {
             only:       'chrome'
         })
             .catch(function () {
-                expect(testReport.warnings[0]).to.match(new RegExp(['You passed a ClientFunction object to \'t\\.expect\\(\\)\'\\.\nIf you want to check ',
-                    'the function\'s return value, call the client function \\(\'clientFunction\\(\\)\'\\) instead\\.'].join('')));
+                expect(testReport.warnings[0]).to.contain(
+                    'You passed a ClientFunction object to \'t.expect()\'.\n' +
+                    'If you want to check the function\'s return value, use parentheses to call the function: fnName().'
+                );
             });
     });
 


### PR DESCRIPTION
Remove the braces from the warning about passing a ClientFunction to `t.expect`.
