### PR TITLE
fix: unmarked session when restarting

### DIFF
--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -12,6 +12,7 @@ import { GeneralError } from '../../errors/runtime';
 import { RUNTIME_ERRORS } from '../../errors/types';
 import { BROWSER_RESTART_TIMEOUT, HEARTBEAT_TIMEOUT } from '../../utils/browser-connection-timeouts';
 import { Dictionary } from '../../configuration/interfaces';
+import BROWSER_JOB_RESULT from '../../runner/browser-job-result';
 import BrowserConnectionGateway from './gateway';
 import BrowserJob from '../../runner/browser-job';
 import WarningLog from '../../notifications/warning-log';
@@ -234,7 +235,8 @@ export default class BrowserConnection extends EventEmitter {
         let isTimeoutExpired                = false;
         let timeout: NodeJS.Timeout | null  = null;
 
-        const restartPromise = this._closeBrowser()
+        const restartPromise = this.reportJobResult(BROWSER_JOB_RESULT.restarted, {})
+            .then(() => this._closeBrowser())
             .then(() => this._runBrowser());
 
         const timeoutPromise = new Promise(resolve => {

--- a/src/runner/browser-job-result.ts
+++ b/src/runner/browser-job-result.ts
@@ -1,7 +1,8 @@
 enum BrowserJobResult {
     done = 'browser-job-done',
     errored = 'browser-job-errored',
-    aborted = 'browser-job-aborted'
+    aborted = 'browser-job-aborted',
+    restarted = 'browser-job-restarted'
 }
 
 export default BrowserJobResult;


### PR DESCRIPTION


<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
_Describe the problem you want to address or the feature you want to implement._
When session is restarted because of heart beat lapsed we close the
current session and opens up a new session and the internal mapping with
the browserid in the provider is also changed. So this leads to one
unmarked session and can be many depending upon the count.

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._

Before closing the browser, we can basically introduce a new job status
as restarted so that users are aware that why there are more session
then the desired count. Fix is to call the reportJob result before
closing the browser.

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
