### PR TITLE
t.dispatchEvent method

### DIFF
--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -49,7 +49,8 @@ import {
     ScrollCommand,
     ScrollByCommand,
     ScrollIntoViewCommand,
-    UseRoleCommand
+    UseRoleCommand,
+    DispatchEventCommand
 } from '../../test-run/commands/actions';
 
 import {
@@ -186,6 +187,10 @@ export default class TestController {
 
     _browser$getter () {
         return getBrowser(this.testRun.browserConnection);
+    }
+
+    _dispatchEvent$ (selector, eventName, options = {}) {
+        return this._enqueueCommand('dispatchEvent', DispatchEventCommand, { selector, eventName, options, relatedTarget: options.relatedTarget });
     }
 
     _click$ (selector, options) {

--- a/src/client/automation/index.js
+++ b/src/client/automation/index.js
@@ -1,4 +1,5 @@
 import hammerhead from './deps/hammerhead';
+import DispatchEventAutomation from './playback/dispatch-event';
 import ScrollAutomation from './playback/scroll';
 import ClickAutomation from './playback/click';
 import SelectChildClickAutomation from './playback/click/select-child';
@@ -30,6 +31,7 @@ import cursor from './cursor';
 
 const exports = {};
 
+exports.DispatchEvent         = DispatchEventAutomation;
 exports.Scroll                = ScrollAutomation;
 exports.Click                 = ClickAutomation;
 exports.SelectChildClick      = SelectChildClickAutomation;

--- a/src/client/automation/playback/dispatch-event.js
+++ b/src/client/automation/playback/dispatch-event.js
@@ -1,0 +1,93 @@
+import hammerhead from '../deps/hammerhead';
+
+const nativeMethods = hammerhead.nativeMethods;
+
+const MOUSE_EVENT_NAME_RE   = /^((mouse\w+)|((dbl)?click)|(contextmenu))$/;
+const DRAG_EVENT_NAME_RE    = /^((drag\w*)|(drop))$/;
+const KEY_EVENT_NAME_RE     = /^key\w+$/;
+const INPUT_EVENT_NAME_RE   = /^(before)?input$/;
+const FOCUS_EVENT_NAME_RE   = /^(blur|(focus(in|out)?))$/;
+const POINTER_EVENT_NAME_RE = /^pointer\w+/;
+
+const DEFAULT_MOUSE_EVENT_DETAIL_PROP_VALUE = {
+    click:     1,
+    dblclick:  2,
+    mousedown: 1,
+    mouseup:   1
+};
+
+// NOTE: default e.buttons for left button pressed
+const DEFAULT_BUTTONS_PARAMETER = 1;
+
+const EVENT_CTORS = {
+    MouseEvent:    'MouseEvent',
+    PointerEvent:  'PointerEvent',
+    KeyboardEvent: 'KeyboardEvent',
+    InputEvent:    'InputEvent',
+    FocusEvent:    'FocusEvent'
+};
+
+export default class DispatchEventAutomation {
+    constructor (element, eventName, options) {
+        this._element = element;
+        this._eventName = eventName;
+        this._options = options;
+    }
+
+    run () {
+        let {
+            bubbles,
+            cancelable,
+            detail,
+            view,
+            buttons
+        } = this._options;
+
+        bubbles    = bubbles !== false;
+        cancelable = cancelable !== false;
+        detail     = detail || DEFAULT_MOUSE_EVENT_DETAIL_PROP_VALUE[this._eventName];
+        view       = document.window;
+        buttons    = buttons === void 0 ? DEFAULT_BUTTONS_PARAMETER : buttons;
+
+        window.Object.assign(this._options, { bubbles, cancelable, detail, view, buttons });
+
+        const Ctor = DispatchEventAutomation._getEventCtorByEventType(this._eventName, this._options.eventConstructor);
+
+        if (Ctor)
+            this._element.dispatchEvent(new Ctor(this._eventName, this._options));
+    }
+
+    static _getEventCtorByEventType (eventName, eventConstructor) {
+        if (eventConstructor && typeof window[eventConstructor] === 'function') {
+            const Ctor = DispatchEventAutomation._getEventCtorFromNativeMethods(eventConstructor);
+
+            if (Ctor && typeof Ctor === 'function')
+                return Ctor;
+        }
+
+        if (MOUSE_EVENT_NAME_RE.test(eventName))
+            return DispatchEventAutomation._getEventCtorFromNativeMethods(EVENT_CTORS.MouseEvent);
+
+        if (DRAG_EVENT_NAME_RE.test(eventName))
+            return DispatchEventAutomation._getEventCtorFromNativeMethods(EVENT_CTORS.MouseEvent);
+
+        if (POINTER_EVENT_NAME_RE.test(eventName))
+            return DispatchEventAutomation._getEventCtorFromNativeMethods(EVENT_CTORS.PointerEvent);
+
+        if (KEY_EVENT_NAME_RE.test(eventName))
+            return DispatchEventAutomation._getEventCtorFromNativeMethods(EVENT_CTORS.KeyboardEvent);
+
+        if (INPUT_EVENT_NAME_RE.test(eventName))
+            return DispatchEventAutomation._getEventCtorFromNativeMethods(EVENT_CTORS.InputEvent);
+
+        if (FOCUS_EVENT_NAME_RE.test(eventName))
+            return DispatchEventAutomation._getEventCtorFromNativeMethods(EVENT_CTORS.FocusEvent);
+
+        return DispatchEventAutomation._getEventCtorFromNativeMethods('CustomEvent');
+    }
+
+    static _getEventCtorFromNativeMethods (eventCtor) {
+        return nativeMethods['Window' + eventCtor] || window[eventCtor];
+    }
+}
+

--- a/src/client/driver/command-executors/execute-action.js
+++ b/src/client/driver/command-executors/execute-action.js
@@ -11,6 +11,7 @@ import {
 
 import {
     calculateSelectTextArguments,
+    DispatchEvent as DispatchEventAutomation,
     Click as ClickAutomation,
     SelectChildClick as SelectChildClickAutomation,
     RClick as RClickAutomation,
@@ -147,6 +148,8 @@ class ActionExecutor {
             elementDescriptors.push(createAdditionalElementDescriptor(this.command.startSelector, 'startSelector'));
             elementDescriptors.push(createAdditionalElementDescriptor(this.command.endSelector || this.command.startSelector, 'endSelector'));
         }
+        else if (this.command.type === COMMAND_TYPE.dispatchEvent && this.command.relatedTarget)
+            elementDescriptors.push(createAdditionalElementDescriptor(this.command.relatedTarget, 'relatedTarget'));
 
         return ensureElements(elementDescriptors, this.globalSelectorTimeout)
             .then(elements => {
@@ -180,6 +183,11 @@ class ActionExecutor {
         let selectArgs = null;
 
         switch (this.command.type) {
+            case COMMAND_TYPE.dispatchEvent:
+                if (this.elements[1])
+                    this.command.options.relatedTarget = this.elements[1];
+
+                return new DispatchEventAutomation(this.elements[0], this.command.eventName, this.command.options);
             case COMMAND_TYPE.click :
                 if (/option|optgroup/.test(domUtils.getTagName(this.elements[0])))
                     return new SelectChildClickAutomation(this.elements[0], this.command.options);

--- a/src/test-run/commands/actions.js
+++ b/src/test-run/commands/actions.js
@@ -92,6 +92,21 @@ function initDialogHandler (name, val, { skipVisibilityCheck, testRun }) {
 }
 
 // Commands
+export class DispatchEventCommand extends CommandBase {
+    constructor (obj, testRun) {
+        super(obj, testRun, TYPE.dispatchEvent);
+    }
+
+    _getAssignableProperties () {
+        return [
+            { name: 'selector', init: initSelector, required: true },
+            { name: 'eventName', type: nonEmptyStringArgument, required: true },
+            { name: 'options', type: actionOptions },
+            { name: 'relatedTarget', init: initSelector, required: false }
+        ];
+    }
+}
+
 export class ClickCommand extends CommandBase {
     constructor (obj, testRun) {
         super(obj, testRun, TYPE.click);

--- a/src/test-run/commands/type.js
+++ b/src/test-run/commands/type.js
@@ -4,6 +4,7 @@
 // -------------------------------------------------------------
 
 export default {
+    dispatchEvent:              'dispatch-event',
     click:                      'click',
     rightClick:                 'right-click',
     doubleClick:                'double-click',

--- a/test/functional/fixtures/api/es-next/dispatch-event/pages/drag.html
+++ b/test/functional/fixtures/api/es-next/dispatch-event/pages/drag.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Dispatch Event</title>
+    <style>
+        body {
+            width: 2000px;
+            height: 2000px;
+        }
+
+        #target {
+            position: absolute;
+            top: 100px;
+            left: 100px;
+            width: 100px;
+            height: 100px;
+            background-color: red;
+        }
+    </style>
+</head>
+<body>
+<div id="target">drag me</div>
+
+<script>
+    var div = document.querySelector('div');
+
+    let isMoving = false;
+    let offsetX  = 0;
+    let offsetY  = 0;
+
+    div.addEventListener('mousedown', function (e) {
+        isMoving = true;
+
+        offsetX = e.offsetX;
+        offsetY = e.offsetY;
+    });
+
+    document.body.addEventListener('mousemove', function (e) {
+        if (!isMoving)
+            return;
+
+        div.style.top  = (e.clientY - offsetY) + 'px';
+        div.style.left = (e.clientX - offsetX) + 'px';
+    });
+
+    document.body.addEventListener('mouseup', function (e) {
+        isMoving = false;
+    });
+</script>
+</body>
+</html>

--- a/test/functional/fixtures/api/es-next/dispatch-event/pages/index.html
+++ b/test/functional/fixtures/api/es-next/dispatch-event/pages/index.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Dispatch event</title>
+</head>
+<body>
+<button>Click me</button>
+<input id="input1" type="text"/>
+<input id="input2" type="text"/>
+
+<script>
+    window.mouseLog = [];
+    window.keyboardLog = [];
+    window.inputLog = [];
+    window.focusLog = [];
+    window.pointerLog = [];
+
+    var btn   = document.querySelector('button');
+    var input = document.querySelector('#input1');
+
+    function mouseHandler (e) {
+        var res = {};
+
+        res.type       = e.type;
+        res.composed   = e.composed;
+        res.bubbles    = e.bubbles;
+        res.cancelable = e.cancelable;
+        res.detail     = e.detail;
+        res.altKey     = e.altKey;
+        res.ctrlKey    = e.ctrlKey;
+        res.shiftKey   = e.shiftKey;
+        res.metaKey    = e.metaKey;
+        res.screenX    = e.screenX;
+        res.screenY    = e.screenY;
+        res.clientX    = e.clientX;
+        res.clientY    = e.clientY;
+        res.button     = e.button;
+        res.buttons    = e.buttons;
+
+        window.mouseLog.push(res);
+    }
+
+    function keyboardHandler (e) {
+        var res = {};
+
+        res.type       = e.type;
+        res.composed   = e.composed;
+        res.bubbles    = e.bubbles;
+        res.cancelable = e.cancelable;
+        res.detail     = e.detail;
+        res.altKey     = e.altKey;
+        res.ctrlKey    = e.ctrlKey;
+        res.shiftKey   = e.shiftKey;
+        res.metaKey    = e.metaKey;
+        res.code       = e.code;
+        res.key        = e.key;
+        res.keyCode    = e.keyCode;
+
+        window.keyboardLog.push(res);
+    }
+
+    function inputHandler (e) {
+        var res = {};
+
+        res.type       = e.type;
+        res.composed   = e.composed;
+        res.bubbles    = e.bubbles;
+        res.cancelable = e.cancelable;
+        res.detail     = e.detail;
+        res.data       = e.data;
+        res.inputType  = e.inputType;
+
+        window.inputLog.push(res);
+    }
+
+    function focusHandler (e) {
+        var res = {};
+
+        res.type          = e.type;
+        res.composed      = e.composed;
+        res.bubbles       = e.bubbles;
+        res.cancelable    = e.cancelable;
+        res.detail        = e.detail;
+
+        if (e.relatedTarget)
+            res.relatedTarget = e.relatedTarget.id;
+
+        window.focusLog.push(res);
+    }
+
+    function pointerHandler (e) {
+        var res = {};
+
+        res.type               = e.type;
+        res.composed           = e.composed;
+        res.bubbles            = e.bubbles;
+        res.cancelable         = e.cancelable;
+        res.detail             = e.detail;
+        res.altKey             = e.altKey;
+        res.ctrlKey            = e.ctrlKey;
+        res.shiftKey           = e.shiftKey;
+        res.metaKey            = e.metaKey;
+        res.screenX            = e.screenX;
+        res.screenY            = e.screenY;
+        res.clientX            = e.clientX;
+        res.clientY            = e.clientY;
+        res.button             = e.button;
+        res.buttons            = e.buttons;
+        res.pointerId          = e.pointerId;
+        res.width              = e.width;
+        res.height             = e.height;
+        res.pressure           = e.pressure;
+        res.tangentialPressure = parseFloat(e.tangentialPressure.toFixed(1));
+        res.tiltX              = e.tiltX;
+        res.tiltY              = e.tiltY;
+        res.twist              = e.twist;
+        res.pointerType        = e.pointerType;
+        res.isPrimary          = e.isPrimary;
+
+        window.pointerLog.push(res);
+    }
+
+    btn.addEventListener('mousedown', mouseHandler);
+    btn.addEventListener('mouseup', mouseHandler);
+    btn.addEventListener('click', mouseHandler);
+
+    btn.addEventListener('customEvent', function (e) {
+        window.mouseLog.push({
+            isMouseEvent:  e instanceof MouseEvent,
+            isCustomEvent: e instanceof CustomEvent,
+            type:          e.type,
+            detail:        e.detail
+        });
+    });
+
+    input.addEventListener('keydown', keyboardHandler);
+    input.addEventListener('keypress', keyboardHandler);
+    input.addEventListener('keyup', keyboardHandler);
+
+    input.addEventListener('beforeinput', inputHandler);
+    input.addEventListener('input', inputHandler);
+
+    input.addEventListener('focus', focusHandler);
+    input.addEventListener('focusin', focusHandler);
+    input.addEventListener('focusout', focusHandler);
+    input.addEventListener('blur', focusHandler);
+
+    input.addEventListener('pointerover', pointerHandler);
+    input.addEventListener('pointerenter', pointerHandler);
+    input.addEventListener('pointerdown', pointerHandler);
+    input.addEventListener('pointermove', pointerHandler);
+    input.addEventListener('pointerrawupdate', pointerHandler);
+    input.addEventListener('pointerup', pointerHandler);
+    input.addEventListener('pointercancel', pointerHandler);
+    input.addEventListener('pointerout', pointerHandler);
+    input.addEventListener('pointerleave', pointerHandler);
+</script>
+</body>
+</html>

--- a/test/functional/fixtures/api/es-next/dispatch-event/test.js
+++ b/test/functional/fixtures/api/es-next/dispatch-event/test.js
@@ -1,10 +1,10 @@
 describe('[API] t.dispatchEvent()', function () {
     it('mouse', function () {
-        return runTests('testcafe-fixtures/index.js', 'mouse', { skip: 'ie' });
+        return runTests('testcafe-fixtures/index.js', 'mouse', { skip: ['ie', 'iphone'] });
     });
 
     it('keyboard', function () {
-        return runTests('testcafe-fixtures/index.js', 'keyboard', { skip: 'ie' });
+        return runTests('testcafe-fixtures/index.js', 'keyboard', { skip: ['ie', 'iphone'] });
     });
 
     it('input', function () {
@@ -16,11 +16,11 @@ describe('[API] t.dispatchEvent()', function () {
     });
 
     it('pointer', function () {
-        return runTests('testcafe-fixtures/index.js', 'pointer', { skip: 'ie' });
+        return runTests('testcafe-fixtures/index.js', 'pointer', { skip: ['ie', 'iphone', 'ipad', 'safari'] });
     });
 
     it('defaults', function () {
-        return runTests('testcafe-fixtures/index.js', 'defaults', { skip: 'ie' });
+        return runTests('testcafe-fixtures/index.js', 'defaults', { skip: ['ie', 'iphone'] });
     });
 
     it('predifined ctor', function () {

--- a/test/functional/fixtures/api/es-next/dispatch-event/test.js
+++ b/test/functional/fixtures/api/es-next/dispatch-event/test.js
@@ -1,0 +1,39 @@
+describe('[API] t.dispatchEvent()', function () {
+    it('mouse', function () {
+        return runTests('testcafe-fixtures/index.js', 'mouse', { skip: 'ie' });
+    });
+
+    it('keyboard', function () {
+        return runTests('testcafe-fixtures/index.js', 'keyboard', { skip: 'ie' });
+    });
+
+    it('input', function () {
+        return runTests('testcafe-fixtures/index.js', 'input', { skip: 'ie' });
+    });
+
+    it('focus', function () {
+        return runTests('testcafe-fixtures/index.js', 'focus', { skip: 'ie' });
+    });
+
+    it('pointer', function () {
+        return runTests('testcafe-fixtures/index.js', 'pointer', { skip: 'ie' });
+    });
+
+    it('defaults', function () {
+        return runTests('testcafe-fixtures/index.js', 'defaults', { skip: 'ie' });
+    });
+
+    it('predifined ctor', function () {
+        return runTests('testcafe-fixtures/index.js', 'predifined ctor', { skip: 'ie' });
+    });
+
+    it('custom event', function () {
+        return runTests('testcafe-fixtures/index.js', 'custom event', { skip: 'ie' });
+    });
+
+    it('simple drag', function () {
+        return runTests('testcafe-fixtures/index.js', 'simple drag', { skip: 'ie' });
+    });
+});
+
+

--- a/test/functional/fixtures/api/es-next/dispatch-event/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/api/es-next/dispatch-event/testcafe-fixtures/index.js
@@ -1,0 +1,243 @@
+import { Selector, ClientFunction } from 'testcafe';
+
+const btn         = Selector('button');
+const firstInput  = Selector('#input1');
+const secondInput = Selector('#input2');
+const div         = Selector('div');
+
+const getMouseLog    = ClientFunction(() => window.mouseLog);
+const getKeyboardLog = ClientFunction(() => window.keyboardLog);
+const getInputLog    = ClientFunction(() => window.inputLog);
+const getFocusLog    = ClientFunction(() => window.focusLog);
+const getPointerLog  = ClientFunction(() => window.pointerLog);
+
+const baseArgs = {
+    composed:   true,
+    bubbles:    false,
+    cancelable: true,
+    detail:     3,
+};
+
+const keyArgs = {
+    altKey:   true,
+    ctrlKey:  true,
+    shiftKey: true,
+    metaKey:  true
+};
+
+const mouseEventArgs = Object.assign({}, baseArgs, keyArgs, {
+    screenX: 1,
+    screenY: 2,
+    clientX: 3,
+    clientY: 4,
+    button:  1,
+    buttons: 3
+});
+
+const keyboardArgs = Object.assign({}, baseArgs, keyArgs, {
+    key:     'q',
+    keyCode: 82,
+    code:    'KeyT'
+});
+
+const inputArgs = Object.assign({}, baseArgs, {
+    data:      'test',
+    inputType: 'insertText'
+});
+
+const focusArgs = Object.assign({}, baseArgs, {
+    relatedTarget: secondInput
+});
+
+const pointerArgs = Object.assign({}, mouseEventArgs, {
+    pointerId:          777,
+    width:              11,
+    height:             12,
+    pressure:           0.5,
+    tangentialPressure: 0.6,
+    tiltX:              21,
+    tiltY:              22,
+    twist:              23,
+    pointerType:        'pen',
+    isPrimary:          true
+});
+
+function createExpectedMouseArgs (eventName) {
+    return Object.assign({
+        type: eventName,
+    }, mouseEventArgs);
+}
+
+function createExpectedPointerArgs (eventName) {
+    return Object.assign({
+        type: eventName
+    }, pointerArgs);
+}
+
+function createExpectedKeyboardArgs (eventName) {
+    return Object.assign({
+        type: eventName,
+    }, keyboardArgs);
+}
+
+function createExpectedInputArgs (eventName) {
+    return Object.assign({
+        type: eventName,
+    }, inputArgs);
+}
+
+function createExpectedFocusArgs (eventName, relatedTargetId) {
+    const result = Object.assign({
+        type: eventName,
+    }, focusArgs);
+
+    result.relatedTarget = relatedTargetId;
+
+    return result;
+}
+
+fixture `Dispatch Event`
+    .page `http://localhost:3000/fixtures/api/es-next/click/dispatch-event/index.html`;
+
+test(`mouse`, async t => {
+    await t.dispatchEvent(btn, 'mousedown', mouseEventArgs);
+    await t.dispatchEvent(btn, 'mouseup', mouseEventArgs);
+    await t.dispatchEvent(btn, 'click', mouseEventArgs);
+
+    await t.expect(getMouseLog()).eql([
+        createExpectedMouseArgs('mousedown'),
+        createExpectedMouseArgs('mouseup'),
+        createExpectedMouseArgs('click')
+    ]);
+});
+
+test(`keyboard`, async t => {
+    await t.dispatchEvent(firstInput, 'keypress', keyboardArgs);
+    await t.dispatchEvent(firstInput, 'keydown', keyboardArgs);
+    await t.dispatchEvent(firstInput, 'keyup', keyboardArgs);
+
+    await t.expect(getKeyboardLog()).eql([
+        createExpectedKeyboardArgs('keypress'),
+        createExpectedKeyboardArgs('keydown'),
+        createExpectedKeyboardArgs('keyup'),
+    ]);
+});
+
+test(`input`, async t => {
+    await t.dispatchEvent(firstInput, 'beforeinput', inputArgs);
+    await t.dispatchEvent(firstInput, 'input', inputArgs);
+
+    const args = [ createExpectedInputArgs('beforeinput'), createExpectedInputArgs('input') ];
+
+    // NOTE: Safari does not set the `inputType` option in `dispatchEvent` method.
+    if (t.browser.name === 'Safari') {
+        args.forEach(arg => {
+            arg.inputType = '';
+        });
+    }
+
+    await t.expect(getInputLog()).eql(args);
+});
+
+test(`focus`, async t => {
+    await t.dispatchEvent(firstInput, 'focus', focusArgs);
+    await t.dispatchEvent(firstInput, 'focusin', focusArgs);
+    await t.dispatchEvent(firstInput, 'focusout', focusArgs);
+    await t.dispatchEvent(firstInput, 'blur', focusArgs);
+
+    await t.expect(getFocusLog()).eql([
+        createExpectedFocusArgs('focus', 'input2'),
+        createExpectedFocusArgs('focusin', 'input2'),
+        createExpectedFocusArgs('focusout', 'input2'),
+        createExpectedFocusArgs('blur', 'input2')
+    ]);
+});
+
+test(`pointer`, async t => {
+    await t.dispatchEvent(firstInput, 'pointerover', pointerArgs);
+    await t.dispatchEvent(firstInput, 'pointerenter', pointerArgs);
+    await t.dispatchEvent(firstInput, 'pointerdown', pointerArgs);
+    await t.dispatchEvent(firstInput, 'pointermove', pointerArgs);
+    await t.dispatchEvent(firstInput, 'pointerrawupdate', pointerArgs);
+    await t.dispatchEvent(firstInput, 'pointerup', pointerArgs);
+    await t.dispatchEvent(firstInput, 'pointercancel', pointerArgs);
+    await t.dispatchEvent(firstInput, 'pointerout', pointerArgs);
+    await t.dispatchEvent(firstInput, 'pointerleave', pointerArgs);
+
+    await t.expect(getPointerLog()).eql([
+        createExpectedPointerArgs('pointerover'),
+        createExpectedPointerArgs('pointerenter'),
+        createExpectedPointerArgs('pointerdown'),
+        createExpectedPointerArgs('pointermove'),
+        createExpectedPointerArgs('pointerrawupdate'),
+        createExpectedPointerArgs('pointerup'),
+        createExpectedPointerArgs('pointercancel'),
+        createExpectedPointerArgs('pointerout'),
+        createExpectedPointerArgs('pointerleave')
+    ]);
+});
+
+test('defaults', async t => {
+    await t.dispatchEvent(btn, 'mousedown');
+
+    await t.dispatchEvent(btn, 'mousedown', {
+        bubbles:    false,
+        cancelable: false,
+        detail:     2,
+        button:     1,
+        buttons:    2
+    });
+
+    const log = await getMouseLog();
+
+    await t.expect(log[0].bubbles).eql(true);
+    await t.expect(log[0].cancelable).eql(true);
+    await t.expect(log[0].detail).eql(1);
+    await t.expect(log[0].button).eql(0);
+    await t.expect(log[0].buttons).eql(1);
+
+    await t.expect(log[1].bubbles).eql(false);
+    await t.expect(log[1].cancelable).eql(false);
+    await t.expect(log[1].detail).eql(2);
+    await t.expect(log[1].button).eql(1);
+    await t.expect(log[1].buttons).eql(2);
+});
+
+test('predifined ctor', async t => {
+    await t.dispatchEvent(btn, 'customEvent', { eventConstructor: 'MouseEvent' });
+
+    await t.expect(getMouseLog()).eql([{ isMouseEvent: true, isCustomEvent: false, detail: 0, type: 'customEvent' }]);
+});
+
+test('custom event', async t => {
+    await t.dispatchEvent(btn, 'customEvent', { detail: { data: 'testing' } });
+
+    await t.expect(getMouseLog()).eql([{
+        isMouseEvent:  false,
+        isCustomEvent: true,
+        type:          'customEvent',
+        detail:        { data: 'testing' }
+    }]);
+});
+
+test.page('../pages/drag.html')('simple drag', async t => {
+    let initialTop  = parseInt(await div.getStyleProperty('top'), 10);
+    let initialLeft = parseInt(await div.getStyleProperty('left'), 10);
+
+    await t.dispatchEvent(div, 'mousedown');
+
+    for (let i = 0; i < 10; i++) {
+        await t.dispatchEvent(div, 'mousemove', {
+            clientX: i * 10,
+            clientY: i * 20
+        });
+
+        await t.expect(parseInt(await div.getStyleProperty('top'), 10)).eql(initialTop);
+        await t.expect(parseInt(await div.getStyleProperty('left'), 10)).eql(initialLeft);
+
+        initialTop  += 20;
+        initialLeft += 10;
+    }
+
+    await t.dispatchEvent(div, 'mouseup');
+});

--- a/test/functional/fixtures/api/es-next/dispatch-event/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/api/es-next/dispatch-event/testcafe-fixtures/index.js
@@ -97,7 +97,7 @@ function createExpectedFocusArgs (eventName, relatedTargetId) {
 }
 
 fixture `Dispatch Event`
-    .page `http://localhost:3000/fixtures/api/es-next/click/dispatch-event/index.html`;
+    .page `http://localhost:3000/fixtures/api/es-next/dispatch-event/pages/index.html`;
 
 test(`mouse`, async t => {
     await t.dispatchEvent(btn, 'mousedown', mouseEventArgs);
@@ -220,7 +220,7 @@ test('custom event', async t => {
     }]);
 });
 
-test.page('../pages/drag.html')('simple drag', async t => {
+test.page('http://localhost:3000/fixtures/api/es-next/dispatch-event/pages/drag.html')('simple drag', async t => {
     let initialTop  = parseInt(await div.getStyleProperty('top'), 10);
     let initialLeft = parseInt(await div.getStyleProperty('left'), 10);
 

--- a/test/server/data/test-controller-reporter-expected/index.js
+++ b/test/server/data/test-controller-reporter-expected/index.js
@@ -34,6 +34,27 @@ const scrollOptions = Object.assign({
 module.exports = [
     {
         testRunId: 'test-run-id',
+        name:    'dispatchEvent',
+        command: {
+            eventName : 'mousedown',
+            selector: { expression: 'Selector(\'#target\')' },
+            options: {},
+            relatedTarget: void 0,
+            type:     'dispatch-event'
+        },
+        test:    {
+            id:    'test-id',
+            name:  'test-name',
+            phase: 'initial'
+        },
+        fixture: {
+            id:   'fixture-id',
+            name: 'fixture-name',
+        },
+        browser: { alias: 'test-browser', headless: false }
+    },
+    {
+        testRunId: 'test-run-id',
         name:    'click',
         command: {
             options:  clickOptions,

--- a/test/server/test-controller-events-test.js
+++ b/test/server/test-controller-events-test.js
@@ -101,6 +101,7 @@ const actionsWithoutOptions = {
 };
 
 const actions = {
+    dispatchEvent:             ['#target', 'mousedown'],
     click:                     ['#target', options],
     rightClick:                ['#target', options],
     doubleClick:               ['#target', options],

--- a/ts-defs-src/test-api/test-controller.d.ts
+++ b/ts-defs-src/test-api/test-controller.d.ts
@@ -112,6 +112,15 @@ interface TestController {
      */
     readonly browser: Browser;
     /**
+     * Dispatches an event over a specified webpage element.
+     *
+     * @param selector - Identifies the EventTarget element.
+     * @param eventName - The name of the event to be dispatched on the DOM element..
+     * @param options - The options which will be passed to EventConstructor.
+     */
+    dispatchEvent(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
+                  eventName: string, options: object): TestControllerPromise;
+    /**
      * Clicks a webpage element.
      *
      * @param selector - Identifies the webpage element being clicked.


### PR DESCRIPTION

**t.dispatchEvent method**
Dispatches an event over a specified webpage element.
Has the following params:
- selector - Identifies the EventTarget element. (required)
- eventName - The name of the event to be dispatched on the DOM element. (required)
- options - The options which will be passed to EventConstructor. (optional)

For mouse/drag events - MouseEvent constructor is called
For input events (beforeinput, input) - InputEvent constructor is called
For keayboard events - KeyboardEvent constructor is called
For focus events - FocusEvent constructor is called
For pointer events - PointerEvent constructor is called

For any other events the `CustomEvent` constructor is called.

If the `eventConstructor` property is passed throuth the options, then the `eventConstructor` Ctor is called.

By default, events have bubbles and cancelable properties set to true.
For mouseevents - buttons property is set to 1 (left button)

the `relatedTarget` property for focus events is supported.
Complex events such as TouchEvent are supported only as CustomEvents

**The feature is not supported in IE11**