### PR TITLE
fix 'Error: [BABEL] unknown: Preset' (close #5808)

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -8,7 +8,7 @@
     "gitTag": true
   },
   "confirm": true,
-  "publishTag": "latest",
+  "publishTag": "rc",
   "prePublishScript": "gulp test-server",
   "postPublishScript": "gulp docker-publish"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.10.0",
+  "version": "1.10.1-rc.1",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"

--- a/src/compiler/babel/get-base-babel-options.ts
+++ b/src/compiler/babel/get-base-babel-options.ts
@@ -1,0 +1,10 @@
+const BASE_BABEL_OPTIONS = {
+    sourceMaps:    false,
+    retainLines:   true,
+    ast:           false,
+    babelrc:       false,
+    configFile:    false,
+    highlightCode: false
+};
+
+export default BASE_BABEL_OPTIONS;

--- a/src/compiler/compile-client-function.js
+++ b/src/compiler/compile-client-function.js
@@ -5,6 +5,7 @@ import loadBabelLibs from './babel/load-libs';
 import { ClientFunctionAPIError } from '../errors/runtime';
 import { RUNTIME_ERRORS } from '../errors/types';
 import formatBabelProducedCode from './babel/format-babel-produced-code';
+import BASE_BABEL_OPTIONS from './babel/get-base-babel-options';
 
 const ANONYMOUS_FN_RE                = /^function\s*\*?\s*\(/;
 const ES6_OBJ_METHOD_NAME_RE         = /^(\S+?)\s*\(/;
@@ -19,14 +20,9 @@ const CLIENT_FUNCTION_WRAPPER      = ({ code, dependencies }) => `(function(){${
 function getBabelOptions () {
     const { presetEnvForClientFunction, transformForOfAsArray } = loadBabelLibs();
 
-    return {
-        presets:       [{ plugins: [transformForOfAsArray] }, presetEnvForClientFunction],
-        sourceMaps:    false,
-        retainLines:   true,
-        ast:           false,
-        babelrc:       false,
-        highlightCode: false
-    };
+    return Object.assign({}, BASE_BABEL_OPTIONS, {
+        presets: [{ plugins: [transformForOfAsArray] }, presetEnvForClientFunction]
+    });
 }
 
 function downgradeES (fnCode) {

--- a/src/compiler/test-file/formats/es-next/compiler.js
+++ b/src/compiler/test-file/formats/es-next/compiler.js
@@ -15,8 +15,9 @@ export default class ESNextTestFileCompiler extends APIBasedTestFileCompilerBase
         } = loadBabelLibs();
 
         const opts = Object.assign({}, BASE_BABEL_OPTIONS, {
-            presets: [presetStage2, presetEnvForTestCode, presetReact],
-            plugins: [transformRuntime, moduleResolver],
+            presets:    [presetStage2, presetEnvForTestCode, presetReact],
+            plugins:    [transformRuntime, moduleResolver],
+            sourceMaps: 'inline',
             filename
         });
 

--- a/src/compiler/test-file/formats/es-next/compiler.js
+++ b/src/compiler/test-file/formats/es-next/compiler.js
@@ -1,6 +1,7 @@
 import loadBabelLibs from '../../../babel/load-libs';
 import APIBasedTestFileCompilerBase from '../../api-based';
 import isFlowCode from './is-flow-code';
+import BASE_BABEL_OPTIONS from '../../../babel/get-base-babel-options';
 
 export default class ESNextTestFileCompiler extends APIBasedTestFileCompilerBase {
     static getBabelOptions (filename, code) {
@@ -13,16 +14,11 @@ export default class ESNextTestFileCompiler extends APIBasedTestFileCompilerBase
             moduleResolver
         } = loadBabelLibs();
 
-        const opts = {
-            presets:       [presetStage2, presetEnvForTestCode, presetReact],
-            plugins:       [transformRuntime, moduleResolver],
-            filename:      filename,
-            retainLines:   true,
-            sourceMaps:    'inline',
-            ast:           false,
-            babelrc:       false,
-            highlightCode: false
-        };
+        const opts = Object.assign({}, BASE_BABEL_OPTIONS, {
+            presets: [presetStage2, presetEnvForTestCode, presetReact],
+            plugins: [transformRuntime, moduleResolver],
+            filename
+        });
 
         if (isFlowCode(code))
             opts.presets.push(presetFlow);


### PR DESCRIPTION
Problem: the Babel 7 [config file](https://babeljs.io/docs/en/options#configfile) at the project root is applied to the internal TestCafe babel config. Sometimes it causes the babel plugins loading problems.

The problem is reproduced only on the first TestCafe loading.
I cannot add a functional test to our test infrastructure because we reuse the Runner instance. Babel caches the config files and created in runtime configuration files is not applied.
I cannot add a server test because I have not found a public API to emulate the first TestCafe loading (clear configuration cache or something else).

I can create a test using a separate `Travis` task, but I cannot do this.

Fix: add the `configFile: false` option to the internal TestCafe config.

