### PR TITLE
Refactor request hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "19.5.0",
+    "testcafe-hammerhead": "20.0.0",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -130,11 +130,7 @@
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
     "testcafe-hammerhead": "20.0.0",
-<<<<<<< HEAD
     "testcafe-legacy-api": "5.0.0",
-=======
-    "testcafe-legacy-api": "4.2.5",
->>>>>>> 8048a0b4... update hammerhead
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",
     "testcafe-reporter-minimal": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,11 @@
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
     "testcafe-hammerhead": "20.0.0",
+<<<<<<< HEAD
     "testcafe-legacy-api": "5.0.0",
+=======
+    "testcafe-legacy-api": "4.2.5",
+>>>>>>> 8048a0b4... update hammerhead
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",
     "testcafe-reporter-minimal": "^2.1.0",

--- a/src/api/request-hooks/hook.ts
+++ b/src/api/request-hooks/hook.ts
@@ -13,15 +13,15 @@ import WarningLog from '../../notifications/warning-log';
 
 
 export default abstract class RequestHook {
-    protected requestFilterRules: RequestFilterRuleInit[];
+    public _requestFilterRules: RequestFilterRuleInit[];
     private readonly _responseEventConfigureOpts?: ConfigureResponseEventOptions;
-    protected warningLog: WarningLog | null;
+    public _warningLog: WarningLog | null;
     public id: string;
 
     protected constructor (ruleInit?: RequestFilterRuleInit | RequestFilterRuleInit[], responseEventConfigureOpts?: ConfigureResponseEventOptions) {
-        this.requestFilterRules          = this._prepareRules(ruleInit);
+        this._requestFilterRules         = this._prepareRules(ruleInit);
         this._responseEventConfigureOpts = responseEventConfigureOpts;
-        this.warningLog                  = null;
+        this._warningLog                 = null;
         this.id                          = generateUniqueId();
     }
 

--- a/src/api/request-hooks/hook.ts
+++ b/src/api/request-hooks/hook.ts
@@ -1,49 +1,37 @@
 import {
-    RequestFilterRule,
     ConfigureResponseEvent,
     ConfigureResponseEventOptions,
     RequestEvent,
     ResponseEvent,
+    RequestFilterRule,
+    RequestFilterRuleInit,
     generateUniqueId
 } from 'testcafe-hammerhead';
 
-import { castArray } from 'lodash';
 import { RequestHookNotImplementedMethodError } from '../../errors/test-run';
-import { RequestFilterRuleInit } from './interfaces';
 import WarningLog from '../../notifications/warning-log';
 
 
 export default abstract class RequestHook {
     protected requestFilterRules: RequestFilterRuleInit[];
-    private _instantiatedRequestFilterRules: RequestFilterRule[];
     private readonly _responseEventConfigureOpts?: ConfigureResponseEventOptions;
     protected warningLog: WarningLog | null;
     public id: string;
 
-    protected constructor (requestFilterRules: RequestFilterRuleInit | RequestFilterRuleInit[] | undefined, responseEventConfigureOpts?: ConfigureResponseEventOptions) {
-        this.requestFilterRules              = this._prepareRequestFilterRules(requestFilterRules);
-        this._instantiatedRequestFilterRules = [];
-        this._responseEventConfigureOpts     = responseEventConfigureOpts;
-        this.id                              = generateUniqueId();
-
-        this.warningLog = null;
+    protected constructor (ruleInit?: RequestFilterRuleInit | RequestFilterRuleInit[], responseEventConfigureOpts?: ConfigureResponseEventOptions) {
+        this.requestFilterRules          = this._prepareRules(ruleInit);
+        this._responseEventConfigureOpts = responseEventConfigureOpts;
+        this.warningLog                  = null;
+        this.id                          = generateUniqueId();
     }
 
-    private _prepareRequestFilterRules (rules: RequestFilterRuleInit | RequestFilterRuleInit[] | undefined): RequestFilterRuleInit[] {
-        if (rules)
-            return castArray(rules);
+    private _prepareRules (ruleInit?: RequestFilterRuleInit | RequestFilterRuleInit[]): RequestFilterRule[] {
+        if (Array.isArray(ruleInit) && !ruleInit.length)
+            return [];
 
-        return [RequestFilterRule.ANY];
-    }
+        const rules = RequestFilterRule.from(ruleInit);
 
-    private _instantiateRequestFilterRules (): void {
-        this._instantiatedRequestFilterRules = [];
-
-        this.requestFilterRules.forEach(rule => {
-            const instantiatedRule = rule instanceof RequestFilterRule ? rule : new RequestFilterRule(rule);
-
-            this._instantiatedRequestFilterRules.push(instantiatedRule);
-        });
+        return !rules.length ? [RequestFilterRule.ANY] : rules;
     }
 
     protected async onRequest (event: RequestEvent): Promise<void> { // eslint-disable-line @typescript-eslint/no-unused-vars

--- a/src/api/request-hooks/interfaces.ts
+++ b/src/api/request-hooks/interfaces.ts
@@ -1,5 +1,3 @@
-export type RequestFilterRuleInit = unknown;
-
 export interface RequestHookLogOptions {
     logRequestHeaders: boolean;
     logRequestBody: boolean;

--- a/src/api/request-hooks/request-logger.ts
+++ b/src/api/request-hooks/request-logger.ts
@@ -1,7 +1,8 @@
 import {
     ConfigureResponseEventOptions,
     RequestEvent,
-    ResponseEvent
+    ResponseEvent,
+    RequestFilterRuleInit
 } from 'testcafe-hammerhead';
 
 import RequestHook from './hook';
@@ -12,7 +13,6 @@ import { APIError } from '../../errors/runtime';
 import { RUNTIME_ERRORS } from '../../errors/types';
 
 import {
-    RequestFilterRuleInit,
     RequestHookLogOptionsInit,
     RequestHookLogOptions
 } from './interfaces';
@@ -56,7 +56,7 @@ class RequestLoggerImplementation extends RequestHook {
     private readonly _options: RequestHookLogOptions;
     private _internalRequests: Dictionary<LoggedRequest>;
 
-    public constructor (requestFilterRuleInit: RequestFilterRuleInit | RequestFilterRuleInit[] | undefined, options: RequestHookLogOptionsInit) {
+    public constructor (requestFilterRuleInit?: RequestFilterRuleInit | RequestFilterRuleInit[], options?: RequestHookLogOptionsInit) {
         const effectiveOptions = Object.assign({}, DEFAULT_OPTIONS, options) as RequestHookLogOptions;
 
         RequestLoggerImplementation._assertLogOptions(effectiveOptions);

--- a/src/api/request-hooks/request-mock.ts
+++ b/src/api/request-hooks/request-mock.ts
@@ -4,13 +4,13 @@ import {
     ResponseMock,
     RequestEvent,
     ResponseEvent,
+    RequestFilterRuleInit,
     RequestFilterRule
 } from 'testcafe-hammerhead';
 
 import { APIError } from '../../errors/runtime';
 import { RUNTIME_ERRORS } from '../../errors/types';
 import WARNING_MESSAGE from '../../notifications/warning-message';
-import { RequestFilterRuleInit } from './interfaces';
 
 
 class RequestMock extends RequestHook {
@@ -54,6 +54,7 @@ class RequestMock extends RequestHook {
 
         this.requestFilterRules.push(rule);
         this._mocks.set(rule, mock);
+
         this._pendingRequestFilterRuleInit = null;
 
         return this;

--- a/src/api/request-hooks/request-mock.ts
+++ b/src/api/request-hooks/request-mock.ts
@@ -32,7 +32,7 @@ class RequestMock extends RequestHook {
 
     public async onResponse (event: ResponseEvent): Promise<void> {
         if (event.isSameOriginPolicyFailed)
-            this.warningLog?.addWarning(WARNING_MESSAGE.requestMockCORSValidationFailed, RequestMock.name, event._requestFilterRule);
+            this._warningLog?.addWarning(WARNING_MESSAGE.requestMockCORSValidationFailed, RequestMock.name, event._requestFilterRule);
     }
 
     // API
@@ -52,7 +52,7 @@ class RequestMock extends RequestHook {
         const mock = new ResponseMock(body, statusCode, headers);
         const rule = new RequestFilterRule(this._pendingRequestFilterRuleInit);
 
-        this.requestFilterRules.push(rule);
+        this._requestFilterRules.push(rule);
         this._mocks.set(rule, mock);
 
         this._pendingRequestFilterRuleInit = null;

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -48,6 +48,7 @@ export default class Runner extends EventEmitter {
         this.configuration       = configuration;
         this.isCli               = false;
         this.warningLog          = new WarningLog();
+        this.compilerService     = compilerService;
 
         this.apiMethodWasCalled = new FlagList([
             OPTION_NAMES.src,

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -219,8 +219,7 @@ export default class TestRun extends AsyncEventEmitter {
     _initRequestHook (hook) {
         hook.warningLog = this.warningLog;
 
-        hook._instantiateRequestFilterRules();
-        hook._instantiatedRequestFilterRules.forEach(rule => {
+        hook.requestFilterRules.forEach(rule => {
             this.session.addRequestEventListeners(rule, {
                 onRequest:           hook.onRequest.bind(hook),
                 onConfigureResponse: hook._onConfigureResponse.bind(hook),
@@ -245,7 +244,7 @@ export default class TestRun extends AsyncEventEmitter {
     _disposeRequestHook (hook) {
         hook.warningLog = null;
 
-        hook._instantiatedRequestFilterRules.forEach(rule => {
+        hook.requestFilterRules.forEach(rule => {
             this.session.removeRequestEventListeners(rule);
         });
     }

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -217,9 +217,9 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     _initRequestHook (hook) {
-        hook.warningLog = this.warningLog;
+        hook._warningLog = this.warningLog;
 
-        hook.requestFilterRules.forEach(rule => {
+        hook._requestFilterRules.forEach(rule => {
             this.session.addRequestEventListeners(rule, {
                 onRequest:           hook.onRequest.bind(hook),
                 onConfigureResponse: hook._onConfigureResponse.bind(hook),
@@ -242,9 +242,9 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     _disposeRequestHook (hook) {
-        hook.warningLog = null;
+        hook._warningLog = null;
 
-        hook.requestFilterRules.forEach(rule => {
+        hook._requestFilterRules.forEach(rule => {
             this.session.removeRequestEventListeners(rule);
         });
     }

--- a/test/server/custom-client-scripts-test.js
+++ b/test/server/custom-client-scripts-test.js
@@ -123,7 +123,10 @@ describe('Client scripts', () => {
 
             return script.load()
                 .then(() => {
-                    expect(script.page).eql(RequestFilterRule.ANY);
+                    const anyRequestFilterRule = RequestFilterRule.ANY;
+
+                    expect(script.page.options).eql(anyRequestFilterRule.options);
+                    expect(script.page.id).not.eql(anyRequestFilterRule.id);
                 });
         });
 

--- a/test/server/request-hooks-test.js
+++ b/test/server/request-hooks-test.js
@@ -223,23 +223,10 @@ describe('RequestMock', () => {
 
 describe('RequestHook', () => {
     it('Should handle any requests by default', () => {
-        const hook                          = new RequestHook();
-        const defaultHookRequestFilterRules = hook.requestFilterRules;
+        const hook = new RequestHook();
 
-        expect(defaultHookRequestFilterRules).to.deep.equal([RequestFilterRule.ANY]);
-    });
-
-    it('Should not duplicate instantiated filter rules between test runs (GH-2650)', () => {
-        const url  = 'http://example.com';
-        const hook = new RequestHook(url);
-
-        hook._instantiateRequestFilterRules();
-
-        expect(hook._instantiatedRequestFilterRules.length).eql(1);
-
-        hook._instantiateRequestFilterRules();
-
-        expect(hook._instantiatedRequestFilterRules.length).eql(1);
+        expect(hook.requestFilterRules.length).eql(1);
+        expect(hook.requestFilterRules[0].options).eql(RequestFilterRule.ANY.options);
     });
 
     it('Should have an identifier', () => {

--- a/test/server/request-hooks-test.js
+++ b/test/server/request-hooks-test.js
@@ -216,8 +216,8 @@ describe('RequestMock', () => {
             .onRequestTo('http://example.com')
             .respond();
 
-        expect(mock.requestFilterRules.length).eql(1);
-        expect(mock.requestFilterRules[0].options.url).eql('http://example.com');
+        expect(mock._requestFilterRules.length).eql(1);
+        expect(mock._requestFilterRules[0].options.url).eql('http://example.com');
     });
 });
 
@@ -225,8 +225,8 @@ describe('RequestHook', () => {
     it('Should handle any requests by default', () => {
         const hook = new RequestHook();
 
-        expect(hook.requestFilterRules.length).eql(1);
-        expect(hook.requestFilterRules[0].options).eql(RequestFilterRule.ANY.options);
+        expect(hook._requestFilterRules.length).eql(1);
+        expect(hook._requestFilterRules[0].options).eql(RequestFilterRule.ANY.options);
     });
 
     it('Should have an identifier', () => {


### PR DESCRIPTION
Changes:
* use the `RequestFilterRuleInit` class from the `testcafe-hammerhead` module
* refactor request hooks initialization