### PR TITLE
`RequestEvent.setMock' method becomes asynchronous

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/6241991/testcafe-hammerhead-21.0.0.zip",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/6243355/testcafe-hammerhead-21.0.0.zip",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "20.2.0",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/6241991/testcafe-hammerhead-21.0.0.zip",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/6243521/testcafe-hammerhead-21.0.0.zip",
+    "testcafe-hammerhead": "21.0.0",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/6243355/testcafe-hammerhead-21.0.0.zip",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/6243521/testcafe-hammerhead-21.0.0.zip",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/src/api/request-hooks/hook.ts
+++ b/src/api/request-hooks/hook.ts
@@ -38,7 +38,7 @@ export default abstract class RequestHook {
         throw new RequestHookNotImplementedMethodError('onRequest', this.constructor.name);
     }
 
-    private _onConfigureResponse (event: ConfigureResponseEvent): void {
+    private async _onConfigureResponse (event: ConfigureResponseEvent): Promise<void> {
         if (!this._responseEventConfigureOpts)
             return;
 

--- a/src/api/request-hooks/request-mock.ts
+++ b/src/api/request-hooks/request-mock.ts
@@ -27,7 +27,7 @@ class RequestMock extends RequestHook {
     public async onRequest (event: RequestEvent): Promise<void> {
         const mock = this._mocks.get(event._requestFilterRule.id) as ResponseMock;
 
-        event.setMock(mock);
+        await event.setMock(mock);
     }
 
     public async onResponse (event: ResponseEvent): Promise<void> {

--- a/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/request-logger/api.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/request-logger/api.js
@@ -26,6 +26,5 @@ test
 
         await t
             .expect(logger.requests.length).eql(1)
-            .expect(logger.requests[0].request.url).eql(pageUrl)
-            .expect(logger.requests[0].response.statusCode).eql(304);
+            .expect(logger.requests[0].request.url).eql(pageUrl);
     });


### PR DESCRIPTION
Changes:
* `RequestEvent.setMock`, `RequestHook._onConfigureResponse` methods became asynchronous.
*  Remove one assertion from the `Request Logger -> API` test because in some environments browser responds with `200` HTTP status code instead of `304`. I do this to avoid conditional logic for the expected result. The test checks the API of the RequestLogger and doesn't connect with HTTP status codes.