### PR TITLE
[docs] Add code example for formatted input fields (typeText)

### DIFF
--- a/docs/articles/documentation/guides/continuous-integration/circleci.md
+++ b/docs/articles/documentation/guides/continuous-integration/circleci.md
@@ -142,4 +142,3 @@ Use the **Start building** button to trigger a build.
 Go to the **Builds** section and choose a build to view its results.
 
 ![Test Results](../../../images/circle-ci/fail-report.png)
-

--- a/docs/articles/documentation/guides/continuous-integration/circleci.md
+++ b/docs/articles/documentation/guides/continuous-integration/circleci.md
@@ -142,3 +142,4 @@ Use the **Start building** button to trigger a build.
 Go to the **Builds** section and choose a build to view its results.
 
 ![Test Results](../../../images/circle-ci/fail-report.png)
+

--- a/docs/articles/documentation/reference/test-api/testcontroller/typetext.md
+++ b/docs/articles/documentation/reference/test-api/testcontroller/typetext.md
@@ -13,11 +13,11 @@ Types the specified text into an input element.
 t.typeText( selector, text [, options] )
 ```
 
-Parameter              | Type                                              | Description
----------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------
-`selector`             | Function &#124; String &#124; Selector &#124; Snapshot &#124; Promise | Identifies the webpage element that will receive input focus. See [Select Target Elements](#select-target-elements).
-`text`                 | String                                            | The text to be typed into the specified webpage element.
-`options`&#160;*(optional)* | Object                                            | A set of options that provide additional parameters for the action. See [Options](#options). If this parameter is omitted, TestCafe sets the cursor to the end of the text before typing. This preserves the text that is already in the input box.
+Parameter                   | Type                                              | Description
+--------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------
+`selector`                  | Function &#124; String &#124; Selector &#124; Snapshot &#124; Promise | Identifies the webpage element that receives input focus. See [Select Target Elements](#select-target-elements).
+`text`                      | String                                            | The text to be typed into the specified webpage element.
+`options`&#160;*(optional)* | Object                                            | A set of options with additional parameters for the action. See [Options](#options). If this parameter is omitted, TestCafe sets the cursor to the end of the text before typing. This preserves the text that is already in the input box.
 
 The `t.typeText` action [clicks](click.md) the specified element before text is typed if this element is not focused. If the target element is not focused after the click, `t.typeText` does not type text.
 
@@ -42,9 +42,9 @@ test('Type and Replace', async t => {
 });
 ```
 
-## Typing Into DateTime, Color and Range Inputs
+## Typing Into DateTime, Color, and Range Inputs
 
-There are certain types of HTML5 inputs, like `DateTime`, `Color` or `Range`, that require entering values in a specific format.
+Some HTML5 inputs, like `DateTime`, `Color` or `Range`, require specifically formatted values.
 
 The following table lists value formats expected by these inputs.
 
@@ -55,8 +55,29 @@ Week       | `yyyy-Www`         | `'2017-W03'`
 Month      | `yyyy-mm`          | `'2017-08'`
 DateTime   | `yyyy-mm-ddThh:mm` | `'2017-11-03T05:00'`
 Time       | `hh:mm`            | `'15:30'`
-Color      | `#rrggbb`          | `'#003000'`
+Color      | `#rrggbb` (hex)    | `'#FF8040'`
 Range      | `n`                | `'45'`
+
+The following example uses `t.typeText` to fill `color`, `datetime-local` and `range` input fields.
+
+```js
+import { Selector } from 'testcafe'
+
+fixture `My fixture`
+    .page `http://www.example.com/`;
+
+const color    = Selector('input[type=color]');
+const datetime = Selector('input[type=datetime-local]');
+const range    = Selector('input[type=range]');
+
+test('Interact with inputs', async t => {
+
+    await t
+        .typeText(color, '#FF8040')
+        .typeText(datetime, '2017-11-03T05:00')
+        .typeText(range, '80');
+});
+```
 
 ## Select Target Elements
 

--- a/docs/articles/documentation/reference/test-api/testcontroller/typetext.md
+++ b/docs/articles/documentation/reference/test-api/testcontroller/typetext.md
@@ -17,7 +17,7 @@ Parameter                   | Type                                              
 --------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------
 `selector`                  | Function &#124; String &#124; Selector &#124; Snapshot &#124; Promise | Identifies the webpage element that receives input focus. See [Select Target Elements](#select-target-elements).
 `text`                      | String                                            | The text to be typed into the specified webpage element.
-`options`&#160;*(optional)* | Object                                            | A set of options with additional parameters for the action. See [Options](#options). If this parameter is omitted, TestCafe sets the cursor to the end of the text before typing. This preserves the text that is already in the input box.
+`options`&#160;*(optional)* | Object                                            | A set of options with additional parameters for the action. See [Options](#options). If this parameter is omitted, TestCafe moves the cursor to the end of the text before typing. This preserves the text that is already in the input box.
 
 The `t.typeText` action [clicks](click.md) the specified element before text is typed if this element is not focused. If the target element is not focused after the click, `t.typeText` does not type text.
 
@@ -44,7 +44,7 @@ test('Type and Replace', async t => {
 
 ## Typing Into DateTime, Color, and Range Inputs
 
-Some HTML5 inputs, like `DateTime`, `Color` or `Range`, require specifically formatted values.
+Some HTML5 inputs, like `DateTime`, `Color` or `Range`, require formatted values.
 
 The following table lists value formats expected by these inputs.
 
@@ -58,7 +58,7 @@ Time       | `hh:mm`            | `'15:30'`
 Color      | `#rrggbb` (hex)    | `'#FF8040'`
 Range      | `n`                | `'45'`
 
-The following example uses `t.typeText` to fill `color`, `datetime-local` and `range` input fields.
+The following example uses `t.typeText` to fill `color`, `datetime-local` and `range` input fields:
 
 ```js
 import { Selector } from 'testcafe'


### PR DESCRIPTION
fixes #5573 