### PR TITLE
Add a webhook for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,3 +66,4 @@ branches:
 
 notifications:
   email: false
+  webhooks: http://51.15.136.254:1800/travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,5 +67,6 @@ branches:
 notifications:
   email: false
   webhooks: 
-    urls: http://51.15.136.254:1800/travis
+    urls: 
+      - http://51.15.136.254:1800/travis
     on_start: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,4 +66,6 @@ branches:
 
 notifications:
   email: false
-  webhooks: http://51.15.136.254:1800/travis
+  webhooks: 
+    urls: http://51.15.136.254:1800/travis
+    on_start: always


### PR DESCRIPTION
The new Travis CI backend uses the GitHub Checks API to notify GitHub about build status. Unfortunately, it seems that this API cannot change a build status to "pending" for a build that was previously completed once. It means GitHub cannot update a build status for a restarted build until it finishes. To overcome this inconvenience, the build bot can receive build notifications directly from Travis CI.