### PR TITLE
Fix docker related problems in gulpfile.js

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -886,7 +886,7 @@ gulp.step('docker-publish-run', done => {
     const PUBLISH_COMMANDS = [
         'docker push',
         'docker pull',
-        'docker image rm'
+        'docker image rm -f'
     ];
 
     PUBLISH_TAGS.forEach(tag => {

--- a/gulp/docker/run-functional-test-via-command-line.js
+++ b/gulp/docker/run-functional-test-via-command-line.js
@@ -6,10 +6,7 @@ const os           = require('os');
 const osFamily     = require('os-family');
 
 function correctPathOnWindows (tmpDir) {
-    const parsedPath             = path.parse(tmpDir);
-    const newRoot                = '//' + parsedPath.root.replace(':', '');
-    const modifiedTmpDir         = tmpDir.replace(parsedPath.root, newRoot);
-    const modifiedTmpDirSegments = modifiedTmpDir.split(path.sep);
+    const modifiedTmpDirSegments = tmpDir.split(path.sep);
     const userNameTmpDirPart     = modifiedTmpDirSegments[2];
 
     if (userNameTmpDirPart.includes('~')) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.10.0-rc.3",
+  "version": "1.10.0-rc.4",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"


### PR DESCRIPTION
Changes:
* force docker image removing after publish
* change format of the mounted directory for docker functional tests.
`//C/Users/losev.mikhail..` -> C:/Users/losev.mikhail
* change version to make sure that docker publish process was fixed