### PR TITLE
Use rule.id in request mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/6222632/testcafe-hammerhead-20.2.0.zip",
+    "testcafe-hammerhead": "20.2.0",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "20.0.0",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/6222632/testcafe-hammerhead-20.2.0.zip",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/src/api/request-hooks/hook.ts
+++ b/src/api/request-hooks/hook.ts
@@ -13,7 +13,7 @@ import WarningLog from '../../notifications/warning-log';
 
 
 export default abstract class RequestHook {
-    public _requestFilterRules: RequestFilterRuleInit[];
+    public _requestFilterRules: RequestFilterRule[];
     private readonly _responseEventConfigureOpts?: ConfigureResponseEventOptions;
     public _warningLog: WarningLog | null;
     public id: string;

--- a/src/api/request-hooks/request-mock.ts
+++ b/src/api/request-hooks/request-mock.ts
@@ -15,7 +15,7 @@ import WARNING_MESSAGE from '../../notifications/warning-message';
 
 class RequestMock extends RequestHook {
     private _pendingRequestFilterRuleInit: null | RequestFilterRuleInit;
-    private _mocks: Map<RequestFilterRule, ResponseMock>;
+    private _mocks: Map<string, ResponseMock>;
 
     public constructor () {
         super([]);
@@ -25,7 +25,7 @@ class RequestMock extends RequestHook {
     }
 
     public async onRequest (event: RequestEvent): Promise<void> {
-        const mock = this._mocks.get(event._requestFilterRule) as ResponseMock;
+        const mock = this._mocks.get(event._requestFilterRule.id) as ResponseMock;
 
         event.setMock(mock);
     }
@@ -53,7 +53,7 @@ class RequestMock extends RequestHook {
         const rule = new RequestFilterRule(this._pendingRequestFilterRuleInit);
 
         this._requestFilterRules.push(rule);
-        this._mocks.set(rule, mock);
+        this._mocks.set(rule.id, mock);
 
         this._pendingRequestFilterRuleInit = null;
 

--- a/src/custom-client-scripts/client-script-init.ts
+++ b/src/custom-client-scripts/client-script-init.ts
@@ -1,9 +1,10 @@
-import { RequestFilterRule } from 'testcafe-hammerhead';
+import { RequestFilterRuleInit } from 'testcafe-hammerhead';
 
 interface ClientScriptInit {
     path: string;
     content: string;
-    page: RequestFilterRule;
+    module: string;
+    page: RequestFilterRuleInit;
 }
 
 //NOTE: https://github.com/Microsoft/TypeScript/issues/3194

--- a/src/custom-client-scripts/client-script.ts
+++ b/src/custom-client-scripts/client-script.ts
@@ -2,7 +2,6 @@ import { readFile } from '../utils/promisified-functions';
 import { GeneralError } from '../errors/runtime';
 import { RUNTIME_ERRORS } from '../errors/types';
 import { isAbsolute, join } from 'path';
-// @ts-ignore Could not find a declaration file for module 'testcafe-hammerhead'
 import { RequestFilterRule, generateUniqueId } from 'testcafe-hammerhead';
 import { createHash } from 'crypto';
 import ClientScriptInit from './client-script-init';
@@ -91,7 +90,7 @@ export default class ClientScript {
         else if (typeof this.init === 'string')
             await this._loadFromPath(this.init);
         else {
-            const { path: initPath, content: initContent, module: initModule, page: initPage } = this.init as ClientScript;
+            const { path: initPath, content: initContent, module: initModule, page: initPage } = this.init as ClientScriptInit;
 
             if (initPath && initContent || initPath && initModule || initContent && initModule)
                 throw new GeneralError(RUNTIME_ERRORS.clientScriptInitializerMultipleContentSources);
@@ -116,7 +115,7 @@ export default class ClientScript {
     }
 
     private _contentToString (): string {
-        let displayContent = '';
+        let displayContent;
 
         if (this.content.length <= CONTENT_STR_MAX_LENGTH - CONTENT_ELLIPSIS_STR.length)
             displayContent = this.content;


### PR DESCRIPTION
Changes:
* use `RequestFilterRule.id` inside of `RequestMock` class
* correct typings