### PR TITLE
continue browser restart if close browser hangs (closes #5238)

### DIFF
--- a/@types/time-limit-promise/index.d.ts
+++ b/@types/time-limit-promise/index.d.ts
@@ -1,3 +1,3 @@
 declare module 'time-limit-promise' {
-    export default function (promise: Promise<any>, timeout: number, options?: { resolveWith: any, rejectWith: any }): Promise<any>;
+    export default function (promise: Promise<any>, timeout: number, options?: { resolveWith: any } | { rejectWith: any }): Promise<any>;
 }

--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -249,7 +249,7 @@ export default class BrowserConnection extends EventEmitter {
         let isTimeoutExpired                = false;
         let timeout: NodeJS.Timeout | null  = null;
 
-        const restartPromise = timeLimit(this._closeBrowser(), this.BROWSER_CLOSE_TIMEOUT, { resolveWith: void 0, rejectWith: new TimeoutError() })
+        const restartPromise = timeLimit(this._closeBrowser(), this.BROWSER_CLOSE_TIMEOUT, { rejectWith: new TimeoutError() })
             .catch(err => this.debugLogger(err))
             .then(() => this._runBrowser());
 

--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -1,3 +1,5 @@
+import debug from 'debug';
+import timeLimit from 'time-limit-promise';
 import { EventEmitter } from 'events';
 import Mustache from 'mustache';
 import { pull as remove } from 'lodash';
@@ -8,14 +10,21 @@ import nanoid from 'nanoid';
 import COMMAND from './command';
 import BrowserConnectionStatus from './status';
 import HeartbeatStatus from './heartbeat-status';
-import { GeneralError } from '../../errors/runtime';
+import { GeneralError, TimeoutError } from '../../errors/runtime';
 import { RUNTIME_ERRORS } from '../../errors/types';
-import { BROWSER_RESTART_TIMEOUT, HEARTBEAT_TIMEOUT } from '../../utils/browser-connection-timeouts';
 import { Dictionary } from '../../configuration/interfaces';
 import BrowserConnectionGateway from './gateway';
 import BrowserJob from '../../runner/browser-job';
 import WarningLog from '../../notifications/warning-log';
 import BrowserProvider from '../provider';
+
+import {
+    BROWSER_RESTART_TIMEOUT,
+    BROWSER_CLOSE_TIMEOUT,
+    HEARTBEAT_TIMEOUT
+} from '../../utils/browser-connection-timeouts';
+
+const DEBUG_SCOPE = (id: string): string => `testcafe:browser:connection:${id}`;
 
 const IDLE_PAGE_TEMPLATE                         = read('../../client/browser/idle-page/index.html.mustache');
 const connections: Dictionary<BrowserConnection> = {};
@@ -61,6 +70,7 @@ export default class BrowserConnection extends EventEmitter {
     public previousActiveWindowId: string | null;
     private readonly disableMultipleWindows: boolean;
     private readonly HEARTBEAT_TIMEOUT: number;
+    private readonly BROWSER_CLOSE_TIMEOUT: number;
     private readonly BROWSER_RESTART_TIMEOUT: number;
     public readonly id: string;
     private readonly jobQueue: BrowserJob[];
@@ -83,6 +93,7 @@ export default class BrowserConnection extends EventEmitter {
     private readonly activeWindowIdUrl: string;
     private statusDoneUrl: string;
     private warningLog: WarningLog;
+    private readonly debugLogger: debug.Debugger;
 
     public idle: boolean;
 
@@ -97,6 +108,7 @@ export default class BrowserConnection extends EventEmitter {
         super();
 
         this.HEARTBEAT_TIMEOUT       = HEARTBEAT_TIMEOUT;
+        this.BROWSER_CLOSE_TIMEOUT   = BROWSER_CLOSE_TIMEOUT;
         this.BROWSER_RESTART_TIMEOUT = BROWSER_RESTART_TIMEOUT;
 
         this.id                       = BrowserConnection._generateId();
@@ -106,6 +118,7 @@ export default class BrowserConnection extends EventEmitter {
         this.disconnectionPromise     = null;
         this.testRunAborted           = false;
         this.warningLog               = new WarningLog();
+        this.debugLogger              = debug(DEBUG_SCOPE(this.id));
 
         this.browserInfo                           = browserInfo;
         this.browserInfo.userAgentProviderMetaInfo = '';
@@ -133,7 +146,8 @@ export default class BrowserConnection extends EventEmitter {
         this.statusUrl     = `${gateway.domain}${this.statusRelativeUrl}`;
         this.statusDoneUrl = `${gateway.domain}${this.statusDoneRelativeUrl}`;
 
-        this.on('error', () => {
+        this.on('error', err => {
+            this.debugLogger(err);
             this._forceIdle();
             this.close();
         });
@@ -179,6 +193,7 @@ export default class BrowserConnection extends EventEmitter {
         }
         catch (err) {
             // NOTE: A warning would be really nice here, but it can't be done while log is stored in a task.
+            this.debugLogger(err);
         }
     }
 
@@ -234,7 +249,8 @@ export default class BrowserConnection extends EventEmitter {
         let isTimeoutExpired                = false;
         let timeout: NodeJS.Timeout | null  = null;
 
-        const restartPromise = this._closeBrowser()
+        const restartPromise = timeLimit(this._closeBrowser(), this.BROWSER_CLOSE_TIMEOUT, { resolveWith: void 0, rejectWith: new TimeoutError() })
+            .catch(err => this.debugLogger(err))
             .then(() => this._runBrowser());
 
         const timeoutPromise = new Promise(resolve => {
@@ -247,7 +263,7 @@ export default class BrowserConnection extends EventEmitter {
             }, this.BROWSER_RESTART_TIMEOUT);
         });
 
-        Promise.race([ restartPromise, timeoutPromise ])
+        return Promise.race([ restartPromise, timeoutPromise ])
             .then(() => {
                 clearTimeout(timeout as NodeJS.Timeout);
 

--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -24,7 +24,7 @@ import {
     HEARTBEAT_TIMEOUT
 } from '../../utils/browser-connection-timeouts';
 
-const DEBUG_SCOPE = (id: string): string => `testcafe:browser:connection:${id}`;
+const getBrowserConnectionDebugScope = (id: string): string => `testcafe:browser:connection:${id}`;
 
 const IDLE_PAGE_TEMPLATE                         = read('../../client/browser/idle-page/index.html.mustache');
 const connections: Dictionary<BrowserConnection> = {};
@@ -118,7 +118,7 @@ export default class BrowserConnection extends EventEmitter {
         this.disconnectionPromise     = null;
         this.testRunAborted           = false;
         this.warningLog               = new WarningLog();
-        this.debugLogger              = debug(DEBUG_SCOPE(this.id));
+        this.debugLogger              = debug(getBrowserConnectionDebugScope(this.id));
 
         this.browserInfo                           = browserInfo;
         this.browserInfo.userAgentProviderMetaInfo = '';

--- a/src/errors/runtime/index.js
+++ b/src/errors/runtime/index.js
@@ -123,3 +123,9 @@ export class ReporterPluginError extends GeneralError {
         super(code, name, method, originalError.stack);
     }
 }
+
+export class TimeoutError extends GeneralError {
+    constructor () {
+        super(RUNTIME_ERRORS.timeLimitedPromiseTimeoutExpired);
+    }
+}

--- a/src/utils/browser-connection-timeouts.js
+++ b/src/utils/browser-connection-timeouts.js
@@ -5,6 +5,7 @@
 
 export const HEARTBEAT_TIMEOUT       = 2 * 60 * 1000;
 export const BROWSER_RESTART_TIMEOUT = 60 * 1000;
+export const BROWSER_CLOSE_TIMEOUT   = BROWSER_RESTART_TIMEOUT / 2;
 
 export const HEARTBEAT_INTERVAL = 2 * 1000;
 

--- a/test/functional/fixtures/browser-provider/browser-reconnect/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/browser-provider/browser-reconnect/testcafe-fixtures/index-test.js
@@ -46,3 +46,19 @@ test('Should fail on 3 disconnects in one browser', async t => {
     await t.expect(counter[userAgent]).eql(1);
 });
 
+test('Should restart browser on timeout if the `closeBrowser` method hangs', async t => {
+    const userAgent = await getUserAgent();
+
+    counter[userAgent] = counter[userAgent] || 0;
+
+    counter[userAgent]++;
+
+    if (counter[userAgent] < 2) {
+        await hang();
+
+        throw new Error('browser has not restarted');
+    }
+
+    await t.expect(counter[userAgent]).eql(2);
+});
+


### PR DESCRIPTION
We need to restart the browser even if the `_closeBrowser` method hangs for some reason. So we wrap `_closeBrowser` with time-limited promised and BROWSER_CLOSE_TIMEOUT.