### PR TITLE
Increase test timeouts

### DIFF
--- a/test/server/bootstrapper-test.js
+++ b/test/server/bootstrapper-test.js
@@ -47,7 +47,9 @@ describe('Bootstrapper', () => {
                 bootstrapper = setupBootstrapper();
             });
 
-            it('Should raise an error when browser is specified as non-headless', async () => {
+            it('Should raise an error when browser is specified as non-headless', async function () {
+                this.timeout(3000);
+
                 bootstrapper.browsers = [ BROWSER_NAME ];
 
                 try {

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -556,7 +556,9 @@ describe('TypeScriptConfiguration', () => {
                 });
         });
 
-        it('TestCafe config + TypeScript config', () => {
+        it('TestCafe config + TypeScript config', function () {
+            this.timeout(3000);
+
             let runner = null;
 
             createTestCafeConfigurationFile({
@@ -590,7 +592,9 @@ describe('TypeScriptConfiguration', () => {
         });
 
         describe('Should warn message on rewrite a non-overridable property', () => {
-            it('TypeScript config', () => {
+            it('TypeScript config', function () {
+                this.timeout(3000);
+
                 let runner = null;
 
                 createConfigFile(customTSConfigFilePath, {


### PR DESCRIPTION
Sometimes, these test failed by timeout in WebStorm the Gulp run task console.
I changed the default timeout (2000 ms) up to 3000 ms.