### PR TITLE
fix issues with window search (closes #5463, #5597)

### DIFF
--- a/src/client/driver/driver-link/messages.js
+++ b/src/client/driver/driver-link/messages.js
@@ -132,5 +132,3 @@ export class RestoreChildLinkMessage extends InterDriverMessage {
         this.windowId = windowId;
     }
 }
-
-

--- a/src/client/driver/driver-link/messages.js
+++ b/src/client/driver/driver-link/messages.js
@@ -12,7 +12,9 @@ export const TYPE = {
     confirmation:             'driver|confirmation',
     setNativeDialogHandler:   'driver|set-native-dialog-handler',
     setAsMaster:              'driver|set-as-master',
-    closeAllChildWindows:     'driver|close-all-child-windows'
+    closeAllChildWindows:     'driver|close-all-child-windows',
+    startToRestoreChildLink:  'driver|start-to-restore-child-link',
+    restoreChildLink:         'driver|restore-child-link'
 };
 
 class InterDriverMessage {
@@ -116,3 +118,19 @@ export class CloseAllChildWindowsMessage extends InterDriverMessage {
         super(TYPE.closeAllChildWindows);
     }
 }
+
+export class StartToRestoreChildLinkMessage extends InterDriverMessage {
+    constructor () {
+        super(TYPE.startToRestoreChildLink);
+    }
+}
+
+export class RestoreChildLinkMessage extends InterDriverMessage {
+    constructor (windowId) {
+        super(TYPE.restoreChildLink);
+
+        this.windowId = windowId;
+    }
+}
+
+

--- a/src/client/driver/driver-link/window/child.js
+++ b/src/client/driver/driver-link/window/child.js
@@ -1,4 +1,9 @@
-import { CloseAllChildWindowsMessage, SetAsMasterMessage } from '../messages';
+import {
+    CloseAllChildWindowsMessage,
+    StartToRestoreChildLinkMessage,
+    SetAsMasterMessage
+} from '../messages';
+
 import sendMessageToDriver from '../send-message-to-driver';
 import { CannotSwitchToWindowError, CloseChildWindowError } from '../../../../shared/errors';
 import { WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT } from '../timeouts';
@@ -23,6 +28,12 @@ export default class ChildWindowDriverLink {
 
     findChildWindows (options, MessageCtor) {
         const msg = new MessageCtor(options);
+
+        return sendMessageToDriver(msg, this.driverWindow, WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT, CannotSwitchToWindowError);
+    }
+
+    startToRestore () {
+        const msg = new StartToRestoreChildLinkMessage();
 
         return sendMessageToDriver(msg, this.driverWindow, WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT, CannotSwitchToWindowError);
     }

--- a/src/client/driver/driver-link/window/parent.js
+++ b/src/client/driver/driver-link/window/parent.js
@@ -1,4 +1,4 @@
-import { SetAsMasterMessage } from '../messages';
+import { SetAsMasterMessage, RestoreChildLinkMessage } from '../messages';
 import sendMessageToDriver from '../send-message-to-driver';
 import { CannotSwitchToWindowError } from '../../../../shared/errors';
 import { WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT } from '../timeouts';
@@ -37,5 +37,12 @@ export default class ParentWindowDriverLink {
         const wnd = this.currentDriverWindow.opener;
 
         return this._setAsMaster(wnd, opts.finalizePendingCommand);
+    }
+
+    async restoreChild (windowId) {
+        const msg = new RestoreChildLinkMessage(windowId);
+        const wnd = this.currentDriverWindow.opener;
+
+        sendMessageToDriver(msg, wnd, WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT, CannotSwitchToWindowError);
     }
 }

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -349,6 +349,9 @@ export default class Driver extends serviceUtils.EventEmitter {
     }
 
     _sendStartToRestoreCommand () {
+        if (!this.contextStorage)
+            return;
+
         // NOTE: the situation is possible when the child window responds before the parent window is reloaded,
         // so we should not respond to the child window if the parent window is not reloaded
         this._stopRespondToChildren = true;

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -1523,7 +1523,7 @@ export default class Driver extends serviceUtils.EventEmitter {
     }
 
     _initParentWindowLink () {
-        if (window.opener)
+        if (window.opener && this.windowId)
             this.parentWindowDriverLink = new ParentWindowDriverLink(window);
     }
 

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -204,6 +204,7 @@ export default class Driver extends serviceUtils.EventEmitter {
 
         this.setCustomCommandHandlers(COMMAND_TYPE.unlockPage, () => this._unlockPageAfterTestIsDone());
 
+        // NOTE: initiate the child links restoring process before the window is reloaded
         listeners.addInternalEventListener(window, ['beforeunload'], () => {
             this._sendStartToRestoreCommand();
         });
@@ -1162,7 +1163,7 @@ export default class Driver extends serviceUtils.EventEmitter {
         }
     }
 
-    async _restoreChildWindowLinks () {
+    _restoreChildWindowLinks () {
         if (!this.contextStorage.getItem(PENDING_CHILD_WINDOW_COUNT))
             return Promise.resolve();
 
@@ -1170,7 +1171,6 @@ export default class Driver extends serviceUtils.EventEmitter {
             this._restoreChildWindowsPromiseResolver = resolve;
         }), RESTORE_CHILD_WINDOWS_TIMEOUT)
             .catch(() => {
-                //
             });
     }
 
