### PR TITLE
Do not supress missing await warnings (closes #5554)

### DIFF
--- a/src/client-functions/selectors/add-api.js
+++ b/src/client-functions/selectors/add-api.js
@@ -111,8 +111,10 @@ function getDerivativeSelectorArgs (options, selectorFn, apiFn, filter, addition
 }
 
 function createPrimitiveGetterWrapper (observedCallsites, callsite) {
-    return () => {
-        if (observedCallsites)
+    return (depth, options) => {
+        const isTestCafeInspect = options?.isTestCafeInspect;
+
+        if (observedCallsites && !isTestCafeInspect)
             observedCallsites.unawaitedSnapshotCallsites.add(callsite);
 
         return SNAPSHOT_PROP_PRIMITIVE;
@@ -152,11 +154,8 @@ function addSnapshotProperties (obj, getSelector, SelectorBuilder, properties, o
                 propertyPromise[inspect.custom]     = primitiveGetterWrapper;
 
                 propertyPromise.then = function (onFulfilled, onRejected) {
-                    if (observedCallsites) {
+                    if (observedCallsites)
                         checkForExcessiveAwaits(observedCallsites.snapshotPropertyCallsites, callsite);
-
-                        observedCallsites.unawaitedSnapshotCallsites.delete(callsite);
-                    }
 
                     this._ensureExecuting();
 

--- a/src/test-run/debug-log.js
+++ b/src/test-run/debug-log.js
@@ -11,7 +11,7 @@ export default class TestRunDebugLog {
     static _addEntry (logger, data) {
         try {
             const entry = data ?
-                indentString(`\n${inspect(data, { compact: false })}\n`, ' ', 4) :
+                indentString(`\n${inspect(data, { isTestCafeInspect: true, compact: false })}\n`, ' ', 4) :
                 '';
 
             logger(entry);

--- a/test/functional/fixtures/api/es-next/assertions/test.js
+++ b/test/functional/fixtures/api/es-next/assertions/test.js
@@ -243,6 +243,30 @@ describe('[API] Assertions', function () {
         expect(missingAwaitWarnings[1]).to.match(createRegExpFromFile('expected-missing-await-on-snapshot-callsite/template-expansion'));
     });
 
+    it('Console.log for promise which will be resolved', async function () {
+        await runTests('./testcafe-fixtures/assertions-test.js', 'Console.log for promise which will be resolved', { only: 'chrome' });
+
+        const missingAwaitWarningRegExp = createRegExp(WARNING_MESSAGES.missingAwaitOnSnapshotProperty);
+
+        const missingAwaitWarnings = testReport.warnings.filter(warningStr => {
+            return warningStr.match(missingAwaitWarningRegExp);
+        });
+
+        expect(missingAwaitWarnings.length).to.eql(1);
+    });
+
+    it('Convert for promise which will be resolved', async function () {
+        await runTests('./testcafe-fixtures/assertions-test.js', 'Convert for promise which will be resolved', { only: 'chrome' });
+
+        const missingAwaitWarningRegExp = createRegExp(WARNING_MESSAGES.missingAwaitOnSnapshotProperty);
+
+        const missingAwaitWarnings = testReport.warnings.filter(warningStr => {
+            return warningStr.match(missingAwaitWarningRegExp);
+        });
+
+        expect(missingAwaitWarnings.length).to.eql(1);
+    });
+
     it('Should not raise a warning when using DOM Node snapshot property without await in assignment', async function () {
         await runTests('./testcafe-fixtures/assertions-test.js', 'Snapshot property without await but valid', { only: 'chrome' });
 
@@ -259,7 +283,7 @@ describe('[API] Assertions', function () {
         await runTests('./testcafe-fixtures/assertions-test.js', 'Reused awaited selector property assertion from a function', { only: 'chrome' });
 
         expect(getSnapshotWarnings().length).to.eql(1);
-        expect(getSnapshotWarnings()[0]).contains("> 221 |        await t.expect(await selector.innerText).eql('');");
+        expect(getSnapshotWarnings()[0]).contains("> 238 |        await t.expect(await selector.innerText).eql('');");
     });
 
     it('Should not raise a warning when reusing selector property assertions in a loop', async function () {
@@ -272,15 +296,15 @@ describe('[API] Assertions', function () {
         await runTests('./testcafe-fixtures/assertions-test.js', 'Reused awaited selector property assertion in a loop', { only: 'chrome' });
 
         expect(getSnapshotWarnings().length).to.eql(1);
-        expect(getSnapshotWarnings()[0]).contains("> 236 |        await t.expect(await Selector('#el1').innerText).eql('');");
+        expect(getSnapshotWarnings()[0]).contains("> 253 |        await t.expect(await Selector('#el1').innerText).eql('');");
     });
 
     it('Should raise multiple warnings when awaiting multiple selector properties in one assertion', async function () {
         await runTests('./testcafe-fixtures/assertions-test.js', 'Multiple awaited selector properties in one assertion', { only: 'chrome' });
 
         expect(getSnapshotWarnings().length).to.eql(2);
-        expect(getSnapshotWarnings()[0]).contains("> 242 |    await t.expect(await selector.innerText + await selector.innerText).eql('');");
-        expect(getSnapshotWarnings()[1]).contains("> 242 |    await t.expect(await selector.innerText + await selector.innerText).eql('');");
+        expect(getSnapshotWarnings()[0]).contains("> 259 |    await t.expect(await selector.innerText + await selector.innerText).eql('');");
+        expect(getSnapshotWarnings()[1]).contains("> 259 |    await t.expect(await selector.innerText + await selector.innerText).eql('');");
     });
 
     it('Should retry assertion for selector results', function () {

--- a/test/functional/fixtures/api/es-next/assertions/testcafe-fixtures/assertions-test.js
+++ b/test/functional/fixtures/api/es-next/assertions/testcafe-fixtures/assertions-test.js
@@ -196,6 +196,23 @@ test('Snapshot property without await', async t => {
     const tag = `element: ${Selector('#el1').tagName}`; //eslint-disable-line
 });
 
+test(`Console.log for promise which will be resolved`, async t => {
+    const a = Selector('#el1').innerText;
+
+    // eslint-disable-next-line no-console
+    console.log(a);
+
+    await t.expect(a).eql('');
+});
+
+test(`Convert for promise which will be resolved`, async t => {
+    const a = Selector('#el1').innerText;
+
+    const tag = `${a}`; //eslint-disable-line
+
+    await t.expect(a).eql('');
+});
+
 test('Snapshot property without await but valid', async t => {
     const b = Selector('#el1').innerText; //eslint-disable-line
 


### PR DESCRIPTION
We should throw a warning in any case when we get into the `createPrimitiveGetterWrapper` function. We can get into it in two cases:
- console.log() - internally uses util.inspect
- type conversion, such as `${a}`
If we are inside the wrapper, this means that we should add a warning.
However, there is a specific moment, that TestCafe uses `inspect` internally and in this case we should not add any warning, so I added the `isTestCafeInspect` parameter into TestCafe inspect call.