### PR TITLE
chore: bump 1.12.1-alpha.1

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -8,7 +8,7 @@
     "gitTag": true
   },
   "confirm": true,
-  "publishTag": "latest",
+  "publishTag": "alpha",
   "prePublishScript": "gulp test-server",
   "postPublishScript": "gulp docker-publish"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.12.0",
+  "version": "1.12.1-alpha.1",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"
@@ -130,7 +130,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.13",
-    "testcafe-hammerhead": "19.4.1",
+    "testcafe-hammerhead": "19.4.2",
     "testcafe-legacy-api": "4.2.4",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -97,7 +97,7 @@ import DriverRole from './role';
 import { CHECK_CHILD_WINDOW_CLOSED_INTERVAL, WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT } from './driver-link/timeouts';
 import sendMessageToDriver from './driver-link/send-message-to-driver';
 
-const settings = hammerhead.get('./settings');
+const settings = hammerhead.settings;
 
 const transport      = hammerhead.transport;
 const Promise        = hammerhead.Promise;

--- a/test/client/before-test.js
+++ b/test/client/before-test.js
@@ -14,14 +14,14 @@
 
     //Hammerhead setup
     const hammerhead   = getTestCafeModule('hammerhead');
-    const INSTRUCTION  = hammerhead.get('../processing/script/instruction');
+    const INSTRUCTION  = hammerhead.PROCESSING_INSTRUCTIONS.dom.script;
     const location     = 'http://localhost/sessionId/https://example.com';
     const browserUtils = hammerhead.utils.browser;
 
-    hammerhead.get('./utils/destination-location').forceLocation(location);
+    hammerhead.utils.destLocation.forceLocation(location);
 
     const iframeTaskScriptTempate = [
-        'window["%hammerhead%"].get("./utils/destination-location").forceLocation("{{{location}}}");',
+        'window["%hammerhead%"].utils.destLocation.forceLocation("{{{location}}}");',
         'window["%hammerhead%"].start({',
         '    referer : "{{{referer}}}",',
         '    cookie: "{{{cookie}}}",',
@@ -49,7 +49,7 @@
 
         if (iframe.id.indexOf('test') !== -1) {
             iframe.contentWindow.eval.call(iframe.contentWindow, [
-                'window["%hammerhead%"].get("./utils/destination-location").forceLocation("' + location + '");',
+                'window["%hammerhead%"].utils.destLocation.forceLocation("' + location + '");',
                 'window["%hammerhead%"].start({',
                 '    referer : "' + referer + '",',
                 '    serviceMsgUrl : "' + serviceMsg + '",',

--- a/test/client/data/dom-utils/iframe.html
+++ b/test/client/data/dom-utils/iframe.html
@@ -15,7 +15,7 @@
 <body>
 <script type="text/javascript">
     const hammerhead = window['%hammerhead%'];
-    const settings = hammerhead.settings;
+    const settings   = hammerhead.settings;
 
     settings.get().crossDomainProxyPort = 2000;
 

--- a/test/client/data/dom-utils/iframe.html
+++ b/test/client/data/dom-utils/iframe.html
@@ -15,7 +15,7 @@
 <body>
 <script type="text/javascript">
     const hammerhead = window['%hammerhead%'];
-    const settings = hammerhead.get('./settings');
+    const settings = hammerhead.settings;
 
     settings.get().crossDomainProxyPort = 2000;
 

--- a/test/client/data/focus-blur-change/iframe.html
+++ b/test/client/data/focus-blur-change/iframe.html
@@ -10,7 +10,7 @@
 <script>
     const hammerhead = window['%hammerhead%'];
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/http://target_url');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/http://target_url');
 
     hammerhead.start({ crossDomainProxyPort: 2000 });
 

--- a/test/client/data/runner/iframe.html
+++ b/test/client/data/runner/iframe.html
@@ -22,10 +22,10 @@
 
     //Hammerhead setup
     const hammerhead  = getTestCafeModule('hammerhead');
-    const INSTRUCTION = hammerhead.get('../processing/script/instruction');
+    const INSTRUCTION = hammerhead.PROCESSING_INSTRUCTIONS.dom.script;
 
 
-    hammerhead.get('./utils/destination-location').forceLocation('http://localhost/sessionId/https://example.com');
+    hammerhead.utils.destLocation.forceLocation('http://localhost/sessionId/https://example.com');
 
     hammerhead.start({ sessionId: 'sessionId' });
 

--- a/test/client/fixtures/core/request-barrier-test.js
+++ b/test/client/fixtures/core/request-barrier-test.js
@@ -1,6 +1,6 @@
 const hammerhead    = window.getTestCafeModule('hammerhead');
 const Promise       = hammerhead.Promise;
-const hhsettings    = hammerhead.get('./settings').get();
+const hhsettings    = hammerhead.settings.get();
 const iframeSandbox = hammerhead.sandbox.iframe;
 
 const testCafeCore   = window.getTestCafeModule('testCafeCore');

--- a/test/client/legacy-fixtures/cross-domain/in-iframe-test.js
+++ b/test/client/legacy-fixtures/cross-domain/in-iframe-test.js
@@ -1,5 +1,5 @@
 const hammerhead   = window.getTestCafeModule('hammerhead');
-const hhsettings   = hammerhead.get('./settings').get();
+const hhsettings   = hammerhead.settings.get();
 const browserUtils = hammerhead.utils.browser;
 
 const testCafeLegacyRunner = window.getTestCafeModule('testCafeLegacyRunner');

--- a/test/client/legacy-fixtures/cross-domain/run-test.js
+++ b/test/client/legacy-fixtures/cross-domain/run-test.js
@@ -1,5 +1,5 @@
 const hammerhead   = window.getTestCafeModule('hammerhead');
-const hhsettings   = hammerhead.get('./settings').get();
+const hhsettings   = hammerhead.settings.get();
 const browserUtils = hammerhead.utils.browser;
 
 const testCafeLegacyRunner = window.getTestCafeModule('testCafeLegacyRunner');

--- a/test/client/legacy-fixtures/runner-base-test.js
+++ b/test/client/legacy-fixtures/runner-base-test.js
@@ -1,5 +1,5 @@
 const hammerhead    = window.getTestCafeModule('hammerhead');
-const hhsettings    = hammerhead.get('./settings').get();
+const hhsettings    = hammerhead.settings.get();
 const iframeSandbox = hammerhead.sandbox.iframe;
 
 const testCafeLegacyRunner = window.getTestCafeModule('testCafeLegacyRunner');

--- a/test/client/legacy-fixtures/runner-test.js
+++ b/test/client/legacy-fixtures/runner-test.js
@@ -1,5 +1,5 @@
 const hammerhead = window.getTestCafeModule('hammerhead');
-const hhsettings = hammerhead.get('./settings').get();
+const hhsettings = hammerhead.settings.get();
 
 const testCafeLegacyRunner = window.getTestCafeModule('testCafeLegacyRunner');
 const COMMAND              = testCafeLegacyRunner.get('../test-run/command');


### PR DESCRIPTION
* update testcafe version to 1.12.1-alpha.1
* update hammerhead version to 19.4.2
* get rid of the `hammerhead.get` method usage in tests