### PR TITLE
Update eslint-plugin-hammerhead plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "devtools-protocol": "0.0.678506",
     "dom-walk": "^0.1.1",
     "escape-string-regexp": "^4.0.0",
-    "eslint-plugin-hammerhead": "0.3.1",
+    "eslint-plugin-hammerhead": "0.4.0",
     "eslint-plugin-no-only-tests": "^2.0.1",
     "express": "^4.13.3",
     "express-ntlm": "2.4.0",


### PR DESCRIPTION
Restrict using the `new Date()` and `Date.now()`  expression in the client code.
Connected with https://github.com/DevExpress/testcafe/commit/78cd2632593806e20ea915c7634fb523e5163f3c