@@ -1523,6 +1523,11 @@ export default class Driver extends serviceUtils.EventEmitter {
     }
 
     _initParentWindowLink () {
+        // NOTE: we need to create parentWindowDriverLinks in the following cases:
+        // multiple-windows mode is enabled
+        // current window has parent window
+        // current window parent is not the same as current window
+        // the last case is possible when we have the series of multiple and non-multiple windows tests
         if (window.opener && window.opener !== window && this.windowId)
             this.parentWindowDriverLink = new ParentWindowDriverLink(window);
     }

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -1523,7 +1523,7 @@ export default class Driver extends serviceUtils.EventEmitter {
     }
 
     _initParentWindowLink () {
-        if (window.opener && this.windowId)
+        if (window.opener && window.opener !== window && this.windowId)
             this.parentWindowDriverLink = new ParentWindowDriverLink(window);
     }
 

--- a/src/errors/test-run/templates.js
+++ b/src/errors/test-run/templates.js
@@ -383,4 +383,8 @@ export default {
     [TEST_RUN_ERRORS.cannotCloseWindowWithoutParent]: () => `
         Cannot close the window because it does not have a parent. The parent window was closed or you are attempting to close the root browser window where tests were launched.
     `,
+
+    [TEST_RUN_ERRORS.cannotRestoreChildWindowError]: () => `
+        Failed to restore connection to window within the allocated timeout.
+    `,
 };

--- a/src/errors/types.js
+++ b/src/errors/types.js
@@ -82,7 +82,8 @@ export const TEST_RUN_ERRORS = {
     actionFunctionArgumentError:                           'E79',
     multipleWindowsModeIsDisabledError:                    'E80',
     multipleWindowsModeIsNotSupportedInRemoteBrowserError: 'E81',
-    cannotCloseWindowWithoutParent:                        'E82'
+    cannotCloseWindowWithoutParent:                        'E82',
+    cannotRestoreChildWindowError:                         'E83'
 };
 
 export const RUNTIME_ERRORS = {

--- a/src/shared/errors/index.js
+++ b/src/shared/errors/index.js
@@ -364,6 +364,18 @@ export class PreviousWindowNotFoundError extends TestRunErrorBase {
     }
 }
 
