### PR TITLE
fix(selectors): withText can't find existing element

### DIFF
--- a/src/client/driver/command-executors/client-functions/eval-function.js
+++ b/src/client/driver/command-executors/client-functions/eval-function.js
@@ -4,11 +4,17 @@ import { Promise, nativeMethods } from '../../deps/hammerhead';
 // NOTE: evalFunction is isolated into a separate module to
 // restrict access to TestCafe intrinsics for the evaluated code.
 // It also accepts `__dependencies$` argument which may be used by evaluated code.
-/* eslint-disable @typescript-eslint/no-unused-vars */
 export default function evalFunction (fnCode, __dependencies$) {
-    // NOTE: `eval` in strict mode will not override context variables
-    const evaluator = new nativeMethods.Function('fnCode', '__dependencies$', 'Promise', '"use strict"; return eval(fnCode)');
+    const evaluator = new nativeMethods.Function(
+        'fnCode',
+        '__dependencies$',
+        'Promise',
+        // NOTE: we should pass the original `RegExp`
+        // to make the `instanceof RegExp` check successful in different contexts
+        'RegExp',
+        // NOTE: `eval` in strict mode will not override context variables
+        '"use strict"; return eval(fnCode)'
+    );
 
-    return evaluator(fnCode, __dependencies$, Promise);
+    return evaluator(fnCode, __dependencies$, Promise, RegExp);
 }
-/* eslint-enable @typescript-eslint/no-unused-vars */

--- a/test/functional/fixtures/regression/gh-5886/pages/index.html
+++ b/test/functional/fixtures/regression/gh-5886/pages/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>gh-5886</title>
+</head>
+<body>
+<iframe id="frame"></iframe>
+<br />
+<script>
+    var iframe = document.getElementById('frame');
+    iframe.contentDocument.open();
+    iframe.contentDocument.write('<html><body><div id="test">The Test Text</div></body></html>');
+    iframe.contentDocument.close();
+</script>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-5886/test.js
+++ b/test/functional/fixtures/regression/gh-5886/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-5886) - Selector for element after switching to the rewritten iframe', function () {
+    it('Should exist', function () {
+        return runTests('testcafe-fixtures/index.js');
+    });
+});

--- a/test/functional/fixtures/regression/gh-5886/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-5886/testcafe-fixtures/index.js
@@ -1,0 +1,10 @@
+import { Selector } from 'testcafe';
+
+fixture `Selector for element after switching to the rewritten iframe`
+    .page `http://localhost:3000/fixtures/regression/gh-5886/pages/index.html`;
+
+test('Should exist', async t => {
+    await t
+        .switchToIframe('#frame')
+        .expect(Selector('#test').withText('The Test Text').exists).ok();
+});


### PR DESCRIPTION
## Purpose
Selector.withText method can't find existing element in the rewritten iframe because [this](https://github.com/DevExpress/testcafe/blob/faec4a93682d51a6f51909514b437236899b08c1/src/client-functions/selectors/selector-text-filter.js#L21) condition fails: `RegExp` is local to the iframe window context, but the `textFilter` instance was created with the global `RegExp` (created by the replicator). All that because check with the `instanceof` operator has special behavior in different contexts: [instanceof and multiple context (e.g. frames or windows)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_context_e.g._frames_or_windows). 

The regression is originated from [this](https://github.com/DevExpress/testcafe/pull/4915#discussion_r402268902) change.

## Approach
Pass the original `RegExp` class to the evaluating function, so in different contexts will be used only global `RegExp`.

## References
fixes #5886

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
