### PR TITLE
refactor(test-run): reject with an error

### DIFF
--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -550,7 +550,7 @@ export default class TestRun extends AsyncEventEmitter {
         const currentTaskRejectedByError = pageError && this._handlePageErrorStatus(pageError);
 
         if (this.disconnected)
-            return new Promise((_, reject) => reject());
+            return Promise.reject(new Error('Disconnected before driver request could be handled'));
 
         this.consoleMessages.concat(driverStatus.consoleMessages);
 


### PR DESCRIPTION
## Purpose

This pull request ensures a `Promise` is rejected with an error instead of `undefined`. This will hopefully address a `try...catch` in testcafe-hammerhead that's blowing up because `error` is `undefined` (see related)

## Approach

There wasn't a clear existing TestCafe `InternalError` to use in this case, so I rejected with `Error`.

## References

Related: https://github.com/DevExpress/testcafe-hammerhead/pull/2481#issuecomment-741517087

## Pre-Merge TODO

- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
