### PR TITLE
fix: added disableScreenshots in RunOptions interface

### DIFF
--- a/ts-defs-src/runner-api/runner-api.d.ts
+++ b/ts-defs-src/runner-api/runner-api.d.ts
@@ -347,6 +347,10 @@ interface RunOptions {
      * Specifies the timeout in milliseconds to complete the AJAX requests (XHR or fetch)
      */
     ajaxRequestTimeout: number;
+    /**
+     * Prevents TestCafe from taking screenshots. When this option is specified, screenshots are not taken whenever a test fails or when t.takeScreenshot or t.takeElementScreenshot is executed.
+     */
+    disableScreenshots: boolean;
 }
 
 interface TestCafeFactory {


### PR DESCRIPTION
## Purpose
Fix bug

## Approach
Correction of an error when passing a parameter disableScreenshots 

## References
Closes #5735
