### PR TITLE
Add 'object-curly-newline' eslint rule.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -67,6 +67,7 @@
     "no-underscore-dangle": 0,
     "no-unneeded-ternary": 2,
     "object-curly-spacing": [2, "always"],
+    "object-curly-newline": [2, { "ImportDeclaration":  { "minProperties": 3 } }],
     "operator-assignment": [2, "always"],
     "quotes": [2, "single", { "avoidEscape": true, "allowTemplateLiterals": true }],
     "keyword-spacing": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -67,7 +67,7 @@
     "no-underscore-dangle": 0,
     "no-unneeded-ternary": 2,
     "object-curly-spacing": [2, "always"],
-    "object-curly-newline": [2, { "ImportDeclaration":  { "minProperties": 3 } }],
+    "object-curly-newline": [2, { "ImportDeclaration":  { "minProperties": 3, "consistent": true } }],
     "operator-assignment": [2, "always"],
     "quotes": [2, "single", { "avoidEscape": true, "allowTemplateLiterals": true }],
     "keyword-spacing": 2,

--- a/src/api/request-hooks/request-mock.js
+++ b/src/api/request-hooks/request-mock.js
@@ -1,0 +1,58 @@
+import RequestHook from './hook';
+import {
+    ResponseMock,
+    RequestFilterRule,
+    SAME_ORIGIN_CHECK_FAILED_STATUS_CODE
+} from 'testcafe-hammerhead';
+
+import { APIError } from '../../errors/runtime';
+import { RUNTIME_ERRORS } from '../../errors/types';
+import WARNING_MESSAGE from '../../notifications/warning-message';
+
+class RequestMock extends RequestHook {
+    constructor () {
+        super([]);
+
+        this.pendingRequestFilterRuleInit = null;
+        this.mocks                        = new Map();
+    }
+
+    async onRequest (event) {
+        const mock = this.mocks.get(event._requestFilterRule);
+
+        event.setMock(mock);
+    }
+
+    async onResponse (event) {
+        if (event.statusCode === SAME_ORIGIN_CHECK_FAILED_STATUS_CODE)
+            this.warningLog.addWarning(WARNING_MESSAGE.requestMockCORSValidationFailed, RequestMock.name, event._requestFilterRule);
+    }
+
+    // API
+    onRequestTo (requestFilterRuleInit) {
+        if (this.pendingRequestFilterRuleInit)
+            throw new APIError('onRequestTo', RUNTIME_ERRORS.requestHookConfigureAPIError, RequestMock.name, "The 'respond' method was not called after 'onRequestTo'. You must call the 'respond' method to provide the mocked response.");
+
+        this.pendingRequestFilterRuleInit = requestFilterRuleInit;
+
+        return this;
+    }
+
+    respond (body, statusCode, headers) {
+        if (!this.pendingRequestFilterRuleInit)
+            throw new APIError('respond', RUNTIME_ERRORS.requestHookConfigureAPIError, RequestMock.name, "The 'onRequestTo' method was not called before 'respond'. You must call the 'onRequestTo' method to provide the URL requests to which are mocked.");
+
+        const mock = new ResponseMock(body, statusCode, headers);
+        const rule = new RequestFilterRule(this.pendingRequestFilterRuleInit);
+
+        this.requestFilterRules.push(rule);
+        this.mocks.set(rule, mock);
+        this.pendingRequestFilterRuleInit = null;
+
+        return this;
+    }
+}
+
+export default function createRequestMock () {
+    return new RequestMock();
+}

--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -60,7 +60,10 @@ import assertRequestHookType from '../request-hooks/assert-type';
 import { createExecutionContext as createContext } from './execution-context';
 import { isClientFunction, isSelector } from '../../client-functions/types';
 
-import { MultipleWindowsModeIsDisabledError, MultipleWindowsModeIsNotAvailableInRemoteBrowserError } from '../../errors/test-run';
+import {
+    MultipleWindowsModeIsDisabledError,
+    MultipleWindowsModeIsNotAvailableInRemoteBrowserError
+} from '../../errors/test-run';
 
 const originalThen = Promise.resolve().then;
 

--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -1,6 +1,12 @@
 // TODO: Fix https://github.com/DevExpress/testcafe/issues/4139 to get rid of Pinkie
 import Promise from 'pinkie';
-import { identity, assign, isNil as isNullOrUndefined, flattenDeep as flatten } from 'lodash';
+import {
+    identity,
+    assign,
+    isNil as isNullOrUndefined,
+    flattenDeep as flatten
+} from 'lodash';
+
 import { getCallsiteForMethod } from '../../errors/get-callsite';
 import ClientFunctionBuilder from '../../client-functions/client-function-builder';
 import Assertion from './assertion';
@@ -54,10 +60,7 @@ import assertRequestHookType from '../request-hooks/assert-type';
 import { createExecutionContext as createContext } from './execution-context';
 import { isClientFunction, isSelector } from '../../client-functions/types';
 
