### PR TITLE
Do not fire mouse events when touch events has been cancelled (close #5380)

### DIFF
--- a/test/client/fixtures/automation/click-test.js
+++ b/test/client/fixtures/automation/click-test.js
@@ -1177,7 +1177,7 @@ $(document).ready(function () {
                 });
         });
 
-        asyncTest('mouse or click events should not be raised if touch event was cancelled', function () {
+        asyncTest('mouse or click events should not be raised if "touchstart" event was cancelled', function () {
             const raisedEvents = [];
 
             const events = [
@@ -1193,6 +1193,39 @@ $(document).ready(function () {
             events.forEach(function (eventName) {
                 $el[0][eventName] = function (e) {
                     if (eventName === 'ontouchstart')
+                        e.preventDefault();
+
+                    raisedEvents.push(eventName);
+                };
+            });
+
+            const click = new ClickAutomation($el[0], new ClickOptions());
+
+            click
+                .run()
+                .then(function () {
+                    deepEqual(raisedEvents, ['ontouchstart', 'ontouchend']);
+
+                    startNext();
+                });
+        });
+
+        asyncTest('mouse or click events should not be raised if "touchend" event was cancelled', function () {
+            const raisedEvents = [];
+
+            const events = [
+                'ontouchstart',
+                'ontouchend',
+                'ontouchmove',
+                'onmousedown',
+                'onmousemove',
+                'onmouseup',
+                'onclick'
+            ];
+
+            events.forEach(function (eventName) {
+                $el[0][eventName] = function (e) {
+                    if (eventName === 'ontouchend')
                         e.preventDefault();
 
                     raisedEvents.push(eventName);

--- a/test/client/fixtures/automation/click-test.js
+++ b/test/client/fixtures/automation/click-test.js
@@ -1190,7 +1190,7 @@ $(document).ready(function () {
                 'onclick'
             ];
 
-            events.forEach(eventName => {
+            events.forEach(function (eventName) {
                 $el[0][eventName] = function (e) {
                     if (eventName === 'ontouchstart')
                         e.preventDefault();

--- a/test/client/fixtures/automation/click-test.js
+++ b/test/client/fixtures/automation/click-test.js
@@ -1176,5 +1176,38 @@ $(document).ready(function () {
                     startNext();
                 });
         });
+
+        asyncTest('mouse or click events should not be raised if touch event was cancelled', function () {
+            const raisedEvents = [];
+
+            const events = [
+                'ontouchstart',
+                'ontouchend',
+                'ontouchmove',
+                'onmousedown',
+                'onmousemove',
+                'onmouseup',
+                'onclick'
+            ];
+
+            events.forEach(eventName => {
+                $el[0][eventName] = function (e) {
+                    if (eventName === 'ontouchstart')
+                        e.preventDefault();
+
+                    raisedEvents.push(eventName);
+                };
+            });
+
+            const click = new ClickAutomation($el[0], new ClickOptions());
+
+            click
+                .run()
+                .then(function () {
+                    deepEqual(raisedEvents, ['ontouchstart', 'ontouchend']);
+
+                    startNext();
+                });
+        });
     }
 });


### PR DESCRIPTION
## Purpose
We need to support the case when the `preventDefault` method is called on the touch event listener to prevent click and mouse events as [stated](https://w3c.github.io/touch-events/#mouse-events) in the W3C specification:
>  If touchstart, touchmove, or touchend are canceled, the user agent should not dispatch any mouse event that would be a consequential result of the prevented touch event.

## Approach
WIP

## References
#5380

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
