### PR TITLE
fix TestCafe hangs during TestCafe Studio tests (closes #5207)

### DIFF
--- a/test/functional/fixtures/regression/gh-5207/pages/index.html
+++ b/test/functional/fixtures/regression/gh-5207/pages/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>gh-5207</title>
+</head>
+<body>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-5207/test.js
+++ b/test/functional/fixtures/regression/gh-5207/test.js
@@ -1,25 +1,15 @@
-function customReporter () {
-    return {
-        async reportTaskStart () {
-        },
-        async reportFixtureStart () {
-        },
-        async reportTestDone () {
-            return new Promise(resolve => {
-                setTimeout(resolve, 5000);
-            });
-        },
-        async reportTaskDone () {
-        }
-    };
-}
+const { createReporter } = require('../../../utils/reporter');
 
 describe('[Regression](GH-5207)', function () {
     it('Should not hand with `disablePageReloads` and async reporter', function () {
         return runTests('testcafe-fixtures/index.js', null, {
-            reporter: customReporter
+            reporter: createReporter({
+                async reportTestDone () {
+                    return new Promise(resolve => {
+                        setTimeout(resolve, 5000);
+                    });
+                }
+            })
         });
     });
 });
-
-

--- a/test/functional/fixtures/regression/gh-5207/test.js
+++ b/test/functional/fixtures/regression/gh-5207/test.js
@@ -1,0 +1,25 @@
+function customReporter () {
+    return {
+        async reportTaskStart () {
+        },
+        async reportFixtureStart () {
+        },
+        async reportTestDone () {
+            return new Promise(resolve => {
+                setTimeout(resolve, 5000);
+            });
+        },
+        async reportTaskDone () {
+        }
+    };
+}
+
+describe('[Regression](GH-5207)', function () {
+    it('Should not hand with `disablePageReloads` and async reporter', function () {
+        return runTests('testcafe-fixtures/index.js', null, {
+            reporter: customReporter
+        });
+    });
+});
+
+

--- a/test/functional/fixtures/regression/gh-5207/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-5207/testcafe-fixtures/index.js
@@ -1,0 +1,16 @@
+fixture `fixture 1`
+    .page `http://localhost:3000/fixtures/regression/gh-5207/pages/index.html`;
+
+test(`test 1`, async t => {
+    await t.wait(2000);
+});
+
+fixture `fixture 2`
+    .disablePageReloads
+    .page `http://example.com`;
+
+test(`test 2`, async t => {
+    await t.wait(2000);
+
+    await t.click('h1');
+});


### PR DESCRIPTION
if we have `disablePageReloads` enabled and the next test is from next fixture, then we need to wait until all reporters finished to prevent redirecting to the `idle` page