-import {
-    MultipleWindowsModeIsDisabledError,
-    MultipleWindowsModeIsNotAvailableInRemoteBrowserError
-} from '../../errors/test-run';
+import { MultipleWindowsModeIsDisabledError, MultipleWindowsModeIsNotAvailableInRemoteBrowserError } from '../../errors/test-run';
 
 const originalThen = Promise.resolve().then;
 

--- a/src/browser/connection/gateway.ts
+++ b/src/browser/connection/gateway.ts
@@ -1,5 +1,12 @@
 import { readSync as read } from 'read-file-relative';
-import { respond404, respond500, respondWithJSON, redirect, preventCaching } from '../../utils/http';
+import {
+    respond404,
+    respond500,
+    respondWithJSON,
+    redirect,
+    preventCaching
+} from '../../utils/http';
+
 import RemotesQueue from './remotes-queue';
 import { Proxy } from 'testcafe-hammerhead';
 import { Dictionary } from '../../configuration/interfaces';

--- a/src/browser/provider/built-in/dedicated/firefox/config.js
+++ b/src/browser/provider/built-in/dedicated/firefox/config.js
@@ -1,4 +1,11 @@
-import { findMatch, isMatchTrue, splitEscaped, parseConfig, getModes, getPathFromParsedModes } from '../../../utils/argument-parsing';
+import {
+    findMatch,
+    isMatchTrue,
+    splitEscaped,
+    parseConfig,
+    getModes,
+    getPathFromParsedModes
+} from '../../../utils/argument-parsing';
 
 
 const AVAILABLE_MODES = ['userProfile', 'headless'];

--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -7,11 +7,22 @@ import { RUNTIME_ERRORS } from '../errors/types';
 import { assertType, is } from '../errors/runtime/type-assertions';
 import getViewPortWidth from '../utils/get-viewport-width';
 import { wordWrap, splitQuotedText } from '../utils/string';
-import { getSSLOptions, getScreenshotOptions, getVideoOptions, getMetaOptions, getGrepOptions } from '../utils/get-options';
+import {
+    getSSLOptions,
+    getScreenshotOptions,
+    getVideoOptions,
+    getMetaOptions,
+    getGrepOptions
+} from '../utils/get-options';
+
 import getFilterFn from '../utils/get-filter-fn';
 import SCREENSHOT_OPTION_NAMES from '../configuration/screenshot-option-names';
 import RUN_OPTION_NAMES from '../configuration/run-option-names';
-import { Dictionary, ReporterOption, RunnerRunOptions } from '../configuration/interfaces';
+import {
+    Dictionary,
+    ReporterOption,
+    RunnerRunOptions
+} from '../configuration/interfaces';
 
 
 const REMOTE_ALIAS_RE = /^remote(?::(\d*))?$/;

--- a/src/client/automation/playback/press/index.js
+++ b/src/client/automation/playback/press/index.js
@@ -1,5 +1,12 @@
 import hammerhead from '../../deps/hammerhead';
-import { arrayUtils, domUtils, promiseUtils, delay, getKeyArray, sendRequestToFrame } from '../../deps/testcafe-core';
+import {
+    arrayUtils,
+    domUtils,
+    promiseUtils,
+    delay,
+    getKeyArray,
+    sendRequestToFrame
+} from '../../deps/testcafe-core';
 import KeyPressSimulator from './key-press-simulator';
 import supportedShortcutHandlers from './shortcuts';
 import { getActualKeysAndEventKeyProperties, getDeepActiveElement } from './utils';

--- a/src/client/automation/playback/press/key-press-simulator.js
+++ b/src/client/automation/playback/press/key-press-simulator.js
@@ -1,7 +1,17 @@
 import hammerhead from '../../deps/hammerhead';
-import { KEY_MAPS, domUtils, getSanitizedKey } from '../../deps/testcafe-core';
+import {
+    KEY_MAPS,
+    domUtils,
+    getSanitizedKey
+} from '../../deps/testcafe-core';
+
 import typeText from '../type/type-text';
-import { getChar, getDeepActiveElement, changeLetterCase } from './utils';
+import {
+    getChar,
+    getDeepActiveElement,
+    changeLetterCase
+} from './utils';
+
 import getKeyCode from '../../utils/get-key-code';
 import getKeyIdentifier from '../../utils/get-key-identifier';
 import isLetterKey from '../../utils/is-letter';

--- a/src/client/automation/playback/press/utils.js
+++ b/src/client/automation/playback/press/utils.js
@@ -1,5 +1,10 @@
 import hammerhead from '../../deps/hammerhead';
-import { KEY_MAPS, domUtils, arrayUtils } from '../../deps/testcafe-core';
+import {
+    KEY_MAPS,
+    domUtils,
+    arrayUtils
+} from '../../deps/testcafe-core';
+
 import isLetter from '../../utils/is-letter';
 
 

--- a/src/client/core/prevent-real-events.js
+++ b/src/client/core/prevent-real-events.js
@@ -4,7 +4,11 @@ import scrollController from './scroll-controller';
 
 import { get, hasDimensions } from './utils/style';
 import { filter } from './utils/array';
-import { isShadowUIElement, isWindow, getParents } from './utils/dom';
+import {
+    isShadowUIElement,
+    isWindow,
+    getParents
+} from './utils/dom';
 
 const browserUtils   = utils.browser;
 const listeners      = eventSandbox.listeners;

