### PR TITLE
update hammerhead

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.13",
     "testcafe-hammerhead": "https://github.com/DevExpress/testcafe-hammerhead/files/5812832/testcafe-hammerhead-19.1.0.zip",
-    "testcafe-legacy-api": "4.0.0",
+    "testcafe-legacy-api": "4.2.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",
     "testcafe-reporter-minimal": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.13",
-    "testcafe-hammerhead": "https://github.com/DevExpress/testcafe-hammerhead/files/5812832/testcafe-hammerhead-19.1.0.zip",
+    "testcafe-hammerhead": "19.1.0",
     "testcafe-legacy-api": "4.2.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.13",
-    "testcafe-hammerhead": "19.0.1",
+    "testcafe-hammerhead": "https://github.com/DevExpress/testcafe-hammerhead/files/5802144/testcafe-hammerhead-19.1.0.zip",
     "testcafe-legacy-api": "4.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.13",
-    "testcafe-hammerhead": "https://github.com/DevExpress/testcafe-hammerhead/files/5802144/testcafe-hammerhead-19.1.0.zip",
+    "testcafe-hammerhead": "https://github.com/DevExpress/testcafe-hammerhead/files/5812832/testcafe-hammerhead-19.1.0.zip",
     "testcafe-legacy-api": "4.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/src/client/automation/playback/move/event-sequence/event-behaviors.js
+++ b/src/client/automation/playback/move/event-sequence/event-behaviors.js
@@ -27,12 +27,10 @@ export class MoveBehaviour {
         while (currentParent && currentParent !== commonAncestor) {
             mouseenterElements.push(currentParent);
 
-            currentParent = nativeMethods.nodeParentNodeGetter.call(currentParent);
+            currentParent = domUtils.getParentExceptShadowRoot(currentParent);
         }
 
-        mouseenterElements.reverse();
-
-        for (let i = 0; i < mouseenterElements.length; i++)
+        for (let i = mouseenterElements.length - 1; i > -1; i--)
             eventSimulator.mouseenter(mouseenterElements[i], extend({ relatedTarget: prevElement }, options));
     }
 

