### PR TITLE
Fix BC in test action result definitions

### DIFF
--- a/test/server/data/test-suites/typescript-defs/test-controller.ts
+++ b/test/server/data/test-suites/typescript-defs/test-controller.ts
@@ -794,3 +794,11 @@ test('messages formatting', async t => {
         .expect(messages.warn.length).eql(0)
         .expect(messages.error.length).eql(0);
 });
+
+test('action result coercion', async t => {
+    function test (): Promise<void> {
+        return t.expect(1).ok();
+    }
+
+    test();
+});

--- a/test/server/data/test-suites/typescript-testcafe-scripts-defs/test-controller.ts
+++ b/test/server/data/test-suites/typescript-testcafe-scripts-defs/test-controller.ts
@@ -789,3 +789,11 @@ const getInputValue = ClientFunction(() => (<HTMLInputElement>document.getElemen
         .expect(messages.warn.length).eql(0)
         .expect(messages.error.length).eql(0);
 })();
+
+(async () => {
+    function test (): Promise<void> {
+        return t.expect(1).ok();
+    }
+
+    test();
+})();

--- a/ts-defs-src/test-api/test-controller.d.ts
+++ b/ts-defs-src/test-api/test-controller.d.ts
@@ -414,9 +414,9 @@ interface TestController {
     removeRequestHooks(...hooks: object[]): TestControllerPromise;
 }
 
-interface TestControllerPromise extends TestController, Promise<unknown> {
+interface TestControllerPromise<T=any> extends TestController, Promise<T> {
 }
 
-interface WindowDescriptorPromise extends TestControllerPromise, Promise<WindowDescriptor> {
+interface WindowDescriptorPromise extends TestControllerPromise<WindowDescriptor> {
 }
 


### PR DESCRIPTION
Fixes the problem with coercion `unknown -> void` and preserves interfaces' inheritance. Better test ideas are welcomed.