+export class ChildWindowClosedBeforeSwitchingError extends TestRunErrorBase {
+    constructor () {
+        super(TEST_RUN_ERRORS.childWindowClosedBeforeSwitchingError);
+    }
+}
+
+export class CannotRestoreChildWindowError extends TestRunErrorBase {
+    constructor () {
+        super(TEST_RUN_ERRORS.cannotRestoreChildWindowError);
+    }
+}
+
 export class CurrentIframeNotFoundError extends TestRunErrorBase {
     constructor () {
         super(TEST_RUN_ERRORS.currentIframeNotFoundError);
@@ -395,11 +407,5 @@ export class UncaughtErrorInNativeDialogHandler extends TestRunErrorBase {
         this.dialogType = dialogType;
         this.errMsg     = errMsg;
         this.pageUrl    = url;
-    }
-}
-
-export class ChildWindowClosedBeforeSwitchingError extends TestRunErrorBase {
-    constructor () {
-        super(TEST_RUN_ERRORS.childWindowClosedBeforeSwitchingError);
     }
 }

--- a/test/functional/fixtures/multiple-windows/test.js
+++ b/test/functional/fixtures/multiple-windows/test.js
@@ -235,5 +235,25 @@ describe('Multiple windows', () => {
                     expect(errs[0]).to.contain('Multi window mode is disabled. Remove the "--disable-multiple-windows" CLI flag or set the "disableMultipleWindows" option to "false" in the API to use the "openWindow" method.');
                 });
         });
+
+        it('Refresh parent and switch to child', () => {
+            return runTests('testcafe-fixtures/api/api-test.js', 'Refresh parent and switch to child', { only: 'chrome' });
+        });
+
+        it('Refresh parent and remove child', () => {
+            return runTests('testcafe-fixtures/api/api-test.js', 'Refresh parent and remove child', { only: 'chrome' });
+        });
+
+        it('Refresh parent with multiple children', () => {
+            return runTests('testcafe-fixtures/api/api-test.js', 'Refresh parent with multiple children', { only: 'chrome' });
+        });
+
+        it('Refresh child and close', () => {
+            return runTests('testcafe-fixtures/api/api-test.js', 'Refresh child and close', { only: 'chrome' });
+        });
+
+        it('Refresh child and switch to parent', () => {
+            return runTests('testcafe-fixtures/api/api-test.js', 'Refresh child and switch to parent', { only: 'chrome' });
+        });
     });
 });

--- a/test/functional/fixtures/multiple-windows/testcafe-fixtures/api/api-test.js
+++ b/test/functional/fixtures/multiple-windows/testcafe-fixtures/api/api-test.js
@@ -299,6 +299,21 @@ test('Refresh parent and remove child', async t => {
     await t.closeWindow(child);
 });
 
