### PR TITLE
Prevent multiple `sendStatus` requests in multiple windows + tests for screenshots in FF

### DIFF
--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -1651,6 +1651,9 @@ export default class Driver extends serviceUtils.EventEmitter {
 
         const role = await this._getDriverRole();
 
+        // NOTE: the child window can become master during the preceding async requests
+        // in this case we do not need to call the `_startInternal` method again
+        // since it was called during the `_handleSetAsMasterMessage` method.
         if (this.role === DriverRole.master)
             return;
 

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -1651,6 +1651,9 @@ export default class Driver extends serviceUtils.EventEmitter {
 
         const role = await this._getDriverRole();
 
+        if (this.role === DriverRole.master)
+            return;
+
         if (role === DriverRole.master)
             this._startInternal();
     }

--- a/test/functional/fixtures/multiple-windows/test.js
+++ b/test/functional/fixtures/multiple-windows/test.js
@@ -9,10 +9,12 @@ const config                     = require('../../config');
 const SCREENSHOTS_PATH = config.testScreenshotsDir;
 
 async function assertScreenshotColor (fileName, pixel) {
-    const filePath = path.join(SCREENSHOTS_PATH, 'custom', fileName);
-    const png      = await readPngFile(filePath);
+    for (const browser of config.currentEnvironment.browsers) {
+        const filePath = path.join(SCREENSHOTS_PATH, 'custom', browser.alias + fileName);
+        const png      = await readPngFile(filePath);
 
-    expect(assertionHelper.hasPixel(png, pixel, 0, 0)).eql(true);
+        expect(assertionHelper.hasPixel(png, pixel, 0, 0)).eql(true);
+    }
 }
 
 describe('Multiple windows', () => {
@@ -102,7 +104,7 @@ describe('Multiple windows', () => {
     });
 
     it('Should make screenshots of different windows', () => {
-        return runTests('testcafe-fixtures/features/screenshots.js', null, { only: 'chrome', setScreenshotPath: true })
+        return runTests('testcafe-fixtures/features/screenshots.js', null, { setScreenshotPath: true })
             .then(() => {
                 return assertScreenshotColor('0.png', RED_PIXEL);
             })

--- a/test/functional/fixtures/multiple-windows/testcafe-fixtures/features/screenshots.js
+++ b/test/functional/fixtures/multiple-windows/testcafe-fixtures/features/screenshots.js
@@ -5,13 +5,13 @@ fixture `Screenshots`
     .page(RED_PAGE);
 
 test('should make screenshots of multiple windows', async t => {
-    await t.takeScreenshot('custom/0.png');
+    await t.takeScreenshot(`custom/${t.browser.alias}0.png`);
 
     const child = await t.openWindow(GREEN_PAGE);
 
-    await t.takeScreenshot('custom/1.png');
+    await t.takeScreenshot(`custom/${t.browser.alias}1.png`);
     await t.openWindow(RED_PAGE);
-    await t.takeScreenshot('custom/2.png');
+    await t.takeScreenshot(`custom/${t.browser.alias}2.png`);
     await t.switchToWindow(child);
-    await t.takeScreenshot('custom/3.png');
+    await t.takeScreenshot(`custom/${t.browser.alias}3.png`);
 });


### PR DESCRIPTION
The child window can become master during the preceding async requests in this case we do not need to call the `_startInternal` method again since it was called during the `_handleSetAsMasterMessage` method.

It's difficult to emulate similar behavior in test, but in theory this fix should prevent flacky tests in the `multiple-windows` travis task