### PR TITLE
add API function listBrowsers

### DIFF
--- a/src/embedding-utils.js
+++ b/src/embedding-utils.js
@@ -16,6 +16,7 @@ const processTestFnError             = lazyRequire('./errors/process-test-fn-err
 const testRunErrorUtils              = lazyRequire('./errors/test-run/utils');
 const browserProviderPool            = lazyRequire('./browser/provider/pool');
 const BrowserConnection              = lazyRequire('./browser/connection');
+const listBrowsers                   = lazyRequire('./utils/list-browsers');
 
 
 // NOTE: we can't use lazy require for TestRun and Assignable, because it breaks prototype chain for inherited classes
@@ -30,6 +31,7 @@ export default {
     errorTypes,
     testRunErrorUtils,
     BrowserConnection,
+    listBrowsers,
 
     get Assignable () {
         if (!Assignable)

--- a/src/utils/list-browsers.js
+++ b/src/utils/list-browsers.js
@@ -1,0 +1,15 @@
+import { APIError } from '../errors/runtime';
+import { RUNTIME_ERRORS } from '../errors/types';
+
+const lazyRequire = require('import-lazy')(require);
+const browserProviderPool = lazyRequire('../browser/provider/pool');
+
+export default async function listBrowsers (providerName = 'locally-installed') {
+    const provider = await browserProviderPool.getProvider(providerName);
+
+    if (!provider)
+        throw new APIError('listBrowsers', RUNTIME_ERRORS.browserProviderNotFound, providerName);
+    return provider.isMultiBrowser
+        ? await provider.getBrowserList()
+        : [providerName];
+}

--- a/test/server/api-test.js
+++ b/test/server/api-test.js
@@ -1688,4 +1688,37 @@ describe('API', function () {
             expect(configuration.getOption(OPTION_NAMES.retryTestPages)).be.true;
         });
     });
+
+    describe('listBrowsers', () => {
+
+        const listBrowsers = require('../../lib/embedding-utils').listBrowsers;
+
+        it('Should return an array of strings', () => {
+            this.timeout(2000);
+            return listBrowsers()
+                .then(browserNames => {
+                    expect(browserNames).to.be.an('array');
+                    if (Array.isArray(browserNames)) {
+                        browserNames.forEach(browserName => {
+                            expect(browserName).to.be.a('string');
+                        });
+                    }
+                })
+                .catch(err => {
+                    expect(err.constructor.name).to.equal('APIError');
+                    throw new Error('Promise resolution expected');
+                });
+        });
+
+        it('Should raise an error if provider name is invalid', function () {
+            return listBrowsers('bad provider name 032940135959086625')
+                .then(() => {
+                    throw new Error('Promise rejection expected');
+                })
+                .catch(err => {
+                    expect(err.constructor.name).to.equal('APIError');
+                    expect(err.rawMessage).to.equal('The specified "bad provider name 032940135959086625" browser provider was not found.');
+                });
+        });
+    });
 });


### PR DESCRIPTION
replace PR #5516
solved all issues raised by @AndreyBelym - thanks for your review

solve issue #3919

add API function

```js
async function listBrowsers (providerName = 'locally-installed')
```

returns array of browser names
these browsers are available to run tests

change in CLI:
remove double quotes from cli output of

```
testcafe --list-browsers someProviderName
```
old format:
```
"someProviderName:browser 1"
"someProviderName:browser 2"
```
new format:
```
someProviderName:browser 1
someProviderName:browser 2
```

