### PR TITLE
Async predicate for request filter rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,7 +214,6 @@
     "run-sequence": "^1.2.2",
     "saucelabs-connector": "^0.2.0",
     "serve-static": "^1.10.0",
-    "server-destroy": "^1.0.1",
     "sinon": "^7.3.0",
     "stack-chain": "^2.0.0",
     "strip-ansi": "^3.0.0",

--- a/test/functional/fixtures/api/es-next/request-hooks/pages/api/request-filter-rule-async-predicate.html
+++ b/test/functional/fixtures/api/es-next/request-hooks/pages/api/request-filter-rule-async-predicate.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Async predicate for request filter rules</title>
+</head>
+<body>
+    <h2>Send request status</h2>
+    <button onclick="sendRequest()">Send request</button>
+    <script>
+        function sendRequest() {
+            fetch('http://dummy-url.com/get')
+                .then(res => {
+                    return res.text();
+                })
+                .then(text => {
+                    document.querySelector('h2').textContent = text;
+                });
+        }
+    </script>
+</body>
+</html>

--- a/test/functional/fixtures/api/es-next/request-hooks/test.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/test.js
@@ -62,5 +62,9 @@ describe('Request Hooks', () => {
         it("Test's request hooks should not override the fixture's request hooks (GH-4122)", () => {
             return runTests('./testcafe-fixtures/api/i4122.js', null, { only: 'chrome' });
         });
+
+        it('Async predicate for request filter rules', () => {
+            return runTests('./testcafe-fixtures/api/request-filter-rule-async-predicate.js', null, { only: 'chrome' });
+        });
     });
 });

--- a/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/request-filter-rule-async-predicate.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/request-filter-rule-async-predicate.js
@@ -10,7 +10,7 @@ const mock = RequestMock()
     .onRequestTo(async req => {
         return req.url === await getUrlPromise;
     })
-    .respond('Done!');
+    .respond('Done!', 200, { 'access-control-allow-origin': '*' });
 
 fixture `Fixture`
     .requestHooks(mock)

--- a/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/request-filter-rule-async-predicate.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/request-filter-rule-async-predicate.js
@@ -1,0 +1,23 @@
+import { RequestMock, Selector } from 'testcafe';
+
+const getUrlPromise = new Promise(resolve => {
+    setTimeout(() => {
+        resolve('http://dummy-url.com/get');
+    }, 2000);
+});
+
+const mock = RequestMock()
+    .onRequestTo(async req => {
+        return req.url === await getUrlPromise;
+    })
+    .respond('Done!');
+
+fixture `Fixture`
+    .requestHooks(mock)
+    .page('http://localhost:3000/fixtures/api/es-next/request-hooks/pages/api/request-filter-rule-async-predicate.html');
+
+test('test', async t => {
+    await t
+        .click('button')
+        .expect(Selector('h2').textContent).eql('Done!');
+});

