### PR TITLE
Don't create thumbnails by default

### DIFF
--- a/src/configuration/default-values.ts
+++ b/src/configuration/default-values.ts
@@ -15,9 +15,10 @@ export const DEFAULT_CONCURRENCY_VALUE = 1;
 
 export const DEFAULT_SOURCE_DIRECTORIES = ['tests', 'test'];
 
-export const DEFAULT_DEVELOPMENT_MODE = false;
-export const DEFAULT_RETRY_TEST_PAGES = false;
-export const DEFAULT_DISABLE_HTTP2    = false;
+export const DEFAULT_DEVELOPMENT_MODE      = false;
+export const DEFAULT_RETRY_TEST_PAGES      = false;
+export const DEFAULT_DISABLE_HTTP2         = false;
+export const DEFAULT_SCREENSHOT_THUMBNAILS = true;
 
 export const DEFAULT_TYPESCRIPT_COMPILER_OPTIONS: Dictionary<boolean | number> = {
     experimentalDecorators:  true,

--- a/src/configuration/screenshot-option-names.ts
+++ b/src/configuration/screenshot-option-names.ts
@@ -2,7 +2,8 @@ enum SCREENSHOT_OPTION_NAMES {
     path = 'path',
     takeOnFails = 'takeOnFails',
     pathPattern = 'pathPattern',
-    fullPage = 'fullPage'
+    fullPage = 'fullPage',
+    thumbnails = 'thumbnails'
 }
 
 export default SCREENSHOT_OPTION_NAMES;

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -18,6 +18,7 @@ import {
     DEFAULT_DEVELOPMENT_MODE,
     DEFAULT_RETRY_TEST_PAGES,
     DEFAULT_DISABLE_HTTP2,
+    DEFAULT_SCREENSHOT_THUMBNAILS,
     getDefaultCompilerOptions,
 } from './default-values';
 
@@ -196,12 +197,15 @@ export default class TestCafeConfiguration extends Configuration {
         filterOption.value = getFilterFn(filterOption.value) as Function;
     }
 
-    private _ensureScreenshotPath (): void {
+    private _ensureScreenshotOptions (): void {
         const path        = resolvePathRelativelyCwd(DEFAULT_SCREENSHOTS_DIRECTORY);
-        const screenshots = this._ensureOption(OPTION_NAMES.screenshots, {}, OptionSource.Configuration).value as Dictionary<string>;
+        const screenshots = this._ensureOption(OPTION_NAMES.screenshots, {}, OptionSource.Configuration).value as Dictionary<string|boolean>;
 
         if (!screenshots.path)
             screenshots.path = path;
+
+        if (screenshots.thumbnails === void 0)
+            screenshots.thumbnails = DEFAULT_SCREENSHOT_THUMBNAILS;
     }
 
     private _prepareReporters (): void {
@@ -236,7 +240,7 @@ export default class TestCafeConfiguration extends Configuration {
         this._ensureOptionWithValue(OPTION_NAMES.retryTestPages, DEFAULT_RETRY_TEST_PAGES, OptionSource.Configuration);
         this._ensureOptionWithValue(OPTION_NAMES.disableHttp2, DEFAULT_DISABLE_HTTP2, OptionSource.Configuration);
 
-        this._ensureScreenshotPath();
+        this._ensureScreenshotOptions();
     }
 
     private _prepareCompilerOptions (): void {

--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -5,6 +5,7 @@ interface ScreenshotOptionValue {
     takeOnFails?: boolean;
     pathPattern?: string;
     fullPage?: boolean;
+    thumbnails?: boolean;
 }
 
 interface QuarantineOptionValue {

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -601,12 +601,13 @@ export default class Runner extends EventEmitter {
 
     screenshots (...options) {
         let fullPage;
+        let thumbnails;
         let [path, takeOnFails, pathPattern] = options;
 
         if (options.length === 1 && options[0] && typeof options[0] === 'object')
-            ({ path, takeOnFails, pathPattern, fullPage } = options[0]);
+            ({ path, takeOnFails, pathPattern, fullPage, thumbnails } = options[0]);
 
-        this._options.screenshots = { path, takeOnFails, pathPattern, fullPage };
+        this._options.screenshots = { path, takeOnFails, pathPattern, fullPage, thumbnails };
 
         return this;
     }

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -59,13 +59,14 @@ export default class Task extends AsyncEventEmitter {
 
         runnerWarningLog.copyTo(this.warningLog);
 
-        const { path, pathPattern, fullPage } = this.opts.screenshots as ScreenshotOptionValue;
+        const { path, pathPattern, fullPage, thumbnails } = this.opts.screenshots as ScreenshotOptionValue;
 
         this.screenshots = new Screenshots({
             enabled: !this.opts.disableScreenshots,
             path,
             pathPattern,
             fullPage,
+            thumbnails,
         });
 
         this.fixtureHookController = new FixtureHookController(tests, browserConnectionGroups.length);

--- a/src/screenshots/capturer.js
+++ b/src/screenshots/capturer.js
@@ -20,7 +20,8 @@ import DEFAULT_SCREENSHOT_EXTENSION from './default-extension';
 
 
 export default class Capturer {
-    constructor (baseScreenshotsPath, testEntry, connection, pathPattern, fullPage, warningLog) {
+    // TODO: refactor to use dictionary
+    constructor (baseScreenshotsPath, testEntry, connection, pathPattern, fullPage, thumbnails, warningLog) {
         this.enabled             = !!baseScreenshotsPath;
         this.baseScreenshotsPath = baseScreenshotsPath;
         this.testEntry           = testEntry;
@@ -29,6 +30,7 @@ export default class Capturer {
         this.warningLog          = warningLog;
         this.pathPattern         = pathPattern;
         this.fullPage            = fullPage;
+        this.thumbnails          = thumbnails;
     }
 
     static _getDimensionWithoutScrollbar (fullDimension, documentDimension, bodyDimension) {
@@ -116,9 +118,11 @@ export default class Capturer {
         await this.provider.takeScreenshot(this.browserId, filePath, pageWidth, pageHeight, fullPage);
     }
 
-    async _capture (forError, { pageDimensions, cropDimensions, markSeed, customPath, fullPage } = {}) {
+    async _capture (forError, { pageDimensions, cropDimensions, markSeed, customPath, fullPage, thumbnails } = {}) {
         if (!this.enabled)
             return null;
+
+        thumbnails = thumbnails === void 0 ? this.thumbnails : thumbnails;
 
         const screenshotPath = customPath ? this._getCustomScreenshotPath(customPath) : this._getScreenshotPath(forError);
         const thumbnailPath  = this._getThumbnailPath(screenshotPath);
@@ -155,7 +159,8 @@ export default class Capturer {
             if (croppedImage)
                 await writePng(screenshotPath, croppedImage);
 
-            await generateThumbnail(screenshotPath, thumbnailPath);
+            if (thumbnails)
+                await generateThumbnail(screenshotPath, thumbnailPath);
         });
 
         const testRunId         = this.testEntry.testRuns[this.browserId].id;

--- a/src/screenshots/index.js
+++ b/src/screenshots/index.js
@@ -6,11 +6,12 @@ import getCommonPath from '../utils/get-common-path';
 import DEFAULT_SCREENSHOT_EXTENSION from './default-extension';
 
 export default class Screenshots {
-    constructor ({ enabled, path, pathPattern, fullPage }) {
+    constructor ({ enabled, path, pathPattern, fullPage, thumbnails }) {
         this.enabled            = enabled;
         this.screenshotsPath    = path;
         this.screenshotsPattern = pathPattern;
         this.fullPage           = fullPage;
+        this.thumbnails         = thumbnails;
         this.testEntries        = [];
         this.now                = moment();
     }
@@ -66,7 +67,7 @@ export default class Screenshots {
             parsedUserAgent:   connection.browserInfo.parsedUserAgent,
         });
 
-        return new Capturer(this.screenshotsPath, testEntry, connection, pathPattern, this.fullPage, warningLog);
+        return new Capturer(this.screenshotsPath, testEntry, connection, pathPattern, this.fullPage, this.thumbnails, warningLog);
     }
 
     addTestRun (test, testRun) {

--- a/src/test-run/browser-manipulation-queue.js
+++ b/src/test-run/browser-manipulation-queue.js
@@ -74,6 +74,7 @@ export default class BrowserManipulationQueue {
                     cropDimensions: driverMsg.cropDimensions,
                     markSeed:       command.markSeed,
                     fullPage:       command.fullPage,
+                    thumbnails:     command.thumbnails,
                 }));
 
             case COMMAND_TYPE.takeScreenshotOnFail:

--- a/src/test-run/commands/browser-manipulation.js
+++ b/src/test-run/commands/browser-manipulation.js
@@ -36,8 +36,8 @@ export class TakeScreenshotBaseCommand extends CommandBase {
 }
 
 export class TakeScreenshotCommand extends TakeScreenshotBaseCommand {
-    constructor (obj, testRun) {
-        super(obj, testRun, TYPE.takeScreenshot);
+    constructor (obj, testRun, validateProperties) {
+        super(obj, testRun, TYPE.takeScreenshot, validateProperties);
     }
 
     _getAssignableProperties () {

--- a/src/test-run/commands/browser-manipulation.js
+++ b/src/test-run/commands/browser-manipulation.js
@@ -44,6 +44,7 @@ export class TakeScreenshotCommand extends TakeScreenshotBaseCommand {
         return [
             { name: 'path', type: screenshotPathArgument, defaultValue: '' },
             { name: 'fullPage', type: booleanArgument, defaultValue: void 0 },
+            { name: 'thumbnails', type: booleanArgument, defaultValue: void 0 },
         ];
     }
 }

--- a/test/functional/fixtures/api/es-next/take-screenshot/test.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/test.js
@@ -53,6 +53,14 @@ describe('[API] t.takeScreenshot()', function () {
                 });
         });
 
+        it('Should not generate thumbnails to take a screenshot', function () {
+            return runTests('./testcafe-fixtures/take-screenshot.js', 'Take a screenshot without thumbnails', { setScreenshotPath: true })
+                .then(function () {
+                    expect(SCREENSHOT_PATH_MESSAGE_RE.test(testReport.screenshotPath)).eql(true);
+                    expect(assertionHelper.checkScreenshotsCreated({ forError: false, screenshotsCount: 1 })).eql(true);
+                });
+        });
+
         it('Should take a screenshot with a custom path (OS separator)', function () {
             return runTests('./testcafe-fixtures/take-screenshot.js', 'Take a screenshot with a custom path (OS separator)',
                 { setScreenshotPath: true })
@@ -126,9 +134,9 @@ describe('[API] t.takeScreenshot()', function () {
                 .catch(function (errs) {
                     expect(errs[0]).to.contains('The "path" argument is expected to be a non-empty string, but it was number.');
                     expect(errs[0]).to.contains(
-                        '38 |test(\'Incorrect action path argument\', async t => {' +
-                        ' > 39 |    await t.takeScreenshot(1); ' +
-                        '40 |});'
+                        '42 |test(\'Incorrect action path argument\', async t => {' +
+                        ' > 43 |    await t.takeScreenshot(1); ' +
+                        '44 |});'
                     );
                 });
         });
@@ -141,9 +149,9 @@ describe('[API] t.takeScreenshot()', function () {
                 .catch(function (errs) {
                     expect(errs[0]).to.contains('There are forbidden characters in the "path:with*forbidden|chars" screenshot path: ":" at index 4 "*" at index 9 "|" at index 19');
                     expect(errs[0]).to.contains(
-                        '42 |test(\'Forbidden characters in the path argument\', async t => {' +
-                        ' > 43 |    await t.takeScreenshot(\'path:with*forbidden|chars\'); ' +
-                        '44 |});'
+                        '46 |test(\'Forbidden characters in the path argument\', async t => {' +
+                        ' > 47 |    await t.takeScreenshot(\'path:with*forbidden|chars\'); ' +
+                        '48 |});'
                     );
                 });
         });

--- a/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-screenshot.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-screenshot.js
@@ -21,6 +21,10 @@ test('Take a screenshot', async t => {
         .takeScreenshot();
 });
 
+test('Take a screenshot without thumbnails', async t => {
+    await t.takeScreenshot({ thumbnails: false });
+});
+
 test('Take a screenshot with a custom path (OS separator)', async t => {
     const ua       = await getUserAgent();
     const parsedUA = parseUserAgent(ua);

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -183,6 +183,7 @@ describe('TestCafeConfiguration', function () {
                             'pathPattern': 'screenshot-path-pattern',
                             'takeOnFails': true,
                             'fullPage':    true,
+                            'thumbnails':  true,
                         },
                     });
 
@@ -194,6 +195,7 @@ describe('TestCafeConfiguration', function () {
                                     pathPattern: 'modified-pattern',
                                     takeOnFails: false,
                                     fullPage:    false,
+                                    thumbnails:  false,
                                 },
                             });
 
@@ -202,6 +204,7 @@ describe('TestCafeConfiguration', function () {
                                 pathPattern: 'modified-pattern',
                                 takeOnFails: false,
                                 fullPage:    false,
+                                thumbnails:  false,
                             });
 
                             expect(testCafeConfiguration._overriddenOptions).eql([
@@ -209,6 +212,7 @@ describe('TestCafeConfiguration', function () {
                                 'screenshots.pathPattern',
                                 'screenshots.takeOnFails',
                                 'screenshots.fullPage',
+                                'screenshots.thumbnails',
                             ]);
                         });
                 });
@@ -270,6 +274,7 @@ describe('TestCafeConfiguration', function () {
                             'pathPattern': 'screenshot-path-pattern-1',
                             'takeOnFails': true,
                             'fullPage':    true,
+                            'thumbnails':  true,
                         },
                         'screenshotPath':         'screenshot-path-2',
                         'screenshotPathPattern':  'screenshot-path-pattern-2',
@@ -285,6 +290,7 @@ describe('TestCafeConfiguration', function () {
                                 pathPattern: 'screenshot-path-pattern-1',
                                 takeOnFails: true,
                                 fullPage:    true,
+                                thumbnails:  true,
                             });
 
                             expect(testCafeConfiguration.getOption('screenshotPath')).eql('screenshot-path-2');

--- a/test/server/data/test-controller-reporter-expected/index.js
+++ b/test/server/data/test-controller-reporter-expected/index.js
@@ -416,6 +416,7 @@ module.exports = [
         command: {
             path:     'screenshotPath',
             fullPage: true,
+            thumbnails: undefined,
             type:     'take-screenshot',
         },
         test:    {


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Make thumbnails generation customizable when taking screenshots.
(By default, thumbnails are not generated when taking screenshots.)

## Approach
- Added thumbnails to Screenshot Options for the -s (--screenshots) command line flag. (e.g. `-s thumbnails=true`)
- Added the thumbnails parameter of the screenshots API method. (e.g. `takeScreenshot({thumbnails: true})`)

## References
resolved #1550 

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
