### PR TITLE
chore: bump testcafe-browser-tools@2.0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "semver": "^5.6.0",
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
-    "testcafe-browser-tools": "2.0.13",
+    "testcafe-browser-tools": "2.0.15",
     "testcafe-hammerhead": "19.4.2",
     "testcafe-legacy-api": "4.2.4",
     "testcafe-reporter-json": "^2.1.0",


### PR DESCRIPTION
* Support Edge on Linux (DevExpress/testcafe-browser-tools#210)
* Disable Occlusion Tracking for Chromium using the `--disable-backgrounding-occluded-windows` flag (DevExpress/testcafe-browser-tools#211)