### PR TITLE
fix: eliminate rollup warnings about parsing TypeScript code

### DIFF
--- a/src/client/rollup.config.js
+++ b/src/client/rollup.config.js
@@ -42,6 +42,9 @@ const CONFIG = CHUNK_NAMES.map(chunk => ({
     input:    chunk,
     external: Object.keys(GLOBALS(chunk)),
 
+    //NOTE: need to keep this to prevent rollup replacing this with undefined in TypeScript polyfills
+    context:  "window",
+
     output: {
         file:    path.join(TARGET_DIR, chunk),
         format:  'iife',
@@ -52,7 +55,6 @@ const CONFIG = CHUNK_NAMES.map(chunk => ({
     },
 
     plugins: [
-        inject({ Promise: 'pinkie' }),
         resolve(),
         alias({
             entries: [{
@@ -61,7 +63,10 @@ const CONFIG = CHUNK_NAMES.map(chunk => ({
             }]
         }),
         commonjs(),
-        typescript({ include: ['*.+(j|t)s', '**/*.+(j|t)s', '../**/*.+(j|t)s'] })
+        typescript({ include: ['*.+(j|t)s', '**/*.+(j|t)s', '../**/*.+(j|t)s'] }),
+
+        //NOTE: Need to keep this after the typescript plugin to allow using both async/await and TypeScript
+        inject({ Promise: 'pinkie' }),
     ]
 }));
 

--- a/src/client/rollup.config.js
+++ b/src/client/rollup.config.js
@@ -42,8 +42,8 @@ const CONFIG = CHUNK_NAMES.map(chunk => ({
     input:    chunk,
     external: Object.keys(GLOBALS(chunk)),
 
-    //NOTE: need to keep this to prevent rollup replacing this with undefined in TypeScript polyfills
-    context:  "window",
+    //NOTE: need to keep this to prevent rollup from generating warnings about replacing `this` in TypeScript polyfills
+    context: 'undefined',
 
     output: {
         file:    path.join(TARGET_DIR, chunk),

--- a/src/client/rollup.config.js
+++ b/src/client/rollup.config.js
@@ -43,7 +43,7 @@ const CONFIG = CHUNK_NAMES.map(chunk => ({
     external: Object.keys(GLOBALS(chunk)),
 
     //NOTE: need to keep this to prevent rollup from generating warnings about replacing `this` in TypeScript polyfills
-    context: 'undefined',
+    context: '(void 0)',
 
     output: {
         file:    path.join(TARGET_DIR, chunk),


### PR DESCRIPTION
Fixes these nasty warnings: https://travis-ci.com/github/DevExpress/testcafe/jobs/494041508#L282