### PR TITLE
test: fix server tests after Babel update

### DIFF
--- a/src/compiler/babel/load-libs.js
+++ b/src/compiler/babel/load-libs.js
@@ -60,6 +60,8 @@ export default function loadLibs () {
         presetEnvForClientFunction: [require('@babel/preset-env'), getPresetEnvForClientFunctionOpts()],
         presetEnvForTestCode:       [require('@babel/preset-env'), getPresetEnvForTestCodeOpts()],
         moduleResolver:             [require('babel-plugin-module-resolver'), getModuleResolverOpts()],
-        presetReact:                getPresetReact()
+        presetReact:                getPresetReact(),
+        proposalPrivateMethods:     [require('@babel/plugin-proposal-private-methods'), { loose: true }],
+        proposalClassProperties:    [require('@babel/plugin-proposal-class-properties'), { loose: true }]
     };
 }

--- a/src/compiler/test-file/formats/es-next/compiler.js
+++ b/src/compiler/test-file/formats/es-next/compiler.js
@@ -17,8 +17,8 @@ export default class ESNextTestFileCompiler extends APIBasedTestFileCompilerBase
         } = loadBabelLibs();
 
         const opts = Object.assign({}, BASE_BABEL_OPTIONS, {
-            presets: [presetStage2, presetEnvForTestCode, presetReact],
-            plugins: [transformRuntime, moduleResolver, proposalPrivateMethods, proposalClassProperties],
+            presets:    [presetStage2, presetEnvForTestCode, presetReact],
+            plugins:    [transformRuntime, moduleResolver, proposalPrivateMethods, proposalClassProperties],
             sourceMaps: 'inline',
             filename
         });

--- a/src/compiler/test-file/formats/es-next/compiler.js
+++ b/src/compiler/test-file/formats/es-next/compiler.js
@@ -11,17 +11,14 @@ export default class ESNextTestFileCompiler extends APIBasedTestFileCompilerBase
             transformRuntime,
             presetEnvForTestCode,
             presetReact,
-            moduleResolver
+            moduleResolver,
+            proposalPrivateMethods,
+            proposalClassProperties
         } = loadBabelLibs();
 
         const opts = Object.assign({}, BASE_BABEL_OPTIONS, {
             presets: [presetStage2, presetEnvForTestCode, presetReact],
-            plugins: [
-                transformRuntime,
-                moduleResolver,
-                ['@babel/plugin-proposal-private-methods', { loose: true }],
-                ['@babel/plugin-proposal-class-properties', { loose: true }]
-            ],
+            plugins: [transformRuntime, moduleResolver, proposalPrivateMethods, proposalClassProperties],
             sourceMaps: 'inline',
             filename
         });

--- a/src/compiler/test-file/formats/es-next/compiler.js
+++ b/src/compiler/test-file/formats/es-next/compiler.js
@@ -15,8 +15,13 @@ export default class ESNextTestFileCompiler extends APIBasedTestFileCompilerBase
         } = loadBabelLibs();
 
         const opts = Object.assign({}, BASE_BABEL_OPTIONS, {
-            presets:    [presetStage2, presetEnvForTestCode, presetReact],
-            plugins:    [transformRuntime, moduleResolver],
+            presets: [presetStage2, presetEnvForTestCode, presetReact],
+            plugins: [
+                transformRuntime,
+                moduleResolver,
+                ['@babel/plugin-proposal-private-methods', { loose: true }],
+                ['@babel/plugin-proposal-class-properties', { loose: true }]
+            ],
             sourceMaps: 'inline',
             filename
         });

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -968,7 +968,7 @@ describe('Compiler', function () {
 
 
                         message: 'Cannot prepare tests due to an error.\n\n' +
-                                 'SyntaxError: ' + testfiles[0] + ': Missing semicolon (1:7)'
+                                 'SyntaxError: ' + testfiles[0] + ': Missing semicolon. (1:7)'
                     }, true);
 
                     return compile(testfiles[1]);
@@ -981,7 +981,7 @@ describe('Compiler', function () {
                         stackTop: null,
 
                         message: 'Cannot prepare tests due to an error.\n\n' +
-                                 'SyntaxError: ' + testfiles[1] + ': Missing semicolon (2:7)'
+                                 'SyntaxError: ' + testfiles[1] + ': Missing semicolon. (2:7)'
                     }, true);
                 });
         });

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -973,6 +973,8 @@ describe('Runner', () => {
 
     describe('Regression', () => {
         it('Should not have unhandled rejections in runner (GH-825)', function () {
+            this.timeout(10000);
+
             let rejectionReason = null;
 
             process.on('unhandledRejection', reason => {
@@ -980,7 +982,7 @@ describe('Runner', () => {
             });
 
             return runner
-                .browsers('remote')
+                .browsers(BROWSER_NAME)
                 .src([])
                 .run()
                 .then(() => {

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -973,8 +973,6 @@ describe('Runner', () => {
 
     describe('Regression', () => {
         it('Should not have unhandled rejections in runner (GH-825)', function () {
-            this.timeout(10000);
-
             let rejectionReason = null;
 
             process.on('unhandledRejection', reason => {
@@ -982,7 +980,7 @@ describe('Runner', () => {
             });
 
             return runner
-                .browsers(BROWSER_NAME)
+                .browsers('remote')
                 .src([])
                 .run()
                 .then(() => {


### PR DESCRIPTION
Some issues with the server tests occurred after Babel updated to v7.14.0 (2021-04-29).
Related change with the updated error message ("Missing semicolon.", additional dot at the end) - https://github.com/babel/babel/pull/13130
Related change with the warning about using the 'loose' option - https://github.com/babel/babel/pull/13091