### PR TITLE
[docs] Add config for the Stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,31 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 1095
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 10
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - "AREA: docs"
+  - "FREQUENCY: critical"
+  - "FREQUENCY: level 2"
+  - "HELP WANTED"
+  - "!IMPORTANT!"
+  - "STATE: Need clarification"
+  - "STATE: Need response"
+  - "STATE: Stale"
+  - "support center"
+# Label to use when marking an issue as stale
+staleLabel: "STATE: Stale"
+issues:
+  # Comment to post when marking an issue as stale. Set to `false` to disable
+  markComment: >
+    This issue has been automatically marked as stale because it has not had any activity for a long period. It will be closed and archived if no further activity occurs. However, we may return to this issue in the future. If it still affects you or you have any additional information regarding it, please leave a comment and we will keep it open.
+  # Comment to post when closing a stale issue. Set to `false` to disable
+  closeComment: >
+    We're closing this issue after a prolonged period of inactivity. If it still affects you, please create a new issue with up-to-date information. Thank you.
+pulls:
+  # Comment to post when marking an issue as stale. Set to `false` to disable
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had any activity for a long period. It will be closed and archived if no further activity occurs. However, we may return to this pull request in the future. If it is still relevant or you have any additional information regarding it, please leave a comment and we will keep it open.
+  # Comment to post when closing a stale issue. Set to `false` to disable
+  closeComment: >
+    We're closing this pull request after a prolonged period of inactivity. If it is still relevant, please ask for this pull request to be reopened. Thank you.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -12,6 +12,7 @@ exemptLabels:
   - "STATE: Need clarification"
   - "STATE: Need response"
   - "STATE: Stale"
+  - "STATE: won't fix"
   - "support center"
 # Label to use when marking an issue as stale
 staleLabel: "STATE: Stale"

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,6 +14,7 @@ exemptLabels:
   - "STATE: Stale"
   - "STATE: won't fix"
   - "support center"
+  - "TYPE: bug"
 # Label to use when marking an issue as stale
 staleLabel: "STATE: Stale"
 issues:


### PR DESCRIPTION
## Purpose
Add config for the Stale bot that closes outdated/stale issues.

## Approach
The bot will clean up the repository from outdated/stale issues.

## References
[https://github.com/marketplace/stale](https://github.com/marketplace/stale)

## Pre-Merge TODO
No need for tests as it is a non-technical PR.