### PR TITLE
fix: incorrect stack trace filtering for internal packages

### DIFF
--- a/src/errors/is-internal-stack-frame.ts
+++ b/src/errors/is-internal-stack-frame.ts
@@ -13,7 +13,7 @@ const TESTCAFE_LIB        = join(__dirname, '../');
 const TESTCAFE_BIN        = join(__dirname, '../../bin');
 const TESTCAFE_SRC        = join(__dirname, '../../src');
 const TESTCAFE_HAMMERHEAD = require.resolve('testcafe-hammerhead');
-const SOURCE_MAP_SUPPORT  = `${sep}source-map-support${sep}`;
+const SOURCE_MAP_SUPPORT  = require.resolve('source-map-support');
 
 const INTERNAL_STARTS_WITH_PATH_SEGMENTS = [
     TESTCAFE_LIB,

--- a/src/errors/is-internal-stack-frame.ts
+++ b/src/errors/is-internal-stack-frame.ts
@@ -12,7 +12,7 @@ const GENSYNC             = BABEL_MODULES_DIR + 'gensync'; // NOTE: @babel/parse
 const TESTCAFE_LIB        = join(__dirname, '../');
 const TESTCAFE_BIN        = join(__dirname, '../../bin');
 const TESTCAFE_SRC        = join(__dirname, '../../src');
-const TESTCAFE_HAMMERHEAD = `${sep}testcafe-hammerhead${sep}`;
+const TESTCAFE_HAMMERHEAD = require.resolve('testcafe-hammerhead');
 const SOURCE_MAP_SUPPORT  = `${sep}source-map-support${sep}`;
 
 const INTERNAL_STARTS_WITH_PATH_SEGMENTS = [

--- a/test/functional/fixtures/api/es-next/assertions/test.js
+++ b/test/functional/fixtures/api/es-next/assertions/test.js
@@ -299,7 +299,7 @@ describe('[API] Assertions', function () {
         expect(getSnapshotWarnings()[0]).contains("> 253 |        await t.expect(await Selector('#el1').innerText).eql('');");
     });
 
-    it.skip('Should raise multiple warnings when awaiting multiple selector properties in one assertion', async function () {
+    it('Should raise multiple warnings when awaiting multiple selector properties in one assertion', async function () {
         await runTests('./testcafe-fixtures/assertions-test.js', 'Multiple awaited selector properties in one assertion', { only: 'chrome' });
 
         expect(getSnapshotWarnings().length).to.eql(2);

--- a/test/functional/fixtures/regression/gh-6205/test.js
+++ b/test/functional/fixtures/regression/gh-6205/test.js
@@ -1,0 +1,13 @@
+const { expect } = require('chai');
+
+describe('[Regression](GH-6205)', function () {
+    it('Stack traces should not be filtered for paths that include a folder named "testcafe-hammerhead"', function () {
+        return runTests(
+            'testcafe-fixtures/testcafe-hammerhead/index.js',
+            'Should throw an error',
+            { shouldFail: true, only: 'chrome' }
+        ).catch((errs) => {
+            expect(errs[0]).match(/at .*index.js:4:11/);
+        });
+    });
+});

--- a/test/functional/fixtures/regression/gh-6205/test.js
+++ b/test/functional/fixtures/regression/gh-6205/test.js
@@ -10,4 +10,14 @@ describe('[Regression](GH-6205)', function () {
             expect(errs[0]).match(/at .*index.js:4:11/);
         });
     });
+
+    it('Stack traces should not be filtered for paths that include a folder named "source-map-support"', function () {
+        return runTests(
+            'testcafe-fixtures/source-map-support/index.js',
+            null,
+            { shouldFail: true, only: 'chrome' }
+        ).catch((err) => {
+            expect(err.stack).match(/at .*index.js:1:7/);
+        });
+    });
 });

--- a/test/functional/fixtures/regression/gh-6205/testcafe-fixtures/source-map-support/index.js
+++ b/test/functional/fixtures/regression/gh-6205/testcafe-fixtures/source-map-support/index.js
@@ -1,0 +1,1 @@
+throw new Error();

--- a/test/functional/fixtures/regression/gh-6205/testcafe-fixtures/testcafe-hammerhead/index.js
+++ b/test/functional/fixtures/regression/gh-6205/testcafe-fixtures/testcafe-hammerhead/index.js
@@ -1,0 +1,5 @@
+fixture `My Fixture`;
+
+test('Should throw an error', async () => {
+    throw new Error();
+});


### PR DESCRIPTION
## Purpose
After migration to GH Actions, the functional test in HH started to fail constantly (the test named "Should raise multiple warnings when awaiting multiple selector properties in one assertion"). It started to fail because the path to the test on CI looks like
> /home/runner/work/testcafe-hammerhead/testcafe/test/functional/**/*/assertions-test.js

Because the path contains "testcafe-hammerhead" and we're filtering stack traces containing such substring, stack traces in the warning messages were filtered, and they became identical. When adding a warning to the warning log we remove duplicates. So, the test showed only one warning instead of two and failed.

## Approach
Check that filename in a stack trace contains the full path to the "testcafe-hammerhead" or "source-map-support" packages.

## References
Part of #6205

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
