### PR TITLE
feat: added settings for downloading files in firefox without dialogue box

### DIFF
--- a/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
+++ b/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
@@ -79,6 +79,45 @@ async function generatePreferences (profileDir: string, { marionettePort, config
     });
 
     await writeFile(prefsFileName, prefs.join('\n'));
+
+    // NOTE: The definitions of actions are there https://searchfox.org/mozilla-release/source/netwerk/mime/nsIMIMEInfo.idl#115
+    const handlersFileName = path.join(profileDir, 'handlers.json');
+    const handlers         = {
+        defaultHandlersVersion: {
+            ru: 5
+        },
+        mimeTypes: {
+            'application/pdf': {
+                action:     0,
+                extensions: [
+                    'pdf'
+                ]
+            },
+            'text/xml': {
+                action:     0,
+                extensions: [
+                    'xml',
+                    'xsl',
+                    'xbl'
+                ]
+            },
+            'image/svg+xml': {
+                action:     0,
+                extensions: [
+                    'svg'
+                ]
+            },
+            'image/webp': {
+                action:     0,
+                extensions: [
+                    'webp'
+                ]
+            }
+        },
+        schemes: {}
+    };
+
+    await writeFile(handlersFileName, JSON.stringify(handlers));
 }
 
 export default async function (runtimeInfo: any): Promise<TempDirectory> {

--- a/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
+++ b/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
@@ -16,6 +16,7 @@ function getMimeTypes (): string {
 
 async function generatePreferences (profileDir: string, { marionettePort, config }: { marionettePort: number; config: any }): Promise<void> {
     const prefsFileName = path.join(profileDir, 'user.js');
+    const mimeTypes = getMimeTypes();
 
     let prefs = [
         'user_pref("browser.link.open_newwindow.override.external", 2);',
@@ -30,7 +31,7 @@ async function generatePreferences (profileDir: string, { marionettePort, config
         'user_pref("browser.tabs.warnOnCloseOtherTabs", false);',
         'user_pref("browser.tabs.warnOnClose", false);',
         'user_pref("browser.sessionstore.resume_from_crash", false);',
-        `user_pref("browser.helperApps.neverAsk.saveToDisk", "${getMimeTypes()}");`,
+        `user_pref("browser.helperApps.neverAsk.saveToDisk", "${mimeTypes}");`,
         `user_pref("pdfjs.disabled", true);`,
         'user_pref("toolkit.telemetry.reportingpolicy.firstRun", false);',
         'user_pref("toolkit.telemetry.enabled", false);',
@@ -70,6 +71,12 @@ async function generatePreferences (profileDir: string, { marionettePort, config
             'user_pref("browser.tabs.remote.autostart.2", false);',
         ]);
     }
+
+    mimeTypes.split(',').forEach(mimeType => {
+        const type = mimeType.split('/')[1];
+
+        prefs.push(`user_pref("browser.download.viewableInternally.typeWasRegistered.${type}", true);`);
+    });
 
     await writeFile(prefsFileName, prefs.join('\n'));
 }

--- a/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
+++ b/src/browser/provider/built-in/dedicated/firefox/create-temp-profile.ts
@@ -79,7 +79,9 @@ async function generatePreferences (profileDir: string, { marionettePort, config
     });
 
     await writeFile(prefsFileName, prefs.join('\n'));
+}
 
+async function writeHandlersFile (profileDir: string): Promise<void> {
     // NOTE: The definitions of actions are there https://searchfox.org/mozilla-release/source/netwerk/mime/nsIMIMEInfo.idl#115
     const handlersFileName = path.join(profileDir, 'handlers.json');
     const handlers         = {
@@ -120,10 +122,12 @@ async function generatePreferences (profileDir: string, { marionettePort, config
     await writeFile(handlersFileName, JSON.stringify(handlers));
 }
 
+
 export default async function (runtimeInfo: any): Promise<TempDirectory> {
     const tmpDir = await TempDirectory.createDirectory('firefox-profile');
 
     await generatePreferences(tmpDir.path, runtimeInfo);
+    await writeHandlersFile(tmpDir.path);
 
     return tmpDir;
 }

--- a/test/functional/fixtures/regression/gh-3127/pages/dummy.xml
+++ b/test/functional/fixtures/regression/gh-3127/pages/dummy.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dummy>dummy</dummy>

--- a/test/functional/fixtures/regression/gh-3127/pages/index.html
+++ b/test/functional/fixtures/regression/gh-3127/pages/index.html
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>GH-3127 + GH-2741</title>
+    <title>GH-3127 + GH-2741 + GH-5892</title>
 </head>
 <body>
 <a id="json" href="/Download">JSON</a>
 <a id="pdf" href="./dummy.pdf">PDF</a>
 <a id="zip" href="./dummy.zip">ZIP</a>
+<a id="xml" href="./dummy.xml" download>XML</a>
 </body>
 </html>

--- a/test/functional/fixtures/regression/gh-3127/test.js
+++ b/test/functional/fixtures/regression/gh-3127/test.js
@@ -1,4 +1,4 @@
-describe('[Regression](GH-3127, GH-2741) Should download files', function () {
+describe('[Regression](GH-3127, GH-2741, GH-5892) Should download files', function () {
     it('JSON', function () {
         return runTests('testcafe-fixtures/index-test.js', 'JSON', { only: ['chrome', 'firefox'] });
     });
@@ -9,5 +9,9 @@ describe('[Regression](GH-3127, GH-2741) Should download files', function () {
 
     it('Download PDF', function () {
         return runTests('testcafe-fixtures/index-test.js', 'PDF', { only: ['firefox', 'chrome'] });
+    });
+
+    it('Download XML', function () {
+        return runTests('testcafe-fixtures/index-test.js', 'XML', { only: ['firefox', 'chrome'] });
     });
 });

--- a/test/functional/fixtures/regression/gh-3127/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/regression/gh-3127/testcafe-fixtures/index-test.js
@@ -9,6 +9,7 @@ import delay from '../../../../../../lib/utils/delay';
 const DOWNLOADED_JSON_FILE_PATH = join(homedir(), 'Downloads', 'package.json');
 const DOWNLOADED_ZIP_FILE_PATH  = join(homedir(), 'Downloads', 'dummy.zip');
 const DOWNLOADED_PDF_FILE_PATH  = join(homedir(), 'Downloads', 'dummy.pdf');
+const DOWNLOADED_XML_FILE_PATH  = join(homedir(), 'Downloads', 'dummy.xml');
 
 const FILE_CHECK_INTERVAL   = 3000;
 
@@ -38,6 +39,7 @@ function deleteFiles () {
     del(DOWNLOADED_JSON_FILE_PATH, { force: true });
     del(DOWNLOADED_ZIP_FILE_PATH, { force: true });
     del(DOWNLOADED_PDF_FILE_PATH, { force: true });
+    del(DOWNLOADED_XML_FILE_PATH, { force: true });
 }
 
 fixture `gh3127`
@@ -62,4 +64,10 @@ test('PDF', async t => {
     await t.click('#pdf');
 
     await waitForFileWithTimeout(DOWNLOADED_PDF_FILE_PATH, 20000);
+});
+
+test('XML', async t => {
+    await t.click('#xml');
+
+    await waitForFileWithTimeout(DOWNLOADED_XML_FILE_PATH, 20000);
 });

--- a/test/functional/site/server.js
+++ b/test/functional/site/server.js
@@ -18,7 +18,8 @@ const CONTENT_TYPES = {
     '.html': 'text/html',
     '.png':  'image/png',
     '.zip':  'application/zip',
-    '.pdf':  'application/pdf'
+    '.pdf':  'application/pdf',
+    '.xml':  'application/xml',
 };
 
 const NON_CACHEABLE_PAGES = [


### PR DESCRIPTION
## Purpose
A dialogue box appears each time the test runs downloading XML.
Need to find reasons and resolve the problem.

## Approach
- added browser.download.viewableInternally.typeWasRegistered.<type> params for user.js
- added creating handlers.json in user profile
- added new XML file and test downloading one

## References
Part of https://github.com/DevExpress/testcafe/issues/5892

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
