### PR TITLE
Support of the RequestHook._onConfigureResponse event (final)

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "23.0.0",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/6311311/testcafe-hammerhead-24.0.0.zip",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/6311311/testcafe-hammerhead-24.0.0.zip",
+    "testcafe-hammerhead": "24.0.0",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "24.0.0",
+    "testcafe-hammerhead": "24.1.0",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/src/api/request-hooks/request-mock.ts
+++ b/src/api/request-hooks/request-mock.ts
@@ -25,14 +25,14 @@ class RequestMock extends RequestHook {
     }
 
     public async onRequest (event: RequestEvent): Promise<void> {
-        const mock = this._mocks.get(event._requestFilterRule.id) as ResponseMock;
+        const mock = this._mocks.get(event.requestFilterRule.id) as ResponseMock;
 
         await event.setMock(mock);
     }
 
     public async onResponse (event: ResponseEvent): Promise<void> {
         if (event.isSameOriginPolicyFailed)
-            this._warningLog?.addWarning(WARNING_MESSAGE.requestMockCORSValidationFailed, RequestMock.name, event._requestFilterRule);
+            this._warningLog?.addWarning(WARNING_MESSAGE.requestMockCORSValidationFailed, RequestMock.name, event.requestFilterRule);
     }
 
     // API

--- a/src/services/compiler/host.ts
+++ b/src/services/compiler/host.ts
@@ -22,12 +22,14 @@ import {
     ExecuteCommandArguments,
     RequestHookEventArguments,
     SetMockArguments,
-    SetConfigureResponseEventOptionsArguments
+    SetConfigureResponseEventOptionsArguments,
+    SetHeaderOnConfigureResponseEventArguments,
+    RemoveHeaderOnConfigureResponseEventArguments
 } from './protocol';
 
 import { CompilerArguments } from '../../compiler/interfaces';
 import Test from '../../api/structure/test';
-import { RequestFilterRule, ResponseMock } from 'testcafe-hammerhead';
+import { ResponseMock } from 'testcafe-hammerhead';
 
 const SERVICE_PATH = require.resolve('./service');
 
@@ -56,7 +58,9 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
             this.ready,
             this.onRequestHookEvent,
             this.setMock,
-            this.setConfigureResponseEventOptions
+            this.setConfigureResponseEventOptions,
+            this.setHeaderOnConfigureResponseEvent,
+            this.removeHeaderOnConfigureResponseEvent
         ], this);
     }
 
@@ -176,16 +180,21 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
         await proxy.call(this.onRequestHookEvent, { name, testRunId, testId, hookId, eventData });
     }
 
