### PR TITLE
Refactor session parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.13",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/5195348/testcafe-hammerhead-18.0.0.zip",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/5231957/testcafe-hammerhead-18.0.0.zip",
     "testcafe-legacy-api": "4.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.13",
-    "testcafe-hammerhead": "17.1.18",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/5195348/testcafe-hammerhead-18.0.0.zip",
     "testcafe-legacy-api": "4.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -59,6 +59,7 @@ export interface BrowserInfo {
 export default class BrowserConnection extends EventEmitter {
     public permanent: boolean;
     public previousActiveWindowId: string | null;
+    private currentActiveWindowId: string | null;
     private readonly disableMultipleWindows: boolean;
     private readonly HEARTBEAT_TIMEOUT: number;
     private readonly BROWSER_RESTART_TIMEOUT: number;
@@ -141,6 +142,7 @@ export default class BrowserConnection extends EventEmitter {
         connections[this.id] = this;
 
         this.previousActiveWindowId = null;
+        this.currentActiveWindowId  = null;
 
         this.browserConnectionGateway.startServingConnection(this);
 
@@ -448,13 +450,12 @@ export default class BrowserConnection extends EventEmitter {
     }
 
     public get activeWindowId (): null | string {
-        return this.provider.getActiveWindowId(this.id);
+        return this.currentActiveWindowId;
     }
 
     public set activeWindowId (val) {
         this.previousActiveWindowId = this.activeWindowId;
-
-        this.provider.setActiveWindowId(this.id, val);
+        this.currentActiveWindowId  = val;
     }
 
     public async canUseDefaultWindowActions (): Promise<boolean> {

--- a/src/browser/provider/built-in/dedicated/base.js
+++ b/src/browser/provider/built-in/dedicated/base.js
@@ -10,14 +10,6 @@ export default {
 
     supportMultipleWindows: true,
 
-    getActiveWindowId (browserId) {
-        return this.openedBrowsers[browserId].activeWindowId;
-    },
-
-    setActiveWindowId (browserId, val) {
-        this.openedBrowsers[browserId].activeWindowId = val;
-    },
-
     _getConfig () {
         throw new Error('Not implemented');
     },

--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -57,9 +57,6 @@ export default {
         runtimeInfo.viewportSize   = await this.runInitScript(browserId, GET_WINDOW_DIMENSIONS_INFO_SCRIPT);
         runtimeInfo.activeWindowId = null;
 
-        if (!disableMultipleWindows)
-            runtimeInfo.activeWindowId = this.calculateWindowId();
-
         await cdp.createClient(runtimeInfo);
 
         this.openedBrowsers[browserId] = runtimeInfo;

--- a/src/browser/provider/built-in/dedicated/chrome/runtime-info.ts
+++ b/src/browser/provider/built-in/dedicated/chrome/runtime-info.ts
@@ -13,14 +13,13 @@ export default class ChromeRuntimeInfo {
     public browserName?: string;
     public browserId?: string;
     public providerMethods?: Dictionary<Function>;
-    public activeWindowId: null | string;
+
 
     protected constructor (configString: string) {
         this.config         = getConfig(configString);
         this.tempProfileDir = null;
         this.cdpPort        = this.config.cdpPort;
         this.inDocker       = isDocker();
-        this.activeWindowId = null;
     }
 
     protected async createTempProfile (proxyHostName: string, disableMultipleWindows: boolean): Promise<TempDirectory> {

--- a/src/browser/provider/built-in/dedicated/firefox/index.js
+++ b/src/browser/provider/built-in/dedicated/firefox/index.js
@@ -40,9 +40,6 @@ export default {
 
         await this.waitForConnectionReady(runtimeInfo.browserId);
 
-        if (!disableMultipleWindows)
-            runtimeInfo.activeWindowId = this.calculateWindowId();
-
         if (runtimeInfo.marionettePort)
             runtimeInfo.marionetteClient = await this._createMarionetteClient(runtimeInfo);
 

--- a/src/browser/provider/built-in/dedicated/firefox/index.js
+++ b/src/browser/provider/built-in/dedicated/firefox/index.js
@@ -30,7 +30,7 @@ export default {
         }
     },
 
-    async openBrowser (browserId, pageUrl, configString, disableMultipleWindows) {
+    async openBrowser (browserId, pageUrl, configString) {
         const runtimeInfo = await getRuntimeInfo(configString);
 
         runtimeInfo.browserName = this._getBrowserName();

--- a/src/browser/provider/built-in/dedicated/firefox/runtime-info.js
+++ b/src/browser/provider/built-in/dedicated/firefox/runtime-info.js
@@ -9,7 +9,6 @@ export default async function (configString) {
     const runtimeInfo    = { config, marionettePort };
 
     runtimeInfo.tempProfileDir = !config.userProfile ? await createTempProfile(runtimeInfo) : null;
-    runtimeInfo.activeWindowId = null;
 
     return runtimeInfo;
 }

--- a/src/browser/provider/index.ts
+++ b/src/browser/provider/index.ts
@@ -365,15 +365,4 @@ export default class BrowserProvider {
     public async reportJobResult (browserId: string, status: string, data: any): Promise<void> {
         await this.plugin.reportJobResult(browserId, status, data);
     }
-
-    public getActiveWindowId (browserId: string): string | null {
-        if (!this.plugin.supportMultipleWindows)
-            return null;
-
-        return this.plugin.getActiveWindowId(browserId);
-    }
-
-    public setActiveWindowId (browserId: string, val: string): void {
-        this.plugin.setActiveWindowId(browserId, val);
-    }
 }

--- a/src/browser/provider/plugin-host.js
+++ b/src/browser/provider/plugin-host.js
@@ -29,10 +29,6 @@ export default class BrowserProviderPluginHost {
         return connection.runInitScript(`(${code})()`);
     }
 
-    calculateWindowId () {
-        return generateUniqueId();
-    }
-
     waitForConnectionReady (browserId) {
         const connection = BrowserConnection.getById(browserId);
 

--- a/src/browser/provider/plugin-host.js
+++ b/src/browser/provider/plugin-host.js
@@ -4,7 +4,6 @@ import promisifyEvent from 'promisify-event';
 import BROWSER_JOB_RESULT from '../../runner/browser-job-result';
 import BrowserConnection from '../connection';
 import WARNING_MESSAGE from '../../notifications/warning-message';
-import { generateUniqueId } from 'testcafe-hammerhead';
 
 const name = Symbol();
 

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -83,10 +83,8 @@ export default class TestRun extends AsyncEventEmitter {
 
         this.warningLog = new WarningLog(globalWarningLog);
 
-        this.opts              = opts;
-        this.test              = test;
-        this.browserConnection = browserConnection;
-
+        this.opts  = opts;
+        this.test  = test;
         this.phase = PHASE.initial;
 
         this.driverTaskQueue       = [];
@@ -102,7 +100,10 @@ export default class TestRun extends AsyncEventEmitter {
 
         this.disableMultipleWindows = opts.disableMultipleWindows;
 
-        this.session = SessionController.getSession(this);
+        this.browserConnection = browserConnection;
+        this.session           = SessionController.getSession(this);
+
+        this.browserConnection.activeWindowId = this.session.windowId;
 
         this.consoleMessages = new BrowserConsoleMessages();
 
@@ -143,8 +144,6 @@ export default class TestRun extends AsyncEventEmitter {
 
         this._addInjectables();
         this._initRequestHooks();
-
-        browserConnection.activeWindowId = this.session.windowId;
     }
 
     _addClientScriptContentWarningsIfNecessary () {
@@ -936,7 +935,7 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     static isMultipleWindowsAllowed (testRun) {
-        const { disableMultipleWindows, test, browserConnection } = testRun;
+        const { disableMultipleWindows, test } = testRun;
 
         return !disableMultipleWindows && !test.isLegacy;
     }

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -143,6 +143,8 @@ export default class TestRun extends AsyncEventEmitter {
 
         this._addInjectables();
         this._initRequestHooks();
+
+        browserConnection.activeWindowId = this.session.windowId;
     }
 
     _addClientScriptContentWarningsIfNecessary () {
@@ -936,7 +938,7 @@ export default class TestRun extends AsyncEventEmitter {
     static isMultipleWindowsAllowed (testRun) {
         const { disableMultipleWindows, test, browserConnection } = testRun;
 
-        return !disableMultipleWindows && !test.isLegacy && !!browserConnection.activeWindowId;
+        return !disableMultipleWindows && !test.isLegacy;
     }
 }
 

--- a/src/test-run/session-controller.js
+++ b/src/test-run/session-controller.js
@@ -8,8 +8,8 @@ const ACTIVE_SESSIONS_MAP = {};
 const UPLOADS_DIR_NAME = '_uploads_';
 
 export default class SessionController extends Session {
-    constructor (uploadRoots) {
-        super(uploadRoots);
+    constructor (uploadRoots, options) {
+        super(uploadRoots, options);
 
         this.currentTestRun = null;
     }
@@ -67,20 +67,21 @@ export default class SessionController extends Session {
             else {
                 const fixtureDir = path.dirname(testRun.test.fixture.path);
 
-                session = new SessionController([
+                const uploadRoots = [
                     path.resolve(UPLOADS_DIR_NAME),
                     path.resolve(fixtureDir, UPLOADS_DIR_NAME),
                     fixtureDir
-                ]);
+                ];
+
+                const options = {
+                    disablePageCaching:   testRun.disablePageCaching,
+                    allowMultipleWindows: TestRun.isMultipleWindowsAllowed(testRun)
+                };
+
+                session = new SessionController(uploadRoots, options);
 
                 session.currentTestRun = testRun;
             }
-
-            session.disablePageCaching   = testRun.disablePageCaching;
-            session.allowMultipleWindows = TestRun.isMultipleWindowsAllowed(testRun);
-
-            if (session.allowMultipleWindows)
-                session.windowId = testRun.browserConnection.activeWindowId;
 
             sessionInfo = {
                 session: session,

--- a/test/functional/fixtures/multiple-windows/test.js
+++ b/test/functional/fixtures/multiple-windows/test.js
@@ -4,7 +4,7 @@ const path           = require('path');
 
 describe('Multiple windows', () => {
     describe('Switch to the child window', () => {
-        it.only('Click on link', () => {
+        it('Click on link', () => {
             return runTests('testcafe-fixtures/switching-to-child/click-on-link.js');
         });
 

--- a/test/functional/fixtures/multiple-windows/test.js
+++ b/test/functional/fixtures/multiple-windows/test.js
@@ -4,7 +4,7 @@ const path           = require('path');
 
 describe('Multiple windows', () => {
     describe('Switch to the child window', () => {
-        it('Click on link', () => {
+        it.only('Click on link', () => {
             return runTests('testcafe-fixtures/switching-to-child/click-on-link.js');
         });
 

--- a/test/server/multiple-windows-test.js
+++ b/test/server/multiple-windows-test.js
@@ -52,8 +52,8 @@ describe('Multiple windows', () => {
     it('`allowMultipleWindows` is passed to session', async () => {
         expect(new TestRunMock().session.options.allowMultipleWindows).eql(true);
 
-        expect(new TestRunMock({ disableMultipleWindows: true }).session.allowMultipleWindows).eql(false);
-        expect(new TestRunMock({ isLegacy: true }).session.allowMultipleWindows).eql(false);
-        expect(new TestRunMock({ activeWindowId: null }).session.allowMultipleWindows).eql(false);
+        expect(new TestRunMock({ disableMultipleWindows: true }).session.options.allowMultipleWindows).eql(false);
+        expect(new TestRunMock({ isLegacy: true }).session.options.allowMultipleWindows).eql(false);
+        expect(new TestRunMock({ activeWindowId: null }).session.options.allowMultipleWindows).eql(false);
     });
 });

--- a/test/server/multiple-windows-test.js
+++ b/test/server/multiple-windows-test.js
@@ -51,9 +51,7 @@ describe('Multiple windows', () => {
 
     it('`allowMultipleWindows` is passed to session', async () => {
         expect(new TestRunMock().session.options.allowMultipleWindows).eql(true);
-
         expect(new TestRunMock({ disableMultipleWindows: true }).session.options.allowMultipleWindows).eql(false);
-        expect(new TestRunMock({ isLegacy: true }).session.options.allowMultipleWindows).eql(false);
-        expect(new TestRunMock({ activeWindowId: null }).session.options.allowMultipleWindows).eql(false);
+        expect(new TestRunMock({ isLegacy: true }).opts.disableMultipleWindows).eql(false);
     });
 });

--- a/test/server/multiple-windows-test.js
+++ b/test/server/multiple-windows-test.js
@@ -50,7 +50,7 @@ describe('Multiple windows', () => {
     });
 
     it('`allowMultipleWindows` is passed to session', async () => {
-        expect(new TestRunMock().session.allowMultipleWindows).eql(true);
+        expect(new TestRunMock().session.options.allowMultipleWindows).eql(true);
 
         expect(new TestRunMock({ disableMultipleWindows: true }).session.allowMultipleWindows).eql(false);
         expect(new TestRunMock({ isLegacy: true }).session.allowMultipleWindows).eql(false);


### PR DESCRIPTION
Changes:
* update Session constructor signature: `Session (uploadRoots)` -> `Session (uploadRoots, options)`
* move `activeWindowId` parameter from `BaseDedicatedBrowserProvider` to `BrowserConnection`.
* move `calculateWindowId` calculation to hammerhead.