### PR TITLE
Adding a type for testRun inside TestController interface

### DIFF
--- a/ts-defs-src/test-api/test-controller.d.ts
+++ b/ts-defs-src/test-api/test-controller.d.ts
@@ -102,6 +102,10 @@ interface TestController {
      */
     ctx: {[key: string]: any};
     /**
+     * Dictionary that holds the information of the current test run
+     */
+    readonly testRun: {[key: string]: any};
+    /**
      * Dictionary that is shared between `fixture.before` and `fixture.after`, test hook functions and test code.
      */
     readonly fixtureCtx: {[key: string]: any};


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
We cannot use `await t.testRun` in Typescript

## Approach
I added the value of testRun into the TestController interface

## References
https://github.com/DevExpress/testcafe/issues/2826

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
