### PR TITLE
Fix excessive "missing await" warnings (closes #5534)

### DIFF
--- a/test/functional/fixtures/api/es-next/assertions/data/expected-missing-await-on-snapshot-callsite
+++ b/test/functional/fixtures/api/es-next/assertions/data/expected-missing-await-on-snapshot-callsite
@@ -1,5 +1,0 @@
-   191 |test('Snapshot property without await', async t => {
-   192 |    await t.expect(Selector('#el1').innerText).eql('');
-   193 |
- > 194 |    Selector('#el1').innerText;
-   195 |});

--- a/test/functional/fixtures/api/es-next/assertions/data/expected-missing-await-on-snapshot-callsite/console-log
+++ b/test/functional/fixtures/api/es-next/assertions/data/expected-missing-await-on-snapshot-callsite/console-log
@@ -1,0 +1,7 @@
+   191 |test('Snapshot property without await', async t => {
+   192 |    await t.expect(Selector('#el1').innerText).eql('');
+   193 |
+ > 194 |    console.log(Selector('#el1').innerText); //eslint-disable-line
+   195 |
+   196 |    const tag = `element: ${Selector('#el1').tagName}`; //eslint-disable-line
+   197 |});

--- a/test/functional/fixtures/api/es-next/assertions/data/expected-missing-await-on-snapshot-callsite/template-expansion
+++ b/test/functional/fixtures/api/es-next/assertions/data/expected-missing-await-on-snapshot-callsite/template-expansion
@@ -1,0 +1,7 @@
+   191 |test('Snapshot property without await', async t => {
+   192 |    await t.expect(Selector('#el1').innerText).eql('');
+   193 |
+   194 |    console.log(Selector('#el1').innerText); //eslint-disable-line
+   195 |
+ > 196 |    const tag = `element: ${Selector('#el1').tagName}`; //eslint-disable-line
+   197 |});

--- a/test/functional/fixtures/api/es-next/assertions/testcafe-fixtures/assertions-test.js
+++ b/test/functional/fixtures/api/es-next/assertions/testcafe-fixtures/assertions-test.js
@@ -191,5 +191,13 @@ test('Await Selector property', async t => {
 test('Snapshot property without await', async t => {
     await t.expect(Selector('#el1').innerText).eql('');
 
-    Selector('#el1').innerText;
+    console.log(Selector('#el1').innerText); //eslint-disable-line
+
+    const tag = `element: ${Selector('#el1').tagName}`; //eslint-disable-line
+});
+
+test('Snapshot property without await but valid', async t => {
+    const b = Selector('#el1').innerText; //eslint-disable-line
+
+    await t.expect(Selector('#el1').innerText).eql('');
 });


### PR DESCRIPTION
Now a "missing await for a snapshot property" is created only when:
 - It is converted to a primitive value (arithmetic operators, template expansions, string concatenation) (overrided `Symbol.toPromitive`)
 - `console.log` or `util.inspect` are invoked (overrided `util.inspect.custom`)