### PR TITLE
Add the testingbot provider to the plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ TestCafe developers and community members made these plugins:
   * [CrossBrowserTesting provider](https://github.com/sijosyn/testcafe-browser-provider-crossbrowsertesting) (by [@sijosyn](https://github.com/sijosyn))
   * [LambdaTest provider](https://github.com/LambdaTest/testcafe-browser-provider-lambdatest) (by [@kanhaiya15](https://github.com/kanhaiya15))
   * [Nightmare headless provider](https://github.com/ryx/testcafe-browser-provider-nightmare) (by [@ryx](https://github.com/ryx))
+  * [Testingbot provider](https://github.com/testingbot/testcafe-browser-provider-testingbot) (by [@testingbot](https://github.com/testingbot)
   * [fbsimctl iOS emulator](https://github.com/Ents24/testcafe-browser-provider-fbsimctl) (by [@ents24](https://github.com/Ents24))
   * [Electron](https://github.com/DevExpress/testcafe-browser-provider-electron) (by [@AndreyBelym](https://github.com/AndreyBelym))
   * [Puppeteer](https://github.com/jdobosz/testcafe-browser-provider-puppeteer) (by [@jdobosz](https://github.com/jdobosz))

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ TestCafe developers and community members made these plugins:
   * [CrossBrowserTesting provider](https://github.com/sijosyn/testcafe-browser-provider-crossbrowsertesting) (by [@sijosyn](https://github.com/sijosyn))
   * [LambdaTest provider](https://github.com/LambdaTest/testcafe-browser-provider-lambdatest) (by [@kanhaiya15](https://github.com/kanhaiya15))
   * [Nightmare headless provider](https://github.com/ryx/testcafe-browser-provider-nightmare) (by [@ryx](https://github.com/ryx))
-  * [Testingbot provider](https://github.com/testingbot/testcafe-browser-provider-testingbot) (by [@testingbot](https://github.com/testingbot)
+  * [Testingbot provider](https://github.com/testingbot/testcafe-browser-provider-testingbot) (by [@testingbot](https://github.com/testingbot))
   * [fbsimctl iOS emulator](https://github.com/Ents24/testcafe-browser-provider-fbsimctl) (by [@ents24](https://github.com/Ents24))
   * [Electron](https://github.com/DevExpress/testcafe-browser-provider-electron) (by [@AndreyBelym](https://github.com/AndreyBelym))
   * [Puppeteer](https://github.com/jdobosz/testcafe-browser-provider-puppeteer) (by [@jdobosz](https://github.com/jdobosz))


### PR DESCRIPTION
https://github.com/testingbot/testcafe-browser-provider-testingbot
