### PR TITLE
Check a pointer test

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -104,9 +104,9 @@ const CLIENT_TESTS_DESKTOP_BROWSERS = [
         version:     '11.0'
     },
     {
-        platform:    'macOS 10.13',
+        platform:    'macOS 10.15',
         browserName: 'safari',
-        version:     '11.1'
+        version:     '13.1'
     },
     {
         platform:    'OS X 10.11',
@@ -131,8 +131,8 @@ const CLIENT_TESTS_MOBILE_BROWSERS = [
         // NOTE: https://github.com/DevExpress/testcafe/issues/471
         // problem with extra scroll reproduced only on saucelabs
         // virtual machines with ios device emulators
-        version:     '10.3',
-        deviceName:  'iPhone 7 Plus Simulator'
+        version:     '14.0',
+        deviceName:  'iPhone X Simulator'
     }
 ];
 

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.13",
-    "testcafe-hammerhead": "19.1.1",
+    "testcafe-hammerhead": "https://github.com/DevExpress/testcafe-hammerhead/files/5886590/testcafe-hammerhead-19.2.1-fix-pointer-events.zip",
     "testcafe-legacy-api": "4.2.3",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/test/client/fixtures/automation/click-test.js
+++ b/test/client/fixtures/automation/click-test.js
@@ -156,6 +156,29 @@ $(document).ready(function () {
             });
     });
 
+    asyncTest('pointerdown and pointerup events should be raised once per click', function () {
+        let pointerdownCount = 0;
+        let pointerupCount   = 0;
+
+        $el[0].addEventListener('pointerdown', function () {
+            pointerdownCount++;
+        });
+
+        $el[0].addEventListener('pointerup', function () {
+            pointerupCount++;
+        });
+
+        const click = new ClickAutomation($el[0], new ClickOptions({ offsetX: 5, offsetY: 5 }));
+
+        click
+            .run()
+            .then(function () {
+                equal(pointerdownCount, 1, 'pointerdown should be raised once per click');
+                equal(pointerupCount, 1, 'pointerup should be raised once per click');
+                startNext();
+            });
+    });
+
     if (!featureDetection.isTouchDevice) {
         asyncTest('over and move events on elements during moving', function () {
             let overed  = false;

--- a/test/client/fixtures/automation/type-test.js
+++ b/test/client/fixtures/automation/type-test.js
@@ -444,12 +444,7 @@ $(document).ready(function () {
         type
             .run()
             .then(function () {
-                // NOTE: in safari target input element is not focused on click
-                // it loses its focus immediately after click
-                // so it's impossible to type into it
-                const expected = !browserUtils.isSafari ? '12345' : '';
-
-                equal(input1.value, expected);
+                equal(input1.value, '12345');
 
                 start();
             });


### PR DESCRIPTION
## `testcafe-hammerhead` version
https://github.com/DevExpress/testcafe-hammerhead/pull/2570

## Local example to check events
```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <title>Document</title>
</head>
<body>
    <div id="content" style="width: 100px; height: 100px; border: 1px solid red;">
        click me
    </div>
    <div id="log">
    </div>
    <script type="text/javascript">
    var c = document.getElementById('content'),
        l = document.getElementById('log');

    [
        'pointerdown',
        'pointerup',
        'mousedown',
        'mouseup',
        'touchstart',
        'touchend'
    ].forEach(function (event) {
        c.addEventListener(event, function (e) {
            console.log(e);
            l.innerText += e.type + '\n';
        })
    })
    </script>
</body>
</html>
```

## References
https://developer.apple.com/documentation/safari-release-notes/safari-13-release-notes:
> Added support for the **Pointer Events API** enabling consistent access to mouse, trackpad, touch, and Apple Pencil events.