### PR TITLE
[docs] Fix Why TestCafe once more

### DIFF
--- a/docs/articles/documentation/why-testcafe/README.md
+++ b/docs/articles/documentation/why-testcafe/README.md
@@ -2,6 +2,8 @@
 layout: docs
 title: Why TestCafe?
 permalink: /documentation/why-testcafe/
+redirect_from:
+  - /documentation/how-it-works/
 ---
 
 # Why TestCafe?

--- a/docs/articles/documentation/why-testcafe/README.md
+++ b/docs/articles/documentation/why-testcafe/README.md
@@ -120,7 +120,7 @@ Tests that run in parallel operate in independent sandboxed environments. This h
 
 TestCafe translates server-side test code into client-side JavaScript, and injects it into the browsers that it controls. This process enables the framework to perform common in-browser actions. Some testing scenarios, however, require the execution of custom client-side code. There are three ways to do it with TestCafe:
 
-[Client Scripts](/../guides/advanced-guides/inject-client-scripts.md) inject custom JavaScript files, such as temporary extra dependencies, into the page.
+[Client Scripts](../guides/advanced-guides/inject-client-scripts.md) inject custom JavaScript files, such as temporary extra dependencies, into the page.
 [Client Functions](../guides/basic-guides/obtain-client-side-info.md) evaluate user-defined JavaScript expressions and pass their return value to the server side. They are useful when you want to examine the page or access its URL.
 The [Selector](../guides/basic-guides/select-page-elements.md) function can launch user-defined client-side code to find a DOM element that cannot be otherwise identified.
 

--- a/docs/nav/docs-top-menu.yml
+++ b/docs/nav/docs-top-menu.yml
@@ -6,7 +6,7 @@
   url: /documentation/reference/
 - text: Recipes
   url: /documentation/recipes/
-- text: How It Works
-  url: /documentation/how-it-works/
+- text: Why TestCafe
+  url: /documentation/why-testcafe/
 - text: Examples
   url: /documentation/examples/


### PR DESCRIPTION
As I presume, Why TestCafe should replace How It Works, so we had to modify the navbar and configure redirects from the old URL.