### PR TITLE
Add .requestHooks to Runner

### DIFF
--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -198,6 +198,7 @@ before(function () {
                 const screenshotPath              = opts && opts.setScreenshotPath ? config.testScreenshotsDir : '';
                 const videoPath                   = opts && opts.setVideoPath ? config.testVideosDir : '';
                 const clientScripts               = opts && opts.clientScripts || [];
+                const requestHooks                = opts && opts.requestHooks || [];
                 const compilerOptions             = opts && opts.compilerOptions;
 
                 const {
@@ -270,6 +271,7 @@ before(function () {
                     .video(videoPath, videoOptions, videoEncodingOptions)
                     .startApp(appCommand, appInitDelay)
                     .clientScripts(clientScripts)
+                    .requestHooks(requestHooks)
                     .compilerOptions(compilerOptions)
                     .run({
                         skipJsErrors,

--- a/test/server/live-test.js
+++ b/test/server/live-test.js
@@ -75,7 +75,8 @@ class BootstrapperMock extends LiveModeBootstrapper {
             tests:               [],
             browserSet:          {},
             testedApp:           {},
-            commonClientScripts: []
+            commonClientScripts: [],
+            commonRequestHooks:  [],
         });
     }
 }

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -10,7 +10,6 @@ const isAlpine                = require('./helpers/is-alpine');
 const createTestCafe          = require('../../lib/');
 const COMMAND                 = require('../../lib/browser/connection/command');
 const Task                    = require('../../lib/runner/task');
-const RequestHook             = require('../../lib/api/request-hooks/hook');
 const BrowserConnection       = require('../../lib/browser/connection');
 const BrowserSet              = require('../../lib/runner/browser-set');
 const browserProviderPool     = require('../../lib/browser/provider/pool');

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -2,7 +2,7 @@
 
 const path                    = require('path');
 const chai                    = require('chai');
-const { expect }              = chai;
+const { expect, assert }      = chai;
 const request                 = require('request');
 const { noop, times, uniqBy } = require('lodash');
 const consoleWrapper          = require('./helpers/console-wrapper');
@@ -10,6 +10,7 @@ const isAlpine                = require('./helpers/is-alpine');
 const createTestCafe          = require('../../lib/');
 const COMMAND                 = require('../../lib/browser/connection/command');
 const Task                    = require('../../lib/runner/task');
+const RequestHook             = require('../../lib/api/request-hooks/hook');
 const BrowserConnection       = require('../../lib/browser/connection');
 const BrowserSet              = require('../../lib/runner/browser-set');
 const browserProviderPool     = require('../../lib/browser/provider/pool');
@@ -855,6 +856,32 @@ describe('Runner', () => {
             }
             catch (err) {
                 expect(err.message).startsWith('You cannot call the "clientScripts" method more than once. Pass an array of parameters to this method instead.');
+            }
+        });
+    });
+
+    describe('.requestHooks', () => {
+        it('Should raise an error for multiple ".requestHooks" method call', () => {
+            try {
+                runner
+                    .requestHooks([])
+                    .requestHooks([]);
+
+                assert.fail('Should raise an appropriate error');
+            }
+            catch (e) {
+                expect(e.message).startsWith('You cannot call the "requestHooks" method more than once. Pass an array of parameters to this method instead.');
+            }
+        });
+
+        it('Should raise an error for invalid requestHooks', () => {
+            try {
+                runner.requestHooks([{}]);
+
+                assert.fail('Should raise an appropriate error');
+            }
+            catch (e) {
+                expect(e.message).startsWith('Cannot prepare tests due to an error.\n\nHook is expected to be a RequestHook subclass, but it was object.');
             }
         });
     });


### PR DESCRIPTION
## Purpose
As a consumer of the TestCafe api, I would like a way to add global requestHooks to tests from the Runner. 

This is valuable for macro-level control over tests. 

Specific use-case: I'm on the platform team that maintains a large mono-repo. We would like a way to add global request hooks to tests without requiring app teams to import and consume them. 

## Approach

I looked at the PR that introduced `clientScripts`, and treated the changes to the `Runner` class as a blueprint.

Marking this as a draft PR because I would like some input on how to more sufficiently test, and general feedback on the api change. Anticipating a larger surface area, but perhaps this is all that's needed in this specific case.

## References
https://github.com/DevExpress/testcafe/issues/5364
https://github.com/DevExpress/testcafe/issues/5412

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
