### PR TITLE
feat: added settings for downloading files in firefox without dialogue box

### DIFF
--- a/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
+++ b/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
@@ -79,6 +79,45 @@ async function generatePreferences (profileDir: string, { marionettePort, config
     });
 
     await writeFile(prefsFileName, prefs.join('\n'));
+
+    // NOTE: The definitions of actions are there https://searchfox.org/mozilla-release/source/netwerk/mime/nsIMIMEInfo.idl#115
+    const handlersFileName = path.join(profileDir, 'handlers.json');
+    const handlers         = {
+        defaultHandlersVersion: {
+            ru: 5
+        },
+        mimeTypes: {
+            'application/pdf': {
+                action:     0,
+                extensions: [
+                    'pdf'
+                ]
+            },
+            'text/xml': {
+                action:     0,
+                extensions: [
+                    'xml',
+                    'xsl',
+                    'xbl'
+                ]
+            },
+            'image/svg+xml': {
+                action:     0,
+                extensions: [
+                    'svg'
+                ]
+            },
+            'image/webp': {
+                action:     0,
+                extensions: [
+                    'webp'
+                ]
+            }
+        },
+        schemes: {}
+    };
+
+    await writeFile(handlersFileName, JSON.stringify(handlers));
 }
 
 export default async function (runtimeInfo: any): Promise<TempDirectory> {

--- a/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
+++ b/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
@@ -16,6 +16,7 @@ function getMimeTypes (): string {
 
 async function generatePreferences (profileDir: string, { marionettePort, config }: { marionettePort: number; config: any }): Promise<void> {
     const prefsFileName = path.join(profileDir, 'user.js');
+    const mimeTypes = getMimeTypes();
 
     let prefs = [
         'user_pref("browser.link.open_newwindow.override.external", 2);',
@@ -30,7 +31,7 @@ async function generatePreferences (profileDir: string, { marionettePort, config
         'user_pref("browser.tabs.warnOnCloseOtherTabs", false);',
         'user_pref("browser.tabs.warnOnClose", false);',
         'user_pref("browser.sessionstore.resume_from_crash", false);',
-        `user_pref("browser.helperApps.neverAsk.saveToDisk", "${getMimeTypes()}");`,
+        `user_pref("browser.helperApps.neverAsk.saveToDisk", "${mimeTypes}");`,
         `user_pref("pdfjs.disabled", true);`,
         'user_pref("toolkit.telemetry.reportingpolicy.firstRun", false);',
         'user_pref("toolkit.telemetry.enabled", false);',
@@ -70,6 +71,12 @@ async function generatePreferences (profileDir: string, { marionettePort, config
             'user_pref("browser.tabs.remote.autostart.2", false);',
         ]);
     }
+
+    mimeTypes.split(',').forEach(mimeType => {
+        const type = mimeType.split('/')[1];
+
+        prefs.push(`user_pref("browser.download.viewableInternally.typeWasRegistered.${type}", true);`);
+    });
 
     await writeFile(prefsFileName, prefs.join('\n'));
 }


### PR DESCRIPTION
## Purpose
A dialogue box appears each time the test runs downloading XML.
Need to find reasons and resolve the problem.

## Approach
- added browser.download.viewableInternally.typeWasRegistered.<type> params for user.js
- added creating handlers.json in user profile

## References
Part of https://github.com/DevExpress/testcafe/issues/5892

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
