### PR TITLE
fix(server-tests): test doesn't properly stub stdout

### DIFF
--- a/test/server/execute-async-expression-test.js
+++ b/test/server/execute-async-expression-test.js
@@ -12,19 +12,10 @@ const TestController = require('../../lib/api/test-controller');
 const COMMAND_TYPE   = require('../../lib/test-run/commands/type');
 const markerSymbol   = require('../../lib/test-run/marker-symbol');
 
-const assertTestRunError = require('./helpers/assert-test-run-error');
+const assertTestRunError         = require('./helpers/assert-test-run-error');
+const { createSimpleTestStream } = require('../functional/utils/stream');
 
 let callsite = 0;
-
-class StubStream {
-    constructor () {
-        this.data = '';
-    }
-
-    write (chunk) {
-        this.data += chunk.toString();
-    }
-}
 
 class TestRunMock extends TestRun {
     _addInjectables () {}
@@ -42,7 +33,7 @@ class TestRunMock extends TestRun {
         this.controller      = new TestController(this);
         this.driverTaskQueue = [];
         this.emit            = noop;
-        this.stubStream      = new StubStream();
+        this.stubStream      = createSimpleTestStream();
 
         const stubModule = require('log-update-async-hook').create(this.stubStream);
 


### PR DESCRIPTION
Test for "debug" method of the test controller doesn't properly stub the stdout stream, which causes the method's code to interfere with mocha's spec reporter's output. As a result, we see broken output after the `gulp test-server` command is executed.

before:
![before](https://user-images.githubusercontent.com/26363017/99499627-3cf75580-298a-11eb-9580-231874ee72ba.png)

after:
![after](https://user-images.githubusercontent.com/26363017/99499638-41237300-298a-11eb-861c-36c13ce7d7e9.png)
