### PR TITLE
Fix compiling client functions with for-of

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "async-exit-hook": "^1.1.2",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-    "babel-plugin-transform-for-of-as-array": "^1.1.1",
     "bin-v8-flags-filter": "^1.1.2",
     "bowser": "^2.8.1",
     "callsite": "^1.0.0",

--- a/src/compiler/babel/load-libs.js
+++ b/src/compiler/babel/load-libs.js
@@ -11,7 +11,7 @@ function getPresetEnvForTestCodeOpts () {
 function getPresetEnvForClientFunctionOpts () {
     return {
         loose:   true,
-        exclude: ['transform-typeof-symbol']
+        exclude: ['transform-typeof-symbol', 'transform-for-of']
     };
 }
 
@@ -26,6 +26,11 @@ function getModuleResolverOpts () {
     };
 }
 
+function getTransformForOfOptions () {
+    // NOTE: allowArrayLike is required to allow iterating non-iterable objects (e.g. NodeList)
+    // to preserve compatibility with older TestCafe code
+    return { loose: true, allowArrayLike: true };
+}
 
 function getTransformRuntimeOpts () {
     // NOTE: We are forced to import helpers to each compiled file
@@ -51,7 +56,7 @@ export default function loadLibs () {
         presetStage2:               require('./preset-stage-2'),
         presetFlow:                 require('@babel/preset-flow'),
         transformRuntime:           [require('@babel/plugin-transform-runtime'), getTransformRuntimeOpts()],
-        transformForOfAsArray:      require('babel-plugin-transform-for-of-as-array').default,
+        transformForOfAsArray:      [require('@babel/plugin-transform-for-of'), getTransformForOfOptions()],
         presetEnvForClientFunction: [require('@babel/preset-env'), getPresetEnvForClientFunctionOpts()],
         presetEnvForTestCode:       [require('@babel/preset-env'), getPresetEnvForTestCodeOpts()],
         moduleResolver:             [require('babel-plugin-module-resolver'), getModuleResolverOpts()],

--- a/src/compiler/compile-client-function.js
+++ b/src/compiler/compile-client-function.js
@@ -10,7 +10,7 @@ const ANONYMOUS_FN_RE                = /^function\s*\*?\s*\(/;
 const ES6_OBJ_METHOD_NAME_RE         = /^(\S+?)\s*\(/;
 const USE_STRICT_RE                  = /^('|")use strict('|");?/;
 const TRAILING_SEMICOLON_RE          = /;\s*$/;
-const REGENERATOR_FOOTPRINTS_RE      = /(_index\d+\.default|_regenerator\d+\.default|regeneratorRuntime)\.wrap\(function _callee\$\(_context\)/;
+const REGENERATOR_FOOTPRINTS_RE      = /(_index\d+\.default|_regenerator\d+\.default|regeneratorRuntime)\.wrap\(function func\$\(_context\)/;
 const ASYNC_TO_GENERATOR_OUTPUT_CODE = formatBabelProducedCode(asyncToGenerator(noop).toString());
 
 const CLIENT_FUNCTION_BODY_WRAPPER = code => `const func = (${code});`;

--- a/test/functional/fixtures/api/es-next/client-function/test.js
+++ b/test/functional/fixtures/api/es-next/client-function/test.js
@@ -38,6 +38,10 @@ describe('[API] ClientFunction', function () {
         return runTests('./testcafe-fixtures/client-fn-test.js', 'Babel artifacts polyfills');
     });
 
+    it('Should correctly compile for-of loops', () => {
+        return runTests('./testcafe-fixtures/client-fn-test.js', 'For-of loops');
+    });
+
     it('Should execute ClientFunction with dependencies', function () {
         return runTests('./testcafe-fixtures/client-fn-test.js', 'ClientFunction with dependencies');
     });

--- a/test/functional/fixtures/api/es-next/client-function/testcafe-fixtures/client-fn-test.js
+++ b/test/functional/fixtures/api/es-next/client-function/testcafe-fixtures/client-fn-test.js
@@ -229,3 +229,17 @@ test('DOM node return value', async () => {
 
     await getSomeNodes();
 });
+
+test('For-of loops', async t => {
+    const getTagNames = ClientFunction(() => {
+        const elements = document.querySelectorAll('body');
+        const result   = [];
+
+        for (const element of elements)
+            result.push(element.tagName);
+
+        return result;
+    });
+
+    await t.expect(getTagNames()).eql(['BODY']);
+});

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -419,7 +419,7 @@ describe('Reporter', () => {
                                         1,
                                         true
                                     ],
-                                    code: '(function(){ return (function (bool) {return function () {return bool;};});})();'
+                                    code: '(function(){ var func = function func(bool) {return function () {return bool;};}; return func;})();'
                                 },
                                 type: 'execute-client-function'
                             }
@@ -571,7 +571,7 @@ describe('Reporter', () => {
                             command: {
                                 clientFn: {
                                     args: [],
-                                    code: '(function(){ return (function () {return document.getElementById(\'#target\');});})();'
+                                    code: '(function(){ var func = function func() {return document.getElementById(\'#target\');}; return func;})();'
                                 },
                                 type: 'execute-client-function'
                             }

--- a/test/server/data/client-fn-compilation/basic/expected.js
+++ b/test/server/data/client-fn-compilation/basic/expected.js
@@ -1,8 +1,9 @@
 (function () {
-    return (function () {
+    var func = function func () {
         var _window$location = __get$(window, "location"),
             hostname         = _window$location.hostname,
             port             = _window$location.port;
         return hostname + ':' + port;
-    });
+    };
+    return func;
 })();

--- a/test/server/data/client-fn-compilation/gh1279/expected.js
+++ b/test/server/data/client-fn-compilation/gh1279/expected.js
@@ -1,5 +1,7 @@
 (function () {
-    return function fn_123$$ () {
+    var func = function fn_123$$ () {
         return true;
     };
+
+    return func;
 })();

--- a/test/server/data/client-fn-compilation/typeof/expected-node10.js
+++ b/test/server/data/client-fn-compilation/typeof/expected-node10.js
@@ -4,7 +4,9 @@
             return typeof obj;
         }
     };
-    return (function () {
+    var func = (function () {
         return typeof someObj === "undefined" ? "undefined" : (0, _typeof3.default)(someObj);
     });
+
+    return func;
 })();

--- a/test/server/data/client-fn-compilation/typeof/expected.js
+++ b/test/server/data/client-fn-compilation/typeof/expected.js
@@ -2,7 +2,8 @@
     var _typeof = function (obj) {
         return typeof obj;
     };
-    return (function () {
+    var func = (function () {
         return typeof someObj === "undefined" ? "undefined" : _typeof(someObj);
     });
+    return func;
 })();

--- a/test/server/data/test-controller-reporter-expected/index.js
+++ b/test/server/data/test-controller-reporter-expected/index.js
@@ -566,7 +566,7 @@ module.exports = [
         command: {
             dialogHandler: {
                 args: [],
-                code: '(function(){ return (function () {return true;});})();'
+                code: '(function(){ var func = function func() {return true;}; return func;})();'
             },
             type: 'set-native-dialog-handler'
         },


### PR DESCRIPTION
Babel 7 injects helpers in a different way than Babel 6. As a result, ClientFunctions cannot be compiled if Babel injects some helper:
```
    var selector = (function() {
        return function firstHelper () {
        }
        function secondHelper () {
        }
        (function () {
            return someElement;
        });
    })();
```

I changed the wrapper to allow declaring Babel helpers and return the ClientFunction body.