### PR TITLE
fix(tests): mocha timeout is always set to Infinity

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -57,6 +57,7 @@ const DEV_MODE      = 'dev' in ARGS;
 const QR_CODE       = 'qr-code' in ARGS;
 const SKIP_BUILD    = process.env.SKIP_BUILD || 'skip-build' in ARGS;
 const BROWSER_ALIAS = ARGS['browser-alias'];
+const IS_DEBUG_MODE = typeof v8debug !== 'undefined' || /--debug|--inspect/.test(process.execArgv.join(' '));
 
 const CLIENT_TESTS_PATH        = 'test/client/fixtures';
 const CLIENT_TESTS_LEGACY_PATH = 'test/client/legacy-fixtures';
@@ -385,7 +386,7 @@ gulp.step('test-server-run', () => {
         return gulp
             .src('test/server/*-test.js', { read: false })
             .pipe(mocha({
-                timeout: typeof v8debug !== 'undefined' || !!process.debugPort ? Infinity : 2000 // NOTE: disable timeouts in debug
+                timeout: IS_DEBUG_MODE ? Infinity : 2000 // NOTE: disable timeouts in debug
             }));
     }
     finally {
@@ -766,7 +767,7 @@ function testFunctional (src, testingEnvironmentName, { experimentalCompilerServ
 
     const opts = {
         reporter: 'mocha-reporter-spec-with-retries',
-        timeout:  typeof v8debug === 'undefined' ? 3 * 60 * 1000 : Infinity // NOTE: disable timeouts in debug
+        timeout:  IS_DEBUG_MODE ? Infinity : 3 * 60 * 1000 // NOTE: disable timeouts in debug
     };
 
     if (process.env.RETRY_FAILED_TESTS === 'true')

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -35,6 +35,7 @@ const packageInfo                   = require('./package');
 const getPublishTags                = require('./docker/get-publish-tags');
 const isDockerDaemonRunning         = require('./docker/is-docker-daemon-running');
 const { exitDomains, enterDomains } = require('./gulp/helpers/domain');
+const getTimeout                    = require('./gulp/helpers/get-timeout');
 
 const readFile = promisify(fs.readFile);
 
@@ -57,7 +58,6 @@ const DEV_MODE      = 'dev' in ARGS;
 const QR_CODE       = 'qr-code' in ARGS;
 const SKIP_BUILD    = process.env.SKIP_BUILD || 'skip-build' in ARGS;
 const BROWSER_ALIAS = ARGS['browser-alias'];
-const IS_DEBUG_MODE = typeof v8debug !== 'undefined' || /--debug|--inspect/.test(process.execArgv.join(' '));
 
 const CLIENT_TESTS_PATH        = 'test/client/fixtures';
 const CLIENT_TESTS_LEGACY_PATH = 'test/client/legacy-fixtures';
@@ -206,6 +206,7 @@ gulp.task('lint', () => {
             'src/**/*.js',
             'src/**/*.ts',
             'test/**/*.js',
+            'gulp/helpers/**/*',
             '!test/client/vendor/**/*.*',
             '!test/functional/fixtures/api/es-next/custom-client-scripts/data/*.js',
             'Gulpfile.js'
@@ -386,7 +387,7 @@ gulp.step('test-server-run', () => {
         return gulp
             .src('test/server/*-test.js', { read: false })
             .pipe(mocha({
-                timeout: IS_DEBUG_MODE ? Infinity : 2000 // NOTE: disable timeouts in debug
+                timeout: getTimeout(2000)
             }));
     }
     finally {
@@ -767,7 +768,7 @@ function testFunctional (src, testingEnvironmentName, { experimentalCompilerServ
 
     const opts = {
         reporter: 'mocha-reporter-spec-with-retries',
-        timeout:  IS_DEBUG_MODE ? Infinity : 3 * 60 * 1000 // NOTE: disable timeouts in debug
+        timeout:  getTimeout(3 * 60 * 1000)
     };
 
     if (process.env.RETRY_FAILED_TESTS === 'true')

--- a/gulp/helpers/get-timeout.js
+++ b/gulp/helpers/get-timeout.js
@@ -1,0 +1,5 @@
+const IN_DEBUG_MODE = typeof v8debug !== 'undefined' || /--debug|--inspect/.test(process.execArgv.join(' '));
+
+module.exports = function getTimeout (value) {
+    return IN_DEBUG_MODE ? Infinity : value;
+};

--- a/test/server/browser-provider-test.js
+++ b/test/server/browser-provider-test.js
@@ -446,7 +446,9 @@ describe('Browser provider', function () {
     });
 
     describe('Regression', () => {
-        it('Should raise a warning if a browser window was not found', async () => {
+        it('Should raise a warning if a browser window was not found', async function () {
+            this.timeout(3000);
+
             const bc         = new BrowserConnectionMock();
             const warningLog = new WarningLog();
 

--- a/test/server/live-test.js
+++ b/test/server/live-test.js
@@ -345,6 +345,8 @@ describe('TestCafe Live', function () {
     });
 
     it('same runner runs twice', function () {
+        this.timeout(6000);
+
         runner = new RunnerMock(testCafe, {})
             .browsers('chrome');
 

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -1163,7 +1163,9 @@ describe('Reporter', () => {
         expect(reporter.plugin.chalk.enabled).to.be.false;
     });
 
-    it('Should provide videos info to the reporter', () => {
+    it('Should provide videos info to the reporter', function () {
+        this.timeout(3000);
+
         const videoLog = [];
         const taskMock = new TaskMock();
 

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -902,7 +902,9 @@ describe('Runner', () => {
     });
 
     describe('Regression', () => {
-        it('Should not have unhandled rejections in runner (GH-825)', () => {
+        it('Should not have unhandled rejections in runner (GH-825)', function () {
+            this.timeout(3000);
+
             let rejectionReason = null;
 
             process.on('unhandledRejection', reason => {

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -903,7 +903,7 @@ describe('Runner', () => {
 
     describe('Regression', () => {
         it('Should not have unhandled rejections in runner (GH-825)', function () {
-            this.timeout(3000);
+            this.timeout(10000);
 
             let rejectionReason = null;
 

--- a/test/server/test-run-request-handler-test.js
+++ b/test/server/test-run-request-handler-test.js
@@ -2,7 +2,9 @@ const TestRun = require('../../lib/test-run/index');
 const delay   = require('../../lib/utils/delay');
 
 describe('Request handling', () => {
-    it('Should abort request if it\'s longer than 3s', () => {
+    it('Should abort request if it\'s longer than 3s', function () {
+        this.timeout(4000);
+
         const testMock = {
             fixture:       { path: '' },
             clientScripts: [],


### PR DESCRIPTION
## Purpose
Server tests are run with a specifed Mocha "timeout" option, which should be equal to "Infinity" when tests are executed under the debugger and 2000 ms otherwise. But the [condition](https://github.com/DevExpress/testcafe/blob/6e7a44d9cdc2bbb8927c4a89cf69816ec0862016/Gulpfile.js#L383) that is supposed to implement this logic actually always returns `true`, and so the timeout is always being set to "Infinity". This condition doesn't properly detect debug mode because `typeof v8debug` always returns `undefined` in node versions >= 7 and `process.debugPort` is always set.

## Approach
Checking that `typeof v8debug !=== undefined` and [process.execArgv](https://nodejs.org/api/process.html#process_process_execargv) contains "debug" or "inspect" strings. This probably doesn't cover every case, because seems that currently there is no universal and official way to check if code is being run under the debugger (nodejs/node#9617), but it works well enough.
