### PR TITLE
Added a check to error formatter. Bump version (v1.9.1-rc.1). Bump hammerhead (v17.1.13)

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -8,7 +8,7 @@
     "gitTag": true
   },
   "confirm": true,
-  "publishTag": "latest",
+  "publishTag": "rc",
   "prePublishScript": "gulp test-server",
   "postPublishScript": "gulp docker-publish"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.9.0",
+  "version": "1.9.1-rc.1",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"
@@ -118,7 +118,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.13",
-    "testcafe-hammerhead": "17.1.12",
+    "testcafe-hammerhead": "17.1.13",
     "testcafe-legacy-api": "4.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/src/errors/test-run/formattable-adapter.js
+++ b/src/errors/test-run/formattable-adapter.js
@@ -41,7 +41,7 @@ export default class TestRunErrorFormattableAdapter {
             if (node.nodeName !== '#document-fragment') {
                 const selector = TestRunErrorFormattableAdapter._getSelector(node);
 
-                msg = decorator[selector](msg, node.attrs);
+                msg = decorator[selector] ? decorator[selector](msg, node.attrs) : msg;
             }
         }
 

--- a/test/server/test-run-error-formatting-test.js
+++ b/test/server/test-run-error-formatting-test.js
@@ -279,7 +279,7 @@ describe('Error formatting', () => {
         });
 
         it('Should not throw if the specified decorator was not found', () => {
-            const errorList  = new Array();
+            const errorList = new Array();
 
             let decoratedHTML;
 

--- a/test/server/test-run-error-formatting-test.js
+++ b/test/server/test-run-error-formatting-test.js
@@ -299,7 +299,6 @@ describe('Error formatting', () => {
             expect(errorList.length).eql(0);
         });
 
-
         it('Should format "actionIntegerOptionError" message', () => {
             assertErrorMessage('action-integer-option-error', new ActionIntegerOptionError('offsetX', '1.01'));
         });

--- a/test/server/test-run-error-formatting-test.js
+++ b/test/server/test-run-error-formatting-test.js
@@ -278,6 +278,27 @@ describe('Error formatting', () => {
             });
         });
 
+        it('Should not throw if the specified decorator was not found', () => {
+            const errorList  = new Array();
+
+            let decoratedHTML;
+
+            try {
+                const error = new ExternalAssertionLibraryError(testAssertionErrorArray, testCallsite);
+
+                error.diff = '<div class="unknown-decorator">text</div>';
+
+                const decorator = getErrorAdapter(error);
+
+                decoratedHTML = decorator.formatMessage('', 100);
+            }
+            catch (e) {
+                errorList.push(e);
+            }
+            
+            expect(errorList.length).eql(0);
+        });
+
 
         it('Should format "actionIntegerOptionError" message', () => {
             assertErrorMessage('action-integer-option-error', new ActionIntegerOptionError('offsetX', '1.01'));

--- a/test/server/test-run-error-formatting-test.js
+++ b/test/server/test-run-error-formatting-test.js
@@ -279,20 +279,13 @@ describe('Error formatting', () => {
         });
 
         it('Should not throw if the specified decorator was not found', () => {
-            const errorList = [];
-
-            try {
+            expect(() => {
                 const error = new ExternalAssertionLibraryError(testAssertionErrorArray, testCallsite);
 
                 error.diff = '<div class="unknown-decorator">text</div>';
 
                 getErrorAdapter(error).formatMessage('', 100);
-            }
-            catch (e) {
-                errorList.push(e);
-            }
-
-            expect(errorList.length).eql(0);
+            }).to.not.throw();
         });
 
         it('Should format "actionIntegerOptionError" message', () => {

--- a/test/server/test-run-error-formatting-test.js
+++ b/test/server/test-run-error-formatting-test.js
@@ -279,23 +279,19 @@ describe('Error formatting', () => {
         });
 
         it('Should not throw if the specified decorator was not found', () => {
-            const errorList = new Array();
-
-            let decoratedHTML;
+            const errorList = [];
 
             try {
                 const error = new ExternalAssertionLibraryError(testAssertionErrorArray, testCallsite);
 
                 error.diff = '<div class="unknown-decorator">text</div>';
 
-                const decorator = getErrorAdapter(error);
-
-                decoratedHTML = decorator.formatMessage('', 100);
+                getErrorAdapter(error).formatMessage('', 100);
             }
             catch (e) {
                 errorList.push(e);
             }
-            
+
             expect(errorList.length).eql(0);
         });
 


### PR DESCRIPTION
Added a check to error formatter in case an unknown decorator is specified.