### PR TITLE
refactor: support fixture before/after in the compiler service mode

### DIFF
--- a/gulp/constants/functional-test-globs.js
+++ b/gulp/constants/functional-test-globs.js
@@ -1,0 +1,23 @@
+const MULTIPLE_WINDOWS_TESTS_GLOB = 'test/functional/fixtures/multiple-windows/test.js';
+const COMPILER_SERVICE_TESTS_GLOB = 'test/functional/fixtures/compiler-service/test.js';
+const LEGACY_TESTS_GLOB           = 'test/functional/legacy-fixtures/**/test.js';
+
+const TESTS_GLOB = [
+    'test/functional/fixtures/**/test.js',
+    `!${MULTIPLE_WINDOWS_TESTS_GLOB}`,
+    `!${COMPILER_SERVICE_TESTS_GLOB}`
+];
+
+const MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB = [
+    'test/functional/fixtures/app-command/test.js',
+    'test/functional/fixtures/driver/test.js',
+    'test/functional/fixtures/api/es-next/request-hooks/test.js'
+];
+
+module.exports = {
+    TESTS_GLOB,
+    LEGACY_TESTS_GLOB,
+    MULTIPLE_WINDOWS_TESTS_GLOB,
+    MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB,
+    COMPILER_SERVICE_TESTS_GLOB
+};

--- a/gulp/helpers/test-functional.js
+++ b/gulp/helpers/test-functional.js
@@ -1,0 +1,44 @@
+const gulp           = require('gulp');
+const mocha          = require('gulp-mocha-simple');
+const { castArray }  = require('lodash');
+const getTimeout     = require('./get-timeout');
+const { TESTS_GLOB } = require('../constants/functional-test-globs');
+
+const RETRY_TEST_RUN_COUNT = 3;
+const SETUP_TESTS_GLOB     = 'test/functional/setup.js';
+
+const SCREENSHOT_TESTS_GLOB = [
+    'test/functional/fixtures/api/es-next/take-screenshot/test.js',
+    'test/functional/fixtures/screenshots-on-fails/test.js'
+];
+
+module.exports = function testFunctional (src, testingEnvironmentName, { experimentalCompilerService } = {}) {
+    process.env.TESTING_ENVIRONMENT       = testingEnvironmentName;
+    process.env.BROWSERSTACK_USE_AUTOMATE = 1;
+
+    if (experimentalCompilerService)
+        process.env.EXPERIMENTAL_COMPILER_SERVICE = 'true';
+
+    if (!process.env.BROWSERSTACK_NO_LOCAL)
+        process.env.BROWSERSTACK_NO_LOCAL = 1;
+
+    let tests = castArray(src);
+
+    // TODO: Run takeScreenshot tests first because other tests heavily impact them
+    if (src === TESTS_GLOB)
+        tests = SCREENSHOT_TESTS_GLOB.concat(tests);
+
+    tests.unshift(SETUP_TESTS_GLOB);
+
+    const opts = {
+        reporter: 'mocha-reporter-spec-with-retries',
+        timeout:  getTimeout(3 * 60 * 1000)
+    };
+
+    if (process.env.RETRY_FAILED_TESTS === 'true')
+        opts.retries = RETRY_TEST_RUN_COUNT;
+
+    return gulp
+        .src(tests)
+        .pipe(mocha(opts));
+};

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "is-ci": "^1.0.10",
     "is-docker": "^2.0.0",
     "is-glob": "^2.0.1",
-    "is-stream": "^1.1.0",
+    "is-stream": "^2.0.0",
     "json5": "^2.1.0",
     "lodash": "^4.17.13",
     "log-update-async-hook": "^2.0.2",

--- a/src/services/compiler/host.ts
+++ b/src/services/compiler/host.ts
@@ -31,7 +31,7 @@ import {
     GetWarningMessagesArguments,
     AddRequestEventListenersArguments,
     RemoveRequestEventListenersArguments,
-    InitializeTestRunProxyArguments
+    InitializeTestRunDataArguments
 } from './protocol';
 
 import { CompilerArguments } from '../../compiler/interfaces';
@@ -89,7 +89,7 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
             this.getWarningMessages,
             this.addRequestEventListeners,
             this.removeRequestEventListeners,
-            this.initializeTestRunProxy
+            this.initializeTestRunData
         ], this);
     }
 
