### PR TITLE
[compiler service process] Support client function in assertions

### DIFF
--- a/@types/map-reverse/index.d.ts
+++ b/@types/map-reverse/index.d.ts
@@ -1,0 +1,5 @@
+declare module 'map-reverse' {
+    function mapReverse<T>(array: T[], callback: (item: T, index: number, currentArray: readonly T[]) => unknown): T[];
+
+    export = mapReverse;
+}

--- a/src/api/test-run-tracker.d.ts
+++ b/src/api/test-run-tracker.d.ts
@@ -9,6 +9,7 @@ export interface TestRun {
     warningLog: WarningLog;
 
     executeAction(apiMethodName: string, command: unknown, callsite: unknown): Promise<unknown>;
+    executeCommand(command: unknown): Promise<unknown>;
 }
 
 export interface TestRunTracker {

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import embeddingUtils from './embedding-utils';
 import exportableLib from './api/exportable-lib';
 import TestCafeConfiguration from './configuration/testcafe-configuration';
 import OPTION_NAMES from './configuration/option-names';
+import ProcessTitle from './services/process-title';
 
 const lazyRequire   = require('import-lazy')(require);
 const TestCafe      = lazyRequire('./testcafe');
@@ -62,6 +63,8 @@ async function getConfiguration (args) {
 
 // API
 async function createTestCafe (...args) {
+    process.title = ProcessTitle.main;
+
     const configuration = await getConfiguration(args);
 
     const [hostname, port1, port2] = await Promise.all([

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -579,7 +579,7 @@ export default class Runner extends EventEmitter {
 
                 const resultOptions = this.configuration.getOptions();
 
-                await this.bootstrapper?.compilerService.setOptions({ value: resultOptions });
+                await this.bootstrapper.compilerService?.setOptions({ value: resultOptions });
 
                 return this._runTask(reporterPlugins, browserSet, tests, testedApp, resultOptions);
             });

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -173,8 +173,8 @@ export default class Runner extends EventEmitter {
         return new Task(tests, browserConnectionGroups, proxy, opts, warningLog);
     }
 
-    _runTask (reporterPlugins, browserSet, tests, testedApp) {
-        const task              = this._createTask(tests, browserSet.browserConnectionGroups, this.proxy, this.configuration.getOptions(), this.warningLog);
+    _runTask (reporterPlugins, browserSet, tests, testedApp, options) {
+        const task              = this._createTask(tests, browserSet.browserConnectionGroups, this.proxy, options, this.warningLog);
         const reporters         = reporterPlugins.map(reporter => new Reporter(reporter.plugin, task, reporter.outStream, reporter.name));
         const completionPromise = this._getTaskResult(task, browserSet, reporters, testedApp);
         let completed           = false;
@@ -577,7 +577,11 @@ export default class Runner extends EventEmitter {
             .then(async ({ reporterPlugins, browserSet, tests, testedApp, commonClientScripts }) => {
                 await this._prepareClientScripts(tests, commonClientScripts);
 
-                return this._runTask(reporterPlugins, browserSet, tests, testedApp);
+                const resultOptions = this.configuration.getOptions();
+
+                await this.bootstrapper?.compilerService.setOptions({ value: resultOptions });
+
+                return this._runTask(reporterPlugins, browserSet, tests, testedApp, resultOptions);
             });
 
         return this._createCancelablePromise(runTaskPromise);

--- a/src/runner/interfaces.ts
+++ b/src/runner/interfaces.ts
@@ -1,6 +1,8 @@
 import CommandBase from '../test-run/commands/base';
 import TestRun from '../test-run';
 import WarningLog from '../notifications/warning-log';
+import { Writable as WritableStream } from 'stream';
+import BrowserConnection from '../browser/connection';
 
 export interface ActionEventArg {
     apiActionName: string;
@@ -29,3 +31,10 @@ export interface BrowserSetOptions {
     browserInitTimeout?: number;
     warningLog: WarningLog;
 }
+
+export interface ReporterInit {
+    name: string;
+    output?: string | WritableStream;
+}
+
+export type BrowserInit = string | object | BrowserConnection;

--- a/src/services/compiler/protocol.ts
+++ b/src/services/compiler/protocol.ts
@@ -1,4 +1,5 @@
 import { CompilerArguments } from '../../compiler/interfaces';
+import { Dictionary } from '../../configuration/interfaces';
 
 export const BEFORE_AFTER_PROPERTIES  = ['beforeFn', 'afterFn'] as const;
 export const BEFORE_AFTER_EACH_PROPERTIES = ['beforeEachFn', 'afterEachFn'] as const;
@@ -24,15 +25,25 @@ export interface RunTestArguments {
     testRunId: string;
 }
 
-export interface ExecuteCommandArguments {
+export interface ExecuteActionArguments {
     id: string;
     apiMethodName: string;
     command: unknown;
     callsite: unknown;
 }
 
+export interface ExecuteCommandArguments {
+    id: string;
+    command: unknown;
+}
+
+export interface SetOptionsArguments {
+    value: Dictionary<OptionValue>;
+}
+
 export interface TestRunDispatcherProtocol {
-    executeAction ({ id, apiMethodName, command, callsite }: ExecuteCommandArguments): Promise<unknown>;
+    executeAction ({ id, apiMethodName, command, callsite }: ExecuteActionArguments): Promise<unknown>;
+    executeCommand ({ command }: ExecuteCommandArguments): Promise<unknown>;
 }
 
 export interface CompilerProtocol extends TestRunDispatcherProtocol {
@@ -43,4 +54,6 @@ export interface CompilerProtocol extends TestRunDispatcherProtocol {
     runTest ({ id, functionName, testRunId }: RunTestArguments): Promise<unknown>;
 
     cleanUp (): Promise<void>;
+
+    setOptions ({ value }: SetOptionsArguments): Promise<void>;
 }

--- a/src/services/compiler/test-run-proxy.ts
+++ b/src/services/compiler/test-run-proxy.ts
@@ -5,9 +5,15 @@ import { TestRunDispatcherProtocol } from './protocol';
 import TestController from '../../api/test-controller';
 import ObservedCallsitesStorage from '../../test-run/observed-callsites-storage';
 import WarningLog from '../../notifications/warning-log';
+import AssertionCommand from '../../test-run/commands/assertion';
+import AssertionExecutor from '../../assertions/executor';
+import { Dictionary } from '../../configuration/interfaces';
+import COMMAND_TYPE from '../../test-run/commands/type';
+import CommandBase from '../../test-run/commands/base';
+import * as serviceCommands from '../../test-run/commands/service';
 
 
-class TestRunMock {
+class TestRunProxy {
     public readonly id: string;
     public readonly controller: TestController;
     public readonly observedCallsites: ObservedCallsitesStorage;
@@ -16,14 +22,16 @@ class TestRunMock {
     private readonly dispatcher: TestRunDispatcherProtocol;
     private readonly fixtureCtx: unknown;
     private readonly ctx: unknown;
+    private readonly _options: Dictionary<OptionValue>;
 
-    public constructor (dispatcher: TestRunDispatcherProtocol, id: string, fixtureCtx: unknown) {
+    public constructor (dispatcher: TestRunDispatcherProtocol, id: string, fixtureCtx: unknown, options: Dictionary<OptionValue>) {
         this.dispatcher = dispatcher;
 
         this.id = id;
 
         this.ctx        = Object.create(null);
         this.fixtureCtx = fixtureCtx;
+        this._options   = options;
 
         // TODO: Synchronize these properties with their real counterparts in the main process.
         // Postponed until (GH-3244). See details in (GH-5250).
@@ -34,14 +42,41 @@ class TestRunMock {
         testRunTracker.activeTestRuns[id] = this;
     }
 
+    private _getAssertionTimeout (command: AssertionCommand): number {
+        // @ts-ignore
+        const { timeout: commandTimeout } = command.options;
+
+        return commandTimeout === void 0
+            ? this._options.assertionTimeout
+            : commandTimeout;
+    }
+
+    private async _executeAssertion (command: AssertionCommand, callsite: unknown): Promise<unknown> {
+        const assertionTimeout = this._getAssertionTimeout(command);
+
+        const executor = new AssertionExecutor(command, assertionTimeout, callsite);
+
+        executor.once('start-assertion-retries', timeout => this.executeCommand(new serviceCommands.ShowAssertionRetriesStatusCommand(timeout)));
+        executor.once('end-assertion-retries', success => this.executeCommand(new serviceCommands.HideAssertionRetriesStatusCommand(success)));
+
+        return executor.run();
+    }
+
     public async executeAction (apiMethodName: string, command: unknown, callsite: unknown): Promise<unknown> {
         if (callsite)
             callsite = prerenderCallsite(callsite);
 
-        return await this.dispatcher.executeAction({ apiMethodName, command, callsite, id: this.id });
+        if ((command as CommandBase).type === COMMAND_TYPE.assertion)
+            return this._executeAssertion(command as AssertionCommand, callsite);
+
+        return this.dispatcher.executeAction({ apiMethodName, command, callsite, id: this.id });
+    }
+
+    public async executeCommand (command: unknown): Promise<unknown> {
+        return this.dispatcher.executeCommand({ command, id: this.id });
     }
 }
 
-export default TestRunMock;
+export default TestRunProxy;
 
 

--- a/src/services/process-title.ts
+++ b/src/services/process-title.ts
@@ -1,0 +1,6 @@
+enum ProcessTitle {
+    main = 'main',
+    service = 'service'
+}
+
+export default ProcessTitle;

--- a/src/services/serialization/prepare-options.ts
+++ b/src/services/serialization/prepare-options.ts
@@ -1,0 +1,16 @@
+import { Dictionary } from '../../configuration/interfaces';
+import OptionNames from '../../configuration/option-names';
+
+const NECESSARY_OPTIONS = [
+    OptionNames.assertionTimeout
+];
+
+export default function (value: Dictionary<OptionValue>): Dictionary<OptionValue> {
+    const result = Object.create(null);
+
+    NECESSARY_OPTIONS.forEach(optionName => {
+        result[optionName] = value[optionName];
+    });
+
+    return result;
+}

--- a/src/services/serialization/test-structure.ts
+++ b/src/services/serialization/test-structure.ts
@@ -1,5 +1,5 @@
 import { uniq, keyBy } from 'lodash';
-import { TEST_FUNCTION_PROPERTIES } from './protocol';
+import { TEST_FUNCTION_PROPERTIES } from '../compiler/protocol';
 
 import Test from '../../api/structure/test';
 import Fixture from '../../api/structure/fixture';

--- a/src/services/utils/ipc/proxy.ts
+++ b/src/services/utils/ipc/proxy.ts
@@ -1,5 +1,6 @@
 import TestCafeErrorList from '../../../errors/error-list';
 import EventEmitter from '../../../utils/async-event-emitter';
+import { castArray } from 'lodash';
 
 import {
     ExternalError,
@@ -122,11 +123,15 @@ export class IPCProxy extends EventEmitter {
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    public register (func: Function, context: any = null): void {
-        if (this._handlers[func.name])
-            return;
+    public register (func: Function | Function[], context: any = null): void {
+        func = castArray(func);
 
-        this._handlers[func.name] = func.bind(context);
+        func.forEach(fn => {
+            if (this._handlers[fn.name])
+                return;
+
+            this._handlers[fn.name] = fn.bind(context);
+        });
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/functional/fixtures/compiler-service/test.js
+++ b/test/functional/fixtures/compiler-service/test.js
@@ -35,4 +35,8 @@ describe('Compiler service', () => {
             ])).to.be.true;
         }
     });
+
+    it('Should allow using ClientFunction in assertions', async () => {
+        await runTests('testcafe-fixtures/client-function-in-assertions.js', 'ClientFunction in assertions');
+    });
 });

--- a/test/functional/fixtures/compiler-service/testcafe-fixtures/client-function-in-assertions.js
+++ b/test/functional/fixtures/compiler-service/testcafe-fixtures/client-function-in-assertions.js
@@ -1,0 +1,17 @@
+import { ClientFunction } from 'testcafe';
+
+fixture `Features`;
+
+const fn = ClientFunction(() => {
+    var counter = window['counter'] || 0; // eslint-disable-line no-var
+
+    counter++;
+
+    window['counter'] = counter;
+
+    return counter;
+});
+
+test('ClientFunction in assertions', async t => {
+    await t.expect(fn()).eql(2);
+});


### PR DESCRIPTION
Changes:
* processes have clear titles (for debug purposes)
* ReExecutablePromise (ClientFunction and Selector results) executed into the service process
* typings and refactoring