### PR TITLE
fix 'documentElement.transform.translate moves the TestCafe UI ' (close #5606)

### DIFF
--- a/src/client/ui/styles.less
+++ b/src/client/ui/styles.less
@@ -22,6 +22,7 @@
     -webkit-transition: none !important;
     -moz-transition: none !important;
     -o-transition: none !important;
+    transform: none !important;
 
     .layout-default();
 


### PR DESCRIPTION
Transforming the main document element is a rare and mostly synthetic scenario.
However, we should protect the root element of our Shadow UI subsystem from transformation.

I make it similar to the `transition` CSS property.


