### PR TITLE
Combine multiple constructor parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
     "testcafe-hammerhead": "19.5.0",
-    "testcafe-legacy-api": "4.2.5",
+    "testcafe-legacy-api": "https://github.com/miherlosev/tmp/files/6180637/testcafe-legacy-api-5.0.0.zip",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",
     "testcafe-reporter-minimal": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
     "testcafe-hammerhead": "19.5.0",
-    "testcafe-legacy-api": "https://github.com/miherlosev/tmp/files/6180637/testcafe-legacy-api-5.0.0.zip",
+    "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",
     "testcafe-reporter-minimal": "^2.1.0",

--- a/src/live/bootstrapper.js
+++ b/src/live/bootstrapper.js
@@ -7,7 +7,7 @@ const originalRequire = Module.prototype.require;
 
 class LiveModeBootstrapper extends Bootstrapper {
     constructor (runner, browserConnectionGateway) {
-        super(browserConnectionGateway);
+        super({ browserConnectionGateway });
 
         this.runner = runner;
     }

--- a/src/live/test-runner.js
+++ b/src/live/test-runner.js
@@ -8,8 +8,8 @@ import { GeneralError } from '../errors/runtime';
 import { RUNTIME_ERRORS } from '../errors/types';
 
 class LiveModeRunner extends Runner {
-    constructor (proxy, browserConnectionGateway, options) {
-        super(proxy, browserConnectionGateway, options);
+    constructor ({ proxy, browserConnectionGateway, configuration }) {
+        super({ proxy, browserConnectionGateway, configuration });
 
         this.stopping              = false;
         this.runnerTaskPromise     = null;

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -37,7 +37,7 @@ import { Metadata } from '../api/structure/interfaces';
 import Test from '../api/structure/test';
 import detectDisplay from '../utils/detect-display';
 import { getPluginFactory, processReporterName } from '../utils/reporter';
-import { BrowserSetOptions } from './interfaces';
+import { BootstrapperInit, BrowserSetOptions } from './interfaces';
 import WarningLog from '../notifications/warning-log';
 import WARNING_MESSAGES from '../notifications/warning-message';
 import guardTimeExecution from '../utils/guard-time-execution';
@@ -109,9 +109,9 @@ export default class Bootstrapper {
     private readonly debugLogger: debug.Debugger;
     private readonly warningLog: WarningLog;
 
-    private TESTS_COMPILATION_UPPERBOUND: number;
+    private readonly TESTS_COMPILATION_UPPERBOUND: number;
 
-    public constructor (browserConnectionGateway: BrowserConnectionGateway, compilerService?: CompilerService) {
+    public constructor ({ browserConnectionGateway, compilerService }: BootstrapperInit) {
         this.browserConnectionGateway = browserConnectionGateway;
         this.concurrency              = 1;
         this.sources                  = [];
@@ -126,10 +126,9 @@ export default class Bootstrapper {
         this.compilerOptions          = void 0;
         this.debugLogger              = debug(DEBUG_SCOPE);
         this.warningLog               = new WarningLog();
+        this.compilerService          = compilerService;
 
         this.TESTS_COMPILATION_UPPERBOUND = 60;
-
-        this.compilerService = compilerService;
     }
 
     private static _getBrowserName (browser: BrowserInfoSource): string {

--- a/src/runner/interfaces.ts
+++ b/src/runner/interfaces.ts
@@ -3,6 +3,14 @@ import TestRun from '../test-run';
 import WarningLog from '../notifications/warning-log';
 import { Writable as WritableStream } from 'stream';
 import BrowserConnection from '../browser/connection';
+import BrowserConnectionGateway from '../browser/connection/gateway';
+import CompilerService from '../services/compiler/host';
+import Test from '../api/structure/test';
+import { Proxy } from 'testcafe-hammerhead';
+import { Dictionary } from '../configuration/interfaces';
+import FixtureHookController from './fixture-hook-controller';
+import Screenshots from '../screenshots';
+import Capturer from '../screenshots/capturer';
 
 export interface ActionEventArg {
     apiActionName: string;
@@ -38,3 +46,48 @@ export interface ReporterInit {
 }
 
 export type BrowserInit = string | object | BrowserConnection;
+
+export interface BootstrapperInit {
+    browserConnectionGateway: BrowserConnectionGateway;
+    compilerService?: CompilerService;
+}
+
+export interface BrowserJobInit {
+    tests: Test[];
+    browserConnections: BrowserConnection[];
+    proxy: Proxy;
+    screenshots: Screenshots;
+    warningLog: WarningLog;
+    fixtureHookController: FixtureHookController;
+    opts: Dictionary<OptionValue>;
+    compilerService?: CompilerService;
+}
+
+export interface TaskInit {
+    tests: Test[];
+    browserConnectionGroups: BrowserConnection[][];
+    proxy: Proxy;
+    opts: Dictionary<OptionValue>;
+    runnerWarningLog: WarningLog;
+    compilerService?: CompilerService;
+}
+
+export interface TestRunControllerInit {
+    test: Test;
+    index: number;
+    proxy: Proxy;
+    screenshots: Screenshots;
+    warningLog: WarningLog;
+    fixtureHookController: FixtureHookController;
+    opts: Dictionary<OptionValue>;
+    compilerService?: CompilerService;
+}
+
+export interface TestRunInit {
+    test: Test;
+    browserConnection: BrowserConnection;
+    screenshotCapturer: Capturer;
+    globalWarningLog: WarningLog;
+    opts: Dictionary<OptionValue>;
+    compilerService?: CompilerService;
+}

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -10,8 +10,9 @@ import Screenshots from '../screenshots';
 import WarningLog from '../notifications/warning-log';
 import FixtureHookController from './fixture-hook-controller';
 import { Dictionary } from '../configuration/interfaces';
-import { ActionEventArg } from './interfaces';
+import { ActionEventArg, TestRunControllerInit } from './interfaces';
 import TestRunErrorFormattableAdapter from '../errors/test-run/formattable-adapter';
+import CompilerService from '../services/compiler/host';
 
 const QUARANTINE_THRESHOLD = 3;
 const DISCONNECT_THRESHOLD = 3;
@@ -83,13 +84,23 @@ export default class TestRunController extends AsyncEventEmitter {
     private readonly _testRunCtor: LegacyTestRun['constructor'] | TestRun['constructor'];
     public testRun: null | LegacyTestRun | TestRun;
     public done: boolean;
+    private readonly compilerService?: CompilerService;
 
-    public constructor (test: Test, index: number, proxy: Proxy, screenshots: Screenshots, warningLog: WarningLog, fixtureHookController: FixtureHookController, opts: Dictionary<OptionValue>) {
+    public constructor ({
+        test,
+        index,
+        proxy,
+        screenshots,
+        warningLog,
+        fixtureHookController,
+        opts,
+        compilerService
+    }: TestRunControllerInit) {
         super();
 
         this.test  = test;
         this.index = index;
-        this._opts  = opts;
+        this._opts = opts;
 
         this._proxy                 = proxy;
         this._screenshots           = screenshots;
@@ -99,9 +110,10 @@ export default class TestRunController extends AsyncEventEmitter {
         this._testRunCtor = TestRunController._getTestRunCtor(test, opts);
 
         this.testRun             = null;
-        this.done               = false;
+        this.done                = false;
         this._quarantine         = this._opts.quarantineMode ? new Quarantine() : null;
         this._disconnectionCount = 0;
+        this.compilerService     = compilerService;
     }
 
     private static _getTestRunCtor (test: Test, opts: Dictionary<OptionValue>): LegacyTestRun | TestRun {
@@ -115,7 +127,14 @@ export default class TestRunController extends AsyncEventEmitter {
         const screenshotCapturer = this._screenshots.createCapturerFor(this.test, this.index, this._quarantine, connection, this._warningLog);
         const TestRunCtor        = this._testRunCtor;
 
-        this.testRun = new TestRunCtor(this.test, connection, screenshotCapturer, this._warningLog, this._opts);
+        this.testRun = new TestRunCtor({
+            test:              this.test,
+            browserConnection: connection,
+            globalWarningLog:  this._warningLog,
+            opts:              this._opts,
+            compilerService:   this.compilerService,
+            screenshotCapturer
+        });
 
         this._screenshots.addTestRun(this.test, this.testRun);
 

--- a/src/services/compiler/service.ts
+++ b/src/services/compiler/service.ts
@@ -77,8 +77,14 @@ class CompilerService implements CompilerProtocol {
     }
 
     private _ensureTestRunProxy (testRunId: string, fixtureCtx: unknown): TestRunProxy {
-        if (!this.state.testRuns[testRunId])
-            this.state.testRuns[testRunId] = new TestRunProxy(this, testRunId, fixtureCtx, this.state.options);
+        if (!this.state.testRuns[testRunId]) {
+            this.state.testRuns[testRunId] = new TestRunProxy({
+                dispatcher: this,
+                id:         testRunId,
+                options:    this.state.options,
+                fixtureCtx
+            });
+        }
 
         return this.state.testRuns[testRunId];
     }

--- a/src/services/compiler/test-run-proxy.ts
+++ b/src/services/compiler/test-run-proxy.ts
@@ -11,7 +11,7 @@ import { Dictionary } from '../../configuration/interfaces';
 import COMMAND_TYPE from '../../test-run/commands/type';
 import CommandBase from '../../test-run/commands/base';
 import * as serviceCommands from '../../test-run/commands/service';
-
+import { TestRunProxyInit } from '../interfaces';
 
 class TestRunProxy {
     public readonly id: string;
@@ -24,7 +24,7 @@ class TestRunProxy {
     private readonly ctx: unknown;
     private readonly _options: Dictionary<OptionValue>;
 
-    public constructor (dispatcher: TestRunDispatcherProtocol, id: string, fixtureCtx: unknown, options: Dictionary<OptionValue>) {
+    public constructor ({ dispatcher, id, fixtureCtx, options }: TestRunProxyInit) {
         this.dispatcher = dispatcher;
 
         this.id = id;

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -1,0 +1,9 @@
+import { TestRunDispatcherProtocol } from './compiler/protocol';
+import { Dictionary } from '../configuration/interfaces';
+
+export interface TestRunProxyInit {
+    dispatcher: TestRunDispatcherProtocol;
+    id: string;
+    fixtureCtx: unknown;
+    options: Dictionary<OptionValue>;
+}

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -76,7 +76,7 @@ const CHILD_WINDOW_READY_TIMEOUT      = 30 * 1000;
 const ALL_DRIVER_TASKS_ADDED_TO_QUEUE_EVENT = 'all-driver-tasks-added-to-queue';
 
 export default class TestRun extends AsyncEventEmitter {
-    constructor (test, browserConnection, screenshotCapturer, globalWarningLog, opts) {
+    constructor ({ test, browserConnection, screenshotCapturer, globalWarningLog, opts, compilerService }) {
         super();
 
         this[testRunMarker] = true;
@@ -142,6 +142,7 @@ export default class TestRun extends AsyncEventEmitter {
         this.debugLogger = this.opts.debugLogger;
 
         this.observedCallsites = new ObservedCallsitesStorage();
+        this.compilerService   = compilerService;
 
         this._addInjectables();
         this._initRequestHooks();
@@ -200,7 +201,7 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     addRequestHook (hook) {
-        if (this.requestHooks.indexOf(hook) !== -1)
+        if (this.requestHooks.includes(hook))
             return;
 
         this.requestHooks.push(hook);
@@ -208,7 +209,7 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     removeRequestHook (hook) {
-        if (this.requestHooks.indexOf(hook) === -1)
+        if (!this.requestHooks.includes(hook))
             return;
 
         pull(this.requestHooks, hook);

--- a/src/testcafe.js
+++ b/src/testcafe.js
@@ -72,7 +72,12 @@ export default class TestCafe {
 
     _createRunner (isLiveMode) {
         const Ctor      = isLiveMode ? LiveModeRunner : Runner;
-        const newRunner = new Ctor(this.proxy, this.browserConnectionGateway, this.configuration.clone(), this.compilerService);
+        const newRunner = new Ctor({
+            proxy:                    this.proxy,
+            browserConnectionGateway: this.browserConnectionGateway,
+            configuration:            this.configuration.clone(),
+            compilerService:          this.compilerService
+        });
 
         this.runners.push(newRunner);
 

--- a/test/functional/fixtures/live/test.js
+++ b/test/functional/fixtures/live/test.js
@@ -46,7 +46,11 @@ class RunnerMock extends LiveModeRunner {
 function createLiveModeRunner (tc, src, browsers = DEFAULT_BROWSERS) {
     const { proxy, browserConnectionGateway, configuration } = tc;
 
-    const runner = new RunnerMock(proxy, browserConnectionGateway, configuration.clone());
+    const runner = new RunnerMock({
+        proxy,
+        browserConnectionGateway,
+        configuration: configuration.clone()
+    });
 
     tc.runners.push(runner);
 

--- a/test/server/bootstrapper-test.js
+++ b/test/server/bootstrapper-test.js
@@ -37,7 +37,7 @@ function setupBootstrapper () {
         getTests: () => [ new Test({ currentFixture: void 0 }) ]
     };
 
-    return new BootstrapperMock(browserConnectionGateway, compilerService);
+    return new BootstrapperMock({ browserConnectionGateway, compilerService });
 }
 
 describe('Bootstrapper', () => {
@@ -148,7 +148,7 @@ describe('Bootstrapper', () => {
                 }
             };
 
-            const bootstrapper = new Bootstrapper(browserConnectionGateway, compilerService);
+            const bootstrapper = new Bootstrapper({ browserConnectionGateway, compilerService });
 
             bootstrapper.browserInitTimeout           = 100;
             bootstrapper.TESTS_COMPILATION_UPPERBOUND = 0;

--- a/test/server/browser-job-test.js
+++ b/test/server/browser-job-test.js
@@ -1,10 +1,21 @@
-const expect     = require('chai').expect;
+const { expect } = require('chai');
+const { noop }   = require('lodash');
 const BrowserJob = require('../../lib/runner/browser-job');
 
 describe('Browser Job', function () {
     it('TestRunController events', function () {
-        const tests             = [1];
-        const job               = new BrowserJob(tests, [], null, null, null, null, { TestRunCtor: function () { } });
+        const tests = [1];
+
+        const job = new BrowserJob({
+            tests,
+            browserConnections:    [],
+            proxy:                 null,
+            screenshots:           null,
+            warningLog:            null,
+            fixtureHookController: null,
+            opts:                  { TestRunCtor: noop }
+        });
+
         const testRunController = job._testRunControllerQueue[0];
 
         expect(testRunController.listenerCount()).eql(8);

--- a/test/server/capturer-test.js
+++ b/test/server/capturer-test.js
@@ -68,9 +68,9 @@ describe('Capturer', () => {
             _screenshots: screenshots,
             test:         { fixture: {} },
             emit:         () => { },
-            _testRunCtor: function (test, connection) {
+            _testRunCtor: function ({ browserConnection }) {
                 this.id                = 'test-run-id';
-                this.browserConnection = connection;
+                this.browserConnection = browserConnection;
             }
         };
 

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -46,7 +46,13 @@ class TestRunMock extends TestRun {
     }
 
     constructor (expectedError) {
-        super({}, {}, {}, {}, {});
+        super({
+            test:               {},
+            browserConnection:  {},
+            screenshotCapturer: {},
+            globalWarningLog:   {},
+            opts:               {}
+        });
 
         this.expectedError = expectedError;
         this.commands = [];

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -342,7 +342,7 @@ describe('TestCafeConfiguration', function () {
 
             return configuration.init()
                 .then(() => {
-                    runner = new RunnerCtor(null, null, configuration);
+                    runner = new RunnerCtor({ configuration });
 
                     runner
                         .tsConfigPath('path-to-ts-config')
@@ -362,7 +362,7 @@ describe('TestCafeConfiguration', function () {
 
             return configuration.init()
                 .then(() => {
-                    runner = new RunnerCtor(null, null, configuration);
+                    runner = new RunnerCtor({ configuration });
 
                     runner
                         .tsConfigPath('path-to-ts-config')
@@ -383,7 +383,7 @@ describe('TestCafeConfiguration', function () {
 
             return configuration.init()
                 .then(() => {
-                    runner = new RunnerCtor(null, null, configuration);
+                    runner = new RunnerCtor({ configuration });
 
                     runner
                         .tsConfigPath('path-to-ts-config')
@@ -580,7 +580,7 @@ describe('TypeScriptConfiguration', function () {
 
             return configuration.init()
                 .then(() => {
-                    runner = new RunnerCtor(null, null, configuration);
+                    runner = new RunnerCtor({ configuration });
 
                     runner.src('test/server/data/test-suites/typescript-basic/testfile1.ts');
                     runner._setBootstrapperOptions();
@@ -606,7 +606,7 @@ describe('TypeScriptConfiguration', function () {
                     }
                 });
 
-                runner = new RunnerCtor(null, null, new TestCafeConfiguration());
+                runner = new RunnerCtor({ configuration: new TestCafeConfiguration() });
 
                 runner.src('test/server/data/test-suites/typescript-basic/testfile1.ts');
                 runner.tsConfigPath(customTSConfigFilePath);
@@ -622,7 +622,7 @@ describe('TypeScriptConfiguration', function () {
             });
 
             it('Custom compiler options', () => {
-                const runner = new RunnerCtor(null, null, new TestCafeConfiguration());
+                const runner = new RunnerCtor({ configuration: new TestCafeConfiguration() });
 
                 runner
                     .src('test/server/data/test-suites/typescript-basic/testfile1.ts')

--- a/test/server/error-handle-test.js
+++ b/test/server/error-handle-test.js
@@ -1,5 +1,5 @@
 const EventEmitter        = require('events');
-const expect              = require('chai').expect;
+const { expect }          = require('chai');
 const { TEST_RUN_ERRORS } = require('../../lib/errors/types');
 const handleErrors        = require('../../lib/utils/handle-errors');
 const TestController      = require('../../lib/api/test-controller');
@@ -8,6 +8,16 @@ const Runner              = require('../../lib/runner');
 const AsyncEventEmitter   = require('../../lib/utils/async-event-emitter');
 const delay               = require('../../lib/utils/delay');
 const semver              = require('semver');
+
+class ConfigurationMock {
+    getOption () {
+        return null;
+    }
+
+    getOptions () {
+        return {};
+    }
+}
 
 class TaskMock extends AsyncEventEmitter {
     constructor () {
@@ -27,16 +37,7 @@ class BrowserSetMock extends EventEmitter {
 
 class RunnerMock extends Runner {
     constructor () {
-        super();
-
-        this.configuration = {
-            getOption: () => {
-                return null;
-            },
-            getOptions: () => {
-                return {};
-            }
-        };
+        super({ configuration: new ConfigurationMock() });
     }
 
     _createTask () {
@@ -167,7 +168,11 @@ describe('Global error handlers', () => {
     it('Should add error to multiple tests of same task', async () => {
         const runner = new RunnerMock();
 
-        const { completionPromise } = runner._runTask([], new BrowserSetMock(), null, null);
+        const { completionPromise } = runner._runTask({
+            reporterPlugins: [],
+            browserSet:      new BrowserSetMock(),
+            testedApp:       null
+        });
 
         const testRunMock1 = new TestRunMock(1);
         const testRunMock2 = new TestRunMock(2);

--- a/test/server/execute-async-expression-test.js
+++ b/test/server/execute-async-expression-test.js
@@ -27,7 +27,13 @@ class TestRunMock extends TestRun {
     }
 
     constructor () {
-        super({ name: 'Test', testFile: { filename: __filename } }, {}, {}, {}, {});
+        super({
+            test:               { name: 'Test', testFile: { filename: __filename } },
+            browserConnection:  {},
+            screenshotCapturer: {},
+            globalWarningLog:   {},
+            opts:               {}
+        });
 
         this.debugLog        = { command: noop };
         this.controller      = new TestController(this);
@@ -208,9 +214,9 @@ describe('Code steps', () => {
                     resolve('hooray!');
                 }, 20);
             });
-            
+
             const result = await promise;
-            
+
             return result;
         `)
             .then(result => {
@@ -247,7 +253,7 @@ describe('Code steps', () => {
             clearTimeout(timeout);
             clearImmediate(immediate);
             clearInterval(interval);
-            
+
             return { __dirname, __filename };
         `);
 

--- a/test/server/live-test.js
+++ b/test/server/live-test.js
@@ -21,6 +21,10 @@ const externalCommonJsModulePath = path.resolve('test/server/data/test-suites/li
 
 const DOCKER_TESTCAFE_FOLDER_REGEXP = /^\/usr\/lib\/node_modules\/testcafe/;
 
+const browserSetMock = {
+    browserConnectionGroups: []
+};
+
 class FileWatcherMock extends FileWatcher {
     addFile (controller, file) {
         if (!FileWatcher.shouldWatchFile(file.replace(DOCKER_TESTCAFE_FOLDER_REGEXP, '')))
@@ -75,7 +79,7 @@ class BootstrapperMock extends LiveModeBootstrapper {
         return Promise.resolve({
             reporterPlugins:     [],
             tests:               [],
-            browserSet:          {},
+            browserSet:          browserSetMock,
             testedApp:           {},
             commonClientScripts: []
         });
@@ -84,7 +88,11 @@ class BootstrapperMock extends LiveModeBootstrapper {
 
 class RunnerMock extends LiveModeRunner {
     constructor ({ proxy, browserConnectionGateway, configuration }, { runTimeout = 0, errorOnValidate = false, onBootstrapDone = noop }) {
-        super(proxy, browserConnectionGateway, configuration.clone());
+        super({
+            proxy,
+            browserConnectionGateway,
+            configuration: configuration.clone()
+        });
 
         this.runCount        = 0;
         this.runTimeout      = runTimeout;

--- a/test/server/multiple-windows-test.js
+++ b/test/server/multiple-windows-test.js
@@ -5,12 +5,13 @@ const { TEST_RUN_ERRORS } = require('../../lib/errors/types');
 
 class TestRunMock extends TestRun {
     constructor ({ activeWindowId = 'id', disableMultipleWindows = false, isLegacy = false } = {}) {
-        super(
-            { id: 'test-id', name: 'test-name', isLegacy: isLegacy, fixture: { path: 'dummy', id: 'fixture-id', name: 'fixture-name' } },
-            { activeWindowId: activeWindowId },
-            {},
-            {},
-            { disableMultipleWindows: disableMultipleWindows });
+        super({
+            test:               { id: 'test-id', name: 'test-name', isLegacy: isLegacy, fixture: { path: 'dummy', id: 'fixture-id', name: 'fixture-name' } },
+            browserConnection:  { activeWindowId: activeWindowId },
+            screenshotCapturer: {},
+            globalWarningLog:   {},
+            opts:               { disableMultipleWindows: disableMultipleWindows }
+        });
     }
 
     _addInjectables () {

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -409,7 +409,13 @@ describe('Reporter', () => {
 
     class TaskMock extends Task {
         constructor () {
-            super(testMocks, chunk(browserConnectionMocks, 1), {}, taskOptions, new WarningLog());
+            super({
+                tests:                   testMocks,
+                browserConnectionGroups: chunk(browserConnectionMocks, 1),
+                proxy:                   {},
+                opts:                    taskOptions,
+                runnerWarningLog:        new WarningLog()
+            });
 
             this.screenshots = new ScreenshotsMock();
 

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -154,8 +154,8 @@ describe('Runner', () => {
         it('Should fallback to the default reporter if reporter was not set', () => {
             const storedRunTaskFn = runner._runTask;
 
-            runner._runTask = reporters => {
-                const reporterPlugin = reporters[0].plugin;
+            runner._runTask = ({ reporterPlugins }) => {
+                const reporterPlugin = reporterPlugins[0].plugin;
 
                 expect(reporterPlugin.reportFixtureStart).to.be.a('function');
                 expect(reporterPlugin.reportTestDone).to.be.a('function');
@@ -455,10 +455,12 @@ describe('Runner', () => {
             runner.bootstrapper._getBrowserConnections = () => {
                 runner.bootstrapper._getBrowserConnections = storedGetBrowserConnectionsFn;
 
-                return Promise.resolve();
+                return Promise.resolve({
+                    browserConnectionGroups: []
+                });
             };
 
-            runner._runTask = (reporterPlugin, browserSet, tests) => {
+            runner._runTask = ({ tests }) => {
                 const actualFiles = uniqBy(tests.map(test => test.testFile.filename));
 
                 expect(actualFiles).eql(expectedFiles);
@@ -536,7 +538,7 @@ describe('Runner', () => {
 
             runner.filter(filterFn);
 
-            runner._runTask = (reporterPlugin, browserSet, tests) => {
+            runner._runTask = ({ tests }) => {
                 const actualTestNames = tests.map(test =>test.name).sort();
 
                 expectedTestNames = expectedTestNames.sort();

--- a/test/server/test-controller-events-test.js
+++ b/test/server/test-controller-events-test.js
@@ -1,4 +1,5 @@
-const expect                         = require('chai').expect;
+const { expect }                     = require('chai');
+const { noop }                       = require('lodash');
 const AsyncEventEmitter              = require('../../lib/utils/async-event-emitter');
 const delay                          = require('../../lib/utils/delay');
 const TestRun                        = require('../../lib/test-run');
@@ -11,7 +12,13 @@ const TestRunErrorFormattableAdapter = require('../../lib/errors/test-run/format
 
 class TestRunMock extends TestRun {
     constructor () {
-        super({ id: 'test-id', name: 'test-name', fixture: { path: 'dummy', id: 'fixture-id', name: 'fixture-name' } }, {}, {}, null, {});
+        super({
+            test:               { id: 'test-id', name: 'test-name', fixture: { path: 'dummy', id: 'fixture-id', name: 'fixture-name' } },
+            browserConnection:  {},
+            screenshotCapturer: {},
+            globalWarningLog:   { addPlainMessage: noop },
+            opts:               {}
+        });
 
         this.disableMultipleWindows = false;
 
@@ -140,7 +147,16 @@ const initializeReporter = (reporter) => {
 
 describe('TestController action events', () => {
     beforeEach(() => {
-        const job               = new BrowserJob([], [], void 0, void 0, void 0, void 0, { TestRunCtor: TestRunMock });
+        const job = new BrowserJob({
+            tests:                 [],
+            browserConnections:    [],
+            proxy:                 null,
+            screenshots:           null,
+            warningLog:            null,
+            fixtureHookController: null,
+            opts:                  { TestRunCtor: TestRunMock }
+        });
+
         const testRunController = job._createTestRunController();
         const testRun           = new TestRunMock();
 

--- a/test/server/test-controller-test.js
+++ b/test/server/test-controller-test.js
@@ -17,7 +17,13 @@ class TestRunMock extends TestRun {
     _initRequestHooks () {}
 
     constructor (reason) {
-        super({}, {}, {}, {}, {});
+        super({
+            test:               {},
+            browserConnection:  {},
+            screenshotCapturer: {},
+            globalWarningLog:   {},
+            opts:               {}
+        });
 
         this.errors = [];
         this.reason = reason;

--- a/test/server/test-run-request-handler-test.js
+++ b/test/server/test-run-request-handler-test.js
@@ -2,7 +2,7 @@ const TestRun = require('../../lib/test-run/index');
 const delay   = require('../../lib/utils/delay');
 
 describe('Request handling', () => {
-    it('Should abort request if it\'s longer than 3s', function () {
+    it("Should abort request if it's longer than 3s", function () {
         this.timeout(4000);
 
         const testMock = {
@@ -11,7 +11,13 @@ describe('Request handling', () => {
             requestHooks:  []
         };
 
-        const testRun = new TestRun(testMock, {}, null, null, {});
+        const testRun = new TestRun({
+            test:               testMock,
+            browserConnection:  {},
+            screenshotCapturer: {},
+            globalWarningLog:   {},
+            opts:               {}
+        });
 
         const handleRequestPromise = testRun.ready({ status: { id: 1, consoleMessages: [] } });
 

--- a/test/server/test-run-tracker-test.js
+++ b/test/server/test-run-tracker-test.js
@@ -19,7 +19,13 @@ class TestRunMock extends TestRun {
     }
 
     constructor () {
-        super({}, {}, {}, {}, {});
+        super({
+            test:               {},
+            browserConnection:  {},
+            screenshotCapturer: {},
+            globalWarningLog:   {},
+            opts:               {}
+        });
     }
 }
 


### PR DESCRIPTION
Changes:
* Combine multiple constructor parameters to a single object for `Bootstrapper`, `BrowserJob`, `Runner`, and etc. classes.
* Pass `compilerService` to the `TestRun` class.