### PR TITLE
fix: switching to an iframe with the srcdoc attr

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "https://git.io/JOlv5",
+    "testcafe-hammerhead": "24.2.0",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "24.1.0",
+    "testcafe-hammerhead": "https://git.io/JOnvF",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "https://git.io/JOnvF",
+    "testcafe-hammerhead": "https://git.io/JOnFV",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "https://git.io/JOnFV",
+    "testcafe-hammerhead": "https://git.io/JOWNr",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "https://git.io/JOWNr",
+    "testcafe-hammerhead": "https://git.io/JOlv5",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/test/functional/fixtures/api/es-next/iframe-switching/pages/index.html
+++ b/test/functional/fixtures/api/es-next/iframe-switching/pages/index.html
@@ -62,5 +62,9 @@
 <h2>Cross-domain iframes</h2>
 <iframe id="cross-domain-iframe" height="200px"
         src="http://localhost:3001/fixtures/api/es-next/iframe-switching/pages/iframe.html"></iframe>
+
+<h2>Iframes with the srcdoc attribute</h2>
+<iframe id="iframe-with-srcdoc" height="200px"
+        srcdoc="<h1 id='target'>text in iframe with the srcdoc attribute</h1>"></iframe>
 </body>
 </html>

--- a/test/functional/fixtures/api/es-next/iframe-switching/test.js
+++ b/test/functional/fixtures/api/es-next/iframe-switching/test.js
@@ -52,6 +52,10 @@ describe('[API] t.switchToIframe(), t.switchToMainWindow()', function () {
         return runTests('./testcafe-fixtures/iframe-switching-test.js', 'Click in a cross-domain iframe with redirect', { skip: 'safari', ...DEFAULT_RUN_OPTIONS });
     });
 
+    it('Should work in an iframe with the srcdoc attribute', function () {
+        return runTests('./testcafe-fixtures/iframe-switching-test.js', 'Click in an iframe with the srcdoc attribute', { skip: 'ie', ...DEFAULT_RUN_OPTIONS });
+    });
+
     describe('Unavailable iframe errors', function () {
         it('Should ensure the iframe element exists before switching to it', function () {
             return runTests('./testcafe-fixtures/iframe-switching-test.js', 'Switch to a non-existent iframe',

--- a/test/functional/fixtures/api/es-next/iframe-switching/testcafe-fixtures/iframe-switching-test.js
+++ b/test/functional/fixtures/api/es-next/iframe-switching/testcafe-fixtures/iframe-switching-test.js
@@ -1,5 +1,5 @@
 // NOTE: to preserve callsites, add new tests AFTER the existing ones
-import { ClientFunction } from 'testcafe';
+import { Selector, ClientFunction } from 'testcafe';
 import { expect } from 'chai';
 
 
@@ -202,4 +202,11 @@ test('Click in an iframe that is not loaded', async t => {
         .click('#too-long-loading-page-link')
         .wait(3000)
         .click('#second-page-btn');
+});
+
+test('Click in an iframe with the srcdoc attribute', async t => {
+    await t
+        .switchToIframe('#iframe-with-srcdoc')
+        .click('#target')
+        .expect(Selector('#target').innerText).eql('text in iframe with the srcdoc attribute');
 });


### PR DESCRIPTION
## Purpose
Switching to an iframe with the srcdoc attribute works incorrectly. After switch to such iframe, the following error occurs: `Content of the iframe in which the test is currently operating did not load.`. This error can be avoided by adding timeout, but switching won't happen actually (and because of that the element inside the iframe is shown as invisible in #6033).

## Approach
Add the functional test for the fix on hammerhead side (https://github.com/DevExpress/testcafe-hammerhead/pull/2618)

## References
fixes #6033

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