--- a/src/client/driver/command-executors/browser-manipulation/index.js
+++ b/src/client/driver/command-executors/browser-manipulation/index.js
@@ -1,7 +1,24 @@
-import { transport, eventSandbox, Promise } from '../../deps/hammerhead';
-import { domUtils, scrollController, sendRequestToFrame, delay } from '../../deps/testcafe-core';
+import {
+    transport,
+    eventSandbox,
+    Promise
+} from '../../deps/hammerhead';
+
+import {
+    domUtils,
+    scrollController,
+    sendRequestToFrame,
+    delay
+} from '../../deps/testcafe-core';
+
 import { Scroll as ScrollAutomation } from '../../deps/testcafe-automation';
-import { hide as hideUI, show as showUI, showScreenshotMark, hideScreenshotMark } from '../../deps/testcafe-ui';
+import {
+    hide as hideUI,
+    show as showUI,
+    showScreenshotMark,
+    hideScreenshotMark
+} from '../../deps/testcafe-ui';
+
 import DriverStatus from '../../status';
 import ensureCropOptions from './ensure-crop-options';
 import { ensureElements, createElementDescriptor } from '../../utils/ensure-elements';

--- a/src/client/driver/command-executors/client-functions/client-function-executor.js
+++ b/src/client/driver/command-executors/client-functions/client-function-executor.js
@@ -1,6 +1,11 @@
 import { Promise } from '../../deps/hammerhead';
 import DriverStatus from '../../status';
-import { createReplicator, FunctionTransform, ClientFunctionNodeTransform } from './replicator';
+import {
+    createReplicator,
+    FunctionTransform,
+    ClientFunctionNodeTransform
+} from './replicator';
+
 import evalFunction from './eval-function';
 import { UncaughtErrorInClientFunctionCode } from '../../../../shared/errors';
 

--- a/src/client/driver/command-executors/client-functions/replicator.js
+++ b/src/client/driver/command-executors/client-functions/replicator.js
@@ -1,6 +1,11 @@
 import Replicator from 'replicator';
 import evalFunction from './eval-function';
-import { NodeSnapshot, ElementSnapshot, ElementActionSnapshot } from './selector-executor/node-snapshots';
+import {
+    NodeSnapshot,
+    ElementSnapshot,
+    ElementActionSnapshot
+} from './selector-executor/node-snapshots';
+
 import { DomNodeClientFunctionResultError, UncaughtErrorInCustomDOMPropertyCode } from '../../../../shared/errors';
 import hammerhead from '../../deps/hammerhead';
 

--- a/src/client/driver/command-executors/client-functions/selector-executor/filter.js
+++ b/src/client/driver/command-executors/client-functions/selector-executor/filter.js
@@ -1,5 +1,10 @@
 import { InvalidSelectorResultError } from '../../../../../shared/errors';
-import { exists, visible, IsNodeCollection } from '../../../utils/element-utils';
+import {
+    exists,
+    visible,
+    IsNodeCollection
+} from '../../../utils/element-utils';
+
 import testCafeCore from '../../../deps/testcafe-core';
 import hammerhead from '../../../deps/hammerhead';
 

--- a/src/client/driver/command-executors/client-functions/selector-executor/index.js
+++ b/src/client/driver/command-executors/client-functions/selector-executor/index.js
@@ -2,7 +2,12 @@ import { Promise, nativeMethods } from '../../../deps/hammerhead';
 import { delay } from '../../../deps/testcafe-core';
 import ClientFunctionExecutor from '../client-function-executor';
 import { exists, visible } from '../../../utils/element-utils';
-import { createReplicator, FunctionTransform, SelectorNodeTransform } from '../replicator';
+import {
+    createReplicator,
+    FunctionTransform,
+    SelectorNodeTransform
+} from '../replicator';
+
 import './filter';
 
 const DateCtor = nativeMethods.date;

