### PR TITLE
fix multiple windows + iframes (closes #5033)

### DIFF
--- a/src/client/driver/driver-link/messages.js
+++ b/src/client/driver/driver-link/messages.js
@@ -1,20 +1,22 @@
 import generateId from '../generate-id';
 
 export const TYPE = {
-    establishConnection:      'driver|establish-connection',
-    switchToWindow:           'driver|switch-to-window',
-    closeWindow:              'driver|close-window',
-    closeWindowValidation:    'driver|close-window-validation',
-    switchToWindowValidation: 'driver|switch-to-window-validation',
-    getWindows:               'driver|get-windows',
-    commandExecuted:          'driver|command-executed',
-    executeCommand:           'driver|execute-command',
-    confirmation:             'driver|confirmation',
-    setNativeDialogHandler:   'driver|set-native-dialog-handler',
-    setAsMaster:              'driver|set-as-master',
-    closeAllChildWindows:     'driver|close-all-child-windows',
-    startToRestoreChildLink:  'driver|start-to-restore-child-link',
-    restoreChildLink:         'driver|restore-child-link'
+    establishConnection:         'driver|establish-connection',
+    switchToWindow:              'driver|switch-to-window',
+    closeWindow:                 'driver|close-window',
+    closeWindowValidation:       'driver|close-window-validation',
+    switchToWindowValidation:    'driver|switch-to-window-validation',
+    getWindows:                  'driver|get-windows',
+    commandExecuted:             'driver|command-executed',
+    executeCommand:              'driver|execute-command',
+    confirmation:                'driver|confirmation',
+    setNativeDialogHandler:      'driver|set-native-dialog-handler',
+    setAsMaster:                 'driver|set-as-master',
+    closeAllChildWindows:        'driver|close-all-child-windows',
+    startToRestoreChildLink:     'driver|start-to-restore-child-link',
+    restoreChildLink:            'driver|restore-child-link',
+    childWindowIsLoadedInIFrame: 'driver|child-window-is-loaded-in-iframe',
+    childWindowIsOpenedInIFrame: 'driver|child-window-is-opened-in-iframe'
 };
 
 class InterDriverMessage {
@@ -130,5 +132,19 @@ export class RestoreChildLinkMessage extends InterDriverMessage {
         super(TYPE.restoreChildLink);
 
         this.windowId = windowId;
+    }
+}
+
+export class ChildWindowIsLoadedInFrameMessage extends InterDriverMessage {
+    constructor (windowId) {
+        super(TYPE.childWindowIsLoadedInIFrame);
+
+        this.windowId = windowId;
+    }
+}
+
+export class ChildWindowIsOpenedInFrameMessage extends InterDriverMessage {
+    constructor () {
+        super(TYPE.childWindowIsOpenedInIFrame);
     }
 }

--- a/src/client/driver/driver-link/window/parent.js
+++ b/src/client/driver/driver-link/window/parent.js
@@ -14,7 +14,7 @@ export default class ParentWindowDriverLink {
         while (topOpened.opener)
             topOpened = topOpened.opener;
 
-        return topOpened;
+        return topOpened.top;
     }
 
     _setAsMaster (wnd, finalizePendingCommand) {

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -762,6 +762,8 @@ export default class Driver extends serviceUtils.EventEmitter {
     }
 
     _handleChildWindowIsOpenedInIFrame () {
+        // NOTE: when the child window is opened in iframe we need to wait until the
+        // child window is fully loaded
         this._pendingChildWindowInIFrame = new Promise(resolve => {
             this._resolvePendingChildWindowInIframe = resolve;
         });

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -71,6 +71,7 @@ import {
     SwitchToWindowCommandMessage,
     SetNativeDialogHandlerMessage,
     GetWindowsMessage,
+    ChildWindowIsLoadedInFrameMessage,
     TYPE as MESSAGE_TYPE
 } from './driver-link/messages';
 
@@ -211,6 +212,12 @@ export default class Driver extends serviceUtils.EventEmitter {
         });
     }
 
+    _isOpenedInIframe () {
+        const opener = window.opener;
+
+        return opener && opener.top && opener.top !== opener;
+    }
+
     set speed (val) {
         this.contextStorage.setItem(TEST_SPEED, val);
     }
@@ -324,6 +331,8 @@ export default class Driver extends serviceUtils.EventEmitter {
             return;
 
         this.setAsMasterInProgress = true;
+
+        this._clearActiveChildIframeInfo();
 
         Promise.resolve()
             .then(() => {
@@ -752,6 +761,23 @@ export default class Driver extends serviceUtils.EventEmitter {
         });
     }
 
+    _handleChildWindowIsOpenedInIFrame () {
+        this._pendingChildWindowInIFrame = new Promise(resolve => {
+            this._resolvePendingChildWindowInIframe = resolve;
+        });
+    }
+
+    _handleChildWindowIsLoadedInIFrame (msg, wnd) {
+        sendConfirmationMessage({
+            requestMsgId: msg.id,
+            window:       wnd
+        });
+
+        this._resolvePendingChildWindowInIframe();
+
+        this._onChildWindowOpened({ window: wnd, windowId: msg.windowId });
+    }
+
     _initChildDriverListening () {
         messageSandbox.on(messageSandbox.SERVICE_MSG_RECEIVED_EVENT, e => {
             const msg    = e.message;
@@ -760,6 +786,12 @@ export default class Driver extends serviceUtils.EventEmitter {
             switch (msg.type) {
                 case MESSAGE_TYPE.establishConnection:
                     this._addChildIframeDriverLink(msg.id, window);
+                    break;
+                case MESSAGE_TYPE.childWindowIsOpenedInIFrame:
+                    this._handleChildWindowIsOpenedInIFrame(msg, window);
+                    break;
+                case MESSAGE_TYPE.childWindowIsLoadedInIFrame:
+                    this._handleChildWindowIsLoadedInIFrame(msg, window);
                     break;
                 case MESSAGE_TYPE.setAsMaster:
                     this._handleSetAsMasterMessage(msg, window);
@@ -822,7 +854,15 @@ export default class Driver extends serviceUtils.EventEmitter {
 
     _onCommandExecutedInIframe (status) {
         this.contextStorage.setItem(this.EXECUTING_IN_IFRAME_FLAG, false);
-        this._onReady(status);
+
+        let promise = Promise.resolve();
+
+        if (this._pendingChildWindowInIFrame)
+            promise = this._pendingChildWindowInIFrame;
+
+        promise.then(() => {
+            this._onReady(status);
+        });
     }
 
     _ensureChildIframeDriverLink (iframeWindow, ErrorCtor, selectorTimeout) {
@@ -988,6 +1028,10 @@ export default class Driver extends serviceUtils.EventEmitter {
         if (this.activeChildIframeDriverLink)
             this.activeChildIframeDriverLink.executeCommand(command);
 
+        this._clearActiveChildIframeInfo();
+    }
+
+    _clearActiveChildIframeInfo () {
         this.contextStorage.setItem(ACTIVE_IFRAME_SELECTOR, null);
         this.activeChildIframeDriverLink = null;
     }
@@ -1095,7 +1139,7 @@ export default class Driver extends serviceUtils.EventEmitter {
     }
 
     async _onWindowCloseCommand (command) {
-        const wnd             = this.parentWindowDriverLink?.getTopOpenedWindow() || window;
+        const wnd             = this._getTopOpenedWindow();
         const windowId        = command.windowId || this.windowId;
         const isCurrentWindow = windowId === this.windowId;
 
@@ -1140,7 +1184,7 @@ export default class Driver extends serviceUtils.EventEmitter {
     }
 
     async _onGetWindowsCommand () {
-        const wnd      = this.parentWindowDriverLink?.getTopOpenedWindow() || window;
+        const wnd      = this._getTopOpenedWindow();
         const response = await sendMessageToDriver(new GetWindowsMessage(), wnd, WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT, CannotSwitchToWindowError);
 
         this._onReady(new DriverStatus({
@@ -1157,8 +1201,14 @@ export default class Driver extends serviceUtils.EventEmitter {
         return sendMessageToDriver(new SwitchToWindowValidationMessage({ windowId, fn }), wnd, WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT, CannotSwitchToWindowError);
     }
 
+    _getTopOpenedWindow () {
+        const wnd = this.parentWindowDriverLink?.getTopOpenedWindow() || window;
+
+        return wnd.top;
+    }
+
     async _onSwitchToWindow (command, err) {
-        const wnd      = this.parentWindowDriverLink ? this.parentWindowDriverLink.getTopOpenedWindow() : window;
+        const wnd      = this._getTopOpenedWindow();
         const response = await this._validateChildWindowSwitchToWindowCommandExists({ windowId: command.windowId, fn: command.findWindow }, wnd);
         const result   = response.result;
 
@@ -1579,6 +1629,9 @@ export default class Driver extends serviceUtils.EventEmitter {
 
         this._initConsoleMessages();
         this._initParentWindowLink();
+
+        if (this._isOpenedInIframe())
+            sendMessageToDriver(new ChildWindowIsLoadedInFrameMessage(this.windowId), window.opener.top, WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT, WindowNotFoundError);
     }
 
     async _doFirstPageLoadSetup () {

--- a/src/client/driver/iframe-driver.js
+++ b/src/client/driver/iframe-driver.js
@@ -5,8 +5,10 @@ import Driver from './driver';
 import ContextStorage from './storage';
 import DriverStatus from './status';
 import ParentIframeDriverLink from './driver-link/iframe/parent';
-import { TYPE as MESSAGE_TYPE } from './driver-link/messages';
+import { ChildWindowIsOpenedInFrameMessage, TYPE as MESSAGE_TYPE } from './driver-link/messages';
 import IframeNativeDialogTracker from './native-dialog-tracker/iframe';
+
+const messageSandbox = eventSandbox.message;
 
 export default class IframeDriver extends Driver {
     constructor (testRunId, options) {
@@ -24,6 +26,12 @@ export default class IframeDriver extends Driver {
 
     _onConsoleMessage () {
         // NOTE: do nothing because hammerhead sends console messages to the top window directly
+    }
+
+    // NOTE: when the new page is opened in the iframe we send a message to the top window
+    // to start waiting for the new page is loaded
+    _onChildWindowOpened () {
+        messageSandbox.sendServiceMsg(new ChildWindowIsOpenedInFrameMessage(), window.top);
     }
 
     // Messaging between drivers

--- a/test/functional/fixtures/multiple-windows/pages/frame/child.html
+++ b/test/functional/fixtures/multiple-windows/pages/frame/child.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Child</title>
+
+</head>
+<body>
+    window opened by `window.open`
+    <button>child</button>
+</body>
+</html>

--- a/test/functional/fixtures/multiple-windows/pages/frame/frame.html
+++ b/test/functional/fixtures/multiple-windows/pages/frame/frame.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Frame</title>
+
+    <script>
+        function createOverlay () {
+            var div = window.top.document.querySelector('div');
+
+            div.style.height   = 0;
+            div.style.overflow = 'hidden';
+
+            div = document.createElement('div');
+
+            div.style.position = 'fixed';
+            div.style.top      = 0;
+            div.style.bottom   = 0;
+            div.style.left     = 0;
+            div.style.right    = 0;
+
+            div.style.backgroundColor = 'red';
+
+            // window.top.document.body.appendChild(div);
+
+            var iframe = window.top.document.querySelector('iframe');
+
+            iframe.style.visibility = 'hidden';
+        }
+    </script>
+</head>
+<body>
+    <a onclick="createOverlay()" href="./child.html" target="_blank">open window</a>
+
+    <button>frame</button>
+</body>
+</html>

--- a/test/functional/fixtures/multiple-windows/pages/frame/frame.html
+++ b/test/functional/fixtures/multiple-windows/pages/frame/frame.html
@@ -5,24 +5,7 @@
     <title>Frame</title>
 
     <script>
-        function createOverlay () {
-            var div = window.top.document.querySelector('div');
-
-            div.style.height   = 0;
-            div.style.overflow = 'hidden';
-
-            div = document.createElement('div');
-
-            div.style.position = 'fixed';
-            div.style.top      = 0;
-            div.style.bottom   = 0;
-            div.style.left     = 0;
-            div.style.right    = 0;
-
-            div.style.backgroundColor = 'red';
-
-            // window.top.document.body.appendChild(div);
-
+        function hideIframe () {
             var iframe = window.top.document.querySelector('iframe');
 
             iframe.style.visibility = 'hidden';
@@ -30,7 +13,7 @@
     </script>
 </head>
 <body>
-    <a onclick="createOverlay()" href="./child.html" target="_blank">open window</a>
+    <a onclick="hideIframe()" href="./child.html" target="_blank">open window</a>
 
     <button>frame</button>
 </body>

--- a/test/functional/fixtures/multiple-windows/pages/frame/parent.html
+++ b/test/functional/fixtures/multiple-windows/pages/frame/parent.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Parent</title>
+</head>
+<body>
+<div>
+    <iframe src="./frame.html"></iframe>
+</div>
+
+<a href="./child.html" target="_blank">open window</a>
+
+<button>parent</button>
+
+</body>
+</html>

--- a/test/functional/fixtures/multiple-windows/test.js
+++ b/test/functional/fixtures/multiple-windows/test.js
@@ -304,7 +304,7 @@ describe('Multiple windows', () => {
             return runTests('testcafe-fixtures/iframe.js', 'Open child window if iframe', { only: 'chrome' });
         });
     });
-    
+
     describe('Emulation', () => {
         it('Should resize window when emulating device', async () => {
             return createTestCafe('127.0.0.1', 1335, 1336)

--- a/test/functional/fixtures/multiple-windows/test.js
+++ b/test/functional/fixtures/multiple-windows/test.js
@@ -299,6 +299,12 @@ describe('Multiple windows', () => {
         });
     });
 
+    describe('iFrames', () => {
+        it('Should switch to child window if it is opened in iFrame', () => {
+            return runTests('testcafe-fixtures/iframe.js', 'Open child window if iframe', { only: 'chrome' });
+        });
+    });
+    
     describe('Emulation', () => {
         it('Should resize window when emulating device', async () => {
             return createTestCafe('127.0.0.1', 1335, 1336)

--- a/test/functional/fixtures/multiple-windows/testcafe-fixtures/iframe.js
+++ b/test/functional/fixtures/multiple-windows/testcafe-fixtures/iframe.js
@@ -1,0 +1,22 @@
+import { Selector } from 'testcafe';
+
+fixture `iFrames`
+    .page `http://localhost:3000/fixtures/multiple-windows/pages/frame/parent.html`;
+
+test('Open child window if iframe', async t => {
+    await t.switchToIframe('iframe');
+
+    await t.click(Selector('button').withText('frame'));
+
+    await t.click('a');
+
+    await t.click(Selector('button').withText('child'));
+
+    await t.switchToPreviousWindow();
+
+    await t.click(Selector('button').withText('parent'));
+
+    await t.switchToPreviousWindow();
+
+    await t.click(Selector('button').withText('child'));
+});


### PR DESCRIPTION
The cause of the issue is that the child window is opened in an iframe.
We need to handle this situation.
My approach:
- information about the child window is stored in the main window, not in the iframe. It allows us to iterate through windows hierarchy without considering iframes
- in the main window we need somehow to wait until the child window is fully loaded in the iframe. The problem is that in the main window we do not know when the window is opened. So, when the child window starts to open in the iframe, I send the message to the main window, that it should wait. Then, when the child window is fully loaded, I send the message from the child window to the main window to stop waiting and switch to the child window.