### PR TITLE
feat: support request hooks (final)

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -29,6 +29,7 @@ const getDockerPublishInfo          = require('./gulp/docker/get-publish-info');
 const runFunctionalTestInDocker     = require('./gulp/docker/run-functional-test-via-command-line');
 const { exitDomains, enterDomains } = require('./gulp/helpers/domain');
 const getTimeout                    = require('./gulp/helpers/get-timeout');
+const promisifyStream               = require('./gulp/helpers/promisify-stream');
 
 const readFile = promisify(fs.readFile);
 
@@ -165,14 +166,9 @@ const RETRY_TEST_RUN_COUNT = 3;
 
 const MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB = [
     'test/functional/fixtures/app-command/test.js',
-    'test/functional/fixtures/driver/test.js'
+    'test/functional/fixtures/driver/test.js',
+    'test/functional/fixtures/api/es-next/request-hooks/test.js'
 ];
-
-function promisifyStream (stream) {
-    return new Promise((resolve, reject) => {
-        stream.on('end', resolve).on('error', reject);
-    });
-}
 
 gulp.task('audit', () => {
     return npmAuditor()

--- a/gulp/helpers/promisify-stream.js
+++ b/gulp/helpers/promisify-stream.js
@@ -1,5 +1,3 @@
-module.exports = function promisifyStream (stream) {
-    return new Promise((resolve, reject) => {
-        stream.on('end', resolve).on('error', reject);
-    });
-};
+const { once } = require('events');
+
+module.exports = stream => once(stream, 'end');

--- a/gulp/helpers/promisify-stream.js
+++ b/gulp/helpers/promisify-stream.js
@@ -1,0 +1,5 @@
+module.exports = function promisifyStream (stream) {
+    return new Promise((resolve, reject) => {
+        stream.on('end', resolve).on('error', reject);
+    });
+};

--- a/src/api/request-hooks/hook.ts
+++ b/src/api/request-hooks/hook.ts
@@ -16,13 +16,15 @@ export default abstract class RequestHook {
     public _requestFilterRules: RequestFilterRule[];
     public readonly _responseEventConfigureOpts?: ConfigureResponseEventOptions;
     public _warningLog: WarningLog | null;
-    public id: string;
+    public readonly id: string;
+    public _className: string;
 
     protected constructor (ruleInit?: RequestFilterRuleInit | RequestFilterRuleInit[], responseEventConfigureOpts?: ConfigureResponseEventOptions) {
         this._requestFilterRules         = this._prepareRules(ruleInit);
         this._responseEventConfigureOpts = responseEventConfigureOpts;
         this._warningLog                 = null;
         this.id                          = generateUniqueId();
+        this._className                  = this.constructor.name;
     }
 
     private _prepareRules (ruleInit?: RequestFilterRuleInit | RequestFilterRuleInit[]): RequestFilterRule[] {

--- a/src/api/request-hooks/request-logger.ts
+++ b/src/api/request-hooks/request-logger.ts
@@ -52,6 +52,8 @@ interface LoggedRequest {
     response?: LoggedResponsePart;
 }
 
+const REQUEST_LOGGER_CLASS_NAME = 'RequestLogger';
+
 class RequestLoggerImplementation extends RequestHook {
     private readonly _options: RequestHookLogOptions;
     private _internalRequests: Dictionary<LoggedRequest>;
@@ -65,6 +67,7 @@ class RequestLoggerImplementation extends RequestHook {
 
         super(requestFilterRuleInit, configureResponseEventOptions);
 
+        this._className        = REQUEST_LOGGER_CLASS_NAME;
         this._options          = effectiveOptions;
         this._internalRequests = {};
     }

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -82,6 +82,8 @@ export default class TestRunController extends AsyncEventEmitter {
             screenshotCapturer
         });
 
+        await this.testRun.initialize();
+
         this._screenshots.addTestRun(this.test, this.testRun);
 
         if (this.testRun.addQuarantineInfo)

--- a/src/services/compiler/protocol.ts
+++ b/src/services/compiler/protocol.ts
@@ -8,7 +8,8 @@ import {
     ResponseEvent,
     ResponseMock,
     RequestInfo,
-    IncomingMessageLikeInitOptions
+    IncomingMessageLikeInitOptions,
+    RequestFilterRule
 } from 'testcafe-hammerhead';
 
 export const BEFORE_AFTER_PROPERTIES  = ['beforeFn', 'afterFn'] as const;
@@ -47,13 +48,22 @@ export interface ExecuteCommandArguments {
     command: unknown;
 }
 
+export interface RemoveRequestEventListenersArguments {
+    rules: RequestFilterRule[];
+}
+
+export interface AddRequestEventListenersArguments {
+    hookId: string;
+    hookClassName: string;
+    rules: RequestFilterRule[];
+}
+
 export interface SetOptionsArguments {
     value: Dictionary<OptionValue>;
 }
 
 export interface RequestHookEventArguments {
     name: RequestHookMethodNames;
-    testRunId: string;
     testId: string;
     hookId: string;
     eventData: RequestEvent | ConfigureResponseEvent | ResponseEvent;
@@ -102,10 +112,17 @@ export interface GetWarningMessagesArguments {
     testRunId: string;
 }
 
+export interface InitializeTestRunProxyArguments {
+    testRunId: string;
+    testId: string;
+}
+
 export interface TestRunDispatcherProtocol {
     executeActionSync ({ id, apiMethodName, command, callsite }: ExecuteActionArguments): unknown;
     executeAction ({ id, apiMethodName, command, callsite }: ExecuteActionArguments): Promise<unknown>;
     executeCommand ({ command }: ExecuteCommandArguments): Promise<unknown>;
+    addRequestEventListeners ( { hookId, hookClassName, rules }: AddRequestEventListenersArguments): Promise<void>;
+    removeRequestEventListeners ({ rules }: RemoveRequestEventListenersArguments): Promise<void>;
 }
 
 export interface CompilerProtocol extends TestRunDispatcherProtocol {
@@ -119,7 +136,7 @@ export interface CompilerProtocol extends TestRunDispatcherProtocol {
 
     setOptions ({ value }: SetOptionsArguments): Promise<void>;
 
-    onRequestHookEvent ({ name, testRunId, testId, hookId, eventData }: RequestHookEventArguments): Promise<void>;
+    onRequestHookEvent ({ name, testId, hookId, eventData }: RequestHookEventArguments): Promise<void>;
 
     setMock ({ responseEventId, mock }: SetMockArguments): Promise<void>;
 
@@ -134,4 +151,6 @@ export interface CompilerProtocol extends TestRunDispatcherProtocol {
     executeMockPredicate ({ testId, hookId, ruleId, requestInfo, res }: ExecuteMockPredicate): Promise<IncomingMessageLikeInitOptions>;
 
     getWarningMessages ({ testRunId }: GetWarningMessagesArguments): Promise<string[]>;
+
+    initializeTestRunProxy ({ testRunId, testId }: InitializeTestRunProxyArguments): Promise<void>;
 }

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -1,9 +1,10 @@
 import { TestRunDispatcherProtocol } from './compiler/protocol';
 import { Dictionary } from '../configuration/interfaces';
+import Test from '../api/structure/test';
 
 export interface TestRunProxyInit {
     dispatcher: TestRunDispatcherProtocol;
     id: string;
-    fixtureCtx: unknown;
+    test: Test;
     options: Dictionary<OptionValue>;
 }

--- a/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/add-remove-request-hook.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/add-remove-request-hook.js
@@ -7,7 +7,9 @@ const pageUrl             = 'http://localhost:3000/fixtures/api/es-next/request-
 
 class TestRequestHook extends RequestHook {
     constructor () {
-        super(pageUrl);
+        super(req => {
+            return req.url === pageUrl;
+        });
 
         this.onResponseCallCountInternal = 0;
     }

--- a/test/functional/fixtures/compiler-service/test.js
+++ b/test/functional/fixtures/compiler-service/test.js
@@ -33,45 +33,4 @@ describe('Compiler service', () => {
     it('Should execute Selectors in sync mode', async () => {
         await runTests('testcafe-fixtures/synchronous-selectors.js');
     });
-
-    describe('Request Hooks', () => {
-        describe('Request Logger', () => {
-            it('Basic', async () => {
-                await runTests('../api/es-next/request-hooks/testcafe-fixtures/request-logger/api.js', 'API');
-            });
-
-            it('Log options', async () => {
-                await runTests('../api/es-next/request-hooks/testcafe-fixtures/request-logger/log-options.js', 'Log options');
-            });
-
-            it('Request filter rule predicate', async () => {
-                await runTests('../api/es-next/request-hooks/testcafe-fixtures/request-logger/request-filter-rule-predicate.js');
-            });
-        });
-
-        describe('Request Mock', function () {
-            it('Basic', async () => {
-                await runTests('../api/es-next/request-hooks/testcafe-fixtures/request-mock/basic.js');
-            });
-
-            it('Asynchronous response function (GH-4467)', () => {
-                return runTests('../api/es-next/request-hooks/testcafe-fixtures/request-mock/async-response-function.js');
-            });
-
-            it('Request failed the CORS validation', async () => {
-                await runTests('../api/es-next/request-hooks/testcafe-fixtures/request-mock/failed-cors-validation.js', 'Failed CORS validation', { only: 'chrome' })
-                    .then(() => {
-                        expect(testReport.warnings).eql([
-                            'RequestMock: CORS validation failed for a request specified as { url: "http://dummy-url.com/get" }'
-                        ]);
-                    });
-            });
-        });
-
-        describe('Request Hook', () => {
-            it('Change and remove response headers', async () => {
-                await runTests('../api/es-next/request-hooks/testcafe-fixtures/api/change-remove-response-headers.js');
-            });
-        });
-    });
 });

--- a/test/server/capturer-test.js
+++ b/test/server/capturer-test.js
@@ -1,3 +1,4 @@
+const { noop }                   = require('lodash');
 const nanoid                     = require('nanoid');
 const { expect }                 = require('chai');
 const { resolve, dirname, join } = require('path');
@@ -62,15 +63,21 @@ describe('Capturer', () => {
     });
 
     it('Screenshot properties for reporter', async () => {
-        const screenshots = new ScreenshotsMock({ enabled: true, path: process.cwd(), pathPattern: '', fullPage: false });
+        const screenshots = new ScreenshotsMock({
+            enabled:     true,
+            path:        process.cwd(),
+            pathPattern: '',
+            fullPage:    false
+        });
 
         const testRunControllerMock = {
             _screenshots: screenshots,
             test:         { fixture: {} },
-            emit:         () => { },
+            emit:         noop,
             _testRunCtor: function ({ browserConnection }) {
                 this.id                = 'test-run-id';
                 this.browserConnection = browserConnection;
+                this.initialize        = noop;
             }
         };
 


### PR DESCRIPTION
Changes:
* support `t.addRequestHook` and `t.removeRequestHook` methods
* move the `promisifyStream` function from the `Gulpfile.js`