### PR TITLE
Remove injected head scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "24.2.0",
+    "testcafe-hammerhead": "https://github.com/DevExpress/testcafe-hammerhead/files/6374754/testcafe-hammerhead-24.1.1.zip",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "https://github.com/DevExpress/testcafe-hammerhead/files/6374754/testcafe-hammerhead-24.1.1.zip",
+    "testcafe-hammerhead": "https://github.com/DevExpress/testcafe-hammerhead/files/6403448/testcafe-hammerhead-24.1.1.zip",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "https://github.com/DevExpress/testcafe-hammerhead/files/6403448/testcafe-hammerhead-24.1.1.zip",
+    "testcafe-hammerhead": "https://github.com/DevExpress/testcafe-hammerhead/files/6419213/testcafe-hammerhead-24.2.0.zip",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "https://github.com/DevExpress/testcafe-hammerhead/files/6419213/testcafe-hammerhead-24.2.0.zip",
+    "testcafe-hammerhead": "24.2.1",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/src/client/automation/index.js.wrapper.mustache
+++ b/src/client/automation/index.js.wrapper.mustache
@@ -10,3 +10,5 @@
 
     initTestCafeAutomation(window);
 })();
+
+window['%hammerhead%'].utils.removeInjectedHeadScript();

--- a/src/client/automation/index.js.wrapper.mustache
+++ b/src/client/automation/index.js.wrapper.mustache
@@ -1,3 +1,5 @@
+window['%hammerhead%'].utils.removeInjectedHeadScript();
+
 // NOTE: We should have the capability to initialize scripts with different contexts.
 // This is required for iframes without the src attribute because Hammerhead does not
 // inject scripts into such iframes. So, we wrap all scripts in initialization functions.
@@ -10,5 +12,3 @@
 
     initTestCafeAutomation(window);
 })();
-
-window['%hammerhead%'].utils.removeInjectedHeadScript();

--- a/src/client/automation/index.js.wrapper.mustache
+++ b/src/client/automation/index.js.wrapper.mustache
@@ -1,4 +1,4 @@
-window['%hammerhead%'].utils.removeInjectedHeadScript();
+window['%hammerhead%'].utils.removeInjectedScript();
 
 // NOTE: We should have the capability to initialize scripts with different contexts.
 // This is required for iframes without the src attribute because Hammerhead does not

--- a/src/client/core/index.js.wrapper.mustache
+++ b/src/client/core/index.js.wrapper.mustache
@@ -10,3 +10,5 @@
 
     initTestCafeCore(window);
 })();
+
+window['%hammerhead%'].utils.removeInjectedHeadScript();

--- a/src/client/core/index.js.wrapper.mustache
+++ b/src/client/core/index.js.wrapper.mustache
@@ -1,3 +1,5 @@
+window['%hammerhead%'].utils.removeInjectedHeadScript();
+
 // NOTE: We should have the capability to initialize scripts with different contexts.
 // This is required for iframes without the src attribute because Hammerhead does not
 // inject scripts into such iframes. So, we wrap all scripts in initialization functions.
@@ -10,5 +12,3 @@
 
     initTestCafeCore(window);
 })();
-
-window['%hammerhead%'].utils.removeInjectedHeadScript();

--- a/src/client/core/index.js.wrapper.mustache
+++ b/src/client/core/index.js.wrapper.mustache
@@ -1,4 +1,4 @@
-window['%hammerhead%'].utils.removeInjectedHeadScript();
+window['%hammerhead%'].utils.removeInjectedScript();
 
 // NOTE: We should have the capability to initialize scripts with different contexts.
 // This is required for iframes without the src attribute because Hammerhead does not

--- a/src/client/driver/index.js.wrapper.mustache
+++ b/src/client/driver/index.js.wrapper.mustache
@@ -10,3 +10,5 @@
 
     initTestCafeClientDrivers(window);
 })();
+
+window['%hammerhead%'].utils.removeInjectedHeadScript();

--- a/src/client/driver/index.js.wrapper.mustache
+++ b/src/client/driver/index.js.wrapper.mustache
@@ -1,3 +1,5 @@
+window['%hammerhead%'].utils.removeInjectedHeadScript();
+
 // NOTE: We should have the capability to initialize scripts with different contexts.
 // This is required for iframes without the src attribute because Hammerhead does not
 // inject scripts into such iframes. So, we wrap all scripts in initialization functions.
@@ -10,5 +12,3 @@
 
     initTestCafeClientDrivers(window);
 })();
-
-window['%hammerhead%'].utils.removeInjectedHeadScript();

--- a/src/client/driver/index.js.wrapper.mustache
+++ b/src/client/driver/index.js.wrapper.mustache
@@ -1,4 +1,4 @@
-window['%hammerhead%'].utils.removeInjectedHeadScript();
+window['%hammerhead%'].utils.removeInjectedScript();
 
 // NOTE: We should have the capability to initialize scripts with different contexts.
 // This is required for iframes without the src attribute because Hammerhead does not

--- a/src/client/ui/index.js.wrapper.mustache
+++ b/src/client/ui/index.js.wrapper.mustache
@@ -10,3 +10,5 @@
 
     initTestCafeUI(window);
 })();
+
+window['%hammerhead%'].utils.removeInjectedHeadScript();

