### PR TITLE
Bump version (v1.9.3)

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -8,7 +8,7 @@
     "gitTag": true
   },
   "confirm": true,
-  "publishTag": "rc",
+  "publishTag": "latest",
   "prePublishScript": "gulp test-server",
   "postPublishScript": "gulp docker-publish"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.9.3-rc.1",
+  "version": "1.9.3",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"


### PR DESCRIPTION
# Changelog (preview)
 - `RequestMock`\`s type definitions was fixed to allow setting custom headers (https://github.com/DevExpress/testcafe/issues/5529)
 - Eliminated "You used a DOM snapshot property without \'await\'. " warning when a snapshot property was saved to a variable but not used in a test (https://github.com/DevExpress/testcafe/issues/5534)
 - Consecutive  `document.getElementsByTagName('body')` calls now produce correct results even if a first call was made before a document's body was completely parsed (#5322)