+test('Refresh parent with multiple children', async t => {
+    await t.openWindow(child1Url);
+    await t.switchToParentWindow();
+    await t.openWindow(child1Url);
+    await t.switchToParentWindow();
+    await t.openWindow(child1Url);
+    await t.switchToParentWindow();
+
+    await reload();
+    await reload();
+    await reload();
+
+    await t.switchToPreviousWindow();
+});
+
 test('Refresh child and close', async t => {
     await t.openWindow(child1Url);
 
@@ -314,12 +329,3 @@ test('Refresh child and switch to parent', async t => {
 
     await t.switchToParentWindow();
 });
-
-// test(`Switch_PreviousWindow`, async t => {
-//     await t.navigateTo("https://www.verizon.com/").maximizeWindow()
-//     await t.openWindow("https://www.verizon.com/")
-//     await t.switchToPreviousWindow()
-//     await t.click(Selector('[aria-label="Shop Menu List"]').nth(0))
-//     await t.click(Selector('[href="/deals/"]'))
-//     await t.switchToPreviousWindow()
-// })

--- a/test/functional/fixtures/multiple-windows/testcafe-fixtures/api/api-test.js
+++ b/test/functional/fixtures/multiple-windows/testcafe-fixtures/api/api-test.js
@@ -1,4 +1,6 @@
-import { Selector } from 'testcafe';
+import { Selector, ClientFunction } from 'testcafe';
+
+const reload = ClientFunction(() => window.location.reload());
 
 const parentUrl = 'http://localhost:3000/fixtures/multiple-windows/pages/api/parent.html';
 const child1Url = 'http://localhost:3000/fixtures/multiple-windows/pages/api/child-1.html';
@@ -272,3 +274,52 @@ test('Close window without parent', async t => {
 test('Open window with `disableMultipleWindows` option', async t => {
     await t.openWindow(child1Url);
 });
+
+test('Refresh parent and switch to child', async t => {
+    await t.openWindow(child1Url);
+
+    await t.switchToParentWindow();
+
+    await reload();
+    await reload();
+    await reload();
+
+    await t.switchToPreviousWindow();
+});
+
+test('Refresh parent and remove child', async t => {
+    const child = await t.openWindow(child1Url);
+
+    await t.switchToParentWindow();
+
+    await reload();
+    await reload();
+    await reload();
+
+    await t.closeWindow(child);
+});
+
+test('Refresh child and close', async t => {
+    await t.openWindow(child1Url);
+
+    await reload();
+
+    await t.closeWindow();
+});
+
+test('Refresh child and switch to parent', async t => {
+    await t.openWindow(child1Url);
+
+    await reload();
+
+    await t.switchToParentWindow();
+});
+
+// test(`Switch_PreviousWindow`, async t => {
+//     await t.navigateTo("https://www.verizon.com/").maximizeWindow()
+//     await t.openWindow("https://www.verizon.com/")
+//     await t.switchToPreviousWindow()
+//     await t.click(Selector('[aria-label="Shop Menu List"]').nth(0))
+//     await t.click(Selector('[href="/deals/"]'))
+//     await t.switchToPreviousWindow()
+// })

--- a/test/server/data/expected-test-run-errors/cannot-restore-child-window-error
+++ b/test/server/data/expected-test-run-errors/cannot-restore-child-window-error
@@ -1,0 +1,19 @@
+Failed to restore connection to window within the allocated timeout.
+
+Browser: Chrome 15.0.874.120 / macOS 10.15
+Screenshot: /unix/path/with/<tag>
+
+   18 |function func1 () {
+   19 |    record = createCallsiteRecord({ byFunctionName: 'func1' });
+   20 |}
+   21 |
+   22 |(function func2 () {
+ > 23 |    func1();
+   24 |})();
+   25 |
+   26 |stackTrace.filter.deattach(stackFilter);
+   27 |
+   28 |module.exports = record;
+
+   at func2 (testfile.js:23:5)
+   at Object.<anonymous> (testfile.js:24:3)

--- a/test/server/test-run-error-formatting-test.js
+++ b/test/server/test-run-error-formatting-test.js
@@ -86,7 +86,8 @@ const {
     CannotCloseWindowWithChildrenError,
     MultipleWindowsModeIsDisabledError,
     CannotCloseWindowWithoutParentError,
-    MultipleWindowsModeIsNotAvailableInRemoteBrowserError
+    MultipleWindowsModeIsNotAvailableInRemoteBrowserError,
+    CannotRestoreChildWindowError
 } = require('../../lib/errors/test-run');
 
 const untestedErrorTypes = Object.keys(TEST_RUN_ERRORS).map(key => TEST_RUN_ERRORS[key]);
@@ -639,6 +640,10 @@ describe('Error formatting', () => {
 
         it('Should format "multipleWindowsModeIsNotSupportedInRemoteBrowserError"', () => {
             assertErrorMessage('multiple-windows-mode-is-not-available-in-remote-browser-error', new MultipleWindowsModeIsNotAvailableInRemoteBrowserError('openWindow'));
+        });
+
+        it('Should format "cannotRestoreChildWindowError"', () => {
+            assertErrorMessage('cannot-restore-child-window-error', new CannotRestoreChildWindowError());
         });
     });
 


### PR DESCRIPTION
The cause:
If the page is reloaded it loses all its childLinks and parent links.

The approach:
Parent link is restorable easily since we have the `window.opener` property.
It is more difficult to restore child links since we do not have parent-child relationship.

So, I handle the `beforeunload` event and send a command to all child windows to start to ping parents.
Child windows get the command and start sending messages to parent. The child will repeat the sending until the parent does not confirm. So while the parent is reloading, the child is sending a message and do not get the confirmation. After the parent is reloaded, the new parent driver gets the message and send a confirmation. When the new parent gets the message it can restore the child window links.