### PR TITLE
[docs] Move options from runner.run to createTestCafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ To enable server-side caching, use any of the following:
 
 * [the `--cache` CLI flag](https://devexpress.github.io/testcafe/documentation/reference/command-line-interface.html#--cache)
 * [the `cache` configuration file property](https://devexpress.github.io/testcafe/documentation/reference/configuration-file.html#cache)
-* [the `cache` runner option](https://devexpress.github.io/testcafe/documentation/reference/testcafe-api/runner/run.html)
+* [the `createTestCafe` function parameter](https://devexpress.github.io/testcafe/documentation/reference/testcafe-api/global/createtestcafe.html)
 
 #### Initialize Request Hooks with Async Predicates
 
@@ -132,12 +132,12 @@ You can enable this functionality with a command line, API, or configuration fil
     testcafe chrome test.js --retry-test-pages
     ```
 
-* the [runner.run](https://devexpress.github.io/testcafe/documentation/using-testcafe/programming-interface/runner.html) option
+* the [createTestCafe](https://devexpress.github.io/testcafe/documentation/reference/testcafe-api/global/createtestcafe.md) function parameter
 
     ```js
-    runner.run({
-        retryTestPages: true
-    });
+    const createTestCafe = require('testcafe');
+
+    const testcafe = await createTestCafe('localhost', 1337, 1338, retryTestPages)
     ```
 
 * the [retryTestPages](https://devexpress.github.io/testcafe/documentation/using-testcafe/configuration-file.html#retrytestpages) configuration file property

--- a/docs/articles/blog/2021-03-03-testcafe-v1-12-0-released.md
+++ b/docs/articles/blog/2021-03-03-testcafe-v1-12-0-released.md
@@ -19,15 +19,15 @@ Use any of the following to enable server-side caching:
 
 * [the `--cache` CLI flag](../documentation/reference/command-line-interface.md#--cache)
 * [the `cache` configuration file property](../documentation/reference/configuration-file.md#cache)
-* [the `cache` runner option](../documentation/reference/testcafe-api/runner/run.md)
+* [the `createTestCafe` function parameter](../documentation/reference/testcafe-api/global/createtestcafe.md)
 
 ### Initialize Request Hooks with Async Predicates
 
 The following request hooks now support **asynchronous** predicate functions:
 
-* [RequestHook Constructor](../documentation/reference/test-api/requesthook/constructor.md)
-* [RequestMock Constructor](../documentation/reference/test-api/requestmock/constructor.md)
-* [RequestLogger Constructor](../documentation/reference/test-api/requestlogger/constructor.md)
+* [RequestHook](../documentation/reference/test-api/requesthook/constructor.md#filter-with-a-predicate)
+* [RequestMock.onRequestTo](../documentation/reference/test-api/requestmock/onrequestto.md#filter-with-a-predicate)
+* [RequestLogger](../documentation/reference/test-api/requestlogger/constructor.md#filter-with-a-predicate)
 
 **Example**
 

--- a/docs/articles/blog/2021-2-15-testcafe-v1-11-0-released.md
+++ b/docs/articles/blog/2021-2-15-testcafe-v1-11-0-released.md
@@ -106,12 +106,12 @@ You can enable this functionality with a command line, API, or configuration fil
     testcafe chrome test.js --retry-test-pages
     ```
 
-* the [runner.run](../documentation/reference/testcafe-api/runner/README.md) option
+* the [createTestCafe](../documentation/reference/testcafe-api/global/createtestcafe.md) function parameter
 
     ```js
-    runner.run({
-        retryTestPages: true
-    });
+    const createTestCafe = require('testcafe');
+
+    const testcafe = await createTestCafe('localhost', 1337, 1338, retryTestPages)
     ```
 
 * the [retryTestPages](../documentation/reference/configuration-file.md#retrytestpages) configuration file property

--- a/docs/articles/documentation/reference/command-line-interface.md
+++ b/docs/articles/documentation/reference/command-line-interface.md
@@ -968,7 +968,7 @@ testcafe chrome test.ts --compiler-options typescript.customCompilerModulePath=.
 
 The values of the `typescript.options.lib` compiler option should be the same as the names of the corresponding library files from your compiler's `node_modules/typescript/lib` folder (for example: `lib.webworker.d.ts`).
 
-*Related configuration file property*: [compilerOptions](configuration-file.md#compileroptions).
+*Related configuration file property*: [compilerOptions](configuration-file.md#compileroptions)  
 *Related API method*: [runner.compilerOptions](testcafe-api/runner/compileroptions.md)
 
 ### --cache

--- a/docs/articles/documentation/reference/configuration-file.md
+++ b/docs/articles/documentation/reference/configuration-file.md
@@ -1119,7 +1119,7 @@ If the tested application loads many heavy assets, enable server-side caching to
 > Important! Support for server-side caching is experimental. Disable the `--cache` flag if you run into compatibility issues with your tests.
 
 *CLI*: [--cache](command-line-interface.md#--cache)  
-*API*: [runner.run({ cache })](testcafe-api/runner/run.md)
+*API*: [createTestCafe](./testcafe-api/global/createtestcafe.md)
 
 ## disablePageCaching
 
@@ -1166,8 +1166,8 @@ If this option is enabled, TestCafe retries failed network requests for webpages
 This feature uses [Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) that require a secure connection.
 To run TestCafe over a secure connection, [setup HTTPS](../guides/advanced-guides/test-https-features-and-http2-websites.md#test-https-websites) or use the [--hostname localhost](command-line-interface.md#--hostname-name) option.
 
-*CLI*: [--retry-test-pages](./command-line-interface.md#--retry-test-pages)
-*API*: [runner.run({ retryTestPages })](testcafe-api/runner/run.md)
+*CLI*: [--retry-test-pages](./command-line-interface.md#--retry-test-pages)  
+*API*: [createTestCafe](./testcafe-api/global/createtestcafe.md)
 
 ## color
 

--- a/docs/articles/documentation/reference/testcafe-api/global/createtestcafe.md
+++ b/docs/articles/documentation/reference/testcafe-api/global/createtestcafe.md
@@ -10,7 +10,7 @@ redirect_from:
 Creates a [TestCafe](../testcafe/README.md) server instance.
 
 ```text
-async createTestCafe([hostname], [port1], [port2], [sslOptions], [developmentMode]) → Promise<TestCafe>
+async createTestCafe([hostname], [port1], [port2], [sslOptions], [developmentMode], [retryTestPages], [cache]) → Promise<TestCafe>
 ```
 
 Parameter                     | Type   | Description                                                                                                                                                                                                  | Default
@@ -19,6 +19,8 @@ Parameter                     | Type   | Description                            
 `port1`, `port2`&#160;*(optional)* | Number | Ports that will be used to serve tested webpages.                                                                                                                                                            | Free ports selected automatically.
 `sslOptions`&#160;*(optional)*     | Object | Options that allow you to establish an HTTPS connection between the TestCafe server and the client browser. This object should contain options required to initialize [a Node.js HTTPS server](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener). The most commonly used SSL options are described in the [TLS topic](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options) in the Node.js documentation. See [Test HTTPS and HTTP/2 Websites](../../../guides/advanced-guides/test-https-features-and-http2-websites.md) for more information.
 `developmentMode`&#160;*(optional)* | Boolean | Enables/disables mechanisms to log and diagnose errors. You should enable this option before you contact TestCafe Support to report an issue. | `false`
+`cache`&#160;*(optional)* | Boolean | If enabled, the TestCafe proxy caches webpage assets (such as stylesheets, images and scripts) for the webpages that it processes. The next time the proxy accesses the page, it loads assets from its cache instead of requesting them from the server. | `false`
+`retryTestPages`&#160;*(optional)* | Boolean | Retry failed network requests for webpages visited during tests. Requires a secure connection. | `false`
 
 *Related configuration file properties*:
 
@@ -26,6 +28,8 @@ Parameter                     | Type   | Description                            
 * [port1, port2](../../configuration-file.md#port1-port2)
 * [ssl](../../configuration-file.md#ssl)
 * [developmentMode](../../configuration-file.md#developmentmode)
+* [retryTestPages](../../configuration-file.md#retrytestpages)
+* [cache](../../configuration-file.md#cache)
 
 **Example**
 

--- a/docs/articles/documentation/reference/testcafe-api/global/createtestcafe.md
+++ b/docs/articles/documentation/reference/testcafe-api/global/createtestcafe.md
@@ -10,26 +10,12 @@ redirect_from:
 Creates a [TestCafe](../testcafe/README.md) server instance.
 
 ```text
-async createTestCafe([hostname], [port1], [port2], [sslOptions], [developmentMode], [retryTestPages], [cache]) → Promise<TestCafe>
+async createTestCafe(options) → Promise<TestCafe>
 ```
 
-Parameter                     | Type   | Description                                                                                                                                                                                                  | Default
------------------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------
-`hostname`&#160;*(optional)*       | String | The hostname or IP on which the TestCafe server runs. Must resolve to the current machine. To test on external devices, use the hostname that is visible in the network shared with these devices. | Hostname of the OS. If the hostname does not resolve to the current machine - its network IP address.
-`port1`, `port2`&#160;*(optional)* | Number | Ports that will be used to serve tested webpages.                                                                                                                                                            | Free ports selected automatically.
-`sslOptions`&#160;*(optional)*     | Object | Options that allow you to establish an HTTPS connection between the TestCafe server and the client browser. This object should contain options required to initialize [a Node.js HTTPS server](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener). The most commonly used SSL options are described in the [TLS topic](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options) in the Node.js documentation. See [Test HTTPS and HTTP/2 Websites](../../../guides/advanced-guides/test-https-features-and-http2-websites.md) for more information.
-`developmentMode`&#160;*(optional)* | Boolean | Enables/disables mechanisms to log and diagnose errors. You should enable this option before you contact TestCafe Support to report an issue. | `false`
-`cache`&#160;*(optional)* | Boolean | If enabled, the TestCafe proxy caches webpage assets (such as stylesheets, images and scripts) for the webpages that it processes. The next time the proxy accesses the page, it loads assets from its cache instead of requesting them from the server. | `false`
-`retryTestPages`&#160;*(optional)* | Boolean | Retry failed network requests for webpages visited during tests. Requires a secure connection. | `false`
-
-*Related configuration file properties*:
-
-* [hostname](../../configuration-file.md#hostname)
-* [port1, port2](../../configuration-file.md#port1-port2)
-* [ssl](../../configuration-file.md#ssl)
-* [developmentMode](../../configuration-file.md#developmentmode)
-* [retryTestPages](../../configuration-file.md#retrytestpages)
-* [cache](../../configuration-file.md#cache)
+Parameter                   | Type     | Description
+----------------------------|----------|-------------
+`options`&#160;*(optional)* | Object   | See [options](#options).
 
 **Example**
 
@@ -37,8 +23,13 @@ Create a `TestCafe` instance with the `createTestCafe` function.
 
 ```js
 const createTestCafe = require('testcafe');
+const options = {
+  hostname: 'localhost',
+  port1: 1337,
+  port2: 1338
+}
 
-const testcafe = await createTestCafe('localhost', 1337, 1338);
+const testCafeOptions = await createTestCafe(options);
 const runner   = testcafe.createRunner();
 /* ... */
 ```
@@ -56,7 +47,14 @@ const sslOptions = {
     cert: selfSignedSertificate.cert
 };
 
-const testcafe = await createTestCafe('localhost', 1337, 1338, sslOptions);
+const testCafeOptions = {
+    hostname: 'localhost',
+    port1: 1337,
+    port2: 1338,
+    sslOptions
+}
+
+const testcafe = await createTestCafe(testCafeOptions);
 const runner   = testcafe.createRunner();
 
 await runner
@@ -70,6 +68,28 @@ await runner
 
 await testcafe.close();
 ```
+
+## options
+  
+**Type**: Object
+
+Parameter                          | Type   | Description | Default
+-----------------------------------|--------|-------------|--------
+`hostname`&#160;*(optional)*       | String | The hostname or IP on which the TestCafe server runs. Must resolve to the current machine. To test on external devices, use the hostname that is visible in the network shared with these devices. | Hostname of the OS. If the hostname does not resolve to the current machine - its network IP address.
+`port1`, `port2`&#160;*(optional)* | Number | Ports that will be used to serve tested webpages.| Free ports selected automatically.
+`sslOptions`&#160;*(optional)*     | Object | Options that allow you to establish an HTTPS connection between the TestCafe server and the client browser. This object should contain options required to initialize [a Node.js HTTPS server](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener). The most commonly used SSL options are described in the [TLS topic](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options) in the Node.js documentation. See [Test HTTPS and HTTP/2 Websites](../../../guides/advanced-guides/test-https-features-and-http2-websites.md) for more information.
+`developmentMode`&#160;*(optional)* | Boolean | Enables/disables mechanisms to log and diagnose errors. You should enable this option before you contact TestCafe Support to report an issue. | `false`
+`cache`&#160;*(optional)* | Boolean | If enabled, the TestCafe proxy caches webpage assets (such as stylesheets, images and scripts) for the webpages that it processes. The next time the proxy accesses the page, it loads assets from its cache instead of requesting them from the server. | `false`
+`retryTestPages`&#160;*(optional)* | Boolean | Retry failed network requests for webpages visited during tests. Requires a secure connection. | `false`
+
+*Related configuration file properties*:
+
+* [hostname](../../configuration-file.md#hostname)
+* [port1, port2](../../configuration-file.md#port1-port2)
+* [ssl](../../configuration-file.md#ssl)
+* [developmentMode](../../configuration-file.md#developmentmode)
+* [retryTestPages](../../configuration-file.md#retrytestpages)
+* [cache](../../configuration-file.md#cache)
 
 ## See Also
 

--- a/docs/articles/documentation/reference/testcafe-api/global/createtestcafe.md
+++ b/docs/articles/documentation/reference/testcafe-api/global/createtestcafe.md
@@ -27,14 +27,10 @@ const options        = {
     hostname: 'localhost',
     port1:    1337,
     port2:    1338
-}
-  hostname: 'localhost',
-  port1: 1337,
-  port2: 1338
-}
+};
 
 const testCafeOptions = await createTestCafe(options);
-const runner   = testcafe.createRunner();
+const runner          = testcafe.createRunner();
 /* ... */
 ```
 
@@ -56,7 +52,7 @@ const testCafeOptions = {
     port1:   1337,
     port2:   1338,
     sslOptions
-}
+};
 
 const testcafe = await createTestCafe(testCafeOptions);
 const runner   = testcafe.createRunner();

--- a/docs/articles/documentation/reference/testcafe-api/global/createtestcafe.md
+++ b/docs/articles/documentation/reference/testcafe-api/global/createtestcafe.md
@@ -23,7 +23,11 @@ Create a `TestCafe` instance with the `createTestCafe` function.
 
 ```js
 const createTestCafe = require('testcafe');
-const options = {
+const options        = {
+    hostname: 'localhost',
+    port1:    1337,
+    port2:    1338
+}
   hostname: 'localhost',
   port1: 1337,
   port2: 1338
@@ -48,9 +52,9 @@ const sslOptions = {
 };
 
 const testCafeOptions = {
-    hostname: 'localhost',
-    port1: 1337,
-    port2: 1338,
+   hostname: 'localhost',
+    port1:   1337,
+    port2:   1338,
     sslOptions
 }
 

--- a/docs/articles/documentation/reference/testcafe-api/runner/run.md
+++ b/docs/articles/documentation/reference/testcafe-api/runner/run.md
@@ -33,12 +33,10 @@ Parameter         | Type    | Description                                       
 `pageRequestTimeout` | Number | Time (in milliseconds) to wait for HTML pages. If the page isn't received within the specified period, an error is thrown. | `25000`
 `browserInitTimeout` | Number | Time (in milliseconds) for browsers to connect to TestCafe and report that they are ready to test. If one or more browsers fail to connect within this period, TestCafe throws an error. | `120000` for [local browsers](../../command-line-interface.md#local-browsers), `360000` for [remote browsers](../../command-line-interface.md#remote-browsers)
 `speed`           | Number  | Specifies the test execution speed. A number between `1` (fastest) and `0.01` (slowest). If an individual action's speed is also specified, the action speed setting overrides the test speed. | `1`
-`cache` | Boolean | If enabled, the TestCafe proxy caches webpage assets (such as stylesheets, images and scripts) for the webpages that it processes. The next time the proxy accesses the page, it loads assets from its cache instead of requesting them from the server. | `false`
 `stopOnFirstFail`    | Boolean | Stops the test run if a test fails. You can focus on the first error before all the tests finish. | `false`
 `disablePageCaching` | Boolean | Prevents the browser from caching page content. When navigation to a cached page occurs in [role code](../../../guides/advanced-guides/authentication.md), local and session storage content is not preserved. Set `disablePageCaching` to `true` to retain the storage items after navigation. For more information, see [Troubleshooting: Test Actions Fail After Authentication](../../../guides/advanced-guides/authentication.md#test-actions-fail-after-authentication). You can also disable page caching for an individual [fixture](../../test-api/fixture/disablepagecaching.md) or [test](../../test-api/test/disablepagecaching.md). | `false`
 `disableScreenshots` | Boolean | Prevents TestCafe from taking screenshots. When this option is specified, screenshots are not taken whenever a test fails or when [t.takeScreenshot](../../test-api/testcontroller/takescreenshot.md) or [t.takeElementScreenshot](../../test-api/testcontroller/takeelementscreenshot.md) is executed. | `false`
 `disableMultipleWindows` | Boolean | Disables support for [multi-window testing](../../../guides/advanced-guides/multiple-browser-windows.md) in Chrome and Firefox. Use this option if you encounter compatibility issues with your existing tests.
-`retryTestPages` | Boolean | Enables retries for failed network requests for webpages visited during tests. Requires a secure connection. See the [related configuration file property](../../configuration-file.md#retrytestpages) for more details.
 
 After all tests are finished, call the [testcafe.close](../testcafe/close.md) function to stop the TestCafe server.
 
@@ -56,12 +54,10 @@ After all tests are finished, call the [testcafe.close](../testcafe/close.md) fu
 * [pageRequestTimeout](../../configuration-file.md#pagerequesttimeout)
 * [browserInitTimeout](../../configuration-file.md#browserinittimeout)
 * [speed](../../configuration-file.md#speed)
-* [cache](../../configuration-file.md#cache)
 * [stopOnFirstFail](../../configuration-file.md#stoponfirstfail)
 * [disablePageCaching](../../configuration-file.md#disablepagecaching)
 * [disableScreenshots](../../configuration-file.md#disablescreenshots)
 * [disableMultipleWindows](../../configuration-file.md#disablemultiplewindows)
-* [retryTestPages](../../configuration-file.md#retrytestpages)
 
 **Example**
 


### PR DESCRIPTION
moves `cache` and `retryTestPages` options description from `runner.run` to `createTestCafe`