-    public async setMock ({ rule, mock }: SetMockArguments): Promise<void> {
+    public async setMock ({ responseEventId, mock }: SetMockArguments): Promise<void> {
         mock = ResponseMock.from(mock);
-        rule = RequestFilterRule.from(rule as object);
 
-        await this.emit('setMock', { rule, mock });
+        await this.emit('setMock', [responseEventId, mock]);
     }
 
-    public async setConfigureResponseEventOptions ({ rule, opts }: SetConfigureResponseEventOptionsArguments): Promise<void> {
-        rule = RequestFilterRule.from(rule as object);
+    public async setConfigureResponseEventOptions ({ eventId, opts }: SetConfigureResponseEventOptionsArguments): Promise<void> {
+        await this.emit('setConfigureResponseEventOptions', [eventId, opts]);
+    }
 
-        await this.emit('setConfigureResponseEventOptions', { rule, opts });
+    public async setHeaderOnConfigureResponseEvent ({ eventId, headerName, headerValue }: SetHeaderOnConfigureResponseEventArguments): Promise<void> {
+        await this.emit('setHeaderOnConfigureResponseEvent', [eventId, headerName, headerValue]);
+    }
+
+    public async removeHeaderOnConfigureResponseEvent ({ eventId, headerName }: RemoveHeaderOnConfigureResponseEventArguments): Promise<void> {
+        await this.emit('removeHeaderOnConfigureResponseEvent', [eventId, headerName]);
     }
 }

--- a/src/services/compiler/protocol.ts
+++ b/src/services/compiler/protocol.ts
@@ -5,7 +5,6 @@ import {
     ConfigureResponseEvent,
     ConfigureResponseEventOptions,
     RequestEvent,
-    RequestFilterRule,
     ResponseEvent,
     ResponseMock
 } from 'testcafe-hammerhead';
@@ -59,13 +58,24 @@ export interface RequestHookEventArguments {
 }
 
 export interface SetMockArguments {
-    rule: RequestFilterRule;
+    responseEventId: string;
     mock: ResponseMock;
 }
 
 export interface SetConfigureResponseEventOptionsArguments {
-    rule: RequestFilterRule;
+    eventId: string;
     opts: ConfigureResponseEventOptions;
+}
+
+export interface SetHeaderOnConfigureResponseEventArguments {
+    eventId: string;
+    headerName: string;
+    headerValue: string;
+}
+
+export interface RemoveHeaderOnConfigureResponseEventArguments {
+    eventId: string;
+    headerName: string;
 }
 
 export interface TestRunDispatcherProtocol {
@@ -86,7 +96,11 @@ export interface CompilerProtocol extends TestRunDispatcherProtocol {
 
     onRequestHookEvent ({ name, testRunId, testId, hookId, eventData }: RequestHookEventArguments): Promise<void>;
 
-    setMock ({ rule, mock }: SetMockArguments): Promise<void>;
+    setMock ({ responseEventId, mock }: SetMockArguments): Promise<void>;
 
-    setConfigureResponseEventOptions ({ rule, opts }: SetConfigureResponseEventOptionsArguments): Promise<void>;
+    setConfigureResponseEventOptions ({ eventId, opts }: SetConfigureResponseEventOptionsArguments): Promise<void>;
+
+    setHeaderOnConfigureResponseEvent ({ eventId, headerName, headerValue }: SetHeaderOnConfigureResponseEventArguments): Promise<void>;
+
+    removeHeaderOnConfigureResponseEvent ({ eventId, headerName }: RemoveHeaderOnConfigureResponseEventArguments): Promise<void>;
 }

--- a/src/services/compiler/test-run-proxy.ts
+++ b/src/services/compiler/test-run-proxy.ts
@@ -104,11 +104,11 @@ class TestRunProxy {
         });
     }
 