--- a/test/functional/fixtures/regression/gh-3049/test.js
+++ b/test/functional/fixtures/regression/gh-3049/test.js
@@ -7,6 +7,8 @@ const isLocalChrome = config.useLocalBrowsers && config.browsers.some(browser =>
 if (isLocalChrome) {
     describe('[Regression](GH-3049) - Should increase small browser window', function () {
         it('Run browser with minimal window size', function () {
+            let failedCount = 0;
+
             return createTestCafe('127.0.0.1', 1335, 1336)
                 .then(tc => {
                     testCafe = tc;
@@ -19,9 +21,12 @@ if (isLocalChrome) {
                         .src(path.join(__dirname, './testcafe-fixtures/index.js'))
                         .run();
                 })
-                .then(failedCount => {
-                    testCafe.close();
+                .then(failed => {
+                    failedCount = failed;
 
+                    return testCafe.close();
+                })
+                .then(() => {
                     if (failedCount)
                         throw new Error('Error occurred');
                 });

--- a/test/functional/fixtures/regression/gh-3456/test.js
+++ b/test/functional/fixtures/regression/gh-3456/test.js
@@ -39,7 +39,7 @@ if (config.useLocalBrowsers) {
                     return assertionHelper.removeScreenshotDir();
                 })
                 .then(() => {
-                    testCafe.close();
+                    return testCafe.close();
                 });
         });
     });

--- a/test/functional/fixtures/regression/gh-3929/test.js
+++ b/test/functional/fixtures/regression/gh-3929/test.js
@@ -7,6 +7,8 @@ if (config.useLocalBrowsers && !config.useHeadlessBrowsers) {
         this.timeout(60000);
 
         it('Should reconnect with bad network conditions', function () {
+            let failedCount = 0;
+
             return createTestCafe('127.0.0.1', 1335, 1336)
                 .then(tc => {
                     testCafe = tc;
@@ -17,11 +19,14 @@ if (config.useLocalBrowsers && !config.useHeadlessBrowsers) {
                         .src(path.join(__dirname, './testcafe-fixtures/index.js'))
                         .run();
                 })
-                .then(err => {
-                    testCafe.close();
+                .then(failed => {
+                    failedCount = failed;
 
-                    if (err)
-                        throw new Error('Error occured');
+                    return testCafe.close();
+                })
+                .then(() => {
+                    if (failedCount)
+                        throw new Error('Error occurred');
                 });
         });
     });

--- a/test/functional/fixtures/regression/gh-5239/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-5239/testcafe-fixtures/index.js
@@ -1,7 +1,7 @@
 import { Selector } from 'testcafe';
 
 fixture `GH-5239 - Should make multiple request for the page if the server does not respond`
-    .page `http://localhost:1340`;
+    .page `http://localhost:${process.env.TEST_SERVER_PORT}`;
 
 test(`Click on the element`, async t => {
     await t.click(Selector('h1').withText('example'));

--- a/test/functional/fixtures/regression/gh-5549/test.js
+++ b/test/functional/fixtures/regression/gh-5549/test.js
@@ -7,6 +7,8 @@ let testCafe = null;
 if (config.useLocalBrowsers) {
     describe(`[Regression](GH-5449) Should not crash if TestCafe is created via "createTestCafe('null')"`, () => {
         it(`[Regression](GH-5449) Should not crash if TestCafe is created via "createTestCafe('null')"`, () => {
+            let failedCount = 0;
+
             return createTestCafe(null)
                 .then(tc => {
                     testCafe = tc;
@@ -18,9 +20,12 @@ if (config.useLocalBrowsers) {
                         .src(path.join(__dirname, './testcafe-fixtures/index.js'))
                         .run();
                 })
-                .then(failedCount => {
-                    testCafe.close();
+                .then(failed => {
+                    failedCount = failed;
 
+                    return testCafe.close();
+                })
+                .then(() => {
                     if (failedCount)
                         throw new Error('Error occurred');
                 });

--- a/test/functional/fixtures/regression/hammerhead/gh-863/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/hammerhead/gh-863/testcafe-fixtures/index.js
@@ -5,7 +5,7 @@ const reload = ClientFunction(() => {
 });
 
 fixture `Fixture`
-    .page('http://localhost:1340/');
+    .page(`http://localhost:${process.env.TEST_SERVER_PORT}/`);
 
 async function assertTestElements () {
     await t


### PR DESCRIPTION
Changes:

1) Now, the predicate can be asynchronous.

https://devexpress.github.io/testcafe/documentation/reference/test-api/requesthook/constructor.html#filter-with-a-predicate

```js
const logger = RequestLogger(request => {
    return request.body === '{ test: true }' &&
           request.headers['content-type'] === 'application/json';
});

->

const logger = RequestLogger(async request => {
    return await someFn();
});
```

2) Rewrite `testcafe.close()` calls because it's asynchronous method.
3) Fix unstable tests: use the free port calculation instead of fixed value because the  `1340` port sometimes can be busy.