### PR TITLE
resize multiple window in local firefox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ jobs:
       env: GULP_TASK="test-functional-local-multiple-windows"
       addons:
         chrome:  stable
+        firefox:  latest
         apt:
           packages:
             - fluxbox

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -849,7 +849,7 @@ gulp.step('test-functional-local-legacy-run', () => {
 gulp.task('test-functional-local-legacy', gulp.series('prepare-tests', 'test-functional-local-legacy-run'));
 
 gulp.step('test-functional-local-multiple-windows-run', () => {
-    return testFunctional(MULTIPLE_WINDOWS_TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localChrome);
+    return testFunctional(MULTIPLE_WINDOWS_TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localBrowsersChromeFirefox);
 });
 
 gulp.task('test-functional-local-multiple-windows', gulp.series('prepare-tests', 'test-functional-local-multiple-windows-run'));

--- a/src/browser/provider/built-in/dedicated/base.js
+++ b/src/browser/provider/built-in/dedicated/base.js
@@ -18,6 +18,25 @@ export default {
         this.openedBrowsers[browserId].activeWindowId = val;
     },
 
+    getPageTitle (browserId) {
+        const runtimeInfo     = this.openedBrowsers[browserId];
+        const isIdlePageShown = !Object.keys(runtimeInfo.windowDescriptors).length;
+
+        return isIdlePageShown ? browserId : runtimeInfo.activeWindowId;
+    },
+
+    getWindowDescriptor (browserId) {
+        const runtimeInfo = this.openedBrowsers[browserId];
+
+        return runtimeInfo.windowDescriptors[runtimeInfo.activeWindowId];
+    },
+
+    setWindowDescriptor (browserId, windowDescriptor) {
+        const runtimeInfo = this.openedBrowsers[browserId];
+
+        runtimeInfo.windowDescriptors[runtimeInfo.activeWindowId] = windowDescriptor;
+    },
+
     _getConfig () {
         throw new Error('Not implemented');
     },

--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -123,25 +123,6 @@ export default {
         };
     },
 
-    getPageTitle (browserId) {
-        const runtimeInfo     = this.openedBrowsers[browserId];
-        const isIdlePageShown = !Object.keys(runtimeInfo.windowDescriptors).length;
-
-        return isIdlePageShown ? browserId : runtimeInfo.activeWindowId;
-    },
-
-    getWindowDescriptor (browserId) {
-        const runtimeInfo = this.openedBrowsers[browserId];
-
-        return runtimeInfo.windowDescriptors[runtimeInfo.activeWindowId];
-    },
-
-    _setWindowDescriptor (browserId, windowDescriptor) {
-        const runtimeInfo = this.openedBrowsers[browserId];
-
-        runtimeInfo.windowDescriptors[runtimeInfo.activeWindowId] = windowDescriptor;
-    },
-
     async _ensureWindowIsExpanded (browserId, { height, width, availableHeight, availableWidth, outerWidth, outerHeight }) {
         if (height < MIN_AVAILABLE_DIMENSION || width < MIN_AVAILABLE_DIMENSION) {
             const newHeight = Math.max(availableHeight, MIN_AVAILABLE_DIMENSION);

--- a/src/browser/provider/built-in/dedicated/firefox/index.js
+++ b/src/browser/provider/built-in/dedicated/firefox/index.js
@@ -19,7 +19,7 @@ export default {
 
     async _createMarionetteClient (runtimeInfo) {
         try {
-            const marionetteClient = new MarionetteClient(runtimeInfo.marionettePort);
+            const marionetteClient = new MarionetteClient(runtimeInfo.marionettePort, runtimeInfo);
 
             await marionetteClient.connect();
 
@@ -33,8 +33,9 @@ export default {
     async openBrowser (browserId, pageUrl, configString, disableMultipleWindows) {
         const runtimeInfo = await getRuntimeInfo(configString);
 
-        runtimeInfo.browserName = this._getBrowserName();
-        runtimeInfo.browserId   = browserId;
+        runtimeInfo.browserName       = this._getBrowserName();
+        runtimeInfo.browserId         = browserId;
+        runtimeInfo.windowDescriptors = {};
 
         await startLocalFirefox(pageUrl, runtimeInfo);
 

--- a/src/browser/provider/built-in/dedicated/firefox/marionette-client/commands.js
+++ b/src/browser/provider/built-in/dedicated/firefox/marionette-client/commands.js
@@ -1,8 +1,11 @@
 export default {
-    newSession:     'WebDriver:NewSession',
-    executeScript:  'WebDriver:ExecuteScript',
-    takeScreenshot: 'WebDriver:TakeScreenshot',
-    getWindowRect:  'WebDriver:GetWindowRect',
-    setWindowRect:  'WebDriver:SetWindowRect',
-    quit:           'Marionette:Quit'
+    newSession:       'WebDriver:NewSession',
+    executeScript:    'WebDriver:ExecuteScript',
+    takeScreenshot:   'WebDriver:TakeScreenshot',
+    getWindowRect:    'WebDriver:GetWindowRect',
+    setWindowRect:    'WebDriver:SetWindowRect',
+    switchToWindow:   'WebDriver:SwitchToWindow',
+    getWindowHandles: 'WebDriver:GetWindowHandles',
+    getTitle:         'WebDriver:GetTitle',
+    quit:             'Marionette:Quit'
 };

--- a/src/browser/provider/built-in/dedicated/firefox/marionette-client/index.js
+++ b/src/browser/provider/built-in/dedicated/firefox/marionette-client/index.js
@@ -12,7 +12,7 @@ const MAX_RESIZE_RETRY_COUNT = 2;
 const HEADER_SEPARATOR       = ':';
 
 module.exports = class MarionetteClient {
-    constructor (port = 2828, host = '127.0.0.1') {
+    constructor (port = 2828, runtimeInfo, host = '127.0.0.1') {
         this.currentPacketNumber = 1;
         this.events              = new EventEmitter();
         this.port                = port;
@@ -22,12 +22,19 @@ module.exports = class MarionetteClient {
         this.getPacketPromise    = Promise.resolve();
         this.sendPacketPromise   = Promise.resolve();
 
+        this._runtimeInfo   = runtimeInfo;
+        this._windowHandles = {};
+
         this.protocolInfo = {
             applicationType:    '',
             marionetteProtocol: '',
         };
 
         this.sessionInfo = null;
+    }
+
+    get activeWindowId () {
+        return this._runtimeInfo.activeWindowId;
     }
 
     async _attemptToConnect (port, host) {
@@ -125,6 +132,51 @@ module.exports = class MarionetteClient {
         throw new Error(`${error.error}${error.message ? ': ' + error.message : ''}`);
     }
 
+    async _switchToWindow (windowHandle) {
+        await this._getResponse({
+            command:    COMMANDS.switchToWindow,
+            parameters: { handle: windowHandle }
+        });
+    }
+
+    async _getActiveWindowHandle () {
+        const windowHandles = await this._getResponse({
+            command: COMMANDS.getWindowHandles
+        });
+
+        for (const handle of windowHandles) {
+            await this._switchToWindow(handle);
+
+            const title = await this._getResponse({ command: COMMANDS.getTitle });
+
+            if (title.value.includes(this.activeWindowId))
+                return handle;
+        }
+
+        return null;
+    }
+
+    async _ensureActiveWindow () {
+        let handle = this._windowHandles[this.activeWindowId];
+
+        if (handle) {
+            await this._switchToWindow(handle);
+
+            return;
+        }
+
+        handle = await this._getActiveWindowHandle();
+
+        if (handle)
+            this._windowHandles[this.activeWindowId] = handle;
+    }
+
+    async _request (packet) {
+        await this._ensureActiveWindow();
+
+        return this._getResponse(packet);
+    }
+
     async _getResponse (packet) {
         const packetNumber = this.currentPacketNumber;
 
@@ -142,7 +194,7 @@ module.exports = class MarionetteClient {
     }
 
     async _getScreenshotRawData (fullPage = false) {
-        return await this._getResponse({
+        return await this._request({
             command:    COMMANDS.takeScreenshot,
             parameters: {
                 full:   fullPage,
@@ -171,7 +223,7 @@ module.exports = class MarionetteClient {
     }
 
     async executeScript (code) {
-        return await this._getResponse({
+        return await this._request({
             command:    COMMANDS.executeScript,
             parameters: { script: `return (${code})()` }
         });
@@ -188,9 +240,9 @@ module.exports = class MarionetteClient {
         let attemptCounter      = 0;
 
         while (attemptCounter++ < MAX_RESIZE_RETRY_COUNT && (pageRect.width !== width || pageRect.height !== height)) {
-            const currentRect = await this._getResponse({ command: COMMANDS.getWindowRect });
+            const currentRect = await this._request({ command: COMMANDS.getWindowRect });
 
-            await this._getResponse({
+            await this._request({
                 command: COMMANDS.setWindowRect,
 
                 parameters: {
@@ -206,7 +258,7 @@ module.exports = class MarionetteClient {
     }
 
     async quit () {
-        await this._getResponse({ command: COMMANDS.quit });
+        await this._request({ command: COMMANDS.quit });
     }
 };
 

--- a/src/browser/provider/index.ts
+++ b/src/browser/provider/index.ts
@@ -92,8 +92,8 @@ export default class BrowserProvider {
     }
 
     private _setWindowDescriptor (browserId: string, windowDescriptor: string | null): void {
-        if (this.plugin._setWindowDescriptor) {
-            this.plugin._setWindowDescriptor(browserId, windowDescriptor);
+        if (this.plugin.setWindowDescriptor) {
+            this.plugin.setWindowDescriptor(browserId, windowDescriptor);
 
             return;
         }

--- a/test/functional/fixtures/multiple-windows/test.js
+++ b/test/functional/fixtures/multiple-windows/test.js
@@ -18,51 +18,51 @@ async function assertScreenshotColor (fileName, pixel) {
 describe('Multiple windows', () => {
     describe('Switch to the child window', () => {
         it('Click on link', () => {
-            return runTests('testcafe-fixtures/switching-to-child/click-on-link.js');
+            return runTests('testcafe-fixtures/switching-to-child/click-on-link.js', null, { only: 'chrome' });
         });
 
         it('Form submit', () => {
-            return runTests('testcafe-fixtures/switching-to-child/form-submit.js');
+            return runTests('testcafe-fixtures/switching-to-child/form-submit.js', null, { only: 'chrome' });
         });
 
         it('window.open', () => {
-            return runTests('testcafe-fixtures/switching-to-child/call-window-open.js');
+            return runTests('testcafe-fixtures/switching-to-child/call-window-open.js', null, { only: 'chrome' });
         });
 
         it('Nested pages', () => {
-            return runTests('testcafe-fixtures/switching-to-child/nested-pages.js');
+            return runTests('testcafe-fixtures/switching-to-child/nested-pages.js', null, { only: 'chrome' });
         });
 
         it('Cross domain', () => {
-            return runTests('testcafe-fixtures/switching-to-child/cross-domain.js');
+            return runTests('testcafe-fixtures/switching-to-child/cross-domain.js', null, { only: 'chrome' });
         });
     });
 
     describe('Switch to the parent window', () => {
         it('"window.close" method call', () => {
-            return runTests('testcafe-fixtures/switching-to-parent/window-close-call.js');
+            return runTests('testcafe-fixtures/switching-to-parent/window-close-call.js', null, { only: 'chrome' });
         });
     });
 
     describe('Cookie synchonization', () => {
         it('cross-domain', () => {
-            return runTests('testcafe-fixtures/cookie-synchronization/cross-domain.js');
+            return runTests('testcafe-fixtures/cookie-synchronization/cross-domain.js', null, { only: 'chrome' });
         });
     });
 
     it('Console messages', () => {
-        return runTests('testcafe-fixtures/console/console-test.js');
+        return runTests('testcafe-fixtures/console/console-test.js', null, { only: 'chrome' });
     });
 
     it('Unhandled JavaScript errors', () => {
-        return runTests('testcafe-fixtures/handle-errors/handle-js-errors.js', null, { shouldFail: true })
+        return runTests('testcafe-fixtures/handle-errors/handle-js-errors.js', null, { only: 'chrome', shouldFail: true })
             .catch(errs => {
                 expect(errs[0]).to.contain('A JavaScript error occurred on "http://localhost:3000/fixtures/multiple-windows/pages/handle-errors/page-with-js-error.html"');
             });
     });
 
     it('Close the window immediately after opening (GH-3762)', () => {
-        return runTests('testcafe-fixtures/close-window-immediately-after-opening.js');
+        return runTests('testcafe-fixtures/close-window-immediately-after-opening.js', null, { only: 'chrome' });
     });
 
     it('headless', () => {
@@ -85,16 +85,16 @@ describe('Multiple windows', () => {
 
     describe('Should not finalize some commands on driver starting (GH-4855)', () => {
         it('ExecuteSelectorCommand', () => {
-            return runTests('testcafe-fixtures/i4855.js', 'ExecuteSelectorCommand');
+            return runTests('testcafe-fixtures/i4855.js', 'ExecuteSelectorCommand', { only: 'chrome' });
         });
 
         it('ExecuteClientFunctionCommand', () => {
-            return runTests('testcafe-fixtures/i4855.js', 'ExecuteClientFunctionCommand');
+            return runTests('testcafe-fixtures/i4855.js', 'ExecuteClientFunctionCommand', { only: 'chrome' });
         });
     });
 
     it('Should correctly synchronize a cookie from a new same-domain window', () => {
-        return runTests('testcafe-fixtures/cookie-synchronization/same-domain.js');
+        return runTests('testcafe-fixtures/cookie-synchronization/same-domain.js', null, { only: 'chrome' });
     });
 
     it('Should continue debugging when a child window closes', () => {
@@ -289,16 +289,6 @@ describe('Multiple windows', () => {
         });
     });
 
-    describe('Resize', () => {
-        it('Resize multiple windows', () => {
-            return runTests('testcafe-fixtures/api/api-test.js', 'Resize multiple windows', { only: 'chrome' });
-        });
-
-        it('Maximize multiple windows', () => {
-            return runTests('testcafe-fixtures/api/api-test.js', 'Maximize multiple windows', { only: 'chrome' });
-        });
-    });
-
     describe('iFrames', () => {
         it('Should switch to child window if it is opened in iFrame', () => {
             return runTests('testcafe-fixtures/iframe.js', 'Open child window if iframe', { only: 'chrome' });
@@ -323,6 +313,42 @@ describe('Multiple windows', () => {
 
                     return testCafe.close();
                 });
+        });
+    });
+
+    describe('Resize', () => {
+        function runTestsResize (browser) {
+            return createTestCafe('127.0.0.1', 1335, 1336)
+                .then(tc => {
+                    testCafe = tc;
+                })
+                .then(() => {
+                    return testCafe
+                        .createRunner()
+                        .src(path.join(__dirname, './testcafe-fixtures/api/api-test.js'))
+                        .filter(testName => testName === 'Resize multiple windows')
+                        .browsers(browser)
+                        .run();
+                })
+                .then(failedCount => {
+                    expect(failedCount).eql(0);
+
+                    return testCafe.close();
+                });
+        }
+
+        it('Resize multiple windows', () => {
+            return runTests('testcafe-fixtures/api/api-test.js', 'Resize multiple windows');
+        });
+
+        it('Maximize multiple windows', () => {
+            return runTests('testcafe-fixtures/api/api-test.js', 'Maximize multiple windows');
+        });
+
+        it('Resize headless', () => {
+            return runTestsResize('firefox:headless').then(() => {
+                return runTestsResize('chrome:headless');
+            });
         });
     });
 });

--- a/test/functional/fixtures/multiple-windows/testcafe-fixtures/api/api-test.js
+++ b/test/functional/fixtures/multiple-windows/testcafe-fixtures/api/api-test.js
@@ -348,9 +348,9 @@ fixture `Resize multiple windows`
     });
 
 test('Resize multiple windows', async t => {
-    await t.resizeWindow(600, 600);
-    await t.expect(await getWindowWidth()).eql(600);
-    await t.expect(await getWindowHeight()).eql(600);
+    await t.resizeWindow(900, 900);
+    await t.expect(await getWindowWidth()).eql(900);
+    await t.expect(await getWindowHeight()).eql(900);
 
     await t.openWindow(child1Url);
 
@@ -360,8 +360,8 @@ test('Resize multiple windows', async t => {
 
     await t.switchToParentWindow();
 
-    await t.expect(await getWindowWidth()).eql(600);
-    await t.expect(await getWindowHeight()).eql(600);
+    await t.expect(await getWindowWidth()).eql(900);
+    await t.expect(await getWindowHeight()).eql(900);
 
     await t.resizeWindow(500, 500);
 
@@ -373,6 +373,8 @@ test('Maximize multiple windows', async t => {
     // NOTE: to be sure that window is is maximized we check
     // that the width/height value increased at least on 10px
     const e = 10;
+
+    await t.resizeWindow(600, 600);
 
     const parentWidth  = await getWindowWidth();
     const parentHeight = await getWindowHeight();


### PR DESCRIPTION
1. Firefox now should support resizing multiple windows using browser-tools. For this, I moved the code from 'chrome' provider to /dedicated/base provider.
2. Firefox should support resizing multiple windows in headless mode by marionette protocol. Before every action in marionette (i.e. resizing) TestCafe finds the activeWindow (by runtimeInfo.activeWindowId) and switches to this window using marionette.
It is required to switch to window in order to make screenshots. ASFAIU we cannot resize specific window by parameter, we need to switch to this window and resize current window.
3. I added FF to `multiple-windows` gulp task, but I add { only: chrome } for most of tests, since these tests are not stable in FF unfortunately. Now only resizing (local and headless) is tested in FF.