### PR TITLE
attemp to fix flaky gh-3904 test

### DIFF
--- a/test/functional/fixtures/regression/gh-3904/test.js
+++ b/test/functional/fixtures/regression/gh-3904/test.js
@@ -1,4 +1,4 @@
-describe('GH-3904 - Should correctly switch to iframe loaded from form', function () {
+describe.skip('GH-3904 - Should correctly switch to iframe loaded from form', function () {
     it('Should correctly switch to iframe loaded from form', function () {
         return runTests('testcafe-fixtures/index.js');
     });


### PR DESCRIPTION
This is attempt to fix 3904 flaky test. The cause of the issue is unclear. 
I remember, that I added timeout intentionally to emulate real scenario. However, it looks like that the test is still correct if remove timeout and add button click. Thus, the test will fail if I remove hammerhead changes, a it passes with hammerhead changes.
So I think, it will be enough to modify the tests a bit.

**UPD**
We decided to skip this test