-    public onRequestHookEvent ({ hookId, name, eventData }: RequestHookEventDescriptor): RequestHook {
+    public async onRequestHookEvent ({ hookId, name, eventData }: RequestHookEventDescriptor): Promise<RequestHook> {
         const targetHook = this.getHook(hookId) as RequestHook;
 
         // @ts-ignore
-        targetHook[name].call(targetHook, eventData);
+        await targetHook[name].call(targetHook, eventData);
 
         return targetHook;
     }

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -76,6 +76,13 @@ const CHILD_WINDOW_READY_TIMEOUT      = 30 * 1000;
 
 const ALL_DRIVER_TASKS_ADDED_TO_QUEUE_EVENT = 'all-driver-tasks-added-to-queue';
 
+const COMPILER_SERVICE_EVENTS = [
+    'setMock',
+    'setConfigureResponseEventOptions',
+    'setHeaderOnConfigureResponseEvent',
+    'removeHeaderOnConfigureResponseEvent'
+];
+
 export default class TestRun extends AsyncEventEmitter {
     constructor ({ test, browserConnection, screenshotCapturer, globalWarningLog, opts, compilerService }) {
         super();
@@ -266,12 +273,10 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     _subscribeOnCompilerServiceEvents () {
-        this.compilerService.on('setMock', async ({ rule, mock }) => {
-            await this.session.setMock(rule, mock);
-        });
-
-        this.compilerService.on('setConfigureResponseEventOptions', async ({ rule, opts }) => {
-            await this.session.setConfigureResponseEventOptions(rule, opts);
+        COMPILER_SERVICE_EVENTS.forEach(eventName => {
+            this.compilerService.on(eventName, async args => {
+                await this.session[eventName](...args);
+            });
         });
     }
 

--- a/test/functional/fixtures/api/es-next/request-hooks/pages/api/change-remove-response-headers.html
+++ b/test/functional/fixtures/api/es-next/request-hooks/pages/api/change-remove-response-headers.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <div>
+        <button id="sendRequest">Send request</button>
+    </div>
+    <div>
+        <div id="requestStatus"></div>
+        <code id="result"></code>
+    </div>
+    <script>
+        const sendRequestBtn   = document.getElementById('sendRequest');
+        const receivedHeaders  = document.getElementById('result');
+        const requestStatusDiv = document.getElementById('requestStatus');
+
+        function filterCustomHeaders (headers) {
+            const resultHeaders = {};
+
+            for (const [key, value] of headers.entries()) {
+                if(key.startsWith('x-header-'))
+                    resultHeaders[key] = value;
+            }
+
+            return resultHeaders;
+        }
+
+        sendRequestBtn.addEventListener('click', () => {
+            let customHeaders = {};
+
+                fetch('/echo-custom-request-headers-in-response-headers', {
+                    method: 'POST',
+                    headers: {
+                        'x-header-1': 'different',
+                        'x-header-4': 'value-4',
+                        'x-header-5': 'value-5'
+                    }
+                })
+                .then(res => {
+                    customHeaders = filterCustomHeaders(res.headers);
+
+                    return res.text();
+                })
+                .then(() => {
+                    requestStatusDiv.textContent = 'Received';
+                    receivedHeaders.textContent  = JSON.stringify(customHeaders, null, 4);
+                })
+                .catch(err => {
+                    requestStatusDiv.textContent = 'Error';
+                    receivedHeaders.textContent  = err.toString();
+                });
+        });
+    </script>
+</body>
+</html>

--- a/test/functional/fixtures/api/es-next/request-hooks/test.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/test.js
@@ -66,5 +66,9 @@ describe('Request Hooks', () => {
         it('Async predicate for request filter rules', () => {
             return runTests('./testcafe-fixtures/api/request-filter-rule-async-predicate.js', null, { only: 'chrome' });
         });
+
+        it('Change and remove response headers', () => {
+            return runTests('./testcafe-fixtures/api/change-remove-response-headers.js', null, { only: 'chrome' });
+        });
     });
 });

--- a/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/change-remove-response-headers.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/change-remove-response-headers.js
@@ -1,0 +1,41 @@
+import { RequestHook, Selector } from 'testcafe';
+
+const HEADER_MANIPULATION_ROUTE = '/echo-custom-request-headers-in-response-headers';
+
+class HeaderManipulationHook extends RequestHook {
+    constructor () {
+        super(new RegExp(HEADER_MANIPULATION_ROUTE));
+    }
+
+    onRequest () { }
+
+    onResponse () { }
+
+    async _onConfigureResponse (event) {
+        await super._onConfigureResponse(event);
+
+        await event.setHeader('x-header-1', 'value-1');
+        await event.setHeader('x-header-2', 'value-2');
+        await event.removeHeader('x-header-3');
+        await event.removeHeader('x-header-4');
+    }
+}
+
+fixture `Fixture`
+    .page('http://localhost:3000/fixtures/api/es-next/request-hooks/pages/api/change-remove-response-headers.html')
+    .requestHooks(new HeaderManipulationHook());
+
+test('test', async t => {
+    await t
+        .click('#sendRequest')
+        .expect(Selector('#requestStatus').textContent).eql('Received');
+
+    const headersText = await Selector('#result').textContent;
+    const headersObj  = JSON.parse(headersText);
+
+    await t.expect(headersObj).eql({
+        'x-header-1': 'value-1',
+        'x-header-2': 'value-2',
+        'x-header-5': 'value-5'
+    });
+});

--- a/test/functional/fixtures/compiler-service/test.js
+++ b/test/functional/fixtures/compiler-service/test.js
@@ -44,5 +44,11 @@ describe('Compiler service', () => {
         it('Request Mock', async () => {
             await runTests('../api/es-next/request-hooks/testcafe-fixtures/request-mock/basic.js');
         });
+
+        describe('Request Hook', () => {
+            it('Change and remove response headers', async () => {
+                await runTests('../api/es-next/request-hooks/testcafe-fixtures/api/change-remove-response-headers.js');
+            });
+        });
     });
 });

--- a/test/functional/site/server.js
+++ b/test/functional/site/server.js
@@ -163,6 +163,15 @@ Server.prototype._setupRoutes = function () {
             res.send(delay.toString());
         }, delay);
     });
+
+    this.app.post('/echo-custom-request-headers-in-response-headers', (req, res) => {
+        Object.keys(req.headers).forEach(headerName => {
+            if (headerName.startsWith('x-header-'))
+                res.setHeader(headerName, req.headers[headerName]);
+        });
+
+        res.end();
+    });
 };
 
 Server.prototype.close = function () {


### PR DESCRIPTION
Changes:
* support `ConfigureResponseEvent.setHeader`, `ConfigureResponseEvent.removeHeader` methods
* refactor usage of the `ConfigureResponseEvent.opts`