### PR TITLE
[docs] Document unexpected behavior when not quoting globs

### DIFF
--- a/docs/articles/documentation/reference/command-line-interface.md
+++ b/docs/articles/documentation/reference/command-line-interface.md
@@ -255,6 +255,8 @@ The following command runs tests from files that match the `tests/*page*` patter
 testcafe ie tests/*page*
 ```
 
+NOTE: You might want to enclose the glob pattern in single quotes to prevent your shell from expanding the glob [in an unexpected way](https://medium.com/@jakubsynowiec/you-should-always-quote-your-globs-in-npm-scripts-621887a2a784).
+
 If you do not specify any file or directory, TestCafe runs tests from the `test` or `tests` directories.
 
 ## Options

--- a/docs/articles/documentation/reference/command-line-interface.md
+++ b/docs/articles/documentation/reference/command-line-interface.md
@@ -247,7 +247,7 @@ The following command runs tests from the specified fixture files:
 testcafe ie js-tests/fixture.js studio-tests/fixture.testcafe
 ```
 
-You can use [glob patterns](https://github.com/isaacs/node-glob#glob-primer) to specify a set of files.
+You can use [glob patterns](https://github.com/isaacs/node-glob#glob-primer) to specify sets of files.
 
 The following command runs tests from files that match the `tests/*page*` pattern (for instance, `tests/example-page.js`, `tests/main-page.js`, or `tests/auth-page.testcafe`):
 
@@ -255,7 +255,7 @@ The following command runs tests from files that match the `tests/*page*` patter
 testcafe ie tests/*page*
 ```
 
-NOTE: You might want to enclose the glob pattern in single quotes to prevent your shell from expanding the glob [in an unexpected way](https://medium.com/@jakubsynowiec/you-should-always-quote-your-globs-in-npm-scripts-621887a2a784).
+NOTE: Enclose glob patterns in single quotes to prevent your shell from [expanding](https://medium.com/@jakubsynowiec/you-should-always-quote-your-globs-in-npm-scripts-621887a2a784) them.
 
 If you do not specify any file or directory, TestCafe runs tests from the `test` or `tests` directories.
 


### PR DESCRIPTION
## Purpose
Today I ran into an issue when using the globstar (**) in the glob I passed into the cli (for example `testcafe chrome tests/**/*.ts`). It turns out that on OSX, the npm cli runner uses /bin/sh which is bash v3 (globstar is implemented in v4). This means that simply adding a subdirectory into a folder can "hide" existing files inside that folder. Advising users to single quote the glob will prevent shell expansion of the glob and ensure that it gets passed to node-glob inside testcafe.

## Approach
This "fix" only updates documentation.

## References
There might be bug "issues" related to this issue, but I didn't search for them.

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
