### PR TITLE
Fix proxing document.title  in iframes (tests), bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.9.4-rc.1",
+  "version": "1.9.4-rc.2",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.13",
-    "testcafe-hammerhead": "17.1.19",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/5273598/testcafe-hammerhead-17.1.20.zip",
     "testcafe-legacy-api": "4.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.13",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/5273598/testcafe-hammerhead-17.1.20.zip",
+    "testcafe-hammerhead": "17.1.20",
     "testcafe-legacy-api": "4.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/test/functional/fixtures/regression/hammerhead/gh-2350/pages/iframes/iframe.html
+++ b/test/functional/fixtures/regression/hammerhead/gh-2350/pages/iframes/iframe.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Iframe page title</title>
+</head>
+<body>
+    <h1>Iframe page</h1>
+</body>
+</html>

--- a/test/functional/fixtures/regression/hammerhead/gh-2350/pages/iframes/index.html
+++ b/test/functional/fixtures/regression/hammerhead/gh-2350/pages/iframes/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Index page title</title>
+</head>
+<body>
+    <h1>Index page</h1>
+    <iframe id="withSrc" src="iframe.html"></iframe>
+    <iframe id="withoutSrc"></iframe>
+</body>
+</html>

--- a/test/functional/fixtures/regression/hammerhead/gh-2350/test.js
+++ b/test/functional/fixtures/regression/hammerhead/gh-2350/test.js
@@ -28,4 +28,8 @@ describe("Should provide a valid value for the 'document.title' property", () =>
     it('Set document.title in body', () => {
         return runTests('./testcafe-fixtures/index.js', 'set document.title in body');
     });
+
+    it('Iframes', () => {
+        return runTests('./testcafe-fixtures/iframes.js');
+    });
 });

--- a/test/functional/fixtures/regression/hammerhead/gh-2350/testcafe-fixtures/iframes.js
+++ b/test/functional/fixtures/regression/hammerhead/gh-2350/testcafe-fixtures/iframes.js
@@ -4,7 +4,7 @@ fixture `Fixture`
     .page('http://localhost:3000/fixtures/regression/hammerhead/gh-2350/pages/iframes/index.html');
 
 const getNativeTitle = ClientFunction(() => {
-    var hammerhead = window['%hammerhead%'];
+    var hammerhead = window['%hammerhead%']; // eslint-disable-line no-var
 
     return hammerhead.nativeMethods.documentTitleGetter.call(document);
 });

--- a/test/functional/fixtures/regression/hammerhead/gh-2350/testcafe-fixtures/iframes.js
+++ b/test/functional/fixtures/regression/hammerhead/gh-2350/testcafe-fixtures/iframes.js
@@ -1,0 +1,20 @@
+import { ClientFunction } from 'testcafe';
+
+fixture `Fixture`
+    .page('http://localhost:3000/fixtures/regression/hammerhead/gh-2350/pages/iframes/index.html');
+
+const getNativeTitle = ClientFunction(() => {
+    var hammerhead = window['%hammerhead%'];
+
+    return hammerhead.nativeMethods.documentTitleGetter.call(document);
+});
+
+test('test', async t => {
+    await t
+        .expect(getNativeTitle()).notEql('Index page title')
+        .switchToIframe('#withSrc')
+        .expect(getNativeTitle()).eql('Iframe page title')
+        .switchToMainWindow()
+        .switchToIframe('#withoutSrc')
+        .expect(getNativeTitle()).eql('');
+});


### PR DESCRIPTION
Changes: 
* add test for fixed case 'proxy document.title in iframes'.