### PR TITLE
allow to run: npx gulp lint --fix

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -208,7 +208,9 @@ gulp.task('lint', () => {
             '!test/functional/fixtures/api/es-next/custom-client-scripts/data/*.js',
             'Gulpfile.js'
         ])
-        .pipe(eslint())
+        .pipe(eslint({
+            fix: process.argv.includes('--fix'),
+        }))
         .pipe(eslint.format(process.env.ESLINT_FORMATTER))
         .pipe(eslint.failAfterError());
 });


### PR DESCRIPTION
allow to auto-fix errors with eslint
like with `eslint --fix`

the api is [here](https://eslint.org/docs/developer-guide/nodejs-api#cliengine) via [here](https://github.com/adametry/gulp-eslint#eslintoptions)