--- a/src/client/ui/index.js.wrapper.mustache
+++ b/src/client/ui/index.js.wrapper.mustache
@@ -1,3 +1,5 @@
+window['%hammerhead%'].utils.removeInjectedHeadScript();
+
 // NOTE: We should have the capability to initialize scripts with different contexts.
 // This is required for iframes without the src attribute because Hammerhead does not
 // inject scripts into such iframes. So, we wrap all scripts in initialization functions.
@@ -10,5 +12,3 @@
 
     initTestCafeUI(window);
 })();
-
-window['%hammerhead%'].utils.removeInjectedHeadScript();

--- a/src/client/ui/index.js.wrapper.mustache
+++ b/src/client/ui/index.js.wrapper.mustache
@@ -1,4 +1,4 @@
-window['%hammerhead%'].utils.removeInjectedHeadScript();
+window['%hammerhead%'].utils.removeInjectedScript();
 
 // NOTE: We should have the capability to initialize scripts with different contexts.
 // This is required for iframes without the src attribute because Hammerhead does not

--- a/test/functional/fixtures/api/es-next/hooks/test.js
+++ b/test/functional/fixtures/api/es-next/hooks/test.js
@@ -93,7 +93,7 @@ describe('[API] t.ctx', () => {
 
 describe('[API] fixture.before/fixture.after hooks', () => {
     it('Should run hooks before and after fixture', () => {
-        return runTests('./testcafe-fixtures/fixture-hooks.js', null);
+        return runTests('./testcafe-fixtures/fixture-hooks.js');
     });
 
     it('Should keep sequential reports with long executing hooks', () => {

--- a/test/functional/fixtures/api/es-next/scroll/test.js
+++ b/test/functional/fixtures/api/es-next/scroll/test.js
@@ -1,6 +1,6 @@
 describe('Scroll', () => {
     it('Should raise events for scroll', () => {
-        return runTests('./testcafe-fixtures/raise-events.js', null);
+        return runTests('./testcafe-fixtures/raise-events.js');
     });
 
     // NOTE: https://github.com/DevExpress/testcafe/issues/4157

--- a/test/functional/fixtures/hammerhead/gh-2622/pages/iframe.html
+++ b/test/functional/fixtures/hammerhead/gh-2622/pages/iframe.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+iframe
+</body>
+</html>

--- a/test/functional/fixtures/hammerhead/gh-2622/pages/index.html
+++ b/test/functional/fixtures/hammerhead/gh-2622/pages/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+<script>
+    var iframe = document.createElement('iframe');
+
+    iframe.src = 'iframe.html';
+
+    document.body.appendChild(iframe);
+</script>
+
+</body>
+</html>

--- a/test/functional/fixtures/hammerhead/gh-2622/test.js
+++ b/test/functional/fixtures/hammerhead/gh-2622/test.js
@@ -1,0 +1,5 @@
+describe('Page and iframe documents should not contain injected head scripts', () => {
+    it('Page and iframe documents should not contain injected head scripts', () => {
+        return runTests('testcafe-fixtures/index.js', null, { only: 'chrome' });
+    });
+});

--- a/test/functional/fixtures/hammerhead/gh-2622/test.js
+++ b/test/functional/fixtures/hammerhead/gh-2622/test.js
@@ -1,5 +1,5 @@
 describe('Page and iframe documents should not contain injected head scripts', () => {
     it('Page and iframe documents should not contain injected head scripts', () => {
-        return runTests('testcafe-fixtures/index.js', null);
+        return runTests('testcafe-fixtures/index.js');
     });
 });

--- a/test/functional/fixtures/hammerhead/gh-2622/test.js
+++ b/test/functional/fixtures/hammerhead/gh-2622/test.js
@@ -1,5 +1,5 @@
 describe('Page and iframe documents should not contain injected head scripts', () => {
     it('Page and iframe documents should not contain injected head scripts', () => {
-        return runTests('testcafe-fixtures/index.js', null, { only: 'chrome' });
+        return runTests('testcafe-fixtures/index.js', null);
     });
 });

--- a/test/functional/fixtures/hammerhead/gh-2622/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/hammerhead/gh-2622/testcafe-fixtures/index.js
@@ -1,0 +1,17 @@
+import { ClientFunction } from 'testcafe';
+
+fixture `Fixture`
+    .page('http://localhost:3000/fixtures/hammerhead/gh-2622/pages/index.html');
+
+const getInjectedHeadScriptsCount        = ClientFunction(() => window['%hammerhead%'].nativeMethods.querySelectorAll.call(document, 'head > script.script-hammerhead-shadow-ui').length);
+const getIframeInjectedHeadScriptsCount  = ClientFunction(() => {
+    const iframeDocument = window['%hammerhead%'].nativeMethods.querySelector.call(document, 'iframe').contentDocument;
+
+    return window['%hammerhead%'].nativeMethods.querySelectorAll.call(iframeDocument, 'head > script.script-hammerhead-shadow-ui').length;
+});
+
+test('Page and iframe documents should not contain injected head scripts', async t => {
+    await t
+        .expect(getInjectedHeadScriptsCount()).eql(0)
+        .expect(getIframeInjectedHeadScriptsCount()).eql(0);
+});


### PR DESCRIPTION
### TODO
- [x] `testcafe-hammerhead` version

Related to https://github.com/DevExpress/testcafe-hammerhead/pull/2623.

## Approach
Remove injected `script-hammerhead-shadow-ui` head scripts from DOM.

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
