### PR TITLE
Fix cross-domain iframe focus in Safari

### DIFF
--- a/src/client/automation/cursor.js
+++ b/src/client/automation/cursor.js
@@ -1,8 +1,9 @@
 import testCafeCore from './deps/testcafe-core';
 import testCafeUI from './deps/testcafe-ui';
+import isWindowInIframe from '../../utils/is-window-in-iframe';
 
 const domUtils = testCafeCore.domUtils;
-const cursorUI = window.top === window ? testCafeUI.cursorUI : testCafeUI.iframeCursorUI;
+const cursorUI = !isWindowInIframe(window)() ? testCafeUI.cursorUI : testCafeUI.iframeCursorUI;
 
 
 // NOTE: the default position should be outside of the page (GH-794)
@@ -40,7 +41,7 @@ export default {
     },
 
     get visible () {
-        return window.top === window && cursorUI.isVisible();
+        return !isWindowInIframe(window)() && cursorUI.isVisible();
     },
 
     move (newX, newY) {
@@ -56,7 +57,7 @@ export default {
     },
 
     show () {
-        if (window.top === window)
+        if (!isWindowInIframe(window)())
             cursorUI.show();
     },
 

--- a/src/client/automation/cursor.js
+++ b/src/client/automation/cursor.js
@@ -3,7 +3,7 @@ import testCafeUI from './deps/testcafe-ui';
 import isWindowInIframe from '../../utils/is-window-in-iframe';
 
 const domUtils = testCafeCore.domUtils;
-const cursorUI = !isWindowInIframe(window)() ? testCafeUI.cursorUI : testCafeUI.iframeCursorUI;
+const cursorUI = !isWindowInIframe(window) ? testCafeUI.cursorUI : testCafeUI.iframeCursorUI;
 
 
 // NOTE: the default position should be outside of the page (GH-794)
@@ -41,7 +41,7 @@ export default {
     },
 
     get visible () {
-        return !isWindowInIframe(window)() && cursorUI.isVisible();
+        return !isWindowInIframe(window) && cursorUI.isVisible();
     },
 
     move (newX, newY) {
@@ -57,7 +57,7 @@ export default {
     },
 
     show () {
-        if (!isWindowInIframe(window)())
+        if (!isWindowInIframe(window))
             cursorUI.show();
     },
 

--- a/src/client/automation/cursor.js
+++ b/src/client/automation/cursor.js
@@ -1,9 +1,9 @@
 import testCafeCore from './deps/testcafe-core';
 import testCafeUI from './deps/testcafe-ui';
-import isWindowInIframe from '../../utils/is-window-in-iframe';
+import isIframeWindow from '../../utils/is-window-in-iframe';
 
 const domUtils = testCafeCore.domUtils;
-const cursorUI = !isWindowInIframe(window) ? testCafeUI.cursorUI : testCafeUI.iframeCursorUI;
+const cursorUI = !isIframeWindow(window) ? testCafeUI.cursorUI : testCafeUI.iframeCursorUI;
 
 
 // NOTE: the default position should be outside of the page (GH-794)
@@ -41,7 +41,7 @@ export default {
     },
 
     get visible () {
-        return !isWindowInIframe(window) && cursorUI.isVisible();
+        return !isIframeWindow(window) && cursorUI.isVisible();
     },
 
     move (newX, newY) {
@@ -57,7 +57,7 @@ export default {
     },
 
     show () {
-        if (!isWindowInIframe(window))
+        if (!isIframeWindow(window))
             cursorUI.show();
     },
 

--- a/src/client/automation/get-element.js
+++ b/src/client/automation/get-element.js
@@ -94,7 +94,7 @@ export function fromPoint (x, y, expectedElement) {
             // In this case, you should hide a top window's shadow-ui root to obtain an element.
             let resChain = Promise.resolve(topElement);
 
-            if (!foundElement && isWindowInIframe(window)() && x > 0 && y > 0) {
+            if (!foundElement && isWindowInIframe(window) && x > 0 && y > 0) {
                 resChain = resChain
                     .then(() => getElementFromPoint(x, y, true))
                     .then(element => {

--- a/src/client/automation/get-element.js
+++ b/src/client/automation/get-element.js
@@ -2,7 +2,7 @@ import hammerhead from './deps/hammerhead';
 import testCafeCore from './deps/testcafe-core';
 import testCafeUI from './deps/testcafe-ui';
 import cursor from './cursor';
-import isWindowInIframe from '../../utils/is-window-in-iframe';
+import isIframeWindow from '../../utils/is-window-in-iframe';
 
 const browserUtils  = hammerhead.utils.browser;
 const Promise       = hammerhead.Promise;
@@ -94,7 +94,7 @@ export function fromPoint (x, y, expectedElement) {
             // In this case, you should hide a top window's shadow-ui root to obtain an element.
             let resChain = Promise.resolve(topElement);
 
-            if (!foundElement && isWindowInIframe(window) && x > 0 && y > 0) {
+            if (!foundElement && isIframeWindow(window) && x > 0 && y > 0) {
                 resChain = resChain
                     .then(() => getElementFromPoint(x, y, true))
                     .then(element => {

--- a/src/client/automation/get-element.js
+++ b/src/client/automation/get-element.js
@@ -2,6 +2,7 @@ import hammerhead from './deps/hammerhead';
 import testCafeCore from './deps/testcafe-core';
 import testCafeUI from './deps/testcafe-ui';
 import cursor from './cursor';
+import isWindowInIframe from '../../utils/is-window-in-iframe';
 
 const browserUtils  = hammerhead.utils.browser;
 const Promise       = hammerhead.Promise;
@@ -82,7 +83,6 @@ function correctTopElementByExpectedElement (topElement, expectedElement) {
 }
 
 export function fromPoint (x, y, expectedElement) {
-    const isInIframe   = window !== window.top;
     let foundElement = null;
 
     return getElementFromPoint(x, y)
@@ -94,7 +94,7 @@ export function fromPoint (x, y, expectedElement) {
             // In this case, you should hide a top window's shadow-ui root to obtain an element.
             let resChain = Promise.resolve(topElement);
 
-            if (!foundElement && isInIframe && x > 0 && y > 0) {
+            if (!foundElement && isWindowInIframe(window)() && x > 0 && y > 0) {
                 resChain = resChain
                     .then(() => getElementFromPoint(x, y, true))
                     .then(element => {

--- a/src/client/automation/playback/move/index.js
+++ b/src/client/automation/playback/move/index.js
@@ -13,7 +13,7 @@ import AutomationSettings from '../../settings';
 import DragAndDropState from '../drag/drag-and-drop-state';
 import createEventSequence from './event-sequence/create-event-sequence';
 import lastHoveredElementHolder from '../last-hovered-element-holder';
-import isWindowInIframe from '../../../../utils/is-window-in-iframe';
+import isIframeWindow from '../../../../utils/is-window-in-iframe';
 
 const Promise          = hammerhead.Promise;
 const nativeMethods    = hammerhead.nativeMethods;
@@ -413,7 +413,7 @@ export default class MoveAutomation {
             .then(message => {
                 cursor.activeWindow = window;
 
-                if (iframeUnderCursor || isWindowInIframe(window))
+                if (iframeUnderCursor || isIframeWindow(window))
                     return cursor.move(message.x, message.y);
 
                 return null;

--- a/src/client/automation/playback/move/index.js
+++ b/src/client/automation/playback/move/index.js
@@ -13,6 +13,7 @@ import AutomationSettings from '../../settings';
 import DragAndDropState from '../drag/drag-and-drop-state';
 import createEventSequence from './event-sequence/create-event-sequence';
 import lastHoveredElementHolder from '../last-hovered-element-holder';
+import isWindowInIframe from '../../../../utils/is-window-in-iframe';
 
 const Promise          = hammerhead.Promise;
 const nativeMethods    = hammerhead.nativeMethods;
@@ -412,7 +413,7 @@ export default class MoveAutomation {
             .then(message => {
                 cursor.activeWindow = window;
 
-                if (iframeUnderCursor || window.top !== window)
+                if (iframeUnderCursor || isWindowInIframe(window)())
                     return cursor.move(message.x, message.y);
 
                 return null;

--- a/src/client/automation/playback/move/index.js
+++ b/src/client/automation/playback/move/index.js
@@ -413,7 +413,7 @@ export default class MoveAutomation {
             .then(message => {
                 cursor.activeWindow = window;
 
-                if (iframeUnderCursor || isWindowInIframe(window)())
+                if (iframeUnderCursor || isWindowInIframe(window))
                     return cursor.move(message.x, message.y);
 
                 return null;

--- a/src/client/automation/playback/press/index.js
+++ b/src/client/automation/playback/press/index.js
@@ -168,7 +168,7 @@ export default class PressAutomation {
         const activeElement         = domUtils.getActiveElement();
         const activeElementIsIframe = domUtils.isIframeElement(activeElement);
 
-        if (!isWindowInIframe(window)() && activeElementIsIframe && nativeMethods.contentWindowGetter.call(activeElement)) {
+        if (!isWindowInIframe(window) && activeElementIsIframe && nativeMethods.contentWindowGetter.call(activeElement)) {
             const msg = {
                 cmd:             PRESS_REQUEST_CMD,
                 keyCombinations: this.keyCombinations,

--- a/src/client/automation/playback/press/index.js
+++ b/src/client/automation/playback/press/index.js
@@ -11,6 +11,7 @@ import KeyPressSimulator from './key-press-simulator';
 import supportedShortcutHandlers from './shortcuts';
 import { getActualKeysAndEventKeyProperties, getDeepActiveElement } from './utils';
 import AutomationSettings from '../../settings';
+import isWindowInIframe from '../../../../utils/is-window-in-iframe';
 
 const Promise        = hammerhead.Promise;
 const browserUtils   = hammerhead.utils.browser;
@@ -167,7 +168,7 @@ export default class PressAutomation {
         const activeElement         = domUtils.getActiveElement();
         const activeElementIsIframe = domUtils.isIframeElement(activeElement);
 
-        if (window.top === window && activeElementIsIframe && nativeMethods.contentWindowGetter.call(activeElement)) {
+        if (!isWindowInIframe(window)() && activeElementIsIframe && nativeMethods.contentWindowGetter.call(activeElement)) {
             const msg = {
                 cmd:             PRESS_REQUEST_CMD,
                 keyCombinations: this.keyCombinations,

--- a/src/client/automation/playback/press/index.js
+++ b/src/client/automation/playback/press/index.js
@@ -11,7 +11,7 @@ import KeyPressSimulator from './key-press-simulator';
 import supportedShortcutHandlers from './shortcuts';
 import { getActualKeysAndEventKeyProperties, getDeepActiveElement } from './utils';
 import AutomationSettings from '../../settings';
-import isWindowInIframe from '../../../../utils/is-window-in-iframe';
+import isIframeWindow from '../../../../utils/is-window-in-iframe';
 
 const Promise        = hammerhead.Promise;
 const browserUtils   = hammerhead.utils.browser;
@@ -168,7 +168,7 @@ export default class PressAutomation {
         const activeElement         = domUtils.getActiveElement();
         const activeElementIsIframe = domUtils.isIframeElement(activeElement);
 
-        if (!isWindowInIframe(window) && activeElementIsIframe && nativeMethods.contentWindowGetter.call(activeElement)) {
+        if (!isIframeWindow(window) && activeElementIsIframe && nativeMethods.contentWindowGetter.call(activeElement)) {
             const msg = {
                 cmd:             PRESS_REQUEST_CMD,
                 keyCombinations: this.keyCombinations,

--- a/src/client/automation/playback/scroll.js
+++ b/src/client/automation/playback/scroll.js
@@ -260,7 +260,7 @@ export default class ScrollAutomation {
 
         return scrollParentsPromise
             .then(() => {
-                if (isWindowInIframe(window)() && !this.skipParentFrames) {
+                if (isWindowInIframe(window) && !this.skipParentFrames) {
                     return sendRequestToFrame({
                         cmd:             SCROLL_REQUEST_CMD,
                         offsetX:         currentOffsetX,

--- a/src/client/automation/playback/scroll.js
+++ b/src/client/automation/playback/scroll.js
@@ -7,7 +7,7 @@ import {
     scrollController,
     sendRequestToFrame
 } from '../deps/testcafe-core';
-import isWindowInIframe from '../../../utils/is-window-in-iframe';
+import isIframeWindow from '../../../utils/is-window-in-iframe';
 
 const Promise        = hammerhead.Promise;
 const messageSandbox = hammerhead.eventSandbox.message;
@@ -260,7 +260,7 @@ export default class ScrollAutomation {
 
         return scrollParentsPromise
             .then(() => {
-                if (isWindowInIframe(window) && !this.skipParentFrames) {
+                if (isIframeWindow(window) && !this.skipParentFrames) {
                     return sendRequestToFrame({
                         cmd:             SCROLL_REQUEST_CMD,
                         offsetX:         currentOffsetX,

--- a/src/client/automation/playback/scroll.js
+++ b/src/client/automation/playback/scroll.js
@@ -7,6 +7,7 @@ import {
     scrollController,
     sendRequestToFrame
 } from '../deps/testcafe-core';
+import isWindowInIframe from '../../../utils/is-window-in-iframe';
 
 const Promise        = hammerhead.Promise;
 const messageSandbox = hammerhead.eventSandbox.message;
@@ -259,7 +260,7 @@ export default class ScrollAutomation {
 
         return scrollParentsPromise
             .then(() => {
-                if (window.top !== window && !this.skipParentFrames) {
+                if (isWindowInIframe(window)() && !this.skipParentFrames) {
                     return sendRequestToFrame({
                         cmd:             SCROLL_REQUEST_CMD,
                         offsetX:         currentOffsetX,

--- a/src/client/automation/playback/scroll.js
+++ b/src/client/automation/playback/scroll.js
@@ -17,7 +17,6 @@ const SCROLL_MARGIN_INCREASE_STEP = 20;
 const SCROLL_REQUEST_CMD  = 'automation|scroll|request';
 const SCROLL_RESPONSE_CMD = 'automation|scroll|response';
 
-
 // Setup cross-iframe interaction
 messageSandbox.on(messageSandbox.SERVICE_MSG_RECEIVED_EVENT, e => {
     if (e.message.cmd === SCROLL_REQUEST_CMD) {

--- a/src/client/automation/utils/utils.js
+++ b/src/client/automation/utils/utils.js
@@ -1,7 +1,7 @@
 import hammerhead from '../deps/hammerhead';
 import testCafeCore from '../deps/testcafe-core';
 import sendRequestToFrame from '../../core/utils/send-request-to-frame';
-import isWindowInIframe from '../../../utils/is-window-in-iframe';
+import isIframeWindow from '../../../utils/is-window-in-iframe';
 
 const Promise          = hammerhead.Promise;
 const nativeMethods    = hammerhead.nativeMethods;
@@ -58,7 +58,7 @@ export function focusAndSetSelection (element, simulateFocus, caretPos) {
         // NOTE: Safari 13 blocks attempts to focus elements inside a third-party iframe before the user interacts with it
         // https://developer.apple.com/documentation/safari-release-notes/safari-13-release-notes
         // We can work around this restriction by focusing the <iframe> element beforehand
-        if (isWindowInIframe(window))
+        if (isIframeWindow(window))
             await sendRequestToFrame({ cmd: GET_IFRAME_REQUEST_CMD }, GET_IFRAME_RESPONSE_CMD, window.parent);
 
         const activeElement               = domUtils.getActiveElement();

--- a/src/client/automation/utils/utils.js
+++ b/src/client/automation/utils/utils.js
@@ -58,7 +58,7 @@ export function focusAndSetSelection (element, simulateFocus, caretPos) {
         // NOTE: Safari 13 blocks attempts to focus elements inside a third-party iframe before the user interacts with it
         // https://developer.apple.com/documentation/safari-release-notes/safari-13-release-notes
         // We can work around this restriction by focusing the <iframe> element beforehand
-        if (isWindowInIframe(window)())
+        if (isWindowInIframe(window))
             await sendRequestToFrame({ cmd: GET_IFRAME_REQUEST_CMD }, GET_IFRAME_RESPONSE_CMD, window.parent);
 
         const activeElement               = domUtils.getActiveElement();

--- a/src/client/automation/utils/utils.js
+++ b/src/client/automation/utils/utils.js
@@ -1,6 +1,7 @@
 import hammerhead from '../deps/hammerhead';
 import testCafeCore from '../deps/testcafe-core';
 import sendRequestToFrame from '../../core/utils/send-request-to-frame';
+import isWindowInIframe from '../../../utils/is-window-in-iframe';
 
 const Promise          = hammerhead.Promise;
 const nativeMethods    = hammerhead.nativeMethods;
@@ -57,7 +58,7 @@ export function focusAndSetSelection (element, simulateFocus, caretPos) {
         // NOTE: Safari 13 blocks attempts to focus elements inside a third-party iframe before the user interacts with it
         // https://developer.apple.com/documentation/safari-release-notes/safari-13-release-notes
         // We can work around this restriction by focusing the <iframe> element beforehand
-        if (window.top !== window)
+        if (isWindowInIframe(window)())
             await sendRequestToFrame({ cmd: GET_IFRAME_REQUEST_CMD }, GET_IFRAME_RESPONSE_CMD, window.parent);
 
         const activeElement               = domUtils.getActiveElement();

--- a/src/client/automation/utils/utils.js
+++ b/src/client/automation/utils/utils.js
@@ -1,5 +1,6 @@
 import hammerhead from '../deps/hammerhead';
 import testCafeCore from '../deps/testcafe-core';
+import sendRequestToFrame from '../../core/utils/send-request-to-frame';
 
 const Promise          = hammerhead.Promise;
 const nativeMethods    = hammerhead.nativeMethods;
@@ -11,6 +12,20 @@ const textSelection   = testCafeCore.textSelection;
 const domUtils        = testCafeCore.domUtils;
 const styleUtils      = testCafeCore.styleUtils;
 
+const messageSandbox = hammerhead.eventSandbox.message;
+
+const GET_IFRAME_REQUEST_CMD  = 'automation|iframe|request';
+const GET_IFRAME_RESPONSE_CMD = 'automation|iframe|response';
+
+messageSandbox.on(messageSandbox.SERVICE_MSG_RECEIVED_EVENT, e => {
+    if (e.message.cmd === GET_IFRAME_REQUEST_CMD) {
+        const iframeElement = domUtils.findIframeByWindow(e.source);
+
+        focusBlurSandbox.focus(iframeElement, () => {
+            messageSandbox.sendServiceMsg({ cmd: GET_IFRAME_RESPONSE_CMD }, e.source);
+        }, false);
+    }
+});
 
 function setCaretPosition (element, caretPos) {
     const isTextEditable    = domUtils.isTextEditableElement(element);
@@ -38,7 +53,13 @@ function setCaretPosition (element, caretPos) {
 }
 
 export function focusAndSetSelection (element, simulateFocus, caretPos) {
-    return new Promise(resolve => {
+    return new Promise(async resolve => {
+        // NOTE: Safari 13 blocks attempts to focus elements inside a third-party iframe before the user interacts with it
+        // https://developer.apple.com/documentation/safari-release-notes/safari-13-release-notes
+        // We can work around this restriction by focusing the <iframe> element beforehand
+        if (window.top !== window)
+            await sendRequestToFrame({ cmd: GET_IFRAME_REQUEST_CMD }, GET_IFRAME_RESPONSE_CMD, window.parent);
+
         const activeElement               = domUtils.getActiveElement();
         const isTextEditable              = domUtils.isTextEditableElement(element);
         const labelWithForAttr            = domUtils.closest(element, 'label[for]');

--- a/src/client/driver/command-executors/browser-manipulation/index.js
+++ b/src/client/driver/command-executors/browser-manipulation/index.js
@@ -163,7 +163,7 @@ class ManipulationExecutor {
     }
 
     _requestManipulation () {
-        if (!isWindowInIframe(window)())
+        if (!isWindowInIframe(window))
             return transport.queuedAsyncServiceMsg(this._createManipulationReadyMessage());
 
         const cropDimensions = this._getAbsoluteCropValues();
@@ -202,7 +202,7 @@ class ManipulationExecutor {
                 return this._runScrollBeforeScreenshot();
             })
             .then(() => {
-                if (!isWindowInIframe(window)())
+                if (!isWindowInIframe(window))
                     return this._hideUI();
 
                 return Promise.resolve();
@@ -216,7 +216,7 @@ class ManipulationExecutor {
 
                 manipulationResult = result;
 
-                if (!isWindowInIframe(window)())
+                if (!isWindowInIframe(window))
                     this._showUI();
 
                 return delay(POSSIBLE_RESIZE_ERROR_DELAY);

--- a/src/client/driver/command-executors/browser-manipulation/index.js
+++ b/src/client/driver/command-executors/browser-manipulation/index.js
@@ -26,6 +26,7 @@ import runWithBarriers from '../../utils/run-with-barriers';
 import MESSAGE from '../../../../test-run/client-messages';
 import COMMAND_TYPE from '../../../../test-run/commands/type';
 import { ScrollOptions, ElementScreenshotOptions } from '../../../../test-run/commands/options';
+import isWindowInIframe from '../../../../utils/is-window-in-iframe';
 
 
 const messageSandbox = eventSandbox.message;
@@ -162,7 +163,7 @@ class ManipulationExecutor {
     }
 
     _requestManipulation () {
-        if (window.top === window)
+        if (!isWindowInIframe(window)())
             return transport.queuedAsyncServiceMsg(this._createManipulationReadyMessage());
 
         const cropDimensions = this._getAbsoluteCropValues();
@@ -201,7 +202,7 @@ class ManipulationExecutor {
                 return this._runScrollBeforeScreenshot();
             })
             .then(() => {
-                if (window.top === window)
+                if (!isWindowInIframe(window)())
                     return this._hideUI();
 
                 return Promise.resolve();
@@ -215,7 +216,7 @@ class ManipulationExecutor {
 
                 manipulationResult = result;
 
-                if (window.top === window)
+                if (!isWindowInIframe(window)())
                     this._showUI();
 
                 return delay(POSSIBLE_RESIZE_ERROR_DELAY);

--- a/src/client/driver/command-executors/browser-manipulation/index.js
+++ b/src/client/driver/command-executors/browser-manipulation/index.js
@@ -26,7 +26,7 @@ import runWithBarriers from '../../utils/run-with-barriers';
 import MESSAGE from '../../../../test-run/client-messages';
 import COMMAND_TYPE from '../../../../test-run/commands/type';
 import { ScrollOptions, ElementScreenshotOptions } from '../../../../test-run/commands/options';
-import isWindowInIframe from '../../../../utils/is-window-in-iframe';
+import isIframeWindow from '../../../../utils/is-window-in-iframe';
 
 
 const messageSandbox = eventSandbox.message;
@@ -163,7 +163,7 @@ class ManipulationExecutor {
     }
 
     _requestManipulation () {
-        if (!isWindowInIframe(window))
+        if (!isIframeWindow(window))
             return transport.queuedAsyncServiceMsg(this._createManipulationReadyMessage());
 
         const cropDimensions = this._getAbsoluteCropValues();
@@ -202,7 +202,7 @@ class ManipulationExecutor {
                 return this._runScrollBeforeScreenshot();
             })
             .then(() => {
-                if (!isWindowInIframe(window))
+                if (!isIframeWindow(window))
                     return this._hideUI();
 
                 return Promise.resolve();
@@ -216,7 +216,7 @@ class ManipulationExecutor {
 
                 manipulationResult = result;
 
-                if (!isWindowInIframe(window))
+                if (!isIframeWindow(window))
                     this._showUI();
 
                 return delay(POSSIBLE_RESIZE_ERROR_DELAY);

--- a/src/client/ui/status-bar/index.js
+++ b/src/client/ui/status-bar/index.js
@@ -224,7 +224,7 @@ export default class StatusBar extends serviceUtils.EventEmitter {
     }
 
     _createBeforeReady () {
-        if (this.state.created || isWindowInIframe(window)())
+        if (this.state.created || isWindowInIframe(window))
             return;
 
         if (document.body)

--- a/src/client/ui/status-bar/index.js
+++ b/src/client/ui/status-bar/index.js
@@ -3,6 +3,7 @@ import testCafeCore from './../deps/testcafe-core';
 import ProgressBar from './progress-bar';
 import uiRoot from '../ui-root';
 import MESSAGES from './messages';
+import isWindowInIframe from '../../../utils/is-window-in-iframe';
 
 
 const Promise          = hammerhead.Promise;
@@ -223,7 +224,7 @@ export default class StatusBar extends serviceUtils.EventEmitter {
     }
 
     _createBeforeReady () {
-        if (this.state.created || window !== window.top)
+        if (this.state.created || isWindowInIframe(window)())
             return;
 
         if (document.body)

--- a/src/client/ui/status-bar/index.js
+++ b/src/client/ui/status-bar/index.js
@@ -3,7 +3,7 @@ import testCafeCore from './../deps/testcafe-core';
 import ProgressBar from './progress-bar';
 import uiRoot from '../ui-root';
 import MESSAGES from './messages';
-import isWindowInIframe from '../../../utils/is-window-in-iframe';
+import isIframeWindow from '../../../utils/is-window-in-iframe';
 
 
 const Promise          = hammerhead.Promise;
@@ -224,7 +224,7 @@ export default class StatusBar extends serviceUtils.EventEmitter {
     }
 
     _createBeforeReady () {
-        if (this.state.created || isWindowInIframe(window))
+        if (this.state.created || isIframeWindow(window))
             return;
 
         if (document.body)

--- a/src/utils/is-window-in-iframe.ts
+++ b/src/utils/is-window-in-iframe.ts
@@ -1,3 +1,3 @@
-export default function isWindowInIframe (window: Window): boolean {
+export default function isIframeWindow (window: Window): boolean {
     return window.top !== window;
 }

--- a/src/utils/is-window-in-iframe.ts
+++ b/src/utils/is-window-in-iframe.ts
@@ -1,0 +1,3 @@
+export default function isWindowInIframe (window: Window): boolean {
+    return window.top !== window;
+}

--- a/test/client/fixtures/automation/type-test.js
+++ b/test/client/fixtures/automation/type-test.js
@@ -423,7 +423,7 @@ $(document).ready(function () {
     asyncTest('GH-4068 - Type to element wrapped in label', function () {
         const input1 = document.createElement('input');
         const input2 = document.createElement('input');
-        const label  =  document.createElement('label');
+        const label  = document.createElement('label');
 
         input1.className = TEST_ELEMENT_CLASS;
         input2.className = TEST_ELEMENT_CLASS;

--- a/test/functional/fixtures/regression/gh-4793/pages/iframe.html
+++ b/test/functional/fixtures/regression/gh-4793/pages/iframe.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+    <input id="input"/>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-4793/pages/index.html
+++ b/test/functional/fixtures/regression/gh-4793/pages/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>GH-4793</title>
+</head>
+<body>
+<iframe id="cross-domain-iframe" src="http://localhost:3001/fixtures/regression/gh-4793/pages/iframe.html"></iframe>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-4793/test.js
+++ b/test/functional/fixtures/regression/gh-4793/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-4793)', function () {
+    it('Elements inside cross-domain iframes should be focusable', function () {
+        return runTests('testcafe-fixtures/index-test.js', 'Type text into an input inside a cross-domain iframe');
+    });
+});

--- a/test/functional/fixtures/regression/gh-4793/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/regression/gh-4793/testcafe-fixtures/index-test.js
@@ -4,7 +4,7 @@ fixture `gh-4793`
     .page `http://localhost:3000/fixtures/regression/gh-4793/pages/index.html`;
 
 test('Type text into an input inside a cross-domain iframe', async t => {
-    const iframe = Selector('#cross-domain-iframe');
+    const iframe = Selector('#cross-domain-iframe', { timeout: 10000 });
     const input  = Selector('#input');
 
     await t

--- a/test/functional/fixtures/regression/gh-4793/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/regression/gh-4793/testcafe-fixtures/index-test.js
@@ -1,0 +1,14 @@
+import { Selector } from 'testcafe';
+
+fixture `gh-4793`
+    .page `http://localhost:3000/fixtures/regression/gh-4793/pages/index.html`;
+
+test('Type text into an input inside a cross-domain iframe', async t => {
+    const iframe = Selector('#cross-domain-iframe');
+    const input  = Selector('#input');
+
+    await t
+        .switchToIframe(iframe)
+        .typeText(input, '1234')
+        .expect(input.value).eql('1234');
+});


### PR DESCRIPTION
## Purpose
[Safari 13](https://developer.apple.com/documentation/safari-release-notes/safari-13-release-notes) does not allow focusing elements inside of cross-domain iframes before the iframe itself is focused.

## Approach
We can focus the iframe before trying to focus the inner element. This should not have side-effects as we focus the element afterwards anyway.

We can't focus the iframe from inside of its context so we need to send a message to the parent context, so that we can focus the iframe there,  and wait for the response.

Possible considerations:
 - Make this logic Safari-exclusive as other browsers work without it

## References
Closes #4793

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
