### PR TITLE
Fix typeText replacing issue (fix #5921)

### DIFF
--- a/src/client/automation/playback/type/type-text.js
+++ b/src/client/automation/playback/type/type-text.js
@@ -263,15 +263,16 @@ function _typeTextToTextEditable (element, text) {
     if (elementMaxLength < 0)
         elementMaxLength = browserUtils.isIE && browserUtils.version < 17 ? 0 : null;
 
-    if (elementMaxLength === null || isNaN(elementMaxLength) || elementMaxLength > elementValue.length) {
+    const newElementValue = elementValue.substring(0, startSelection) + text + elementValue.substring(endSelection, elementValue.length);
+
+    if (elementMaxLength === null || isNaN(elementMaxLength) || elementMaxLength >= newElementValue.length) {
         // NOTE: B254013
         if (isInputTypeNumber && browserUtils.isIOS && elementValue[elementValue.length - 1] === '.') {
             startSelection += 1;
             endSelection += 1;
         }
 
-        domUtils.setElementValue(element, elementValue.substring(0, startSelection) + text +
-                          elementValue.substring(endSelection, elementValue.length));
+        domUtils.setElementValue(element, newElementValue);
 
         textSelection.select(element, startSelection + textLength, startSelection + textLength);
     }

--- a/test/functional/fixtures/regression/gh-5921/pages/index.html
+++ b/test/functional/fixtures/regression/gh-5921/pages/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <input type="text" id="input" maxlength="4" value="test">
 </head>
 <body>
+    <input type="text" id="input" maxlength="4" value="test">
 </body>
 </html>

--- a/test/functional/fixtures/regression/gh-5921/pages/index.html
+++ b/test/functional/fixtures/regression/gh-5921/pages/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <input type="text" id="input" maxlength="4" value="test">
+</head>
+<body>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-5921/test.js
+++ b/test/functional/fixtures/regression/gh-5921/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-5921) typeText should replace the old value when the old value length fits maxlength', () => {
+    it('Should replace the old value when it fits the maxlength', () => {
+        return runTests('testcafe-fixtures/index.js');
+    });
+});

--- a/test/functional/fixtures/regression/gh-5921/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-5921/testcafe-fixtures/index.js
@@ -1,0 +1,10 @@
+import { Selector } from 'testcafe';
+
+fixture `GH-5921 - typeText should replace the old value when the old value length fits maxlength`
+    .page `http://localhost:3000/fixtures/regression/gh-5921/pages/index.html`;
+
+test(`Replace the old value`, async t => {
+    await t
+        .typeText('#input', 'cafe', { replace: true })
+        .expect(Selector('#input').value).eql('cafe');
+});


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Fix the issue in tyepText that it doesn't replace the old value when the old value fits input maxlength.
 
## Approach
Following the support from @AlexKamaev in #5921
By fixing if condition which compare the maxlength with element value.


## References
#5921

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
