### PR TITLE
Improve data serialization between processes (main and service)

### DIFF
--- a/@types/replicator/index.d.ts
+++ b/@types/replicator/index.d.ts
@@ -1,0 +1,24 @@
+declare module 'replicator' {
+    export interface Transform {
+        type: string;
+        shouldTransform (type: string, val: unknown): boolean;
+        toSerializable (val: unknown): unknown;
+        fromSerializable (val: unknown): unknown;
+    }
+
+    interface Replicator {
+        removeTransforms(transforms: Transform | Transform[]): Replicator;
+        addTransforms(transforms: Transform | Transform[]): Replicator;
+        transforms: Transform[];
+        decode (val: unknown): unknown;
+        encode (val: unknown): string;
+    }
+
+    interface ReplicatorConstructor {
+        new (): Replicator;
+    }
+
+    const Replicator: ReplicatorConstructor;
+
+    export default Replicator;
+}

--- a/src/services/serialization/replicator/create-replicator.ts
+++ b/src/services/serialization/replicator/create-replicator.ts
@@ -1,0 +1,23 @@
+import Replicator, { Transform } from 'replicator';
+import CustomErrorTransform from './custom-error-transform';
+
+const DEFAULT_ERROR_TRANSFORM_TYPE = '[[Error]]';
+
+function getDefaultErrorTransform (replicator: Replicator): Transform | undefined {
+    return replicator.transforms.find(transform => {
+        return transform.type === DEFAULT_ERROR_TRANSFORM_TYPE;
+    });
+}
+
+export default function (): Replicator {
+    // We need to move the 'CustomErrorTransform' transform before the default transform for the 'Error' class
+    // to ensure the correct transformation order:
+    // TestCafe's and custom errors will be transformed by CustomErrorTransform, built-in errors - by the built-in replicator's transformer.
+    const replicator            = new Replicator();
+    const defaultErrorTransform = getDefaultErrorTransform(replicator) as Transform;
+    const customErrorTransform  = new CustomErrorTransform();
+
+    return replicator
+        .removeTransforms(defaultErrorTransform)
+        .addTransforms([customErrorTransform, defaultErrorTransform]);
+}

--- a/src/services/serialization/replicator/custom-error-transform.ts
+++ b/src/services/serialization/replicator/custom-error-transform.ts
@@ -1,11 +1,11 @@
 export default class CustomErrorTransform {
     public readonly type: string;
 
-    constructor() {
+    public constructor () {
         this.type = 'CustomError';
     }
 
-    private _isBuiltInError (type:string): boolean {
+    private _isBuiltInError (type: string): boolean {
         // @ts-ignore
         return !!global[type];
     }

--- a/src/services/serialization/replicator/custom-error-transform.ts
+++ b/src/services/serialization/replicator/custom-error-transform.ts
@@ -1,0 +1,31 @@
+export default class CustomErrorTransform {
+    public readonly type: string;
+
+    constructor() {
+        this.type = 'CustomError';
+    }
+
+    private _isBuiltInError (type:string): boolean {
+        // @ts-ignore
+        return !!global[type];
+    }
+
+    public shouldTransform (_: unknown, val: unknown): boolean {
+        // @ts-ignore
+        return val instanceof Error && (val.isTestCafeError || !this._isBuiltInError(val.name));
+    }
+
+    public toSerializable (err: Error): Error {
+        const errorData = Object.assign({}, err);
+
+        errorData.name    = errorData.name || err.name;
+        errorData.message = errorData.message || err.message;
+        errorData.stack   = errorData.stack || err.stack;
+
+        return errorData;
+    }
+
+    public fromSerializable (val: unknown): unknown {
+        return val;
+    }
+}

--- a/src/services/utils/ipc/proxy.ts
+++ b/src/services/utils/ipc/proxy.ts
@@ -49,20 +49,9 @@ export class IPCProxy extends EventEmitter {
                 if (item.callsite)
                     item.callsite = prerenderCallsite(item.callsite);
             }
-
-            return error;
         }
 
-        // NOTE: The properties of the 'Error' class lost during serialization using the 'JSON.stringify' way
-        // because they are not enumerable.
-        // We clone the object and copy these properties explicitly to mark these properties as enumerable.
-        const errorData = Object.assign({}, error);
-
-        errorData.name    = errorData.name || error.name;
-        errorData.message = errorData.message || error.message;
-        errorData.stack   = errorData.stack || error.stack;
-
-        return errorData;
+        return error;
     }
 
     private async _onRead (packet: IPCPacket): Promise<void> {

--- a/test/server/ipc-message-test.js
+++ b/test/server/ipc-message-test.js
@@ -82,8 +82,8 @@ describe('IPC Message', () => {
         const serializer = new smallMessage.MessageSerializer();
         const parser     = new smallMessage.MessageParser();
 
-        // NOTE: must be serialized to [Buffer('"A'), Buffer('BB'), Buffer('C"')];
-        const correctData = serializer.serialize('ABBC');
+        // NOTE: must be serialized to [Buffer('["'), Buffer('AC'), Buffer('"]')];
+        const correctData = serializer.serialize('AC');
 
         expect(correctData.length).equal(3);
 
@@ -95,5 +95,24 @@ describe('IPC Message', () => {
         expect(() => parser.parse(unexpectedHeadData)).throw('Cannot create an IPC message due to an unexpected IPC head packet.');
         expect(() => parser.parse(unexpectedBodyData)).throw('Cannot create an IPC message due to an unexpected IPC body packet.');
         expect(() => parser.parse(unexpectedTailData)).throw('Cannot create an IPC message due to an unexpected IPC tail packet.');
+    });
+
+    it('Should serialize messages with RegExp fields', () => {
+        const serializer = new MessageSerializer();
+        const parser     = new MessageParser();
+
+        const originMessage = {
+            id:   1,
+            type: 'text',
+            url:  new RegExp('.*', 'i')
+        };
+
+        const data          = serializer.serialize(originMessage);
+        const parsedMessage = parser.parse(data[0])[0];
+
+        expect(parsedMessage.id).equal(originMessage.id);
+        expect(parsedMessage.type).equal(originMessage.type);
+        expect(parsedMessage.url).be.instanceOf(RegExp);
+        expect(parsedMessage.url.toString()).eql(originMessage.url.toString());
     });
 });


### PR DESCRIPTION
Changes:
* use `replicator` to decode/encode data between processes.
* create transformer for custom errors. The built-in errors are processed by the built-in replicator's transfromer.
* add typings to the `replicator` module