--- a/src/client/driver/command-executors/execute-action.js
+++ b/src/client/driver/command-executors/execute-action.js
@@ -30,7 +30,11 @@ import {
 import DriverStatus from '../status';
 
 import runWithBarriers from '../utils/run-with-barriers';
-import { ensureElements, createElementDescriptor, createAdditionalElementDescriptor } from '../utils/ensure-elements';
+import {
+    ensureElements,
+    createElementDescriptor,
+    createAdditionalElementDescriptor
+} from '../utils/ensure-elements';
 
 import {
     ActionElementIsInvisibleError,

--- a/src/client/driver/command-executors/execute-navigate-to.js
+++ b/src/client/driver/command-executors/execute-navigate-to.js
@@ -1,5 +1,10 @@
 import hammerhead from '../deps/hammerhead';
-import { RequestBarrier, pageUnloadBarrier, browser } from '../deps/testcafe-core';
+import {
+    RequestBarrier,
+    pageUnloadBarrier,
+    browser
+} from '../deps/testcafe-core';
+
 import DriverStatus from '../status';
 
 

--- a/src/client/driver/driver-link/iframe/child.js
+++ b/src/client/driver/driver-link/iframe/child.js
@@ -1,14 +1,31 @@
-import { Promise, eventSandbox, nativeMethods } from '../../deps/hammerhead';
-import { domUtils, delay, waitFor, positionUtils } from '../../deps/testcafe-core';
+import {
+    Promise,
+    eventSandbox,
+    nativeMethods
+} from '../../deps/hammerhead';
+
+import {
+    domUtils,
+    delay,
+    waitFor,
+    positionUtils
+} from '../../deps/testcafe-core';
+
 import {
     CurrentIframeIsNotLoadedError,
     CurrentIframeNotFoundError,
     CurrentIframeIsInvisibleError
 } from '../../../../shared/errors';
+
 import sendMessageToDriver from '../send-message-to-driver';
 import { ExecuteCommandMessage, TYPE as MESSAGE_TYPE } from '../messages';
 import DriverStatus from '../../status';
-import { CHECK_IFRAME_EXISTENCE_INTERVAL, CHECK_IFRAME_VISIBLE_INTERVAL, WAIT_IFRAME_RESPONSE_DELAY } from '../timeouts';
+import {
+    CHECK_IFRAME_EXISTENCE_INTERVAL,
+    CHECK_IFRAME_VISIBLE_INTERVAL,
+    WAIT_IFRAME_RESPONSE_DELAY
+} from '../timeouts';
+
 import sendConfirmationMessage from '../send-confirmation-message';
 
 export default class ChildIframeDriverLink {

--- a/src/client/driver/driver-link/iframe/parent.js
+++ b/src/client/driver/driver-link/iframe/parent.js
@@ -1,8 +1,5 @@
 import { eventSandbox } from '../../deps/hammerhead';
-import {
-    EstablishConnectionMessage,
-    CommandExecutedMessage
-} from '../messages';
+import { EstablishConnectionMessage, CommandExecutedMessage } from '../messages';
 import { CurrentIframeIsNotLoadedError } from '../../../../shared/errors';
 import sendMessageToDriver from '../send-message-to-driver';
 import { WAIT_FOR_IFRAME_DRIVER_RESPONSE_TIMEOUT } from '../timeouts';

--- a/src/client/driver/driver-link/send-message-to-driver.js
+++ b/src/client/driver/driver-link/send-message-to-driver.js
@@ -1,4 +1,9 @@
-import { Promise, eventSandbox, nativeMethods } from '../deps/hammerhead';
+import {
+    Promise,
+    eventSandbox,
+    nativeMethods
+} from '../deps/hammerhead';
+
 import { delay } from '../deps/testcafe-core';
 import { TYPE as MESSAGE_TYPE } from './messages';
 

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -81,7 +81,11 @@ import ChildIframeDriverLink from './driver-link/iframe/child';
 import executeActionCommand from './command-executors/execute-action';
 import executeManipulationCommand from './command-executors/browser-manipulation';
 import executeNavigateToCommand from './command-executors/execute-navigate-to';
-import { getResult as getExecuteSelectorResult, getResultDriverStatus as getExecuteSelectorResultDriverStatus } from './command-executors/execute-selector';
+import {
+    getResult as getExecuteSelectorResult,
+    getResultDriverStatus as getExecuteSelectorResultDriverStatus
+} from './command-executors/execute-selector';
+
 import executeChildWindowDriverLinkSelector from './command-executors/execute-child-window-driver-link-selector';
 import ClientFunctionExecutor from './command-executors/client-functions/client-function-executor';
 import ChildWindowDriverLink from './driver-link/window/child';

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -81,10 +81,7 @@ import ChildIframeDriverLink from './driver-link/iframe/child';
 import executeActionCommand from './command-executors/execute-action';
 import executeManipulationCommand from './command-executors/browser-manipulation';
 import executeNavigateToCommand from './command-executors/execute-navigate-to';
-import {
-    getResult as getExecuteSelectorResult,
-    getResultDriverStatus as getExecuteSelectorResultDriverStatus
-} from './command-executors/execute-selector';
+import { getResult as getExecuteSelectorResult, getResultDriverStatus as getExecuteSelectorResultDriverStatus } from './command-executors/execute-selector';
 import executeChildWindowDriverLinkSelector from './command-executors/execute-child-window-driver-link-selector';
 import ClientFunctionExecutor from './command-executors/client-functions/client-function-executor';
 import ChildWindowDriverLink from './driver-link/window/child';

--- a/src/client/ui/screenshot-mark.js
+++ b/src/client/ui/screenshot-mark.js
@@ -1,5 +1,9 @@
 import { shadowUI, nativeMethods } from './deps/hammerhead';
-import { MARK_LENGTH, MARK_HEIGHT, MARK_RIGHT_MARGIN } from '../../screenshots/constants';
+import {
+    MARK_LENGTH,
+    MARK_HEIGHT,
+    MARK_RIGHT_MARGIN
+} from '../../screenshots/constants';
 
 
 export default {

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -1,4 +1,10 @@
-import { flattenDeep, find, chunk, uniq } from 'lodash';
+import {
+    flattenDeep,
+    find,
+    chunk,
+    uniq
+} from 'lodash';
+
 import stripBom from 'strip-bom';
 import { readFile } from '../utils/promisified-functions';
 import { GeneralError } from '../errors/runtime';

--- a/src/compiler/test-file/api-based.js
+++ b/src/compiler/test-file/api-based.js
@@ -1,4 +1,10 @@
-import { dirname, relative, join, sep as pathSep } from 'path';
+import {
+    dirname,
+    relative,
+    join,
+    sep as pathSep
+} from 'path';
+
 import { readFileSync } from 'fs';
 import stripBom from 'strip-bom';
 import TestFileCompilerBase from './base';

--- a/src/configuration/configuration-base.ts
+++ b/src/configuration/configuration-base.ts
@@ -1,7 +1,13 @@
 import { isAbsolute } from 'path';
 import debug from 'debug';
 import JSON5 from 'json5';
-import { castArray, cloneDeep, isPlainObject, mergeWith } from 'lodash';
+import {
+    castArray,
+    cloneDeep,
+    isPlainObject,
+    mergeWith
+} from 'lodash';
+
 import { stat, readFile } from '../utils/promisified-functions';
 import Option from './option';
 import OptionSource from './option-source';

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -21,7 +21,12 @@ import {
 } from './default-values';
 
 import OptionSource from './option-source';
-import { Dictionary, FilterOption, ReporterOption, StaticContentCachingOptions } from './interfaces';
+import {
+    Dictionary,
+    FilterOption,
+    ReporterOption,
+    StaticContentCachingOptions
+} from './interfaces';
 
 const CONFIGURATION_FILENAME = '.testcaferc.json';
 

--- a/src/configuration/typescript-configuration.ts
+++ b/src/configuration/typescript-configuration.ts
@@ -1,5 +1,10 @@
 import Configuration from './configuration-base';
-import { DEFAULT_TYPESCRIPT_COMPILER_OPTIONS, TYPESCRIPT_COMPILER_NON_OVERRIDABLE_OPTIONS, TYPESCRIPT_BLACKLISTED_OPTIONS } from './default-values';
+import {
+    DEFAULT_TYPESCRIPT_COMPILER_OPTIONS,
+    TYPESCRIPT_COMPILER_NON_OVERRIDABLE_OPTIONS,
+    TYPESCRIPT_BLACKLISTED_OPTIONS
+} from './default-values';
+
 import { intersection, omit } from 'lodash';
 import WARNING_MESSAGES from '../notifications/warning-message';
 import renderTemplate from '../utils/render-template';

--- a/src/errors/runtime/type-assertions.js
+++ b/src/errors/runtime/type-assertions.js
@@ -1,4 +1,9 @@
-import { isFinite as isFiniteNumber, isRegExp, isNil as isNullOrUndefined } from 'lodash';
+import {
+    isFinite as isFiniteNumber,
+    isRegExp,
+    isNil as isNullOrUndefined
+} from 'lodash';
+
 import { APIError, GeneralError } from './';
 import { RUNTIME_ERRORS } from '../types';
 import RequestHook from '../../api/request-hooks/hook';

--- a/src/errors/test-run/index.js
+++ b/src/errors/test-run/index.js
@@ -1,9 +1,6 @@
 import { TEST_RUN_ERRORS } from '../types';
 import * as diff from '../../utils/diff/';
-import {
-    TestRunErrorBase
-} from '../../shared/errors';
-
+import { TestRunErrorBase } from '../../shared/errors';
 export * from '../../shared/errors';
 
 // Base

--- a/src/errors/test-run/render-error-template.js
+++ b/src/errors/test-run/render-error-template.js
@@ -1,6 +1,11 @@
 import { renderers } from 'callsite-record';
 import { TEST_RUN_ERRORS } from '../types';
-import { markup, shouldSkipCallsite, formatExpressionMessage } from './utils';
+import {
+    markup,
+    shouldSkipCallsite,
+    formatExpressionMessage
+} from './utils';
+
 import TEMPLATES from './templates';
 
 function getTestCafeErrorInCustomScriptError (err, viewportWidth) {

--- a/src/reporter/command/command-formatter.ts
+++ b/src/reporter/command/command-formatter.ts
@@ -1,8 +1,18 @@
 import { isEmpty } from 'lodash';
 import { ExecuteSelectorCommand, ExecuteClientFunctionCommand } from '../../test-run/commands/observation';
-import { NavigateToCommand, SetNativeDialogHandlerCommand, UseRoleCommand } from '../../test-run/commands/actions';
+import {
+    NavigateToCommand,
+    SetNativeDialogHandlerCommand,
+    UseRoleCommand
+} from '../../test-run/commands/actions';
+
 import { createReplicator, SelectorNodeTransform } from '../../client-functions/replicator';
-import { Command, FormattedCommand, SelectorInfo } from './interfaces';
+import {
+    Command,
+    FormattedCommand,
+    SelectorInfo
+} from './interfaces';
+
 import { Dictionary } from '../../configuration/interfaces';
 import diff from '../../utils/diff';
 

--- a/src/reporter/index.js
+++ b/src/reporter/index.js
@@ -1,4 +1,9 @@
-import { find, sortBy, union } from 'lodash';
+import {
+    find,
+    sortBy,
+    union
+} from 'lodash';
+
 import { writable as isWritableStream } from 'is-stream';
 import ReporterPluginHost from './plugin-host';
 import ReporterPluginMethod from './plugin-methods';

--- a/src/reporter/plugin-host.js
+++ b/src/reporter/plugin-host.js
@@ -1,6 +1,11 @@
 import chalk from 'chalk';
 import indentString from 'indent-string';
-import { identity, escape as escapeHtml, assignIn } from 'lodash';
+import {
+    identity,
+    escape as escapeHtml,
+    assignIn
+} from 'lodash';
+
 import moment from '../utils/moment-loader';
 import OS from 'os-family';
 import { wordWrap, removeTTYColors } from '../utils/string';

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -1,7 +1,12 @@
 import path from 'path';
 import fs from 'fs';
 import isCI from 'is-ci';
-import { flatten, chunk, times } from 'lodash';
+import {
+    flatten,
+    chunk,
+    times
+} from 'lodash';
+
 import makeDir from 'make-dir';
 import OS from 'os-family';
 import { errors, findWindow } from 'testcafe-browser-tools';

--- a/src/runner/browser-set.ts
+++ b/src/runner/browser-set.ts
@@ -1,7 +1,12 @@
 import { EventEmitter } from 'events';
 import getTimeLimitedPromise from 'time-limit-promise';
 import promisifyEvent from 'promisify-event';
-import { flatten, noop, pull as remove } from 'lodash';
+import {
+    flatten,
+    noop,
+    pull as remove
+} from 'lodash';
+
 // @ts-ignore
 import mapReverse from 'map-reverse';
 import { GeneralError } from '../errors/runtime';

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -3,7 +3,12 @@ import debug from 'debug';
 import promisifyEvent from 'promisify-event';
 import mapReverse from 'map-reverse';
 import { EventEmitter } from 'events';
-import { flattenDeep as flatten, pull as remove, isFunction } from 'lodash';
+import {
+    flattenDeep as flatten,
+    pull as remove,
+    isFunction
+} from 'lodash';
+
 import Bootstrapper from './bootstrapper';
 import Reporter from '../reporter';
 import Task from './task';
@@ -14,7 +19,13 @@ import { assertType, is } from '../errors/runtime/type-assertions';
 import { renderForbiddenCharsList } from '../errors/test-run/utils';
 import detectFFMPEG from '../utils/detect-ffmpeg';
 import checkFilePath from '../utils/check-file-path';
-import { addRunningTest, removeRunningTest, startHandlingTestErrors, stopHandlingTestErrors } from '../utils/handle-errors';
+import {
+    addRunningTest,
+    removeRunningTest,
+    startHandlingTestErrors,
+    stopHandlingTestErrors
+} from '../utils/handle-errors';
+
 import OPTION_NAMES from '../configuration/option-names';
 import FlagList from '../utils/flag-list';
 import prepareReporters from '../utils/prepare-reporters';

--- a/src/screenshots/capturer.js
+++ b/src/screenshots/capturer.js
@@ -1,11 +1,20 @@
-import { join as joinPath, dirname, basename } from 'path';
+import {
+    join as joinPath,
+    dirname,
+    basename
+} from 'path';
+
 import { generateThumbnail } from 'testcafe-browser-tools';
 import { cropScreenshot } from './crop';
 import { isInQueue, addToQueue } from '../utils/async-queue';
 import WARNING_MESSAGE from '../notifications/warning-message';
 import escapeUserAgent from '../utils/escape-user-agent';
 import correctFilePath from '../utils/correct-file-path';
-import { readPngFile, stat, writePng } from '../utils/promisified-functions';
+import {
+    readPngFile,
+    stat,
+    writePng
+} from '../utils/promisified-functions';
 
 
 export default class Capturer {

--- a/src/screenshots/crop.js
+++ b/src/screenshots/crop.js
@@ -3,7 +3,12 @@ import limitNumber from '../utils/limit-number';
 import renderTemplate from '../utils/render-template';
 import { deleteFile } from '../utils/promisified-functions';
 import { InvalidElementScreenshotDimensionsError } from '../errors/test-run/';
-import { MARK_LENGTH, MARK_RIGHT_MARGIN, MARK_BYTES_PER_PIXEL } from './constants';
+import {
+    MARK_LENGTH,
+    MARK_RIGHT_MARGIN,
+    MARK_BYTES_PER_PIXEL
+} from './constants';
+
 import WARNING_MESSAGES from '../notifications/warning-message';
 
 const MARK_SEED_ERROR_THRESHOLD = 10;

--- a/src/screenshots/utils.js
+++ b/src/screenshots/utils.js
@@ -1,7 +1,17 @@
 import { PNG } from 'pngjs';
-import { map, flatten, times, constant } from 'lodash';
+import {
+    map,
+    flatten,
+    times,
+    constant
+} from 'lodash';
+
 import generateId from 'nanoid/generate';
-import { MARK_LENGTH, MARK_HEIGHT, MARK_BYTES_PER_PIXEL } from './constants';
+import {
+    MARK_LENGTH,
+    MARK_HEIGHT,
+    MARK_BYTES_PER_PIXEL
+} from './constants';
 
 const ALPHABET = '01';
 

--- a/src/services/compiler/host.ts
+++ b/src/services/compiler/host.ts
@@ -1,5 +1,10 @@
 import { spawn, ChildProcess } from 'child_process';
-import { HOST_INPUT_FD, HOST_OUTPUT_FD, HOST_SYNC_FD } from './io';
+import {
+    HOST_INPUT_FD,
+    HOST_OUTPUT_FD,
+    HOST_SYNC_FD
+} from './io';
+
 import { restore as restoreTestStructure } from './test-structure';
 import { default as testRunTracker, TestRun } from '../../api/test-run-tracker';
 import { IPCProxy } from '../utils/ipc/proxy';
@@ -7,7 +12,13 @@ import { HostTransport } from '../utils/ipc/transport';
 import EventEmitter from '../../utils/async-event-emitter';
 import TestCafeErrorList from '../../errors/error-list';
 
-import { CompilerProtocol, RunTestArguments, ExecuteCommandArguments, FunctionProperties } from './protocol';
+import {
+    CompilerProtocol,
+    RunTestArguments,
+    ExecuteCommandArguments,
+    FunctionProperties
+} from './protocol';
+
 import { CompilerArguments } from '../../compiler/interfaces';
 import Test from '../../api/structure/test';
 

--- a/src/services/compiler/service.ts
+++ b/src/services/compiler/service.ts
@@ -3,13 +3,20 @@ import Compiler from '../../compiler';
 import TestRunProxy from './test-run-proxy';
 
 import {
-    flatten as flattenTestStructure, isFixture,
+    flatten as flattenTestStructure,
+    isFixture,
     isTest,
-    serialize as serializeTestStructure, Unit,
+    serialize as serializeTestStructure,
+    Unit,
     Units
 } from './test-structure';
 
-import { SERVICE_INPUT_FD, SERVICE_OUTPUT_FD, SERVICE_SYNC_FD } from './io';
+import {
+    SERVICE_INPUT_FD,
+    SERVICE_OUTPUT_FD,
+    SERVICE_SYNC_FD
+} from './io';
+
 import { IPCProxy } from '../utils/ipc/proxy';
 import { ServiceTransport } from '../utils/ipc/transport';
 import sourceMapSupport from 'source-map-support';

--- a/src/services/utils/ipc/transport.ts
+++ b/src/services/utils/ipc/transport.ts
@@ -1,8 +1,19 @@
-import { AsyncReader, AsyncWriter, SyncReader, SyncWriter } from './io';
+import {
+    AsyncReader,
+    AsyncWriter,
+    SyncReader,
+    SyncWriter
+} from './io';
+
 import EventEmitter from '../../../utils/async-event-emitter';
 import { GeneralError } from '../../../errors/runtime';
 import { RUNTIME_ERRORS } from '../../../errors/types';
-import { IPCPacket, IPCResponsePacket, IPCTransport, isIPCResponsePacket } from './interfaces';
+import {
+    IPCPacket,
+    IPCResponsePacket,
+    IPCTransport,
+    isIPCResponsePacket
+} from './interfaces';
 
 
 export class HostTransport extends EventEmitter implements IPCTransport {

--- a/src/test-run/bookmark.js
+++ b/src/test-run/bookmark.js
@@ -10,10 +10,7 @@ import {
     SetPageLoadTimeoutCommand
 } from './commands/actions';
 
-import {
-    CurrentIframeNotFoundError,
-    CurrentIframeIsNotLoadedError
-} from '../errors/test-run';
+import { CurrentIframeNotFoundError, CurrentIframeIsNotLoadedError } from '../errors/test-run';
 
 export default class TestRunBookmark {
     constructor (testRun, role) {

--- a/src/test-run/commands/actions.js
+++ b/src/test-run/commands/actions.js
@@ -3,7 +3,14 @@ import SelectorBuilder from '../../client-functions/selectors/selector-builder';
 import ClientFunctionBuilder from '../../client-functions/client-function-builder';
 import functionBuilderSymbol from '../../client-functions/builder-symbol';
 import CommandBase from './base';
-import { ActionOptions, ClickOptions, MouseOptions, TypeOptions, DragToElementOptions } from './options';
+import {
+    ActionOptions,
+    ClickOptions,
+    MouseOptions,
+    TypeOptions,
+    DragToElementOptions
+} from './options';
+
 import { initSelector, initUploadSelector } from './validations/initializers';
 import { executeJsExpression } from '../execute-js-expression';
 import { isJSExpression } from './utils';

--- a/src/test-run/commands/assertion.js
+++ b/src/test-run/commands/assertion.js
@@ -5,8 +5,11 @@ import { APIError } from '../../errors/runtime';
 import { AssertionExecutableArgumentError } from '../../errors/test-run';
 import { executeJsExpression } from '../execute-js-expression';
 import { isJSExpression } from './utils';
-
-import { stringArgument, actionOptions, nonEmptyStringArgument } from './validations/argument';
+import {
+    stringArgument,
+    actionOptions,
+    nonEmptyStringArgument
+} from './validations/argument';
 
 // Initializers
 function initAssertionOptions (name, val) {

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -1,4 +1,9 @@
-import { pull, remove, chain } from 'lodash';
+import {
+    pull,
+    remove,
+    chain
+} from 'lodash';
+
 import { readSync as read } from 'read-file-relative';
 import promisifyEvent from 'promisify-event';
 import Mustache from 'mustache';
@@ -14,6 +19,7 @@ import {
     SwitchToWindowPredicateError,
     WindowNotFoundError
 } from '../errors/test-run/';
+
 import PHASE from './phase';
 import CLIENT_MESSAGES from './client-messages';
 import COMMAND_TYPE from './commands/type';
@@ -42,10 +48,7 @@ import {
     isResizeWindowCommand
 } from './commands/utils';
 
-import {
-    GetCurrentWindowsCommand,
-    SwitchToWindowCommand
-} from './commands/actions';
+import { GetCurrentWindowsCommand, SwitchToWindowCommand } from './commands/actions';
 
 import { TEST_RUN_ERRORS } from '../errors/types';
 import processTestFnError from '../errors/process-test-fn-error';

--- a/src/video-recorder/recorder.js
+++ b/src/video-recorder/recorder.js
@@ -6,7 +6,11 @@ import makeDir from 'make-dir';
 import TempDirectory from '../utils/temp-directory';
 import PathPattern from '../utils/path-pattern';
 import WARNING_MESSAGES from '../notifications/warning-message';
-import { getPluralSuffix, getConcatenatedValuesString, getToBeInPastTense } from '../utils/string';
+import {
+    getPluralSuffix,
+    getConcatenatedValuesString,
+    getToBeInPastTense
+} from '../utils/string';
 
 import TestRunVideoRecorder from './test-run-video-recorder';
 import { EventEmitter } from 'events';

--- a/src/video-recorder/videos.ts
+++ b/src/video-recorder/videos.ts
@@ -2,7 +2,13 @@ import VideoRecorder from './recorder';
 import BrowserJob from '../runner/browser-job';
 import { Dictionary } from '../configuration/interfaces';
 import WarningLog from '../notifications/warning-log';
-import { VideoOptions, TestVideoInfo, TestRunVideoInfo, TestRunVideoSavedEventArgs } from './interfaces';
+import {
+    VideoOptions,
+    TestVideoInfo,
+    TestRunVideoInfo,
+    TestRunVideoSavedEventArgs
+} from './interfaces';
+
 import moment from 'moment';
 
 export default class Videos {

--- a/test/functional/.eslintrc
+++ b/test/functional/.eslintrc
@@ -4,7 +4,8 @@
   ],
   "rules": {
     "max-nested-callbacks": [2, 6],
-    "no-only-tests/no-only-tests": 2
+    "no-only-tests/no-only-tests": 2,
+    "object-curly-newline": [2, { "ImportDeclaration":  { "minProperties": 4 } }]
   },
   "env": {
     "browser": true,

--- a/test/functional/fixtures/run-options/disable-page-caching/common/index.js
+++ b/test/functional/fixtures/run-options/disable-page-caching/common/index.js
@@ -1,4 +1,9 @@
-import { ClientFunction, Role, Selector, t } from 'testcafe';
+import {
+    ClientFunction,
+    Role,
+    Selector,
+    t
+} from 'testcafe';
 
 const getPageLocation = ClientFunction(() => window.location.toString());
 

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -11,7 +11,6 @@ const { ReporterPluginError }         = require('../../lib/errors/runtime');
 chai.use(require('chai-string'));
 
 describe('Reporter', () => {
-    // Runnable configuration mocks
     const screenshotDir = '/screenshots/1445437598847';
 
     const browserConnectionMocks = [
@@ -21,7 +20,8 @@ describe('Reporter', () => {
                 alias:           'Chrome',
                 parsedUserAgent: { userAgent: 'Chrome' }
             },
-            isHeadlessBrowser: () => false },
+            isHeadlessBrowser: () => false
+        },
         {
             userAgent:   'Firefox',
             browserInfo: {


### PR DESCRIPTION
https://github.com/DevExpress/testcafe/issues/5391#issuecomment-689562436

> newlines are required after any multiline expressions with curly braces - https://eslint.org/docs/rules/object-curly-newline

The [object-curly-newline](https://eslint.org/docs/rules/object-curly-newline) affects the line breaks only inside of the statement (not after). However, I guess we can add this rule to standardize the new lines inside of `import` statements.

The new lines are required if there are:
* 3 imported items in code (https://github.com/DevExpress/testcafe/compare/master...miherlosev:add_eslint_rule?expand=1#diff-1dc6ee56b778cd91e0327b52aaeaa1b9R70)
* 4 imported items in tests (https://github.com/DevExpress/testcafe/compare/master...miherlosev:add_eslint_rule?expand=1#diff-0c5dfecfad9f1add47f85e04db2379dcR8)

I added a special rule for tests because the statement `import { Selector, Role, t } from 'testcafe'` with 3 items looks good.