@@ -156,7 +156,7 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
     private _wrapTestFunction (id: string, functionName: FunctionProperties): TestFunction {
         return async testRun => {
             try {
-                return await this.runTest({ id, functionName, testRunId: testRun.id });
+                return await this.runTestFn({ id, functionName, testRunId: testRun.id });
             }
             catch (err) {
                 const errList = new TestCafeErrorList();
@@ -218,10 +218,10 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
         );
     }
 
-    public async runTest ({ id, functionName, testRunId }: RunTestArguments): Promise<unknown> {
+    public async runTestFn ({ id, functionName, testRunId }: RunTestArguments): Promise<unknown> {
         const { proxy } = await this._getRuntime();
 
-        return await proxy.call(this.runTest, { id, functionName, testRunId });
+        return await proxy.call(this.runTestFn, { id, functionName, testRunId });
     }
 
     public async cleanUp (): Promise<void> {
@@ -302,9 +302,9 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
         await this.emit('removeRequestEventListeners', { rules });
     }
 
-    public async initializeTestRunProxy ({ testRunId, testId }: InitializeTestRunProxyArguments): Promise<void> {
+    public async initializeTestRunData ({ testRunId, testId }: InitializeTestRunDataArguments): Promise<void> {
         const { proxy } = await this._getRuntime();
 
-        return proxy.call(this.initializeTestRunProxy, { testRunId, testId });
+        return proxy.call(this.initializeTestRunData, { testRunId, testId });
     }
 }

--- a/src/services/compiler/protocol.ts
+++ b/src/services/compiler/protocol.ts
@@ -12,14 +12,15 @@ import {
     RequestFilterRule
 } from 'testcafe-hammerhead';
 
-export const BEFORE_AFTER_PROPERTIES  = ['beforeFn', 'afterFn'] as const;
+export const BEFORE_AFTER_PROPERTIES      = ['beforeFn', 'afterFn'] as const;
 export const BEFORE_AFTER_EACH_PROPERTIES = ['beforeEachFn', 'afterEachFn'] as const;
-export const TEST_FUNCTION_PROPERTIES = ['fn', ...BEFORE_AFTER_PROPERTIES] as const;
-export const FUNCTION_PROPERTIES = [...TEST_FUNCTION_PROPERTIES, ...BEFORE_AFTER_EACH_PROPERTIES] as const;
+export const TEST_FUNCTION_PROPERTIES     = ['fn', ...BEFORE_AFTER_PROPERTIES] as const;
+export const FIXTURE_FUNCTION_PROPERTIES  = [...BEFORE_AFTER_PROPERTIES, ...BEFORE_AFTER_EACH_PROPERTIES] as const;
+export const FUNCTION_PROPERTIES          = [...TEST_FUNCTION_PROPERTIES, ...BEFORE_AFTER_EACH_PROPERTIES] as const;
 
 export type FunctionProperties = typeof FUNCTION_PROPERTIES[number];
 export type TestFunctionProperties = typeof TEST_FUNCTION_PROPERTIES[number];
-export type FixtureFunctionProperties = typeof BEFORE_AFTER_EACH_PROPERTIES[number];
+export type FixtureFunctionProperties = typeof FIXTURE_FUNCTION_PROPERTIES[number];
 
 
 export function isTestFunctionProperty (value: FunctionProperties): value is TestFunctionProperties {
@@ -27,7 +28,7 @@ export function isTestFunctionProperty (value: FunctionProperties): value is Tes
 }
 
 export function isFixtureFunctionProperty (value: FunctionProperties): value is FixtureFunctionProperties {
-    return BEFORE_AFTER_EACH_PROPERTIES.includes(value as FixtureFunctionProperties);
+    return FIXTURE_FUNCTION_PROPERTIES.includes(value as FixtureFunctionProperties);
 }
 
 export interface RunTestArguments {
@@ -112,7 +113,7 @@ export interface GetWarningMessagesArguments {
     testRunId: string;
 }
 
-export interface InitializeTestRunProxyArguments {
+export interface InitializeTestRunDataArguments {
     testRunId: string;
     testId: string;
 }
@@ -130,7 +131,7 @@ export interface CompilerProtocol extends TestRunDispatcherProtocol {
 
     getTests ({ sourceList, compilerOptions }: CompilerArguments): Promise<unknown>;
 
-    runTest ({ id, functionName, testRunId }: RunTestArguments): Promise<unknown>;
+    runTestFn ({ id, functionName, testRunId }: RunTestArguments): Promise<unknown>;
 
     cleanUp (): Promise<void>;
 
@@ -152,5 +153,5 @@ export interface CompilerProtocol extends TestRunDispatcherProtocol {
 
     getWarningMessages ({ testRunId }: GetWarningMessagesArguments): Promise<string[]>;
 
-    initializeTestRunProxy ({ testRunId, testId }: InitializeTestRunProxyArguments): Promise<void>;
+    initializeTestRunData ({ testRunId, testId }: InitializeTestRunDataArguments): Promise<void>;
 }

--- a/src/services/compiler/test-run-proxy.ts
+++ b/src/services/compiler/test-run-proxy.ts
@@ -35,7 +35,7 @@ class TestRunProxy {
     public readonly controller: TestController;
     public readonly observedCallsites: ObservedCallsitesStorage;
     public readonly warningLog: WarningLog;
-
+    public fixtureCtx?: object;
     private readonly dispatcher: TestRunDispatcherProtocol;
     private readonly ctx: unknown;
     private readonly _options: Dictionary<OptionValue>;

--- a/src/test-run/index.js
+++ b/src/test-run/index.js
@@ -93,6 +93,7 @@ export default class TestRun extends AsyncEventEmitter {
         this.opts              = opts;
         this.test              = test;
         this.browserConnection = browserConnection;
+        this.unstable          = false;
 
         this.phase = PHASE.initial;
 
@@ -994,7 +995,7 @@ export default class TestRun extends AsyncEventEmitter {
         if (!this.compilerService)
             return;
 
-        await this.compilerService.initializeTestRunProxy({
+        await this.compilerService.initializeTestRunData({
             testRunId: this.id,
             testId:    this.test.id
         });

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -218,7 +218,7 @@ module.exports = {
     },
 
     get devMode () {
-        return !!process.env.DEV_MODE;
+        return process.env.DEV_MODE === 'true';
     },
 
     get retryTestPages () {

--- a/test/functional/fixtures/compiler-service/test.js
+++ b/test/functional/fixtures/compiler-service/test.js
@@ -1,5 +1,6 @@
 const path       = require('path');
 const { expect } = require('chai');
+const config     = require('../../config');
 
 
 describe('Compiler service', () => {
@@ -32,5 +33,44 @@ describe('Compiler service', () => {
 
     it('Should execute Selectors in sync mode', async () => {
         await runTests('testcafe-fixtures/synchronous-selectors.js');
+    });
+
+    describe('Test hooks', () => {
+        describe('fixture.before/fixture.after', () => {
+            it('Should run hooks before and after fixture', () => {
+                return runTests('../api/es-next/hooks/testcafe-fixtures/fixture-hooks.js');
+            });
+
+            it('Should keep sequential reports with long executing hooks', () => {
+                return runTests('../api/es-next/hooks/testcafe-fixtures/fixture-hooks-seq.js', null, {
+                    shouldFail: true
+                }).catch(errs => {
+                    expect(errs[0]).contains('$$test1$$');
+                    expect(errs[1]).contains('$$afterhook1$$');
+                    expect(errs[2]).contains('$$test2$$');
+                    expect(errs[3]).contains('$$afterhook2$$');
+                    expect(errs[4]).contains('$$test3$$');
+                });
+            });
+
+            it('Should fail all tests in fixture if fixture.before hooks fails', () => {
+                return runTests('../api/es-next/hooks/testcafe-fixtures/fixture-before-fail.js', null, {
+                    shouldFail: true
+                }).catch(errs => {
+                    const allErrors = config.currentEnvironment.browsers.length === 1 ? errs : errs['chrome'].concat(errs['firefox']);
+
+                    expect(allErrors.length).eql(config.currentEnvironment.browsers.length * 3);
+
+                    allErrors.forEach(err => {
+                        expect(err).contains('Error in fixture.before hook');
+                        expect(err).contains('$$before$$');
+                    });
+                });
+            });
+
+            it('Fixture context', () => {
+                return runTests('../api/es-next/hooks/testcafe-fixtures/fixture-ctx.js');
+            });
+        });
     });
 });

--- a/test/functional/fixtures/concurrency/common/timeline.js
+++ b/test/functional/fixtures/concurrency/common/timeline.js
@@ -1,0 +1,20 @@
+const fs   = require('fs');
+const path = require('path');
+
+const TIMELINE_FILENAME  = 'concurrency_test_timeline.txt';
+const FULL_TIMELINE_PATH = path.resolve(__dirname, '..', TIMELINE_FILENAME);
+
+exports.getTimeline = () => {
+    const data = fs.readFileSync(FULL_TIMELINE_PATH).toString();
+
+    return JSON.parse(data);
+};
+
+exports.deleteTimeline = () => {
+    if (fs.existsSync(FULL_TIMELINE_PATH))
+        fs.unlinkSync(FULL_TIMELINE_PATH);
+};
+
+exports.saveTimeline = (timeline) => {
+    fs.writeFileSync(FULL_TIMELINE_PATH, JSON.stringify(timeline));
+};

--- a/test/functional/fixtures/concurrency/testcafe-fixtures/concurrent-test.js
+++ b/test/functional/fixtures/concurrency/testcafe-fixtures/concurrent-test.js
@@ -1,19 +1,25 @@
-fixture `Concurrent`.page`../pages/index.html`;
+import { saveTimeline } from '../common/timeline';
 
-global.timeline = [];
+const timeline = [];
+
+fixture `Concurrent`
+    .page`../pages/index.html`
+    .after(() => {
+        saveTimeline(timeline);
+    });
 
 test('Long test', async t => {
-    global.timeline.push('test started');
+    timeline.push('test started');
 
     await t.wait(10000);
 
-    global.timeline.push('long finished');
+    timeline.push('long finished');
 });
 
 test('Short test', async t => {
-    global.timeline.push('test started');
+    timeline.push('test started');
 
     await t.wait(1000);
 
-    global.timeline.push('short finished');
+    timeline.push('short finished');
 });

--- a/test/functional/fixtures/concurrency/testcafe-fixtures/multibrowser-concurrent-test.js
+++ b/test/functional/fixtures/concurrency/testcafe-fixtures/multibrowser-concurrent-test.js
@@ -1,28 +1,33 @@
+import { saveTimeline } from '../common/timeline';
 import { ClientFunction } from 'testcafe';
 
 const getUserAgent = ClientFunction(() => navigator.userAgent);
+const timeline     = Object.create(null);
 
 fixture `Concurrent`
     .page`../pages/index.html`
     .beforeEach(async t => {
         t.ctx.userAgent = await getUserAgent();
 
-        if (!global.timeline[t.ctx.userAgent])
-            global.timeline[t.ctx.userAgent] = [];
+        if (!timeline[t.ctx.userAgent])
+            timeline[t.ctx.userAgent] = [];
+    })
+    .after(() => {
+        saveTimeline(timeline);
     });
 
 test('Long test', async t => {
-    global.timeline[t.ctx.userAgent].push('test started');
+    timeline[t.ctx.userAgent].push('test started');
 
     await t.wait(10000);
 
-    global.timeline[t.ctx.userAgent].push('long finished');
+    timeline[t.ctx.userAgent].push('long finished');
 });
 
 test('Short test', async t => {
-    global.timeline[t.ctx.userAgent].push('test started');
+    timeline[t.ctx.userAgent].push('test started');
 
     await t.wait(1000);
 
-    global.timeline[t.ctx.userAgent].push('short finished');
+    timeline[t.ctx.userAgent].push('short finished');
 });

--- a/test/functional/fixtures/concurrency/testcafe-fixtures/sequential-test.js
+++ b/test/functional/fixtures/concurrency/testcafe-fixtures/sequential-test.js
@@ -1,17 +1,25 @@
-fixture `Sequential`.page`../pages/index.html`;
+import { saveTimeline } from '../common/timeline';
+
+const timeline = [];
+
+fixture `Sequential`
+    .page`../pages/index.html`
+    .after(() => {
+        saveTimeline(timeline);
+    });
 
 test('Long test', async t => {
-    global.timeline.push('long started');
+    timeline.push('long started');
 
     await t.wait(10000);
 
-    global.timeline.push('long finished');
+    timeline.push('long finished');
 });
 
 test('Short test', async t => {
-    global.timeline.push('short started');
+    timeline.push('short started');
 
     await t.wait(1000);
 
-    global.timeline.push('short finished');
+    timeline.push('short finished');
 });


### PR DESCRIPTION
Changes:
* Gulpfile.js: move the `testFunctional` function to the separate file.
* Rewrite the `src/reporter/index.ts` file to TypeScript.
* Rewrite the `concurrent-test.js` tests to make them work in the compiler service mode.
* Support fixture before/after in the compiler service mode.