--- a/src/client/automation/playback/type/type-text.js
+++ b/src/client/automation/playback/type/type-text.js
@@ -196,7 +196,7 @@ function _typeTextToContentEditable (element, text) {
         nextTick()
             .then(() => {
                 if (needRaiseInputEvent)
-                    eventSimulator.input(element);
+                    eventSimulator.input(element, text);
 
                 listeners.removeInternalEventListener(window, ['input'], onInput);
                 listeners.removeInternalEventListener(window, ['textinput'], onTextInput);
@@ -277,7 +277,7 @@ function _typeTextToTextEditable (element, text) {
     }
 
     // NOTE: We should simulate the 'input' event after typing a char (B253410, T138385)
-    eventSimulator.input(element);
+    eventSimulator.input(element, text);
 }
 
 function _typeTextToNonTextEditable (element, text, caretPos) {
@@ -290,7 +290,7 @@ function _typeTextToNonTextEditable (element, text, caretPos) {
         domUtils.setElementValue(element, text);
 
     eventSimulator.change(element);
-    eventSimulator.input(element);
+    eventSimulator.input(element, text);
 }
 
 export default function (element, text, caretPos) {

--- a/src/client/core/utils/dom.js
+++ b/src/client/core/utils/dom.js
@@ -57,6 +57,7 @@ export const closest                                = hammerhead.utils.dom.close
 export const getParents                             = hammerhead.utils.dom.getParents;
 export const findParent                             = hammerhead.utils.dom.findParent;
 export const getTopSameDomainWindow                 = hammerhead.utils.dom.getTopSameDomainWindow;
+export const getParentExceptShadowRoot              = hammerhead.utils.dom.getParentExceptShadowRoot;
 
 function getElementsWithTabIndex (elements) {
     return arrayUtils.filter(elements, el => el.tabIndex > 0);

--- a/test/client/before-test.js
+++ b/test/client/before-test.js
@@ -65,8 +65,8 @@
 
     //TestCafe setup
     const testCafeLegacyRunner = getTestCafeModule('testCafeLegacyRunner');
-    const tcSettings           = testCafeLegacyRunner.get('./settings');
-    const sandboxedJQuery      = testCafeLegacyRunner.get('./sandboxed-jquery');
+    const tcSettings           = testCafeLegacyRunner.SETTINGS;
+    const sandboxedJQuery      = testCafeLegacyRunner.sandboxedJQuery;
 
     tcSettings.get().REFERER          = 'https://example.com';
     tcSettings.get().SELECTOR_TIMEOUT = 10000;

--- a/test/client/fixtures/automation/type-test.js
+++ b/test/client/fixtures/automation/type-test.js
@@ -548,19 +548,43 @@ $(document).ready(function () {
         const expectedAllEvents = [
             { type: 'beforeinput', data: '1' },
             { type: 'textInput', data: '1' },
+            { type: 'input', data: '1' },
+            { type: 'beforeinput', data: '2' },
+            { type: 'textInput', data: '2' },
+            { type: 'input', data: '2' },
+            { type: 'beforeinput', data: '3' },
+            { type: 'textInput', data: '3' },
+            { type: 'input', data: '3' },
+        ];
+
+        const expectedAllEventsReversed = [
+            { type: 'textInput', data: '1' },
+            { type: 'beforeinput', data: '1' },
+            { type: 'input', data: '1' },
+            { type: 'textInput', data: '2' },
+            { type: 'beforeinput', data: '2' },
+            { type: 'input', data: '2' },
+            { type: 'textInput', data: '3' },
+            { type: 'beforeinput', data: '3' },
+            { type: 'input', data: '3' }
+        ];
+
+        const expectedEventsWithoutInput = [
+            { type: 'beforeinput', data: '1' },
+            { type: 'textInput', data: '1' },
             { type: 'beforeinput', data: '2' },
             { type: 'textInput', data: '2' },
             { type: 'beforeinput', data: '3' },
             { type: 'textInput', data: '3' },
         ];
 
-        const expectedAllEventsReversed = [
+        const expectedEventsWithoutInputReversed = [
             { type: 'textInput', data: '1' },
             { type: 'beforeinput', data: '1' },
             { type: 'textInput', data: '2' },
             { type: 'beforeinput', data: '2' },
             { type: 'textInput', data: '3' },
-            { type: 'beforeinput', data: '3' }
+            { type: 'beforeinput', data: '3' },
         ];
 
         const expectedOnlyBeforeInput = [
@@ -604,6 +628,10 @@ $(document).ready(function () {
                 logEvents(e, log1);
             });
 
+            input1.addEventListener('input', function (e) {
+                logEvents(e, log1);
+            });
+
             input2.addEventListener('beforeinput', function (e) {
                 logEvents(e, log2);
 
@@ -611,6 +639,10 @@ $(document).ready(function () {
             });
 
             input2.addEventListener('textInput', function (e) {
+                logEvents(e, log2);
+            });
+
+            input2.addEventListener('input', function (e) {
                 logEvents(e, log2);
             });
 
@@ -622,6 +654,10 @@ $(document).ready(function () {
                 logEvents(e, log3);
 
                 e.preventDefault();
+            });
+
+            input3.addEventListener('input', function (e) {
+                logEvents(e, log3);
             });
 
             const automation1 = new TypeAutomation(input1, '123', new TypeOptions());
@@ -639,12 +675,12 @@ $(document).ready(function () {
                     if (browserUtils.isChrome) {
                         deepEqual(log1, expectedAllEvents);
                         deepEqual(log2, expectedOnlyBeforeInput);
-                        deepEqual(log3, expectedAllEvents);
+                        deepEqual(log3, expectedEventsWithoutInput);
                     }
 
                     if (browserUtils.isSafari) {
                         deepEqual(log1, expectedAllEventsReversed);
-                        deepEqual(log2, expectedAllEventsReversed);
+                        deepEqual(log2, expectedEventsWithoutInputReversed);
                         deepEqual(log3, expectedOnlyTextInput);
                     }
 
@@ -689,6 +725,10 @@ $(document).ready(function () {
                 logEvents(e, log1);
             });
 
+            input1.addEventListener('input', function (e) {
+                logEvents(e, log1);
+            });
+
             input2.addEventListener('beforeinput', function (e) {
                 logEvents(e, log2);
 
@@ -696,6 +736,10 @@ $(document).ready(function () {
             });
 
             input2.addEventListener('textInput', function (e) {
+                logEvents(e, log2);
+            });
+
+            input2.addEventListener('input', function (e) {
                 logEvents(e, log2);
             });
 
@@ -707,6 +751,10 @@ $(document).ready(function () {
                 logEvents(e, log3);
 
                 e.preventDefault();
+            });
+
+            input3.addEventListener('input', function (e) {
+                logEvents(e, log3);
             });
 
             const automation1 = new TypeAutomation(input1, '123', new TypeOptions());
@@ -724,7 +772,7 @@ $(document).ready(function () {
                     if (browserUtils.isChrome) {
                         deepEqual(log1, expectedAllEvents);
                         deepEqual(log2, expectedOnlyBeforeInput);
-                        deepEqual(log3, expectedAllEvents);
+                        deepEqual(log3, expectedEventsWithoutInput);
                     }
 
                     if (browserUtils.isSafari) {


### PR DESCRIPTION
Shadow root is a document fragment. Because of that the `nativeMethods.nodeParentNodeGetter` was changed to the `domUtils.getParentExceptShadowRoot`.
```
// div1(HTMLDivElement) -> shadow-root(DocumentFragment) -> div2(HTMLDivElement)
domUtils.getParentExceptShadowRoot(div2); // return div1
```