### PR TITLE
[docs] Add a note that cdpPort is required when you override the user dir

### DIFF
--- a/docs/articles/documentation/guides/advanced-guides/screenshots-and-videos.md
+++ b/docs/articles/documentation/guides/advanced-guides/screenshots-and-videos.md
@@ -200,6 +200,12 @@ You should provide the base path where TestCafe stores videos to this flag, meth
 
 TestCafe records all the tests and saves the recording of each test in a separate file. To change this behavior, use the `failedOnly` and `singleFile` [video options](#basic-video-options).
 
+> When you specify the [:userProfile](../concepts/browsers.md#user-profiles) or `--user-data-dir` flag to override the user directory in Google Chrome, set the [cdpPort](../concepts/browsers.md#emulator-parameters) property to `9222` to record videos:
+>
+> ```sh
+> testcafe "chrome:emulation:cdpPort=9222 --user-data-dir=/my/user/data" test.js --video artifacts/videos
+> ```
+
 ### Basic Video Options
 
 TestCafe supports the following video options:

--- a/docs/articles/documentation/guides/advanced-guides/screenshots-and-videos.md
+++ b/docs/articles/documentation/guides/advanced-guides/screenshots-and-videos.md
@@ -200,7 +200,7 @@ You should provide the base path where TestCafe stores videos to this flag, meth
 
 TestCafe records all the tests and saves the recording of each test in a separate file. To change this behavior, use the `failedOnly` and `singleFile` [video options](#basic-video-options).
 
-> When you specify the [:userProfile](../concepts/browsers.md#user-profiles) or `--user-data-dir` flag to override the user directory in Google Chrome, set the [cdpPort](../concepts/browsers.md#emulator-parameters) property to `9222` to record videos:
+> When you specify the [:userProfile](../concepts/browsers.md#user-profiles) or `--user-data-dir` flag to override the user directory in Chrome and Chromium-based browsers, set the [cdpPort](../concepts/browsers.md#emulator-parameters) property to `9222` to record videos:
 >
 > ```sh
 > testcafe "chrome:emulation:cdpPort=9222 --user-data-dir=/my/user/data" test.js --video artifacts/videos

--- a/docs/articles/documentation/guides/concepts/browsers.md
+++ b/docs/articles/documentation/guides/concepts/browsers.md
@@ -334,7 +334,7 @@ When you pass the `:userProfile` flag to a portable browser, also use the [brows
 testcafe chrome:d:\chrome_portable\chrome.exe:userProfile tests/test.js
 ```
 
-Set the [cdpPort](#emulator-parameters) property to `9222` if you use the `:userProfile` flag and video recording:
+Set the [cdpPort](#emulator-parameters) property to `9222` if you use the `:userProfile` flag and video recording in Chrome:
 
 ```sh
 testcafe chrome:userProfile:emulation:cdpPort=9222 test.js --video artifacts/videos

--- a/docs/articles/documentation/guides/concepts/browsers.md
+++ b/docs/articles/documentation/guides/concepts/browsers.md
@@ -309,7 +309,7 @@ Parameter                      | Type   | Description             | Default
 `orientation` *(optional)*  | `vertical` &#124; `horizontal` | The device orientation | `vertical`
 `userAgent` *(optional)*    | String  | The user agent string | The user agent string of the selected `device` or the browser.
 `touch` *(optional)*        | Boolean | Enables or disables touch event emulation. | `true` if a touch-supported device is set via the `device` property or your system supports touch events. Otherwise, `false`.
-`cdpPort` *(optional)*      | Number  | A port (0-65535) used for Chrome Debugging Protocol. | `9222` if you load a user profile with the [:userProfile](#user-profiles) or `--user-data-dir` flag. Otherwise, TestCafe automatically assigns a free port.
+`cdpPort` *(optional)*      | Number  | A port (0-65535) used for Chrome Debugging Protocol. Specify port `9222` if you use the [:userProfile](#user-profiles) or `--user-data-dir` flag to load a user profile. | TestCafe automatically assigns a free port.
 
 ## User Profiles
 
@@ -334,4 +334,10 @@ When you pass the `:userProfile` flag to a portable browser, also use the [brows
 testcafe chrome:d:\chrome_portable\chrome.exe:userProfile tests/test.js
 ```
 
-> It is not recommended that you combine the :userProfile flag with either headless or emulation mode, because this can lead to unstable behavior.
+Set the [cdpPort](#emulator-parameters) property to `9222` if you pass the `:userProfile` flag:
+
+```sh
+testcafe chrome:userProfile:emulation:cdpPort=9222 test.js
+```
+
+> It is not recommended that you combine the `:userProfile` flag with either headless or emulation mode, because this can lead to unstable behavior.

--- a/docs/articles/documentation/guides/concepts/browsers.md
+++ b/docs/articles/documentation/guides/concepts/browsers.md
@@ -334,10 +334,10 @@ When you pass the `:userProfile` flag to a portable browser, also use the [brows
 testcafe chrome:d:\chrome_portable\chrome.exe:userProfile tests/test.js
 ```
 
-Set the [cdpPort](#emulator-parameters) property to `9222` if you pass the `:userProfile` flag:
+Set the [cdpPort](#emulator-parameters) property to `9222` if you use the `:userProfile` flag and video recording:
 
 ```sh
-testcafe chrome:userProfile:emulation:cdpPort=9222 test.js
+testcafe chrome:userProfile:emulation:cdpPort=9222 test.js --video artifacts/videos
 ```
 
 > It is not recommended that you combine the `:userProfile` flag with either headless or emulation mode, because this can lead to unstable behavior.

--- a/docs/articles/documentation/guides/concepts/browsers.md
+++ b/docs/articles/documentation/guides/concepts/browsers.md
@@ -334,7 +334,7 @@ When you pass the `:userProfile` flag to a portable browser, also use the [brows
 testcafe chrome:d:\chrome_portable\chrome.exe:userProfile tests/test.js
 ```
 
-Set the [cdpPort](#emulator-parameters) property to `9222` if you use the `:userProfile` flag and video recording in Chrome:
+Set the [cdpPort](#emulator-parameters) property to `9222` if you use the `:userProfile` flag and video recording in Chrome and Chromium-based browsers:
 
 ```sh
 testcafe chrome:userProfile:emulation:cdpPort=9222 test.js --video artifacts/videos

--- a/docs/articles/documentation/guides/concepts/browsers.md
+++ b/docs/articles/documentation/guides/concepts/browsers.md
@@ -334,7 +334,7 @@ When you pass the `:userProfile` flag to a portable browser, also use the [brows
 testcafe chrome:d:\chrome_portable\chrome.exe:userProfile tests/test.js
 ```
 
-Set the [cdpPort](#emulator-parameters) property to `9222` if you use the `:userProfile` flag and video recording in Chrome and Chromium-based browsers:
+If you use the `:userProfile` flag, set the [cdpPort](#emulator-parameters) property to `9222`  to record videos in Chrome and Chromium-based browsers.
 
 ```sh
 testcafe chrome:userProfile:emulation:cdpPort=9222 test.js --video artifacts/videos

--- a/test/website/test.js
+++ b/test/website/test.js
@@ -120,7 +120,8 @@ class WebsiteTester {
             const siteChecker = new blc.SiteChecker({
                 excludeLinksToSamePage: false,
                 excludedKeywords:       ['*linkedin.com*'],
-                requestMethod:          'get'
+                requestMethod:          'get',
+                userAgent:              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36'
             },
             {
                 link: result => linkTests.push(this._getBrokenLink(result)),


### PR DESCRIPTION
fixes #5627 