### PR TITLE
feat: mask values typed into input[type=password] in a reporter

### DIFF
--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -202,10 +202,7 @@ export default class Driver extends serviceUtils.EventEmitter {
         hammerhead.on(hammerhead.EVENTS.windowOpened, e => this._onChildWindowOpened(e));
 
         this.setCustomCommandHandlers(COMMAND_TYPE.unlockPage, () => this._unlockPageAfterTestIsDone());
-        this.setCustomCommandHandlers(
-            COMMAND_TYPE.getActiveElement,
-            () => Promise.resolve(createReplicator(new SelectorNodeTransform()).encode(domUtils.getActiveElement()))
-        );
+        this.setCustomCommandHandlers(COMMAND_TYPE.getActiveElement, () => this._getActiveElement());
 
         // NOTE: initiate the child links restoring process before the window is reloaded
         listeners.addInternalEventBeforeListener(window, ['beforeunload'], () => {
@@ -272,6 +269,13 @@ export default class Driver extends serviceUtils.EventEmitter {
         disableRealEventsPreventing();
 
         return Promise.resolve();
+    }
+
+    _getActiveElement () {
+        const activeElement = domUtils.getActiveElement();
+        const encodedResult = createReplicator(new SelectorNodeTransform()).encode(activeElement);
+
+        return Promise.resolve(encodedResult);
     }
 
     _failIfClientCodeExecutionIsInterrupted () {

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -80,6 +80,8 @@ import DriverStatus from './status';
 import generateId from './generate-id';
 import ChildIframeDriverLink from './driver-link/iframe/child';
 
+import { createReplicator, SelectorNodeTransform } from './command-executors/client-functions/replicator';
+
 import executeActionCommand from './command-executors/execute-action';
 import executeManipulationCommand from './command-executors/browser-manipulation';
 import executeNavigateToCommand from './command-executors/execute-navigate-to';
@@ -200,6 +202,10 @@ export default class Driver extends serviceUtils.EventEmitter {
         hammerhead.on(hammerhead.EVENTS.windowOpened, e => this._onChildWindowOpened(e));
 
         this.setCustomCommandHandlers(COMMAND_TYPE.unlockPage, () => this._unlockPageAfterTestIsDone());
+        this.setCustomCommandHandlers(
+            COMMAND_TYPE.getActiveElement,
+            () => Promise.resolve(createReplicator(new SelectorNodeTransform()).encode(domUtils.getActiveElement()))
+        );
 
         // NOTE: initiate the child links restoring process before the window is reloaded
         listeners.addInternalEventBeforeListener(window, ['beforeunload'], () => {

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -208,6 +208,8 @@ export default class Driver extends serviceUtils.EventEmitter {
         listeners.addInternalEventBeforeListener(window, ['beforeunload'], () => {
             this._sendStartToRestoreCommand();
         });
+
+        this.replicator = createReplicator([ new SelectorNodeTransform() ]);
     }
 
     _isOpenedInIframe () {
@@ -271,11 +273,11 @@ export default class Driver extends serviceUtils.EventEmitter {
         return Promise.resolve();
     }
 
-    _getActiveElement () {
+    async _getActiveElement () {
         const activeElement = domUtils.getActiveElement();
-        const encodedResult = createReplicator(new SelectorNodeTransform()).encode(activeElement);
+        const encodedResult = this.replicator.encode(activeElement);
 
-        return Promise.resolve(encodedResult);
+        return encodedResult;
     }
 
     _failIfClientCodeExecutionIsInterrupted () {

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -275,9 +275,8 @@ export default class Driver extends serviceUtils.EventEmitter {
 
     async _getActiveElement () {
         const activeElement = domUtils.getActiveElement();
-        const encodedResult = this.replicator.encode(activeElement);
 
-        return encodedResult;
+        return this.replicator.encode(activeElement);
     }
 
     _failIfClientCodeExecutionIsInterrupted () {

--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -12,8 +12,4 @@ interface QuarantineOptionValue {
     passCount?: number;
 }
 
-interface CompilerOptions {
-    [key: string]: object;
-}
-
 type OptionValue = undefined | null | string | boolean | number | string[] | Function | { [key: string]: any } | ScreenshotOptionValue | QuarantineOptionValue | CompilerOptions;

--- a/src/reporter/command/command-formatter.ts
+++ b/src/reporter/command/command-formatter.ts
@@ -63,7 +63,7 @@ export class CommandFormatter {
     }
 
     private _maskConfidentialInfo (command: FormattedCommand): void {
-        if (!command.options?.confidential)
+        if (!(command.options as any)?.confidential)
             return;
 
         if (this._command instanceof TypeTextCommand)

--- a/src/reporter/command/command-formatter.ts
+++ b/src/reporter/command/command-formatter.ts
@@ -2,7 +2,9 @@ import { isEmpty } from 'lodash';
 import { ExecuteSelectorCommand, ExecuteClientFunctionCommand } from '../../test-run/commands/observation';
 import {
     NavigateToCommand,
+    PressKeyCommand,
     SetNativeDialogHandlerCommand,
+    TypeTextCommand,
     UseRoleCommand
 } from '../../test-run/commands/actions';
 
@@ -22,6 +24,8 @@ import {
     AssertionOptions
 } from '../../test-run/commands/options';
 
+
+const CONFIDENTIAL_INFO_PLACEHOLDER = '********';
 
 function isCommandOptions (obj: object): boolean {
     return obj instanceof ActionOptions || obj instanceof ResizeToFitDeviceOptions || obj instanceof AssertionOptions;
@@ -53,7 +57,19 @@ export class CommandFormatter {
         else
             this._assignProperties(this._command, formattedCommand);
 
+        this._maskConfidentialInfo(formattedCommand);
+
         return formattedCommand;
+    }
+
+    private _maskConfidentialInfo (command: FormattedCommand): void {
+        if (!command.options?.confidential)
+            return;
+
+        if (this._command instanceof TypeTextCommand)
+            command.text = CONFIDENTIAL_INFO_PLACEHOLDER;
+        else if (this._command instanceof PressKeyCommand)
+            command.keys = CONFIDENTIAL_INFO_PLACEHOLDER;
     }
 
     private _getElementByPropertyName (propertyName: string): HTMLElement {

--- a/src/reporter/command/interfaces.ts
+++ b/src/reporter/command/interfaces.ts
@@ -6,7 +6,7 @@ export interface Command {
 }
 
 export interface FormattedCommand {
-    [key: string]: any;
+    [key: string]: unknown;
     type: string;
 }
 

--- a/src/reporter/command/interfaces.ts
+++ b/src/reporter/command/interfaces.ts
@@ -6,7 +6,7 @@ export interface Command {
 }
 
 export interface FormattedCommand {
-    [key: string]: unknown;
+    [key: string]: any;
     type: string;
 }
 

--- a/src/test-run/commands/actions.js
+++ b/src/test-run/commands/actions.js
@@ -8,6 +8,7 @@ import {
     ClickOptions,
     MouseOptions,
     TypeOptions,
+    PressOptions,
     DragToElementOptions,
     OffsetOptions
 } from './options';
@@ -58,6 +59,10 @@ function initTypeOptions (name, val) {
 
 function initDragToElementOptions (name, val) {
     return new DragToElementOptions(val, true);
+}
+
+function initPressOptions (name, val) {
+    return new PressOptions(val, true);
 }
 
 function initDialogHandler (name, val, { skipVisibilityCheck, testRun }) {
@@ -325,7 +330,7 @@ export class PressKeyCommand extends CommandBase {
     _getAssignableProperties () {
         return [
             { name: 'keys', type: nonEmptyStringArgument, required: true },
-            { name: 'options', type: actionOptions, init: initActionOptions, required: true }
+            { name: 'options', type: actionOptions, init: initPressOptions, required: true }
         ];
     }
 }

--- a/src/test-run/commands/options.js
+++ b/src/test-run/commands/options.js
@@ -186,8 +186,9 @@ export class TypeOptions extends ClickOptions {
     constructor (obj, validate) {
         super();
 
-        this.replace = false;
-        this.paste   = false;
+        this.replace      = false;
+        this.paste        = false;
+        this.confidential = void 0;
 
         this._assignFrom(obj, validate);
     }
@@ -195,7 +196,8 @@ export class TypeOptions extends ClickOptions {
     _getAssignableProperties () {
         return super._getAssignableProperties().concat([
             { name: 'replace', type: booleanOption },
-            { name: 'paste', type: booleanOption }
+            { name: 'paste', type: booleanOption },
+            { name: 'confidential', type: booleanOption }
         ]);
     }
 }
@@ -252,5 +254,22 @@ export class AssertionOptions extends Assignable {
             { name: 'timeout', type: positiveIntegerOption },
             { name: 'allowUnawaitedPromise', type: booleanOption }
         ];
+    }
+}
+
+// Press
+export class PressOptions extends ActionOptions {
+    constructor (obj, validate) {
+        super();
+
+        this.confidential = void 0;
+
+        this._assignFrom(obj, validate);
+    }
+
+    _getAssignableProperties () {
+        return super._getAssignableProperties().concat([
+            { name: 'confidential', type: booleanOption }
+        ]);
     }
 }

--- a/src/test-run/commands/service.js
+++ b/src/test-run/commands/service.js
@@ -40,3 +40,8 @@ export class UnlockPageCommand {
     }
 }
 
+export class GetActiveElementCommand {
+    constructor () {
+        this.type = TYPE.getActiveElement;
+    }
+}

--- a/src/test-run/commands/type.js
+++ b/src/test-run/commands/type.js
@@ -48,6 +48,7 @@ export default {
     setNativeDialogHandler:     'set-native-dialog-handler',
     getNativeDialogHistory:     'get-native-dialog-history',
     getBrowserConsoleMessages:  'get-browser-console-messages',
+    getActiveElement:           'get-active-element',
     setTestSpeed:               'set-test-speed',
     setPageLoadTimeout:         'set-page-load-timeout',
     debug:                      'debug',

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -24,6 +24,7 @@ import PHASE from './phase';
 import CLIENT_MESSAGES from './client-messages';
 import COMMAND_TYPE from './commands/type';
 import delay from '../utils/delay';
+import isPasswordInput from '../utils/is-password-input';
 import testRunMarker from './marker-symbol';
 import testRunTracker from '../api/test-run-tracker';
 import ROLE_PHASE from '../role/phase';
@@ -52,6 +53,8 @@ import { GetCurrentWindowsCommand, SwitchToWindowCommand } from './commands/acti
 import { RUNTIME_ERRORS, TEST_RUN_ERRORS } from '../errors/types';
 import processTestFnError from '../errors/process-test-fn-error';
 import RequestHookMethodNames from '../api/request-hooks/hook-method-names';
+
+import { createReplicator, SelectorNodeTransform } from '../client-functions/replicator';
 
 const lazyRequire                 = require('import-lazy')(require);
 const SessionController           = lazyRequire('./session-controller');
@@ -691,6 +694,33 @@ export default class TestRun extends AsyncEventEmitter {
             command.generateScreenshotMark();
     }
 
+    async _adjustCommandOptions (command) {
+        if (command.options?.confidential !== void 0)
+            return;
+
+        if (command.type === COMMAND_TYPE.typeText) {
+            const result = await this.executeCommand(command.selector);
+
+            if (!result)
+                return;
+
+            const node = createReplicator(new SelectorNodeTransform()).decode(result);
+
+            command.options.confidential = isPasswordInput(node);
+        }
+
+        else if (command.type === COMMAND_TYPE.pressKey) {
+            const result = await this.executeCommand(new serviceCommands.GetActiveElementCommand());
+
+            if (!result)
+                return;
+
+            const node = createReplicator(new SelectorNodeTransform()).decode(result);
+
+            command.options.confidential = isPasswordInput(node);
+        }
+    }
+
     async _setBreakpointIfNecessary (command, callsite) {
         if (!this.disableDebugBreakpoints && this.debugging && canSetDebuggerBreakpointBeforeCommand(command))
             await this._enqueueSetBreakpointCommand(callsite);
@@ -702,6 +732,8 @@ export default class TestRun extends AsyncEventEmitter {
         let errorAdapter = null;
         let error        = null;
         let result       = null;
+
+        await this._adjustCommandOptions(command);
 
         await this.emitActionEvent('action-start', actionArgs);
 

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -154,6 +154,8 @@ export default class TestRun extends AsyncEventEmitter {
         this.observedCallsites = new ObservedCallsitesStorage();
         this.compilerService   = compilerService;
 
+        this.replicator = createReplicator([ new SelectorNodeTransform() ]);
+
         this._addInjectables();
         this._initRequestHooks();
     }
@@ -704,7 +706,7 @@ export default class TestRun extends AsyncEventEmitter {
             if (!result)
                 return;
 
-            const node = createReplicator(new SelectorNodeTransform()).decode(result);
+            const node = this.replicator.decode(result);
 
             command.options.confidential = isPasswordInput(node);
         }
@@ -715,7 +717,7 @@ export default class TestRun extends AsyncEventEmitter {
             if (!result)
                 return;
 
-            const node = createReplicator(new SelectorNodeTransform()).decode(result);
+            const node = this.replicator.decode(result);
 
             command.options.confidential = isPasswordInput(node);
         }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,5 +1,9 @@
 {
-  "include": [ "../@types", "./"],
+  "include": [
+    "../@types",
+    "../ts-defs-src",
+    "./"
+  ],
   "exclude": ["./client"],
   "compilerOptions": {
     "outDir": "../lib",

--- a/src/utils/is-password-input.ts
+++ b/src/utils/is-password-input.ts
@@ -1,3 +1,6 @@
-export default function isPasswordInput (node: any): boolean {
-    return node && node.tagName === 'input' && node.attributes.type === 'password';
+export default function isPasswordInput (node?: NodeSnapshot): boolean {
+    if (!node)
+        return false;
+
+    return node.tagName === 'input' && node.attributes?.type === 'password';
 }

--- a/src/utils/is-password-input.ts
+++ b/src/utils/is-password-input.ts
@@ -1,0 +1,3 @@
+export default function isPasswordInput (node: any): boolean {
+    return node && node.tagName === 'input' && node.attributes.type === 'password';
+}

--- a/test/functional/fixtures/reporter/pages/index.html
+++ b/test/functional/fixtures/reporter/pages/index.html
@@ -18,5 +18,6 @@
     <div id="contenteditable" contenteditable="true"></div>
     <input type="file" id="file"/>
     <iframe id="iframe" src="./index.html"></iframe>
+    <input type="password" id="masked-input"></input>
 </body>
 </html>

--- a/test/functional/fixtures/reporter/pages/index.html
+++ b/test/functional/fixtures/reporter/pages/index.html
@@ -18,6 +18,6 @@
     <div id="contenteditable" contenteditable="true"></div>
     <input type="file" id="file"/>
     <iframe id="iframe" src="./index.html"></iframe>
-    <input type="password" id="masked-input"></input>
+    <input type="password" id="password-input"></input>
 </body>
 </html>

--- a/test/functional/fixtures/reporter/reporter.js
+++ b/test/functional/fixtures/reporter/reporter.js
@@ -14,12 +14,13 @@ function generateReporter (log, options = {}) {
         emitOnStart = true,
         emitOnDone = true,
         includeBrowserInfo = false,
-        includeTestInfo = false
+        includeTestInfo = false,
+        includeCommandInfo = false
     } = options;
 
     return function () {
         return Object.assign({}, baseReport, {
-            async reportTestActionStart (name, { browser, test, fixture }) {
+            async reportTestActionStart (name, { browser, test, fixture, command }) {
                 if (!emitOnStart)
                     return;
 
@@ -44,6 +45,9 @@ function generateReporter (log, options = {}) {
                         };
                     }
                 }
+
+                if (includeCommandInfo)
+                    item.command = command;
 
                 log.push(item);
             },

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -588,119 +588,213 @@ describe('Reporter', () => {
         });
 
         it('Value typed using the "typeText" action in the input[type=password] should be masked', () => {
-            return runTests('testcafe-fixtures/index-test.js', 'The "typeText" action with masked input', { reporter: generateReporter(log, { includeCommandInfo: true }) })
-                .then(() => {
-                    expect(log).eql([
-                        {
-                            name:    'typeText',
-                            action:  'start',
-                            command: {
-                                type:     'type-text',
-                                selector: {
-                                    expression: "Selector('#masked-input')",
-                                },
-                                options: {
-                                    confidential: true
-                                },
-                                text: '********',
+            return runTests(
+                'testcafe-fixtures/index-test.js',
+                'The "typeText" action with the input[type=password]',
+                { reporter: generateReporter(log, { includeCommandInfo: true }) }
+            ).then(() => {
+                expect(log).to.include.deep.members([
+                    {
+                        name:    'typeText',
+                        action:  'start',
+                        command: {
+                            type:     'type-text',
+                            selector: {
+                                expression: "Selector('#password-input')"
                             },
-                        },
-                        {
-                            name:    'typeText',
-                            action:  'done',
-                            command: {
-                                type:     'type-text',
-                                selector: "Selector('#masked-input')",
-                                options:  {
-                                    confidential: true
-                                },
-                                text: '********'
-                            }
-                        },
-                    ]);
-                });
+                            options: {
+                                confidential: true
+                            },
+                            text: '********'
+                        }
+                    },
+                    {
+                        name:    'typeText',
+                        action:  'done',
+                        command: {
+                            type:     'type-text',
+                            selector: "Selector('#password-input')",
+                            options:  {
+                                confidential: true
+                            },
+                            text: '********'
+                        }
+                    }
+                ]);
+            });
         });
 
-        it('Value typed using the "typeText" action in the inpu[type=password] shouldnt be masked if "confidential" flag is set to false', () => {
-            return runTests('testcafe-fixtures/index-test.js', 'The "typeText" action with masked input and the "confidential" flag set to false', { reporter: generateReporter(log, { includeCommandInfo: true }) })
-                .then(() => {
-                    expect(log).eql([
-                        {
-                            name:    'typeText',
-                            action:  'start',
-                            command: {
-                                type:     'type-text',
-                                selector: {
-                                    expression: "Selector('#masked-input')",
-                                },
-                                options: {
-                                    confidential: false
-                                },
-                                text: 'pa$$w0rd',
+        it('Value typed using the "typeText" action should be masked if "confidential" flag is set to true', () => {
+            return runTests(
+                'testcafe-fixtures/index-test.js',
+                'The "typeText" action with the input[type=text] and the "confidential" flag set to true',
+                { reporter: generateReporter(log, { includeCommandInfo: true }) }
+            ).then(() => {
+                expect(log).to.include.deep.members([
+                    {
+                        name:    'typeText',
+                        action:  'start',
+                        command: {
+                            type:     'type-text',
+                            selector: {
+                                expression: "Selector('#input')"
                             },
-                        },
-                        {
-                            name:    'typeText',
-                            action:  'done',
-                            command: {
-                                type:     'type-text',
-                                selector: "Selector('#masked-input')",
-                                options:  {
-                                    confidential: false
-                                },
-                                text: 'pa$$w0rd'
-                            }
-                        },
-                    ]);
-                });
+                            options: {
+                                confidential: true
+                            },
+                            text: '********'
+                        }
+                    },
+                    {
+                        name:    'typeText',
+                        action:  'done',
+                        command: {
+                            type:     'type-text',
+                            selector: "Selector('#input')",
+                            options:  {
+                                confidential: true
+                            },
+                            text: '********'
+                        }
+                    }
+                ]);
+            });
+        });
+
+        it('Value typed using the "typeText" action shouldn\'t be masked if "confidential" flag is set to false', () => {
+            return runTests(
+                'testcafe-fixtures/index-test.js',
+                'The "typeText" action with the input[type=password] and the "confidential" flag set to false',
+                { reporter: generateReporter(log, { includeCommandInfo: true }) }
+            ).then(() => {
+                expect(log).to.include.deep.members([
+                    {
+                        name:    'typeText',
+                        action:  'start',
+                        command: {
+                            type:     'type-text',
+                            selector: {
+                                expression: "Selector('#password-input')"
+                            },
+                            options: {
+                                confidential: false
+                            },
+                            text: 'pa$$w0rd'
+                        }
+                    },
+                    {
+                        name:    'typeText',
+                        action:  'done',
+                        command: {
+                            type:     'type-text',
+                            selector: "Selector('#password-input')",
+                            options:  {
+                                confidential: false
+                            },
+                            text: 'pa$$w0rd'
+                        }
+                    }
+                ]);
+            });
         });
 
         it('Value typed using the "pressKey" action in the input[type=password] should be masked', () => {
-            return runTests('testcafe-fixtures/index-test.js', 'The "pressKey" action with masked input', { reporter: generateReporter(log, { includeCommandInfo: true }) })
-                .then(() => {
-                    expect(log).eql([
-                        {
-                            name:    'click',
-                            action:  'start',
-                            command: {
-                                type:     'click',
-                                selector: {
-                                    expression: "Selector('#masked-input')",
-                                }
+            return runTests(
+                'testcafe-fixtures/index-test.js',
+                'The "pressKey" action with the input[type=password]',
+                { reporter: generateReporter(log, { includeCommandInfo: true }) }
+            ).then(() => {
+                expect(log).to.include.deep.members([
+                    {
+                        name:    'pressKey',
+                        action:  'start',
+                        command: {
+                            type:    'press-key',
+                            options: {
+                                confidential: true
                             },
-                        },
-                        {
-                            name:    'click',
-                            action:  'done',
-                            command: {
-                                type:     'click',
-                                selector: "Selector('#masked-input')"
-                            }
-                        },
-                        {
-                            name:    'pressKey',
-                            action:  'start',
-                            command: {
-                                type:    'press-key',
-                                options: {
-                                    confidential: true
-                                },
-                                keys: '********'
+                            keys: '********'
+                        }
+                    },
+                    {
+                        name:    'pressKey',
+                        action:  'done',
+                        command: {
+                            type:    'press-key',
+                            options: {
+                                confidential: true
                             },
-                        },
-                        {
-                            name:    'pressKey',
-                            action:  'done',
-                            command: {
-                                type:    'press-key',
-                                options: {
-                                    confidential: true
-                                },
-                                keys: '********'
-                            }
-                        },
-                    ]);
-                });
+                            keys: '********'
+                        }
+                    }
+                ]);
+            });
+        });
+
+        it('Value typed using the "pressKey" action should be masked if "confidential" flag is set to true', () => {
+            return runTests(
+                'testcafe-fixtures/index-test.js',
+                'The "pressKey" action with the input[type=text] and the "confidential" flag set to true',
+                { reporter: generateReporter(log, { includeCommandInfo: true }) }
+            ).then(() => {
+                expect(log).to.include.deep.members([
+                    {
+                        name:    'pressKey',
+                        action:  'start',
+                        command: {
+                            type:    'press-key',
+                            options: {
+                                confidential: true,
+                            },
+                            keys: '********'
+                        }
+                    },
+                    {
+                        name:    'pressKey',
+                        action:  'done',
+                        command: {
+                            type:    'press-key',
+                            options: {
+                                confidential: true,
+                            },
+                            keys: '********'
+                        }
+                    }
+                ]);
+            });
+        });
+
+        it('Value typed using the "pressKey" action shouldn\'t be masked if "confidential" flag is set to false', () => {
+            return runTests(
+                'testcafe-fixtures/index-test.js',
+                'The "pressKey" action with the input[type=password] and the "confidential" flag set to false',
+                { reporter: generateReporter(log, { includeCommandInfo: true }) }
+            ).then(() => {
+                expect(log).to.include.deep.members([
+                    {
+                        name:    'pressKey',
+                        action:  'start',
+                        command: {
+                            type:    'press-key',
+                            options: {
+                                confidential: false
+                            },
+                            keys: 'p a $ $ w 0 r d enter'
+                        }
+                    },
+                    {
+                        name:    'pressKey',
+                        action:  'done',
+                        command: {
+                            type:    'press-key',
+                            options: {
+                                confidential: false
+                            },
+                            keys: 'p a $ $ w 0 r d enter'
+                        }
+                    }
+                ]);
+            });
         });
     });
 

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -244,9 +244,13 @@ describe('Reporter', () => {
             };
         }
 
-        it('Simple command', function () {
-            const log = [];
+        let log = null;
 
+        beforeEach(() => {
+            log = [];
+        });
+
+        it('Simple command', function () {
             return runTests('testcafe-fixtures/index-test.js', 'Simple command test', generateRunOptions(log, {
                 includeBrowserInfo: true,
                 includeTestInfo:    true
@@ -292,8 +296,6 @@ describe('Reporter', () => {
         });
 
         it('Simple command Error', function () {
-            const log = [];
-
             return runTests('testcafe-fixtures/index-test.js', 'Simple command err test', generateRunOptions(log))
                 .then(() => {
                     expect(log).eql([
@@ -315,8 +317,6 @@ describe('Reporter', () => {
         });
 
         it('Simple assertion', function () {
-            const log = [];
-
             return runTests('testcafe-fixtures/index-test.js', 'Simple assertion', generateRunOptions(log))
                 .then(() => {
                     expect(log).eql([
@@ -344,8 +344,6 @@ describe('Reporter', () => {
         });
 
         it('Selector assertion', function () {
-            const log = [];
-
             return runTests('testcafe-fixtures/index-test.js', 'Selector assertion', generateRunOptions(log))
                 .then(() => {
                     expect(log).eql([
@@ -370,8 +368,6 @@ describe('Reporter', () => {
         });
 
         it('Snapshot', function () {
-            const log = [];
-
             return runTests('testcafe-fixtures/index-test.js', 'Snapshot', generateRunOptions(log))
                 .then(() => {
                     expect(log).eql([
@@ -404,8 +400,6 @@ describe('Reporter', () => {
         });
 
         it('Client Function', function () {
-            const log = [];
-
             return runTests('testcafe-fixtures/index-test.js', 'Client Function', generateRunOptions(log))
                 .then(() => {
                     expect(log).eql([
@@ -429,8 +423,6 @@ describe('Reporter', () => {
         });
 
         it('Complex command', function () {
-            const log = [];
-
             return runTests('testcafe-fixtures/index-test.js', 'Complex command test', generateRunOptions(log))
                 .then(() => {
                     expect(log).eql([
@@ -452,8 +444,6 @@ describe('Reporter', () => {
         });
 
         it('Complex nested command', function () {
-            const log = [];
-
             return runTests('testcafe-fixtures/index-test.js', 'Complex nested command test', generateRunOptions(log, { includeTestInfo: true }))
                 .then(() => {
                     expect(log).eql([
@@ -526,8 +516,6 @@ describe('Reporter', () => {
         });
 
         it('Complex nested command error', function () {
-            const log = [];
-
             return runTests('testcafe-fixtures/index-test.js', 'Complex nested command error', generateRunOptions(log))
                 .then(() => {
                     expect(log).eql([
@@ -559,8 +547,6 @@ describe('Reporter', () => {
         });
 
         it('Eval', function () {
-            const log = [];
-
             return runTests('testcafe-fixtures/index-test.js', 'Eval', generateRunOptions(log))
                 .then(() => {
                     expect(log).eql([
@@ -581,8 +567,6 @@ describe('Reporter', () => {
         });
 
         it('Should not add action information in report if action was emitted after test done (GH-5650)', () => {
-            const log = [];
-
             return runTests('testcafe-fixtures/index-test.js', 'Action done after test done', generateRunOptions(log))
                 .then(() => {
                     expect(log).eql([
@@ -599,6 +583,122 @@ describe('Reporter', () => {
                                 }
                             }
                         }
+                    ]);
+                });
+        });
+
+        it('Value typed using the "typeText" action in the input[type=password] should be masked', () => {
+            return runTests('testcafe-fixtures/index-test.js', 'The "typeText" action with masked input', { reporter: generateReporter(log, { includeCommandInfo: true }) })
+                .then(() => {
+                    expect(log).eql([
+                        {
+                            name:    'typeText',
+                            action:  'start',
+                            command: {
+                                type:     'type-text',
+                                selector: {
+                                    expression: "Selector('#masked-input')",
+                                },
+                                options: {
+                                    confidential: true
+                                },
+                                text: '********',
+                            },
+                        },
+                        {
+                            name:    'typeText',
+                            action:  'done',
+                            command: {
+                                type:     'type-text',
+                                selector: "Selector('#masked-input')",
+                                options:  {
+                                    confidential: true
+                                },
+                                text: '********'
+                            }
+                        },
+                    ]);
+                });
+        });
+
+        it('Value typed using the "typeText" action in the inpu[type=password] shouldnt be masked if "confidential" flag is set to false', () => {
+            return runTests('testcafe-fixtures/index-test.js', 'The "typeText" action with masked input and the "confidential" flag set to false', { reporter: generateReporter(log, { includeCommandInfo: true }) })
+                .then(() => {
+                    expect(log).eql([
+                        {
+                            name:    'typeText',
+                            action:  'start',
+                            command: {
+                                type:     'type-text',
+                                selector: {
+                                    expression: "Selector('#masked-input')",
+                                },
+                                options: {
+                                    confidential: false
+                                },
+                                text: 'pa$$w0rd',
+                            },
+                        },
+                        {
+                            name:    'typeText',
+                            action:  'done',
+                            command: {
+                                type:     'type-text',
+                                selector: "Selector('#masked-input')",
+                                options:  {
+                                    confidential: false
+                                },
+                                text: 'pa$$w0rd'
+                            }
+                        },
+                    ]);
+                });
+        });
+
+        it('Value typed using the "pressKey" action in the input[type=password] should be masked', () => {
+            return runTests('testcafe-fixtures/index-test.js', 'The "pressKey" action with masked input', { reporter: generateReporter(log, { includeCommandInfo: true }) })
+                .then(() => {
+                    expect(log).eql([
+                        {
+                            name:    'click',
+                            action:  'start',
+                            command: {
+                                type:     'click',
+                                selector: {
+                                    expression: "Selector('#masked-input')",
+                                }
+                            },
+                        },
+                        {
+                            name:    'click',
+                            action:  'done',
+                            command: {
+                                type:     'click',
+                                selector: "Selector('#masked-input')"
+                            }
+                        },
+                        {
+                            name:    'pressKey',
+                            action:  'start',
+                            command: {
+                                type:    'press-key',
+                                options: {
+                                    confidential: true
+                                },
+                                keys: '********'
+                            },
+                        },
+                        {
+                            name:    'pressKey',
+                            action:  'done',
+                            command: {
+                                type:    'press-key',
+                                options: {
+                                    confidential: true
+                                },
+                                keys: '********'
+                            }
+                        },
                     ]);
                 });
         });

--- a/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
@@ -75,3 +75,17 @@ test('Action done after test done', async t => {
         .wait(5000)
         .eval(() => location.reload(true));
 });
+
+test('The "typeText" action with masked input', async t => {
+    await t.typeText('#masked-input', 'pa$$w0rd');
+});
+
+test('The "typeText" action with masked input and the "confidential" flag set to false', async t => {
+    await t.typeText('#masked-input', 'pa$$w0rd', { confidential: false });
+});
+
+test('The "pressKey" action with masked input', async t => {
+    await t
+        .click('#masked-input')
+        .pressKey('p a $ $ w 0 r d enter');
+});

--- a/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
@@ -76,16 +76,32 @@ test('Action done after test done', async t => {
         .eval(() => location.reload(true));
 });
 
-test('The "typeText" action with masked input', async t => {
-    await t.typeText('#masked-input', 'pa$$w0rd');
+test('The "typeText" action with the input[type=password]', async t => {
+    await t.typeText('#password-input', 'pa$$w0rd');
 });
 
-test('The "typeText" action with masked input and the "confidential" flag set to false', async t => {
-    await t.typeText('#masked-input', 'pa$$w0rd', { confidential: false });
+test('The "typeText" action with the input[type=text] and the "confidential" flag set to true', async t => {
+    await t.typeText('#input', 'pa$$w0rd', { confidential: true });
 });
 
-test('The "pressKey" action with masked input', async t => {
+test('The "typeText" action with the input[type=password] and the "confidential" flag set to false', async t => {
+    await t.typeText('#password-input', 'pa$$w0rd', { confidential: false });
+});
+
+test('The "pressKey" action with the input[type=password]', async t => {
     await t
-        .click('#masked-input')
+        .click('#password-input')
         .pressKey('p a $ $ w 0 r d enter');
+});
+
+test('The "pressKey" action with the input[type=text] and the "confidential" flag set to true', async t => {
+    await t
+        .click('#input')
+        .pressKey('p a $ $ w 0 r d enter', { confidential: true });
+});
+
+test('The "pressKey" action with the input[type=password] and the "confidential" flag set to false', async t => {
+    await t
+        .click('#password-input')
+        .pressKey('p a $ $ w 0 r d enter', { confidential: false });
 });

--- a/test/server/test-run-commands-test.js
+++ b/test/server/test-run-commands-test.js
@@ -512,7 +512,9 @@ describe('Test run commands', () => {
                         dummy: 'yo',
                         alt:   false,
                         meta:  false
-                    }
+                    },
+
+                    confidential: true
                 }
             };
 
@@ -536,7 +538,9 @@ describe('Test run commands', () => {
                         alt:   false,
                         shift: false,
                         meta:  false
-                    }
+                    },
+
+                    confidential: true
                 }
             });
 

--- a/ts-defs-src/test-api/action-options.d.ts
+++ b/ts-defs-src/test-api/action-options.d.ts
@@ -138,6 +138,17 @@ interface TypeActionOptions extends ClickActionOptions {
      * and false to insert the current text character by character.
      */
     paste?: boolean;
+    /**
+     * `true` to replace the typed text with a placeholder when sending action logs to a reporter.
+     */
+    confidential?: boolean;
+}
+
+interface PressActionOptions extends ActionOptions {
+    /**
+     * `true` to replace the pressed keys with a placeholder when sending action logs to a reporter.
+     */
+    confidential?: boolean;
 }
 
 interface DragToElementOptions extends MouseActionOptions {

--- a/ts-defs-src/test-api/test-controller.d.ts
+++ b/ts-defs-src/test-api/test-controller.d.ts
@@ -290,7 +290,7 @@ interface TestController {
      * @param keys - The sequence of keys and key combinations to be pressed.
      * @param options - A set of options that provide additional parameters for the action.
      */
-    pressKey(keys: string, options?: ActionOptions): TestControllerPromise;
+    pressKey(keys: string, options?: PressActionOptions): TestControllerPromise;
     /**
      * Pauses a test for a specified period of time.
      *


### PR DESCRIPTION
## Purpose
Values typed into input[type=password] should be replaced by a placeholder before sending action logs with these values to a reporter. Also the `pressKey` and the `typeText` actions have the `confidential` flag. If it set to 'true', then any typed text & pressed keys would be replaced by a placeholder in action logs.

## Approach
Detect what is the target element (either specified in the `typeText` action or current active element for the `pressKey` action). If it's the input which type is 'password' or the `confidential` flag is set to true, then replace info with a placeholder.

## References
Closes #6014

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
