### PR TITLE
Fix server tests in Node v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "lib/index",
   "types": "ts-defs/index.d.ts",
   "bin": {
-    "testcafe": "bin/testcafe-with-v8-flag-filter.js"
+    "testcafe": "./bin/testcafe-with-v8-flag-filter.js"
   },
   "files": [
     "lib",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "main": "lib/index",
   "types": "ts-defs/index.d.ts",
   "bin": {
-    "testcafe": "./bin/testcafe-with-v8-flag-filter.js"
+    "testcafe": "bin/testcafe-with-v8-flag-filter.js"
   },
   "files": [
     "lib",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.13",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/5437234/testcafe-hammerhead-17.1.23.zip",
+    "testcafe-hammerhead": "17.1.23",
     "testcafe-legacy-api": "4.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.13",
-    "testcafe-hammerhead": "17.1.20",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/5437234/testcafe-hammerhead-17.1.23.zip",
     "testcafe-legacy-api": "4.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/src/errors/create-stack-filter.js
+++ b/src/errors/create-stack-filter.js
@@ -16,7 +16,8 @@ const TESTCAFE_HAMMERHEAD = `${sep}testcafe-hammerhead${sep}`;
 
 const SOURCE_MAP_SUPPORT = `${sep}source-map-support${sep}`;
 
-const INTERNAL = 'internal/';
+const INTERNAL                   = 'internal/';
+const INTERNAL_PREFIX_IN_NODE_15 = 'node:';
 
 export default function createStackFilter (limit) {
     let passedFramesCount = 0;
@@ -31,6 +32,7 @@ export default function createStackFilter (limit) {
         const pass = filename &&
                    filename.indexOf(sep) > -1 &&
                    filename.indexOf(INTERNAL) !== 0 &&
+                   filename.indexOf(INTERNAL_PREFIX_IN_NODE_15) !== 0 &&
                    filename.indexOf(TESTCAFE_LIB) !== 0 &&
                    filename.indexOf(TESTCAFE_BIN) !== 0 &&
                    filename.indexOf(TESTCAFE_HAMMERHEAD) < 0 &&

--- a/src/errors/process-test-fn-error.js
+++ b/src/errors/process-test-fn-error.js
@@ -10,7 +10,8 @@ import {
 } from './test-run';
 
 
-const INTERNAL = 'internal/';
+const INTERNAL                   = 'internal/';
+const INTERNAL_PREFIX_IN_NODE_15 = 'node:';
 
 function isAssertionErrorCallsiteFrame (frame) {
     const filename = frame.getFileName();
@@ -19,6 +20,7 @@ function isAssertionErrorCallsiteFrame (frame) {
     return filename &&
            filename.indexOf(sep) > -1 &&
            filename.indexOf(INTERNAL) !== 0 &&
+           filename.indexOf(INTERNAL_PREFIX_IN_NODE_15) !== 0 &&
            filename.indexOf(`${sep}node_modules${sep}`) < 0;
 }
 

--- a/test/server/helpers/assert-runtime-error.js
+++ b/test/server/helpers/assert-runtime-error.js
@@ -20,6 +20,7 @@ function assertStack (err, expected) {
         parsedStack.forEach(function (frame, idx) {
             const filename   = frame.fileName;
             const isInternal = frame.fileName.indexOf('internal/') === 0 ||
+                               frame.fileName.indexOf('node:') === 0 &&
                                frame.fileName.indexOf(sep) < 0;
 
             // NOTE: assert that stack is clean from internals


### PR DESCRIPTION
Node.js v15 adds a prefix to builtin module filenames in stacktraces: [src: use node:moduleName as builtin module filename](https://github.com/nodejs/node/pull/35498).

We need to take into account this change by adding one more case to our filtering logic of filenames in stacktraces.