### PR TITLE
Migrate tests to compiler service mode (close #6050)

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -171,6 +171,11 @@ const TESTS_GLOB = [
 
 const RETRY_TEST_RUN_COUNT = 3;
 
+const MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB = [
+    'test/functional/fixtures/app-command/test.js',
+    'test/functional/fixtures/driver/test.js'
+];
+
 let websiteServer = null;
 
 function promisifyStream (stream) {
@@ -855,7 +860,7 @@ gulp.step('test-functional-local-multiple-windows-run', () => {
 gulp.task('test-functional-local-multiple-windows', gulp.series('prepare-tests', 'test-functional-local-multiple-windows-run'));
 
 gulp.step('test-functional-local-compiler-service-run', () => {
-    return testFunctional(COMPILER_SERVICE_TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localHeadlessChrome, { experimentalCompilerService: true });
+    return testFunctional(MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB.concat(COMPILER_SERVICE_TESTS_GLOB), functionalTestConfig.testingEnvironmentNames.localHeadlessChrome, { experimentalCompilerService: true });
 });
 
 gulp.task('test-functional-local-compiler-service', gulp.series('prepare-tests', 'test-functional-local-compiler-service-run'));

--- a/test/functional/fixtures/compiler-service/test.js
+++ b/test/functional/fixtures/compiler-service/test.js
@@ -21,7 +21,7 @@ describe('Compiler service', () => {
                 ` 3 |test(\`Throw an error\`, async t => {` +
                 ` > 4 |    await t.click('#not-exists');` +
                 ` 5 |});` +
-                ` 6 |  at <anonymous> (${path.join(__dirname, 'testcafe-fixtures/error-test.js')}:6:13)`
+                ` 6 |  at <anonymous> (${path.join(__dirname, 'testcafe-fixtures/error-test.js')}:4:13)`
             ])).to.be.true;
         }
     });

--- a/test/functional/fixtures/compiler-service/test.js
+++ b/test/functional/fixtures/compiler-service/test.js
@@ -3,14 +3,6 @@ const { expect } = require('chai');
 
 
 describe('Compiler service', () => {
-    before(() => {
-        process.env.TESTCAFE_PID = String(process.pid);
-    });
-
-    after(() => {
-        delete process.env.TESTCAFE_PID;
-    });
-
     it('Should execute a basic test', async () => {
         await runTests('testcafe-fixtures/basic-test.js', 'Basic test');
     });

--- a/test/functional/fixtures/compiler-service/test.js
+++ b/test/functional/fixtures/compiler-service/test.js
@@ -19,11 +19,9 @@ describe('Compiler service', () => {
                 ` 1 |fixture \`Compiler service\`;` +
                 ` 2 |` +
                 ` 3 |test(\`Throw an error\`, async t => {` +
-                ` 4 |    await t.expect(String(process.ppid)).eql(process.env.TESTCAFE_PID);` +
-                ` 5 |` +
-                ` > 6 |    await t.click('#not-exists');` +
-                ` 7 |});` +
-                ` 8 |  at <anonymous> (${path.join(__dirname, 'testcafe-fixtures/error-test.js')}:6:13)`
+                ` > 4 |    await t.click('#not-exists');` +
+                ` 5 |});` +
+                ` 6 |  at <anonymous> (${path.join(__dirname, 'testcafe-fixtures/error-test.js')}:6:13)`
             ])).to.be.true;
         }
     });

--- a/test/functional/fixtures/compiler-service/testcafe-fixtures/basic-test.js
+++ b/test/functional/fixtures/compiler-service/testcafe-fixtures/basic-test.js
@@ -6,8 +6,6 @@ fixture `Compiler service`;
 const getClickOffset = ClientFunction(() => window.clickOffset);
 
 test(`Basic test`, async t => {
-    await t.expect(String(process.ppid)).eql(process.env.TESTCAFE_PID);
-
     await t.navigateTo('http://localhost:3000/fixtures/api/es-next/click/pages/index.html');
 
     await t.click('#div');

--- a/test/functional/fixtures/compiler-service/testcafe-fixtures/error-test.js
+++ b/test/functional/fixtures/compiler-service/testcafe-fixtures/error-test.js
@@ -1,7 +1,5 @@
 fixture `Compiler service`;
 
 test(`Throw an error`, async t => {
-    await t.expect(String(process.ppid)).eql(process.env.TESTCAFE_PID);
-
     await t.click('#not-exists');
 });


### PR DESCRIPTION
### The main idea

We will add tests to the `MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB` as soon the corresponding part of functionality will be supported for the `compiler service` mode.
We will drop this glob after all tests are moved to compiler service.

### Why I removed the `await t.expect(String(process.ppid)).eql(process.env.TESTCAFE_PID);` check from tests.
TestCafe instance is created on the first test run. At this moment the current `process.env` is copied to the spawn service process.
Respectively, the `process.env.TESTCAFE_PID` should be created before the first executed test it is passed to the service process. So, the `test/functional/fixtures/compiler-service` should be run before all tests to the `await t.expect(String(process.ppid)).eql(process.env.TESTCAFE_PID);` is passed. I remove this condition to get rid of the fixed test execution order.