### PR TITLE
GH5940 - Inconsistent results with the use of a

### DIFF
--- a/test/functional/fixtures/regression/gh-5940/pages/index.html
+++ b/test/functional/fixtures/regression/gh-5940/pages/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>GH-5940</title>
+</head>
+<body>
+
+<div>
+    <label for="ctrlshift+">ctrl+shift++</label>
+    <input id="ctrlshiftplus" type="checkbox"></input>
+</div>
+
+<div>
+    <label for="ctrl+">ctrl++</label>
+    <input id="ctrlplus" type="checkbox"></input>
+</div>
+
+<div>
+    <label for="shift+">shift++</label>
+    <input id="shiftplus" type="checkbox"></input>
+</div>
+
+<div>
+    <label for="+">+</label>
+    <input id="plus" type="checkbox"></input>
+</div>
+
+<div>
+    <label for="altplus">alt++
+    </label>
+    <input id="altplus" type="checkbox"></input>
+</div>
+<script>
+
+    document.addEventListener('keypress', function (e) {
+
+        if (e.key === '+' && e.shiftKey && e.ctrlKey && !e.altKey) {
+            ctrlshiftplus.checked = true;
+        }
+
+        if (e.key === '+' && e.shiftKey && !e.ctrlKey && !e.altKey) {
+            shiftplus.checked = true;
+        }
+
+        if (e.key === '+' && !e.shiftKey && e.ctrlKey && !e.altKey) {
+            ctrlplus.checked = true;
+        }
+
+        if (e.key === '+' && !e.shiftKey && !e.ctrlKey && !e.altKey) {
+            plus.checked = true;
+        }
+
+        if (e.key === '+' && !e.shiftKey && !e.ctrlKey && e.altKey) {
+            altplus.checked = true;
+        }
+
+    });
+
+</script>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-5940/test.js
+++ b/test/functional/fixtures/regression/gh-5940/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-993)', function () {
+    it("Key events should have the 'key' or 'keyIdentifier' property when t.pressKey('enter') is performed", function () {
+        return runTests('testcafe-fixtures/index.test.js', 'Press the "Enter" key');
+    });
+});

--- a/test/functional/fixtures/regression/gh-5940/testcafe-fixtures/index.test.js
+++ b/test/functional/fixtures/regression/gh-5940/testcafe-fixtures/index.test.js
@@ -1,0 +1,101 @@
+import { ClientFunction, Selector, t } from 'testcafe';
+
+fixture `Check modifier keys`
+    .page('http://localhost:3000/fixtures/regression/gh-xxx/pages/index.html');
+
+async function uncheckIfNecessary(selector) {
+    if (selector.checked) {
+        return await t.click(selector);
+    }
+}
+
+test('Press the ctrl+shift++ key combo', async t => {
+    const selector = await Selector('#ctrlshiftplus');
+
+    await t.pressKey('ctrl+shift++');
+    await t.expect(selector.checked).eql(true);
+
+    await uncheckIfNecessary(selector);
+
+    await t.pressKey('ctrl+shift+\+');
+    await t.expect(selector.checked).eql(true);
+
+    await uncheckIfNecessary(selector);
+
+    await t.pressKey('ctrl+shift+plus');
+    await t.expect(selector.checked).eql(true);
+});
+
+test('Press the ctrl++ key combo', async t => {
+    const selector = await Selector('#ctrlplus');
+
+    await t.pressKey('ctrl++');
+    await t.expect(selector.checked).eql(false);
+
+    await uncheckIfNecessary(selector);
+
+    await t.pressKey('ctrl+\+');
+    await t.expect(selector.checked).eql(true);
+
+    await uncheckIfNecessary(selector);
+
+    await t.pressKey('ctrl+plus');
+    await t.expect(selector.checked).eql(false);
+});
+
+test('Press the shift++ key combo', async t => {
+
+    const selector = await Selector('#shiftplus');
+
+    await t.pressKey('shift++');
+    await t.expect(selector.checked).eql(true);
+
+    await uncheckIfNecessary(selector);
+
+    await t.pressKey('shift+\+');
+    await t.expect(selector.checked).eql(true);
+
+    await uncheckIfNecessary(selector);
+
+    await t.pressKey('shift+plus');
+    await t.expect(selector.checked).eql(true);
+
+});
+
+test('Press the + key', async t => {
+
+    const selector = await Selector('#plus');
+
+    await t.pressKey('+');
+    await t.expect(selector.checked).eql(false);
+
+    await uncheckIfNecessary(selector);
+
+    await t.pressKey('\+');
+    await t.expect(selector.checked).eql(true);
+
+    await uncheckIfNecessary(selector);
+
+    await t.pressKey('plus');
+    await t.expect(selector.checked).eql(false);
+
+});
+
+test('Press the alt++ key combo', async t => {
+
+    const selector = await Selector('#altplus');
+
+    await t.pressKey('alt++');
+    await t.expect(selector.checked).eql(false);
+
+    await uncheckIfNecessary(selector);
+
+    await t.pressKey('alt+\+');
+    await t.expect(selector.checked).eql(true);
+
+    await uncheckIfNecessary(selector);
+
+    await t.pressKey('alt+plus');
+    await t.expect(selector.checked).eql(false);
+
+});


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Test for https://github.com/DevExpress/testcafe/issues/5940

## Approach
Just sample tests to prove inconsistencies for https://github.com/DevExpress/testcafe/issues/5940

## References
https://github.com/DevExpress/testcafe/issues/5940

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
