### PR TITLE
Fix wrong request timeout options overriding

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.11.0-rc.1",
+  "version": "1.11.0-rc.2",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -149,8 +149,8 @@ export default class TestRun extends AsyncEventEmitter {
 
     _getRequestTimeout (test, opts) {
         return {
-            page: opts.pageRequestTimeout || test.timeouts?.pageRequestTimeout,
-            ajax: opts.ajaxRequestTimeout || test.timeouts?.ajaxRequestTimeout
+            page: test.timeouts?.pageRequestTimeout || opts.pageRequestTimeout,
+            ajax: test.timeouts?.ajaxRequestTimeout || opts.ajaxRequestTimeout
         };
     }
 

--- a/test/functional/fixtures/run-options/request-timeout/test.js
+++ b/test/functional/fixtures/run-options/request-timeout/test.js
@@ -3,20 +3,20 @@ const { expect } = require('chai');
 describe('Request timeout', () => {
     describe('Test level', () => {
         it('Page request timeout', () => {
-            return runTests('testcafe-fixtures/test-level.js', 'page request timeout', { pageRequestTimeout: 100, only: 'chrome' })
+            return runTests('testcafe-fixtures/test-level.js', 'page request timeout', { only: 'chrome', shouldFail: true })
                 .catch(errs => {
                     expect(errs[0]).contain('Failed to complete a request to "http://localhost:3000/fixtures/run-options/request-timeout/pages/page.html?delay=5000" within the timeout period.');
                 });
         });
 
         it('Ajax request timeout', () => {
-            return runTests('testcafe-fixtures/test-level.js', 'ajax request timeout', { ajaxRequestTimeout: 100, only: 'chrome' });
+            return runTests('testcafe-fixtures/test-level.js', 'ajax request timeout', { only: 'chrome' });
         });
     });
 
     describe('Run level', () => {
         it('Page request timeout', () => {
-            return runTests('testcafe-fixtures/run-level.js', 'page request timeout', { pageRequestTimeout: 100, only: 'chrome' })
+            return runTests('testcafe-fixtures/run-level.js', 'page request timeout', { pageRequestTimeout: 100, only: 'chrome', shouldFail: true })
                 .catch(errs => {
                     expect(errs[0]).contain('Failed to complete a request to "http://localhost:3000/fixtures/run-options/request-timeout/pages/page.html?delay=5000" within the timeout period.');
                 });
@@ -24,6 +24,19 @@ describe('Request timeout', () => {
 
         it('Ajax request timeout', () => {
             return runTests('testcafe-fixtures/run-level.js', 'ajax request timeout', { ajaxRequestTimeout: 100, only: 'chrome' });
+        });
+    });
+
+    describe('Overriding', () => {
+        it('Page request timeout', () => {
+            return runTests('testcafe-fixtures/test-level.js', 'page request timeout', { pageRequestTimeout: 100000, only: 'chrome', shouldFail: true })
+                .catch(errs => {
+                    expect(errs[0]).contain('Failed to complete a request to "http://localhost:3000/fixtures/run-options/request-timeout/pages/page.html?delay=5000" within the timeout period.');
+                });
+        });
+
+        it('Ajax request timeout', () => {
+            return runTests('testcafe-fixtures/test-level.js', 'ajax request timeout', { ajaxRequestTimeout: 100000, only: 'chrome' });
         });
     });
 });


### PR DESCRIPTION
The test's request timeout options should override the test run's request timeout options.