### PR TITLE
[docs] Fix the required nodejs version on the main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Read the following article to learn how TestCafe Studio could fit into your work
 
 ### Installation
 
-Ensure that [Node.js](https://nodejs.org/) (version 6 or newer) and [npm](https://www.npmjs.com/) are installed on your computer before running it:
+Ensure that [Node.js](https://nodejs.org/) ([Current or Active LTS](https://github.com/nodejs/Release#release-phases)) and [npm](https://www.npmjs.com/) are installed on your computer before running it:
 
 ```sh
 npm install -g testcafe

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Read the following article to learn how TestCafe Studio could fit into your work
 
 ### Installation
 
-Ensure that [Node.js](https://nodejs.org/) ([Current or Active LTS](https://github.com/nodejs/Release#release-phases)) and [npm](https://www.npmjs.com/) are installed on your computer before running it:
+Ensure that [Node.js](https://nodejs.org/) ([Current or Active LTS](https://github.com/nodejs/Release#release-phases) is recommended, version 10 at minimum) and [npm](https://www.npmjs.com/) are installed on your computer before running it:
 
 ```sh
 npm install -g testcafe


### PR DESCRIPTION
## Purpose
The main page (README.MD) has a mention of the outdated nodejs version (version 6) which is unsupported by the current TestCafe version (1.10.1).

## Approach
Let's recommend that the Current or Active LTS versions are preferable.

## References
https://github.com/nodejs/Release#release-phases

## Pre-Merge TODO
All's good.