### PR TITLE
refactor: rewrite TestRun to typescript

### DIFF
--- a/gulp/constants/client-test-settings.js
+++ b/gulp/constants/client-test-settings.js
@@ -1,0 +1,98 @@
+const { assignIn } = require('lodash');
+
+const CLIENT_TEST_LOCAL_BROWSERS_ALIASES = ['ie', 'edge', 'chrome', 'firefox', 'safari'];
+
+const CLIENT_TESTS_PATH        = 'test/client/fixtures';
+const CLIENT_TESTS_LEGACY_PATH = 'test/client/legacy-fixtures';
+
+const CLIENT_TESTS_SETTINGS_BASE = {
+    port:            2000,
+    crossDomainPort: 2001,
+
+    scripts: [
+        { src: '/async.js', path: 'test/client/vendor/async.js' },
+        { src: '/hammerhead.js', path: 'node_modules/testcafe-hammerhead/lib/client/hammerhead.min.js' },
+        { src: '/core.js', path: 'lib/client/core/index.min.js' },
+        { src: '/ui.js', path: 'lib/client/ui/index.min.js' },
+        { src: '/automation.js', path: 'lib/client/automation/index.min.js' },
+        { src: '/driver.js', path: 'lib/client/driver/index.js' },
+        { src: '/legacy-runner.js', path: 'node_modules/testcafe-legacy-api/lib/client/index.js' },
+        { src: '/before-test.js', path: 'test/client/before-test.js' }
+    ],
+
+    configApp: require('../../test/client/config-qunit-server-app')
+};
+
+const CLIENT_TESTS_SETTINGS        = assignIn({}, CLIENT_TESTS_SETTINGS_BASE, { basePath: CLIENT_TESTS_PATH });
+const CLIENT_TESTS_LOCAL_SETTINGS  = assignIn({}, CLIENT_TESTS_SETTINGS);
+const CLIENT_TESTS_LEGACY_SETTINGS = assignIn({}, CLIENT_TESTS_SETTINGS_BASE, { basePath: CLIENT_TESTS_LEGACY_PATH });
+
+const CLIENT_TESTS_DESKTOP_BROWSERS = [
+    {
+        platform:    'Windows 10',
+        browserName: 'microsoftedge'
+    },
+    {
+        platform:    'Windows 10',
+        browserName: 'chrome'
+    },
+    {
+        platform:    'Windows 10',
+        browserName: 'firefox'
+    },
+    {
+        platform:    'Windows 10',
+        browserName: 'internet explorer',
+        version:     '11.0'
+    },
+    {
+        platform:    'macOS 10.13',
+        browserName: 'safari',
+        version:     '11.1'
+    },
+    {
+        platform:    'OS X 10.11',
+        browserName: 'chrome'
+    },
+    {
+        platform:    'OS X 10.11',
+        browserName: 'firefox'
+    }
+];
+
+const CLIENT_TESTS_MOBILE_BROWSERS = [
+    {
+        platform:    'Linux',
+        browserName: 'android',
+        version:     '6.0',
+        deviceName:  'Android Emulator'
+    },
+    {
+        platform:    'iOS',
+        browserName: 'Safari',
+        // NOTE: https://github.com/DevExpress/testcafe/issues/471
+        // problem with extra scroll reproduced only on saucelabs
+        // virtual machines with ios device emulators
+        version:     '10.3',
+        deviceName:  'iPhone 7 Plus Simulator'
+    }
+];
+
+const CLIENT_TESTS_SAUCELABS_SETTINGS = {
+    username:  process.env.SAUCE_USERNAME,
+    accessKey: process.env.SAUCE_ACCESS_KEY,
+    build:     process.env.TRAVIS_BUILD_ID || '',
+    tags:      [process.env.TRAVIS_BRANCH || 'master'],
+    name:      'testcafe client tests',
+    timeout:   720
+};
+
+module.exports = {
+    CLIENT_TEST_LOCAL_BROWSERS_ALIASES,
+    CLIENT_TESTS_SETTINGS,
+    CLIENT_TESTS_LOCAL_SETTINGS,
+    CLIENT_TESTS_LEGACY_SETTINGS,
+    CLIENT_TESTS_SAUCELABS_SETTINGS,
+    CLIENT_TESTS_DESKTOP_BROWSERS,
+    CLIENT_TESTS_MOBILE_BROWSERS
+};

--- a/gulp/helpers/test-client.js
+++ b/gulp/helpers/test-client.js
@@ -1,0 +1,27 @@
+const gulp                                   = require('gulp');
+const qunitHarness                           = require('gulp-qunit-harness');
+const { getInstallations: listBrowsers }     = require('testcafe-browser-tools');
+const { CLIENT_TEST_LOCAL_BROWSERS_ALIASES } = require('../constants/client-test-settings');
+
+function runTests (env, runOpts, tests, settings) {
+    return gulp
+        .src(tests)
+        .pipe(qunitHarness(settings, env, runOpts));
+}
+
+module.exports = function testClient (tests, settings, envSettings, cliMode) {
+    if (!cliMode)
+        return runTests(envSettings, settings, tests);
+
+    return listBrowsers().then(browsers => {
+        const browserNames   = Object.keys(browsers);
+        const targetBrowsers = [];
+
+        browserNames.forEach(browserName => {
+            if (CLIENT_TEST_LOCAL_BROWSERS_ALIASES.includes(browserName))
+                targetBrowsers.push({ browserInfo: browsers[browserName], browserName: browserName });
+        });
+
+        return runTests({ browsers: targetBrowsers }, { cliMode: true }, tests, settings);
+    });
+};

--- a/gulp/helpers/test-client.js
+++ b/gulp/helpers/test-client.js
@@ -3,7 +3,7 @@ const qunitHarness                           = require('gulp-qunit-harness');
 const { getInstallations: listBrowsers }     = require('testcafe-browser-tools');
 const { CLIENT_TEST_LOCAL_BROWSERS_ALIASES } = require('../constants/client-test-settings');
 
-function runTests (env, runOpts, tests, settings) {
+function runTests (env, tests, settings, runOpts) {
     return gulp
         .src(tests)
         .pipe(qunitHarness(settings, env, runOpts));
@@ -11,7 +11,7 @@ function runTests (env, runOpts, tests, settings) {
 
 module.exports = function testClient (tests, settings, envSettings, cliMode) {
     if (!cliMode)
-        return runTests(envSettings, settings, tests);
+        return runTests(envSettings, tests, settings);
 
     return listBrowsers().then(browsers => {
         const browserNames   = Object.keys(browsers);
@@ -22,6 +22,6 @@ module.exports = function testClient (tests, settings, envSettings, cliMode) {
                 targetBrowsers.push({ browserInfo: browsers[browserName], browserName: browserName });
         });
 
-        return runTests({ browsers: targetBrowsers }, { cliMode: true }, tests, settings);
+        return runTests({ browsers: targetBrowsers }, tests, settings, { cliMode: true });
     });
 };

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/6472452/testcafe-hammerhead-24.3.0.zip",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/6478961/testcafe-hammerhead-24.2.2.zip",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "24.2.1",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/6472452/testcafe-hammerhead-24.3.0.zip",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.15",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/6478961/testcafe-hammerhead-24.2.2.zip",
+    "testcafe-hammerhead": "24.2.2",
     "testcafe-legacy-api": "5.0.0",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "promisify-event": "^1.0.0",
     "qrcode-terminal": "^0.10.0",
     "read-file-relative": "^1.2.0",
-    "replicator": "^1.0.3",
+    "replicator": "1.0.3",
     "resolve-cwd": "^1.0.0",
     "resolve-from": "^4.0.0",
     "sanitize-filename": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "promisify-event": "^1.0.0",
     "qrcode-terminal": "^0.10.0",
     "read-file-relative": "^1.2.0",
-    "replicator": "1.0.3",
+    "replicator": "^1.0.3",
     "resolve-cwd": "^1.0.0",
     "resolve-from": "^4.0.0",
     "sanitize-filename": "^1.6.0",

--- a/src/api/request-hooks/hook.ts
+++ b/src/api/request-hooks/hook.ts
@@ -36,11 +36,11 @@ export default abstract class RequestHook {
         return !rules.length ? [RequestFilterRule.ANY] : rules;
     }
 
-    protected async onRequest (event: RequestEvent): Promise<void> { // eslint-disable-line @typescript-eslint/no-unused-vars
+    public async onRequest (event: RequestEvent): Promise<void> { // eslint-disable-line @typescript-eslint/no-unused-vars
         throw new RequestHookNotImplementedMethodError('onRequest', this.constructor.name);
     }
 
-    private async _onConfigureResponse (event: ConfigureResponseEvent): Promise<void> {
+    public async _onConfigureResponse (event: ConfigureResponseEvent): Promise<void> {
         if (!this._responseEventConfigureOpts)
             return;
 
@@ -48,7 +48,7 @@ export default abstract class RequestHook {
         event.opts.includeBody    = this._responseEventConfigureOpts.includeBody;
     }
 
-    protected async onResponse (event: ResponseEvent): Promise<void> { // eslint-disable-line @typescript-eslint/no-unused-vars
+    public async onResponse (event: ResponseEvent): Promise<void> { // eslint-disable-line @typescript-eslint/no-unused-vars
         throw new RequestHookNotImplementedMethodError('onResponse', this.constructor.name);
     }
 }

--- a/src/api/test-controller/index.d.ts
+++ b/src/api/test-controller/index.d.ts
@@ -1,0 +1,12 @@
+import TestRun from '../../test-run';
+import TestRunProxy from '../../services/compiler/test-run-proxy';
+
+interface TestController {
+    browser: string;
+    new (testRun: TestRun | TestRunProxy): TestController;
+    _enqueueCommand (apiMethodName: string, CmdCtor: unknown, cmdArgs:object): () => Promise<unknown>;
+}
+
+declare const TestController: TestController;
+
+export default TestController;

--- a/src/api/test-controller/index.d.ts
+++ b/src/api/test-controller/index.d.ts
@@ -1,12 +1,8 @@
 import TestRun from '../../test-run';
 import TestRunProxy from '../../services/compiler/test-run-proxy';
 
-interface TestController {
-    browser: string;
-    new (testRun: TestRun | TestRunProxy): TestController;
-    _enqueueCommand (apiMethodName: string, CmdCtor: unknown, cmdArgs:object): () => Promise<unknown>;
+export default class TestController {
+    public browser: string;
+    public constructor (testRun: TestRun | TestRunProxy);
+    public _enqueueCommand (apiMethodName: string, CmdCtor: unknown, cmdArgs: object): () => Promise<unknown>;
 }
-
-declare const TestController: TestController;
-
-export default TestController;

--- a/src/api/test-run-tracker.d.ts
+++ b/src/api/test-run-tracker.d.ts
@@ -1,19 +1,8 @@
-import ObservedCallsitesStorage from '../test-run/observed-callsites-storage';
-import TestController from './test-controller';
-import WarningLog from '../notifications/warning-log';
-
-export interface TestRun {
-    id: string;
-    controller: TestController;
-    observedCallsites: ObservedCallsitesStorage;
-    warningLog: WarningLog;
-
-    executeAction(apiMethodName: string, command: unknown, callsite: unknown): Promise<unknown>;
-    executeCommand(command: unknown): Promise<unknown>;
-}
+import TestRun from '../test-run';
+import TestRunProxy from '../services/compiler/test-run-proxy';
 
 export interface TestRunTracker {
-    activeTestRuns: { [id: string]: TestRun };
+    activeTestRuns: { [id: string]: TestRun | TestRunProxy };
     addTrackingMarkerToFunction(testRunId: string, fn: Function): Function;
     ensureEnabled(): void;
     resolveContextTestRun(): TestRun;

--- a/src/api/wrap-test-function.ts
+++ b/src/api/wrap-test-function.ts
@@ -1,6 +1,6 @@
 import TestController from './test-controller';
 import testRunTracker from './test-run-tracker';
-import { TestRun } from './test-run-tracker.d';
+import TestRun from '../test-run';
 import TestCafeErrorList from '../errors/error-list';
 import { MissingAwaitError } from '../errors/test-run';
 import addRenderedWarning from '../notifications/add-rendered-warning';

--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -87,12 +87,12 @@ export default class BrowserConnection extends EventEmitter {
     public readonly idleUrl: string;
     private forcedIdleUrl: string;
     private readonly initScriptUrl: string;
-    private readonly heartbeatRelativeUrl: string;
-    private readonly statusRelativeUrl: string;
-    private readonly statusDoneRelativeUrl: string;
+    public readonly heartbeatRelativeUrl: string;
+    public readonly statusRelativeUrl: string;
+    public readonly statusDoneRelativeUrl: string;
     private readonly heartbeatUrl: string;
     private readonly statusUrl: string;
-    private readonly activeWindowIdUrl: string;
+    public readonly activeWindowIdUrl: string;
     private statusDoneUrl: string;
     private readonly debugLogger: debug.Debugger;
 

--- a/src/errors/test-run/index.js
+++ b/src/errors/test-run/index.js
@@ -276,22 +276,26 @@ export class SetNativeDialogHandlerCodeWrongTypeError extends TestRunErrorBase {
     }
 }
 
-export class RequestHookUnhandledError extends TestRunErrorBase {
-    constructor (err, hookClassName, methodName) {
-        super(TEST_RUN_ERRORS.requestHookUnhandledError);
+export class RequestHookBaseError extends TestRunErrorBase {
+    constructor (code, hookClassName, methodName) {
+        super(code);
 
-        this.errMsg        = String(err);
         this.hookClassName = hookClassName;
         this.methodName    = methodName;
     }
 }
 
-export class RequestHookNotImplementedMethodError extends TestRunErrorBase {
-    constructor (methodName, hookClassName) {
-        super(TEST_RUN_ERRORS.requestHookNotImplementedError);
+export class RequestHookUnhandledError extends RequestHookBaseError {
+    constructor (err, hookClassName, methodName) {
+        super(TEST_RUN_ERRORS.requestHookUnhandledError, hookClassName, methodName);
 
-        this.methodName    = methodName;
-        this.hookClassName = hookClassName;
+        this.errMsg = String(err);
+    }
+}
+
+export class RequestHookNotImplementedMethodError extends RequestHookBaseError {
+    constructor (methodName, hookClassName) {
+        super(TEST_RUN_ERRORS.requestHookNotImplementedError, hookClassName, methodName);
     }
 }
 

--- a/src/notifications/warning-log.ts
+++ b/src/notifications/warning-log.ts
@@ -4,7 +4,7 @@ export default class WarningLog {
     public messages: string[];
     public globalLog: WarningLog | null;
 
-    public constructor (globalLog = null) {
+    public constructor (globalLog: WarningLog | null = null) {
         this.globalLog = globalLog;
         this.messages  = [];
     }

--- a/src/reporter/command/command-formatter.ts
+++ b/src/reporter/command/command-formatter.ts
@@ -138,7 +138,7 @@ export class CommandFormatter {
             const property = this._command[key];
 
             if (property instanceof ExecuteSelectorCommand)
-                formattedCommand[key] = this._prepareSelector(property, key);
+                formattedCommand[key] = this._prepareSelector(property as unknown as Command, key);
             else if (isCommandOptions(property)) {
                 const modifiedOptions = CommandFormatter._getModifiedOptions(property);
 

--- a/src/reporter/command/format-command.ts
+++ b/src/reporter/command/format-command.ts
@@ -1,7 +1,8 @@
-import { Command, FormattedCommand } from './interfaces';
+import { FormattedCommand } from './interfaces';
 import { CommandFormatter } from './command-formatter';
+import CommandBase from '../../test-run/commands/base';
 
-export default function formatCommand (command: Command, result: unknown): FormattedCommand {
+export default function formatCommand (command: CommandBase, result: unknown): FormattedCommand {
     const commandFormatter = new CommandFormatter(command, result);
 
     return commandFormatter.format();

--- a/src/reporter/command/interfaces.ts
+++ b/src/reporter/command/interfaces.ts
@@ -1,10 +1,3 @@
-export interface Command {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [key: string]: any;
-    type: string;
-    _getAssignableProperties(): { name: string }[];
-}
-
 export interface FormattedCommand {
     [key: string]: unknown;
     type: string;

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -17,7 +17,8 @@ import TestRun from '../test-run';
 import Test from '../api/structure/test';
 import Fixture from '../api/structure/fixture';
 import TestRunErrorFormattableAdapter from '../errors/test-run/formattable-adapter';
-import { Command } from './command/interfaces';
+import CommandBase from '../test-run/commands/base';
+
 
 interface PendingPromise {
     resolve: Function | null;
@@ -64,7 +65,7 @@ interface PluginMethodArguments {
 }
 
 interface ReportTestActionEventArguments {
-    command: Command;
+    command: CommandBase;
     duration: number;
     result: unknown;
     testRun: TestRun;

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -268,9 +268,6 @@ export default class Reporter {
                 id:   testRun.test.fixture.id
             },
             command: formatCommand(command, result),
-            // TestController doesn't have the browser property in its definition.
-            // It is dynamically added later.
-            // @ts-ignore
             browser: testRun.controller?.browser,
         });
     }

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -31,7 +31,7 @@ interface ReportItem {
     screenshotPath: null | string;
     screenshots: unknown[];
     videos: unknown[];
-    quarantine: null;
+    quarantine: null | Record<string, object>;
     errs: TestRunErrorFormattableAdapter[];
     warnings: string[];
     unstable: boolean;
@@ -267,7 +267,10 @@ export default class Reporter {
                 id:   testRun.test.fixture.id
             },
             command: formatCommand(command, result),
-            browser: testRun.controller.browser,
+            // TestController doesn't have the browser property in its definition.
+            // It is dynamically added later.
+            // @ts-ignore
+            browser: testRun.controller?.browser,
         });
     }
 

--- a/src/reporter/plugin-host.ts
+++ b/src/reporter/plugin-host.ts
@@ -31,7 +31,7 @@ interface ReporterSymbols {
 }
 
 export default class ReporterPluginHost {
-    public name: string;
+    public name?: string;
     public streamController: ReporterStreamController | null;
     public chalk: Chalk;
     public moment: Moment;
@@ -42,7 +42,7 @@ export default class ReporterPluginHost {
     private [indent]: number;
     private [errorDecorator]: Record<string, Function>;
 
-    public constructor (plugin: any, outStream: Writable, name: string) {
+    public constructor (plugin: any, outStream?: Writable, name?: string) {
         this.name             = name;
         this.streamController = null;
         this[stream]          = outStream || process.stdout;

--- a/src/role/index.ts
+++ b/src/role/index.ts
@@ -1,81 +1,10 @@
-import { EventEmitter } from 'events';
-import nanoid from 'nanoid';
-import RolePhase from './phase';
 import { assertType, is } from '../errors/runtime/type-assertions';
 import wrapTestFunction from '../api/wrap-test-function';
 import { getUrl, assertRoleUrl } from '../api/test-page-url';
-import roleMarker from './marker-symbol';
-import { StateSnapshot } from 'testcafe-hammerhead';
-import TestRun from '../test-run';
+import Role from './role';
 
 interface RoleOptions {
     preserveUrl?: boolean;
-}
-
-class Role extends EventEmitter {
-    public id: string;
-    public phase: RolePhase;
-    public loginUrl: string | null;
-    public redirectUrl: string | null;
-    private readonly _initFn: Function | null;
-    public opts: RoleOptions;
-    public initErr: null | Error;
-    public stateSnapshot: StateSnapshot;
-
-    public constructor (loginUrl: string | null, initFn: Function | null, options = {}) {
-        super();
-
-        // @ts-ignore
-        this[roleMarker]   = true;
-        this.id            = nanoid(7);
-        this.phase         = loginUrl ? RolePhase.uninitialized : RolePhase.initialized;
-        this.loginUrl      = loginUrl;
-        this._initFn       = initFn;
-        this.opts          = options;
-        this.redirectUrl   = null;
-        this.stateSnapshot = StateSnapshot.empty();
-        this.initErr       = null;
-    }
-
-    private async _storeStateSnapshot (testRun: TestRun): Promise<void> {
-        if (this.initErr)
-            return;
-
-        this.stateSnapshot = await testRun.getStateSnapshot();
-    }
-
-    private async _executeInitFn (testRun: TestRun): Promise<void> {
-        try {
-            let fn = (): Promise<void> => (this._initFn as Function)(testRun);
-
-            fn = testRun.decoratePreventEmitActionEvents(fn, { prevent: false });
-            fn = testRun.decorateDisableDebugBreakpoints(fn, { disable: false });
-
-            await fn();
-        }
-        catch (err) {
-            this.initErr = err;
-        }
-    }
-
-    public async initialize (testRun: TestRun): Promise<void> {
-        this.phase = RolePhase.pendingInitialization;
-
-        await testRun.switchToCleanRun(this.loginUrl);
-
-        await this._executeInitFn(testRun);
-        await this._storeStateSnapshot(testRun);
-
-        if (this.opts.preserveUrl)
-            await this.setCurrentUrlAsRedirectUrl(testRun);
-
-        this.phase = RolePhase.initialized;
-        this.emit('initialized');
-    }
-
-    public async setCurrentUrlAsRedirectUrl (testRun: TestRun): Promise<void> {
-        this.redirectUrl = await testRun.getCurrentUrl();
-    }
 }
 
 export function createRole (loginUrl: string, initFn: Function, options: RoleOptions = { preserveUrl: false }): Role {

--- a/src/role/marker-symbol.ts
+++ b/src/role/marker-symbol.ts
@@ -1,6 +1,6 @@
-/*global Symbol*/
-
 // HACK: used to validate that UseRoleCommand argument value
 // is a Role. With the marker symbol approach we can safely use
 // commands in Role without circular reference.
-export default Symbol('testRun');
+const markerSymbol = Symbol('testRun');
+
+export default markerSymbol;

--- a/src/role/role.ts
+++ b/src/role/role.ts
@@ -1,0 +1,73 @@
+import { EventEmitter } from 'events';
+import RolePhase from './phase';
+import { StateSnapshot } from 'testcafe-hammerhead';
+import roleMarker from './marker-symbol';
+import nanoid from 'nanoid';
+import TestRun from '../test-run';
+
+
+export default class Role extends EventEmitter {
+    public id: string;
+    public phase: RolePhase;
+    public loginUrl: string | null;
+    public redirectUrl: string | null;
+    private readonly _initFn: Function | null;
+    public opts: RoleOptions;
+    public initErr: null | Error;
+    public stateSnapshot: StateSnapshot;
+
+    public constructor (loginUrl: string | null, initFn: Function | null, options = {}) {
+        super();
+
+        // @ts-ignore
+        this[roleMarker]   = true;
+        this.id            = nanoid(7);
+        this.phase         = loginUrl ? RolePhase.uninitialized : RolePhase.initialized;
+        this.loginUrl      = loginUrl;
+        this._initFn       = initFn;
+        this.opts          = options;
+        this.redirectUrl   = null;
+        this.stateSnapshot = StateSnapshot.empty();
+        this.initErr       = null;
+    }
+
+    private async _storeStateSnapshot (testRun: TestRun): Promise<void> {
+        if (this.initErr)
+            return;
+
+        this.stateSnapshot = await testRun.getStateSnapshot();
+    }
+
+    private async _executeInitFn (testRun: TestRun): Promise<void> {
+        try {
+            let fn = (): Promise<void> => (this._initFn as Function)(testRun);
+
+            fn = testRun.decoratePreventEmitActionEvents(fn, { prevent: false });
+            fn = testRun.decorateDisableDebugBreakpoints(fn, { disable: false });
+
+            await fn();
+        }
+        catch (err) {
+            this.initErr = err;
+        }
+    }
+
+    public async initialize (testRun: TestRun): Promise<void> {
+        this.phase = RolePhase.pendingInitialization;
+
+        await testRun.switchToCleanRun(this.loginUrl as string);
+
+        await this._executeInitFn(testRun);
+        await this._storeStateSnapshot(testRun);
+
+        if (this.opts.preserveUrl)
+            await this.setCurrentUrlAsRedirectUrl(testRun);
+
+        this.phase = RolePhase.initialized;
+        this.emit('initialized');
+    }
+
+    public async setCurrentUrlAsRedirectUrl (testRun: TestRun): Promise<void> {
+        this.redirectUrl = await testRun.getCurrentUrl();
+    }
+}

--- a/src/role/role.ts
+++ b/src/role/role.ts
@@ -15,11 +15,11 @@ export default class Role extends EventEmitter {
     public opts: RoleOptions;
     public initErr: null | Error;
     public stateSnapshot: StateSnapshot;
+    private [roleMarker]: boolean;
 
     public constructor (loginUrl: string | null, initFn: Function | null, options = {}) {
         super();
 
-        // @ts-ignore
         this[roleMarker]   = true;
         this.id            = nanoid(7);
         this.phase         = loginUrl ? RolePhase.uninitialized : RolePhase.initialized;

--- a/src/runner/fixture-hook-controller.ts
+++ b/src/runner/fixture-hook-controller.ts
@@ -72,7 +72,7 @@ export default class FixtureHookController {
                 item.runningFixtureBeforeHook = true;
 
                 try {
-                    await fixture.beforeFn(item.fixtureCtx);
+                    await (fixture.beforeFn as Function)(item.fixtureCtx);
                 }
                 catch (err) {
                     item.fixtureBeforeHookErr = processTestFnError(err);

--- a/src/services/compiler/host.ts
+++ b/src/services/compiler/host.ts
@@ -7,7 +7,8 @@ import {
 
 import { restore as restoreTestStructure } from '../serialization/test-structure';
 import prepareOptions from '../serialization/prepare-options';
-import { default as testRunTracker, TestRun } from '../../api/test-run-tracker';
+import { default as testRunTracker } from '../../api/test-run-tracker';
+import TestRun from '../../test-run';
 import { IPCProxy } from '../utils/ipc/proxy';
 import { HostTransport } from '../utils/ipc/transport';
 import AsyncEventEmitter from '../../utils/async-event-emitter';
@@ -45,6 +46,8 @@ import {
     ResponseEvent,
     RequestFilterRule
 } from 'testcafe-hammerhead';
+
+import { CallsiteRecord } from 'callsite-record';
 
 const SERVICE_PATH = require.resolve('./service');
 
@@ -190,7 +193,7 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
         if (!targetTestRun)
             return void 0;
 
-        return targetTestRun.executeAction(data.apiMethodName, data.command, data.callsite);
+        return targetTestRun.executeAction(data.apiMethodName, data.command, data.callsite as CallsiteRecord);
     }
 
     public executeActionSync (): never {

--- a/src/services/compiler/protocol.ts
+++ b/src/services/compiler/protocol.ts
@@ -1,6 +1,7 @@
 import { CompilerArguments } from '../../compiler/interfaces';
 import { Dictionary } from '../../configuration/interfaces';
 import RequestHookMethodNames from '../../api/request-hooks/hook-method-names';
+
 import {
     ConfigureResponseEvent,
     ConfigureResponseEventOptions,
@@ -11,6 +12,8 @@ import {
     IncomingMessageLikeInitOptions,
     RequestFilterRule
 } from 'testcafe-hammerhead';
+
+import CommandBase from '../../test-run/commands/base';
 
 export const BEFORE_AFTER_PROPERTIES      = ['beforeFn', 'afterFn'] as const;
 export const BEFORE_AFTER_EACH_PROPERTIES = ['beforeEachFn', 'afterEachFn'] as const;
@@ -40,13 +43,13 @@ export interface RunTestArguments {
 export interface ExecuteActionArguments {
     id: string;
     apiMethodName: string;
-    command: unknown;
+    command: CommandBase;
     callsite: unknown;
 }
 
 export interface ExecuteCommandArguments {
     id: string;
-    command: unknown;
+    command: CommandBase;
 }
 
 export interface RemoveRequestEventListenersArguments {

--- a/src/services/compiler/service.ts
+++ b/src/services/compiler/service.ts
@@ -77,12 +77,6 @@ interface ServiceState {
     options: Dictionary<OptionValue>;
 }
 
-interface TestRunProxyCreationArgs {
-    testRunId: string;
-    testId: string;
-    fixtureCtx: unknown;
-}
-
 interface WrapSetMockArguments extends RequestHookLocator {
     event: RequestEvent;
 }

--- a/src/services/compiler/test-run-proxy.ts
+++ b/src/services/compiler/test-run-proxy.ts
@@ -85,7 +85,7 @@ class TestRunProxy {
     public async executeAction (apiMethodName: string, command: CommandBase, callsite: CallsiteRecord): Promise<unknown> {
         const renderedCallsite = callsite ? prerenderCallsite(callsite) : null;
 
-        if ((command as CommandBase).type === COMMAND_TYPE.assertion)
+        if (command.type === COMMAND_TYPE.assertion)
             return this._executeAssertion(command as AssertionCommand, renderedCallsite);
 
         return this.dispatcher.executeAction({
@@ -98,6 +98,9 @@ class TestRunProxy {
 
     public executeActionSync (apiMethodName: string, command: CommandBase, callsite: CallsiteRecord): unknown {
         const renderedCallsite = callsite ? prerenderCallsite(callsite) : null;
+
+        if (command.type === COMMAND_TYPE.assertion)
+            return this._executeAssertion(command as AssertionCommand, renderedCallsite);
 
         return this.dispatcher.executeActionSync({
             apiMethodName,

--- a/src/services/compiler/test-run-proxy.ts
+++ b/src/services/compiler/test-run-proxy.ts
@@ -14,7 +14,7 @@ import * as serviceCommands from '../../test-run/commands/service';
 import { TestRunProxyInit } from '../interfaces';
 import Test from '../../api/structure/test';
 import RequestHook from '../../api/request-hooks/hook';
-import RequestHookMethodNames from '../../api/request-hooks/hook-method-names';
+import getAssertionTimeout from '../../utils/get-options/get-assertion-timeout';
 
 import {
     ConfigureResponseEvent,
@@ -23,11 +23,7 @@ import {
     ResponseEvent
 } from 'testcafe-hammerhead';
 
-interface RequestHookEventDescriptor {
-    hookId: string;
-    name: RequestHookMethodNames;
-    eventData: RequestEvent | ConfigureResponseEvent | ResponseEvent;
-}
+import { CallsiteRecord } from 'callsite-record';
 
 class TestRunProxy {
     public readonly id: string;
@@ -67,22 +63,13 @@ class TestRunProxy {
         event.requestFilterRule = RequestFilterRule.from(event.requestFilterRule as object);
     }
 
-    private _getAssertionTimeout (command: AssertionCommand): number {
-        // @ts-ignore
-        const { timeout: commandTimeout } = command.options;
-
-        return commandTimeout === void 0
-            ? this._options.assertionTimeout
-            : commandTimeout;
-    }
-
     private async _executeAssertion (command: AssertionCommand, callsite: unknown): Promise<unknown> {
-        const assertionTimeout = this._getAssertionTimeout(command);
+        const assertionTimeout = getAssertionTimeout(command, this._options);
 
         const executor = new AssertionExecutor(command, assertionTimeout, callsite);
 
-        executor.once('start-assertion-retries', timeout => this.executeCommand(new serviceCommands.ShowAssertionRetriesStatusCommand(timeout)));
-        executor.once('end-assertion-retries', success => this.executeCommand(new serviceCommands.HideAssertionRetriesStatusCommand(success)));
+        executor.once('start-assertion-retries', timeout => this.executeCommand(new serviceCommands.ShowAssertionRetriesStatusCommand(timeout) as unknown as CommandBase));
+        executor.once('end-assertion-retries', success => this.executeCommand(new serviceCommands.HideAssertionRetriesStatusCommand(success) as unknown as CommandBase));
 
         return executor.run();
     }
@@ -95,24 +82,32 @@ class TestRunProxy {
         hook._warningLog = null;
     }
 
-    public async executeAction (apiMethodName: string, command: unknown, callsite: unknown): Promise<unknown> {
-        if (callsite)
-            callsite = prerenderCallsite(callsite);
+    public async executeAction (apiMethodName: string, command: CommandBase, callsite: CallsiteRecord): Promise<unknown> {
+        const renderedCallsite = callsite ? prerenderCallsite(callsite) : null;
 
         if ((command as CommandBase).type === COMMAND_TYPE.assertion)
-            return this._executeAssertion(command as AssertionCommand, callsite);
+            return this._executeAssertion(command as AssertionCommand, renderedCallsite);
 
-        return this.dispatcher.executeAction({ apiMethodName, command, callsite, id: this.id });
+        return this.dispatcher.executeAction({
+            apiMethodName,
+            command,
+            callsite: renderedCallsite,
+            id:       this.id
+        });
     }
 
-    public executeActionSync (apiMethodName: string, command: unknown, callsite: unknown): unknown {
-        if (callsite)
-            callsite = prerenderCallsite(callsite);
+    public executeActionSync (apiMethodName: string, command: CommandBase, callsite: CallsiteRecord): unknown {
+        const renderedCallsite = callsite ? prerenderCallsite(callsite) : null;
 
-        return this.dispatcher.executeActionSync({ apiMethodName, command, callsite, id: this.id });
+        return this.dispatcher.executeActionSync({
+            apiMethodName,
+            command,
+            callsite: renderedCallsite,
+            id:       this.id
+        });
     }
 
-    public async executeCommand (command: unknown): Promise<unknown> {
+    public async executeCommand (command: CommandBase): Promise<unknown> {
         return this.dispatcher.executeCommand({ command, id: this.id });
     }
 

--- a/src/test-run/commands/actions.d.ts
+++ b/src/test-run/commands/actions.d.ts
@@ -1,0 +1,39 @@
+import CommandBase from './base';
+import { ExecuteClientFunctionCommand, ExecuteSelectorCommand } from './observation';
+import { PressOptions, TypeOptions } from './options';
+import Role from '../../role/role';
+
+export class SetNativeDialogHandlerCommand extends CommandBase {
+    public dialogHandler: ExecuteClientFunctionCommand;
+}
+
+export class NavigateToCommand extends CommandBase {
+    public url: string;
+    public stateSnapshot: string;
+    public forceReload: boolean;
+}
+
+export class PressKeyCommand extends CommandBase {
+    public keys: string;
+    public options: PressOptions;
+}
+
+export class TypeTextCommand extends CommandBase {
+    public selector: ExecuteSelectorCommand | unknown;
+    public text: string;
+    public options: TypeOptions;
+}
+
+export class UseRoleCommand extends CommandBase {
+    public role: Role;
+}
+
+export class GetCurrentWindowsCommand extends CommandBase { }
+
+export class SwitchToWindowCommand extends CommandBase {
+    public windowId: string;
+}
+
+export class SwitchToWindowByPredicateCommand extends CommandBase {
+    public findWindow: Function;
+}

--- a/src/test-run/commands/assertion.d.ts
+++ b/src/test-run/commands/assertion.d.ts
@@ -1,10 +1,6 @@
 import CommandBase from './base';
 import { AssertionOptions } from './options';
 
-interface AssertionCommand extends CommandBase {
-    options: AssertionOptions;
+export default class AssertionCommand extends CommandBase {
+    public options: AssertionOptions;
 }
-
-declare const AssertionCommand: AssertionCommand;
-
-export default AssertionCommand;

--- a/src/test-run/commands/assertion.d.ts
+++ b/src/test-run/commands/assertion.d.ts
@@ -1,0 +1,10 @@
+import CommandBase from './base';
+import { AssertionOptions } from './options';
+
+interface AssertionCommand extends CommandBase {
+    options: AssertionOptions;
+}
+
+declare const AssertionCommand: AssertionCommand;
+
+export default AssertionCommand;

--- a/src/test-run/commands/base.d.ts
+++ b/src/test-run/commands/base.d.ts
@@ -1,0 +1,7 @@
+interface CommandBase {
+    type: string;
+}
+
+declare const CommandBase: CommandBase;
+
+export default CommandBase;

--- a/src/test-run/commands/base.d.ts
+++ b/src/test-run/commands/base.d.ts
@@ -1,7 +1,8 @@
-interface CommandBase {
-    type: string;
+import TestRun from '../index';
+
+export default class CommandBase {
+    public constructor(obj?: object, testRun?: TestRun, type?: string, validateProperties?: boolean);
+    public type: string;
+    [key: string]: unknown;
+    public _getAssignableProperties(): { name: string }[];
 }
-
-declare const CommandBase: CommandBase;
-
-export default CommandBase;

--- a/src/test-run/commands/browser-manipulation.js
+++ b/src/test-run/commands/browser-manipulation.js
@@ -22,7 +22,7 @@ function initElementScreenshotOptions (name, val) {
 }
 
 // Commands
-class TakeScreenshotBaseCommand extends CommandBase {
+export class TakeScreenshotBaseCommand extends CommandBase {
     constructor (obj, testRun, type) {
         super(obj, testRun, type);
 

--- a/src/test-run/commands/observation.d.ts
+++ b/src/test-run/commands/observation.d.ts
@@ -1,0 +1,16 @@
+declare class ExecuteClientFunctionCommandBase {
+    public instantiationCallsiteName: string;
+    public fnCode: string;
+    public args: string[];
+    public dependencies: string[];
+}
+
+export class ExecuteClientFunctionCommand extends ExecuteClientFunctionCommandBase {}
+
+export class ExecuteSelectorCommand extends ExecuteClientFunctionCommandBase {
+    public visibilityCheck: boolean;
+    public timeout: number;
+    public apiFnChain: string[];
+    public needError: boolean;
+    public index: number;
+}

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -17,10 +17,10 @@ import {
     PageLoadError,
     RoleSwitchInRoleInitializerError,
     SwitchToWindowPredicateError,
-    WindowNotFoundError
+    WindowNotFoundError,
+    RequestHookBaseError
 } from '../errors/test-run/';
 
-import PHASE from './phase';
 import CLIENT_MESSAGES from './client-messages';
 import COMMAND_TYPE from './commands/type';
 import delay from '../utils/delay';
@@ -32,7 +32,17 @@ import ReporterPluginHost from '../reporter/plugin-host';
 import BrowserConsoleMessages from './browser-console-messages';
 import WarningLog from '../notifications/warning-log';
 import WARNING_MESSAGE from '../notifications/warning-message';
-import { StateSnapshot, SPECIAL_ERROR_PAGE } from 'testcafe-hammerhead';
+import {
+    StateSnapshot,
+    SPECIAL_ERROR_PAGE,
+    RequestFilterRule,
+    InjectableResources,
+    RequestEvent,
+    ConfigureResponseEvent,
+    ResponseEvent,
+    RequestHookMethodError,
+    StoragesSnapshot
+} from 'testcafe-hammerhead';
 import * as INJECTABLES from '../assets/injectables';
 import { findProblematicScripts } from '../custom-client-scripts/utils';
 import getCustomClientScriptUrl from '../custom-client-scripts/get-url';
@@ -48,19 +58,43 @@ import {
     isResizeWindowCommand
 } from './commands/utils';
 
-import { GetCurrentWindowsCommand, SwitchToWindowCommand } from './commands/actions';
+import {
+    GetCurrentWindowsCommand, SwitchToWindowByPredicateCommand,
+    SwitchToWindowCommand
+} from './commands/actions';
 
 import { RUNTIME_ERRORS, TEST_RUN_ERRORS } from '../errors/types';
 import processTestFnError from '../errors/process-test-fn-error';
 import RequestHookMethodNames from '../api/request-hooks/hook-method-names';
-
 import { createReplicator, SelectorNodeTransform } from '../client-functions/replicator';
+import Test from '../api/structure/test';
+import Capturer from '../screenshots/capturer';
+import { Dictionary } from '../configuration/interfaces';
+import CompilerService from '../services/compiler/host';
+import SessionController from './session-controller';
+import TestController from '../api/test-controller';
+import BrowserManipulationQueue from './browser-manipulation-queue';
+import ObservedCallsitesStorage from './observed-callsites-storage';
+import ClientScript from '../custom-client-scripts/client-script';
+import BrowserConnection from '../browser/connection';
+import { Quarantine } from '../utils/get-options/quarantine';
+import RequestHook from '../api/request-hooks/hook';
+import DriverStatus from '../client/driver/status';
+import Command from './commands/base.js';
+import Role from '../role/role';
+import { TestRunErrorBase } from '../shared/errors';
+import { CallsiteRecord } from 'callsite-record';
+import EventEmitter from 'events';
+import getAssertionTimeout from '../utils/get-options/get-assertion-timeout';
+import AssertionCommand from './commands/assertion';
+import { TakeScreenshotBaseCommand } from './commands/browser-manipulation';
+//@ts-ignore
+import { TestRun as LegacyTestRun } from 'testcafe-legacy-api';
+import { AuthCredentials } from '../api/structure/interfaces';
+import TestRunPhase from './phase';
 
 const lazyRequire                 = require('import-lazy')(require);
-const SessionController           = lazyRequire('./session-controller');
-const ObservedCallsitesStorage    = lazyRequire('./observed-callsites-storage');
 const ClientFunctionBuilder       = lazyRequire('../client-functions/client-function-builder');
-const BrowserManipulationQueue    = lazyRequire('./browser-manipulation-queue');
 const TestRunBookmark             = lazyRequire('./bookmark');
 const AssertionExecutor           = lazyRequire('../assertions/executor');
 const actionCommands              = lazyRequire('./commands/actions');
@@ -70,8 +104,8 @@ const observationCommands         = lazyRequire('./commands/observation');
 
 const { executeJsExpression, executeAsyncJsExpression } = lazyRequire('./execute-js-expression');
 
-const TEST_RUN_TEMPLATE               = read('../client/test-run/index.js.mustache');
-const IFRAME_TEST_RUN_TEMPLATE        = read('../client/test-run/iframe.js.mustache');
+const TEST_RUN_TEMPLATE               = read('../client/test-run/index.js.mustache') as string;
+const IFRAME_TEST_RUN_TEMPLATE        = read('../client/test-run/iframe.js.mustache') as string;
 const TEST_DONE_CONFIRMATION_RESPONSE = 'test-done-confirmation';
 const MAX_RESPONSE_DELAY              = 3000;
 const CHILD_WINDOW_READY_TIMEOUT      = 30 * 1000;
@@ -85,33 +119,119 @@ const COMPILER_SERVICE_EVENTS = [
     'removeHeaderOnConfigureResponseEvent'
 ];
 
+interface TestRunInit {
+    test: Test;
+    browserConnection: BrowserConnection;
+    screenshotCapturer: Capturer;
+    globalWarningLog: WarningLog;
+    opts: Dictionary<OptionValue>;
+    compilerService?: CompilerService;
+}
+
+interface DriverTask {
+    command: Command;
+    resolve: Function;
+    reject: Function;
+    callsite: CallsiteRecord;
+}
+
+interface DriverMessage {
+    status: DriverStatus;
+}
+
+interface RequestTimeout {
+    page?: number;
+    ajax?: number;
+}
+
+interface PendingRequest {
+    responseTimeout: NodeJS.Timeout;
+    resolve: Function;
+    reject: Function;
+}
+
+interface BrowserManipulationResult {
+    result: unknown;
+    error: Error;
+}
+
+interface OpenedWindowInformation {
+    id: string;
+    url: string;
+    title: string;
+}
+
 export default class TestRun extends AsyncEventEmitter {
-    constructor ({ test, browserConnection, screenshotCapturer, globalWarningLog, opts, compilerService }) {
+    private [testRunMarker]: boolean;
+    public readonly warningLog: WarningLog;
+    private readonly opts: Dictionary<OptionValue>;
+    public readonly test: Test;
+    public readonly browserConnection: BrowserConnection;
+    public unstable: boolean;
+    public phase: TestRunPhase;
+    private driverTaskQueue: DriverTask[];
+    private testDoneCommandQueued: boolean;
+    private activeDialogHandler: Function | null;
+    private activeIframeSelector: Function | null;
+    private speed: number;
+    private pageLoadTimeout: number;
+    private disablePageReloads: boolean;
+    private disablePageCaching: boolean;
+    private disableMultipleWindows: boolean;
+    private requestTimeout: RequestTimeout;
+    private readonly session: SessionController;
+    private consoleMessages: BrowserConsoleMessages;
+    private pendingRequest: PendingRequest | null;
+    private pendingPageError: PageLoadError | Error | null;
+    public controller: TestController | null;
+    private ctx: object;
+    public fixtureCtx: object | null;
+    private currentRoleId: string | null;
+    private readonly usedRoleStates: Record<string, any>;
+    public errs: TestRunErrorFormattableAdapter[];
+    private lastDriverStatusId: string | null;
+    private lastDriverStatusResponse: Command | null | string;
+    private fileDownloadingHandled: boolean;
+    private resolveWaitForFileDownloadingPromise: Function | null;
+    private addingDriverTasksCount: number;
+    private debugging: boolean;
+    private readonly debugOnFail: boolean;
+    private readonly disableDebugBreakpoints: boolean;
+    private readonly debugReporterPluginHost: ReporterPluginHost;
+    private readonly browserManipulationQueue: BrowserManipulationQueue;
+    private debugLog: TestRunDebugLog;
+    public quarantine: Quarantine | null;
+    private readonly debugLogger: any;
+    public observedCallsites: ObservedCallsitesStorage;
+    private readonly compilerService?: CompilerService;
+    private readonly replicator: any;
+    private disconnected: boolean;
+    private errScreenshotPath: string | null;
+
+    public constructor ({ test, browserConnection, screenshotCapturer, globalWarningLog, opts, compilerService }: TestRunInit) {
         super();
 
-        this[testRunMarker] = true;
-
-        this.warningLog = new WarningLog(globalWarningLog);
-
+        this[testRunMarker]    = true;
+        this.warningLog        = new WarningLog(globalWarningLog);
         this.opts              = opts;
         this.test              = test;
         this.browserConnection = browserConnection;
         this.unstable          = false;
 
-        this.phase = PHASE.initial;
+        this.phase = TestRunPhase.initial;
 
         this.driverTaskQueue       = [];
         this.testDoneCommandQueued = false;
 
         this.activeDialogHandler  = null;
         this.activeIframeSelector = null;
-        this.speed                = this.opts.speed;
+        this.speed                = this.opts.speed as number;
         this.pageLoadTimeout      = this._getPageLoadTimeout(test, opts);
 
-        this.disablePageReloads   = test.disablePageReloads || opts.disablePageReloads && test.disablePageReloads !== false;
-        this.disablePageCaching   = test.disablePageCaching || opts.disablePageCaching;
+        this.disablePageReloads   = test.disablePageReloads || opts.disablePageReloads as boolean && test.disablePageReloads !== false;
+        this.disablePageCaching   = test.disablePageCaching || opts.disablePageCaching as boolean;
 
-        this.disableMultipleWindows = opts.disableMultipleWindows;
+        this.disableMultipleWindows = opts.disableMultipleWindows as boolean;
 
         this.requestTimeout = this._getRequestTimeout(test, opts);
 
@@ -139,8 +259,8 @@ export default class TestRun extends AsyncEventEmitter {
 
         this.addingDriverTasksCount = 0;
 
-        this.debugging               = this.opts.debugMode;
-        this.debugOnFail             = this.opts.debugOnFail;
+        this.debugging               = this.opts.debugMode as boolean;
+        this.debugOnFail             = this.opts.debugOnFail as boolean;
         this.disableDebugBreakpoints = false;
         this.debugReporterPluginHost = new ReporterPluginHost({ noColors: false });
 
@@ -157,26 +277,29 @@ export default class TestRun extends AsyncEventEmitter {
 
         this.replicator = createReplicator([ new SelectorNodeTransform() ]);
 
+        this.disconnected      = false;
+        this.errScreenshotPath = null;
+
         this._addInjectables();
         this._initRequestHooks();
     }
 
-    _getPageLoadTimeout (test, opts) {
+    private _getPageLoadTimeout (test: Test, opts: Dictionary<OptionValue>): number {
         if (test.timeouts?.pageLoadTimeout !== void 0)
             return test.timeouts.pageLoadTimeout;
 
-        return opts.pageLoadTimeout;
+        return opts.pageLoadTimeout as number;
     }
 
-    _getRequestTimeout (test, opts) {
+    private _getRequestTimeout (test: Test, opts: Dictionary<OptionValue>): RequestTimeout {
         return {
-            page: test.timeouts?.pageRequestTimeout || opts.pageRequestTimeout,
-            ajax: test.timeouts?.ajaxRequestTimeout || opts.ajaxRequestTimeout
+            page: test.timeouts?.pageRequestTimeout || opts.pageRequestTimeout as number,
+            ajax: test.timeouts?.ajaxRequestTimeout || opts.ajaxRequestTimeout as number
         };
     }
 
-    _addClientScriptContentWarningsIfNecessary () {
-        const { empty, duplicatedContent } = findProblematicScripts(this.test.clientScripts);
+    private _addClientScriptContentWarningsIfNecessary (): void {
+        const { empty, duplicatedContent } = findProblematicScripts(this.test.clientScripts as ClientScript[]);
 
         if (empty.length)
             this.warningLog.addWarning(WARNING_MESSAGE.clientScriptsWithEmptyContent);
@@ -189,31 +312,31 @@ export default class TestRun extends AsyncEventEmitter {
         }
     }
 
-    _addInjectables () {
+    private _addInjectables (): void {
         this._addClientScriptContentWarningsIfNecessary();
         this.injectable.scripts.push(...INJECTABLES.SCRIPTS);
         this.injectable.userScripts.push(...this.test.clientScripts.map(script => {
             return {
-                url:  getCustomClientScriptUrl(script),
-                page: script.page
+                url:  getCustomClientScriptUrl(script as ClientScript),
+                page: script.page as RequestFilterRule
             };
         }));
         this.injectable.styles.push(INJECTABLES.TESTCAFE_UI_STYLES);
     }
 
-    get id () {
+    public get id (): string {
         return this.session.id;
     }
 
-    get injectable () {
+    public get injectable (): InjectableResources {
         return this.session.injectable;
     }
 
-    addQuarantineInfo (quarantine) {
+    public addQuarantineInfo (quarantine: Quarantine): void {
         this.quarantine = quarantine;
     }
 
-    addRequestHook (hook) {
+    public addRequestHook (hook: RequestHook): void {
         if (this.test.requestHooks.includes(hook))
             return;
 
@@ -221,7 +344,7 @@ export default class TestRun extends AsyncEventEmitter {
         this._initRequestHook(hook);
     }
 
-    removeRequestHook (hook) {
+    public removeRequestHook (hook: RequestHook): void {
         if (!this.test.requestHooks.includes(hook))
             return;
 
@@ -229,7 +352,7 @@ export default class TestRun extends AsyncEventEmitter {
         this._disposeRequestHook(hook);
     }
 
-    _initRequestHook (hook) {
+    private _initRequestHook (hook: RequestHook): void {
         hook._warningLog = this.warningLog;
 
         hook._requestFilterRules.forEach(rule => {
@@ -237,25 +360,25 @@ export default class TestRun extends AsyncEventEmitter {
                 onRequest:           hook.onRequest.bind(hook),
                 onConfigureResponse: hook._onConfigureResponse.bind(hook),
                 onResponse:          hook.onResponse.bind(hook)
-            }, err => this._onRequestHookMethodError(err, hook._className));
+            }, (err: RequestHookMethodError) => this._onRequestHookMethodError(err, hook._className));
         });
     }
 
-    _initRequestHookForCompilerService (hookId, hookClassName, rules) {
+    private _initRequestHookForCompilerService (hookId: string, hookClassName: string, rules: RequestFilterRule[]): void {
         const testId = this.test.id;
 
         rules.forEach(rule => {
             this.session.addRequestEventListeners(rule, {
-                onRequest:           event => this.compilerService.onRequestHookEvent({ testId, hookId, name: RequestHookMethodNames.onRequest, eventData: event }),
-                onConfigureResponse: event => this.compilerService.onRequestHookEvent({ testId, hookId, name: RequestHookMethodNames._onConfigureResponse, eventData: event }),
-                onResponse:          event => this.compilerService.onRequestHookEvent({ testId, hookId, name: RequestHookMethodNames.onResponse, eventData: event })
+                onRequest:           (event: RequestEvent) => this.compilerService?.onRequestHookEvent({ testId, hookId, name: RequestHookMethodNames.onRequest, eventData: event }),
+                onConfigureResponse: (event: ConfigureResponseEvent) => this.compilerService?.onRequestHookEvent({ testId, hookId, name: RequestHookMethodNames._onConfigureResponse, eventData: event }),
+                onResponse:          (event: ResponseEvent) => this.compilerService?.onRequestHookEvent({ testId, hookId, name: RequestHookMethodNames.onResponse, eventData: event })
             }, err => this._onRequestHookMethodError(err, hookClassName));
         });
     }
 
-    _onRequestHookMethodError (event, hookClassName) {
-        let err                                      = event.error;
-        const isRequestHookNotImplementedMethodError = err?.code === TEST_RUN_ERRORS.requestHookNotImplementedError;
+    private _onRequestHookMethodError (event: RequestHookMethodError, hookClassName: string): void {
+        let err: Error | TestRunErrorBase            = event.error;
+        const isRequestHookNotImplementedMethodError = (err as unknown as TestRunErrorBase)?.code === TEST_RUN_ERRORS.requestHookNotImplementedError;
 
         if (!isRequestHookNotImplementedMethodError)
             err = new RequestHookUnhandledError(err, hookClassName, event.methodName);
@@ -263,7 +386,7 @@ export default class TestRun extends AsyncEventEmitter {
         this.addError(err);
     }
 
-    _disposeRequestHook (hook) {
+    private _disposeRequestHook (hook: RequestHook): void {
         hook._warningLog = null;
 
         hook._requestFilterRules.forEach(rule => {
@@ -271,29 +394,30 @@ export default class TestRun extends AsyncEventEmitter {
         });
     }
 
-    _detachRequestEventListeners (rules) {
+    private _detachRequestEventListeners (rules: RequestFilterRule[]): void {
         rules.forEach(rule => {
             this.session.removeRequestEventListeners(rule);
         });
     }
 
-    _subscribeOnCompilerServiceEvents () {
+    private _subscribeOnCompilerServiceEvents (): void {
         COMPILER_SERVICE_EVENTS.forEach(eventName => {
-            this.compilerService.on(eventName, async args => {
+            this.compilerService?.on(eventName, async args => {
+                // @ts-ignore
                 await this.session[eventName](...args);
             });
         });
 
-        this.compilerService.on('addRequestEventListeners', async ({ hookId, hookClassName, rules }) => {
+        this.compilerService?.on('addRequestEventListeners', async ({ hookId, hookClassName, rules }) => {
             this._initRequestHookForCompilerService(hookId, hookClassName, rules);
         });
 
-        this.compilerService.on('removeRequestEventListeners', async ({ rules }) => {
+        this.compilerService?.on('removeRequestEventListeners', async ({ rules }) => {
             this._detachRequestEventListeners(rules);
         });
     }
 
-    _initRequestHooks () {
+    private _initRequestHooks (): void {
         if (this.compilerService) {
             this._subscribeOnCompilerServiceEvents();
             this.test.requestHooks.forEach(hook => {
@@ -305,7 +429,7 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     // Hammerhead payload
-    async getPayloadScript () {
+    public async getPayloadScript (): Promise<string> {
         this.fileDownloadingHandled               = false;
         this.resolveWaitForFileDownloadingPromise = null;
 
@@ -330,7 +454,7 @@ export default class TestRun extends AsyncEventEmitter {
         });
     }
 
-    async getIframePayloadScript () {
+    public async getIframePayloadScript (): Promise<string> {
         return Mustache.render(IFRAME_TEST_RUN_TEMPLATE, {
             testRunId:       JSON.stringify(this.session.id),
             selectorTimeout: this.opts.selectorTimeout,
@@ -342,11 +466,11 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     // Hammerhead handlers
-    getAuthCredentials () {
+    public getAuthCredentials (): null | AuthCredentials {
         return this.test.authCredentials;
     }
 
-    handleFileDownload () {
+    public handleFileDownload (): void {
         if (this.resolveWaitForFileDownloadingPromise) {
             this.resolveWaitForFileDownloadingPromise(true);
             this.resolveWaitForFileDownloadingPromise = null;
@@ -355,14 +479,14 @@ export default class TestRun extends AsyncEventEmitter {
             this.fileDownloadingHandled = true;
     }
 
-    handlePageError (ctx, err) {
+    public handlePageError (ctx: any, err: Error): void {
         this.pendingPageError = new PageLoadError(err, ctx.reqOpts.url);
 
         ctx.redirect(ctx.toProxyUrl(SPECIAL_ERROR_PAGE));
     }
 
     // Test function execution
-    async _executeTestFn (phase, fn) {
+    private async _executeTestFn (phase: TestRunPhase, fn: Function): Promise<boolean> {
         this.phase = phase;
 
         try {
@@ -382,32 +506,32 @@ export default class TestRun extends AsyncEventEmitter {
         return !this._addPendingPageErrorIfAny();
     }
 
-    async _runBeforeHook () {
+    private async _runBeforeHook (): Promise<boolean> {
         if (this.test.beforeFn)
-            return await this._executeTestFn(PHASE.inTestBeforeHook, this.test.beforeFn);
+            return await this._executeTestFn(TestRunPhase.inTestBeforeHook, this.test.beforeFn);
 
         if (this.test.fixture.beforeEachFn)
-            return await this._executeTestFn(PHASE.inFixtureBeforeEachHook, this.test.fixture.beforeEachFn);
+            return await this._executeTestFn(TestRunPhase.inFixtureBeforeEachHook, this.test.fixture.beforeEachFn);
 
         return true;
     }
 
-    async _runAfterHook () {
+    private async _runAfterHook (): Promise<boolean> {
         if (this.test.afterFn)
-            return await this._executeTestFn(PHASE.inTestAfterHook, this.test.afterFn);
+            return await this._executeTestFn(TestRunPhase.inTestAfterHook, this.test.afterFn);
 
         if (this.test.fixture.afterEachFn)
-            return await this._executeTestFn(PHASE.inFixtureAfterEachHook, this.test.fixture.afterEachFn);
+            return await this._executeTestFn(TestRunPhase.inFixtureAfterEachHook, this.test.fixture.afterEachFn);
 
         return true;
     }
 
-    async start () {
+    public async start (): Promise<void> {
         testRunTracker.activeTestRuns[this.session.id] = this;
 
         await this.emit('start');
 
-        const onDisconnected = err => this._disconnect(err);
+        const onDisconnected = (err: Error): void => this._disconnect(err);
 
         this.browserConnection.once('disconnected', onDisconnected);
 
@@ -416,7 +540,7 @@ export default class TestRun extends AsyncEventEmitter {
         await this.emit('ready');
 
         if (await this._runBeforeHook()) {
-            await this._executeTestFn(PHASE.inTest, this.test.fn);
+            await this._executeTestFn(TestRunPhase.inTest, this.test.fn as Function);
             await this._runAfterHook();
         }
 
@@ -425,8 +549,11 @@ export default class TestRun extends AsyncEventEmitter {
 
         this.browserConnection.removeListener('disconnected', onDisconnected);
 
-        if (this.errs.length && this.debugOnFail)
-            await this._enqueueSetBreakpointCommand(null, this.debugReporterPluginHost.formatError(this.errs[0]));
+        if (this.errs.length && this.debugOnFail) {
+            const errStr = this.debugReporterPluginHost.formatError(this.errs[0]);
+
+            await this._enqueueSetBreakpointCommand(void 0, errStr);
+        }
 
         await this.emit('before-done');
 
@@ -442,17 +569,18 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     // Errors
-    _addPendingPageErrorIfAny () {
+    private _addPendingPageErrorIfAny (): boolean {
         if (this.pendingPageError) {
             this.addError(this.pendingPageError);
             this.pendingPageError = null;
+
             return true;
         }
 
         return false;
     }
 
-    _createErrorAdapter (err) {
+    private _createErrorAdapter (err: Error): TestRunErrorFormattableAdapter {
         return new TestRunErrorFormattableAdapter(err, {
             userAgent:      this.browserConnection.userAgent,
             screenshotPath: this.errScreenshotPath || '',
@@ -461,7 +589,7 @@ export default class TestRun extends AsyncEventEmitter {
         });
     }
 
-    addError (err) {
+    public addError (err: Error | TestCafeErrorList | TestRunErrorBase): void {
         const errList = err instanceof TestCafeErrorList ? err.items : [err];
 
         errList.forEach(item => {
@@ -471,16 +599,20 @@ export default class TestRun extends AsyncEventEmitter {
         });
     }
 
-    normalizeRequestHookErrors () {
+    public normalizeRequestHookErrors (): void {
         const requestHookErrors = remove(this.errs, e =>
-            e.code === TEST_RUN_ERRORS.requestHookNotImplementedError ||
-            e.code === TEST_RUN_ERRORS.requestHookUnhandledError);
+            (e as unknown as TestRunErrorBase).code === TEST_RUN_ERRORS.requestHookNotImplementedError ||
+            (e as unknown as TestRunErrorBase).code === TEST_RUN_ERRORS.requestHookUnhandledError);
 
         if (!requestHookErrors.length)
             return;
 
         const uniqRequestHookErrors = chain(requestHookErrors)
-            .uniqBy(e => e.hookClassName + e.methodName)
+            .uniqBy(e => {
+                const err = e as unknown as RequestHookBaseError;
+
+                return err.hookClassName + err.methodName;
+            })
             .sortBy(['hookClassName', 'methodName'])
             .value();
 
@@ -488,7 +620,7 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     // Task queue
-    _enqueueCommand (command, callsite) {
+    private _enqueueCommand (command: Command, callsite: CallsiteRecord): Promise<unknown> {
         if (this.pendingRequest)
             this._resolvePendingRequest(command);
 
@@ -501,19 +633,20 @@ export default class TestRun extends AsyncEventEmitter {
         });
     }
 
-    get driverTaskQueueLength () {
-        return this.addingDriverTasksCount ? promisifyEvent(this, ALL_DRIVER_TASKS_ADDED_TO_QUEUE_EVENT) : Promise.resolve(this.driverTaskQueue.length);
+    public get driverTaskQueueLength (): Promise<number> {
+        return this.addingDriverTasksCount ? promisifyEvent(this as unknown as EventEmitter, ALL_DRIVER_TASKS_ADDED_TO_QUEUE_EVENT) : Promise.resolve(this.driverTaskQueue.length);
     }
 
-    async _enqueueBrowserConsoleMessagesCommand (command, callsite) {
+    public async _enqueueBrowserConsoleMessagesCommand (command: Command, callsite: CallsiteRecord): Promise<unknown> {
         await this._enqueueCommand(command, callsite);
 
         const consoleMessageCopy = this.consoleMessages.getCopy();
 
-        return consoleMessageCopy[this.browserConnection.activeWindowId];
+        // @ts-ignore
+        return consoleMessageCopy[String(this.browserConnection.activeWindowId)];
     }
 
-    async _enqueueSetBreakpointCommand (callsite, error) {
+    private async _enqueueSetBreakpointCommand (callsite: CallsiteRecord | undefined, error?: string): Promise<void> {
         if (this.browserConnection.isHeadlessBrowser()) {
             this.warningLog.addWarning(WARNING_MESSAGE.debugInHeadlessError);
             return;
@@ -522,21 +655,21 @@ export default class TestRun extends AsyncEventEmitter {
         if (this.debugLogger)
             this.debugLogger.showBreakpoint(this.session.id, this.browserConnection.userAgent, callsite, error);
 
-        this.debugging = await this.executeCommand(new serviceCommands.SetBreakpointCommand(!!error), callsite);
+        this.debugging = await this.executeCommand(new serviceCommands.SetBreakpointCommand(!!error), callsite) as boolean;
     }
 
-    _removeAllNonServiceTasks () {
+    private _removeAllNonServiceTasks (): void {
         this.driverTaskQueue = this.driverTaskQueue.filter(driverTask => isServiceCommand(driverTask.command));
 
         this.browserManipulationQueue.removeAllNonServiceManipulations();
     }
 
     // Current driver task
-    get currentDriverTask () {
+    public get currentDriverTask (): DriverTask {
         return this.driverTaskQueue[0];
     }
 
-    _resolveCurrentDriverTask (result) {
+    private _resolveCurrentDriverTask (result?: unknown): void {
         this.currentDriverTask.resolve(result);
         this.driverTaskQueue.shift();
 
@@ -544,7 +677,8 @@ export default class TestRun extends AsyncEventEmitter {
             this._removeAllNonServiceTasks();
     }
 
-    _rejectCurrentDriverTask (err) {
+    private _rejectCurrentDriverTask (err: Error): void {
+        // @ts-ignore
         err.callsite = err.callsite || this.currentDriverTask.callsite;
 
         this.currentDriverTask.reject(err);
@@ -552,21 +686,21 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     // Pending request
-    _clearPendingRequest () {
+    private _clearPendingRequest (): void {
         if (this.pendingRequest) {
             clearTimeout(this.pendingRequest.responseTimeout);
             this.pendingRequest = null;
         }
     }
 
-    _resolvePendingRequest (command) {
+    private _resolvePendingRequest (command: Command | null): void {
         this.lastDriverStatusResponse = command;
-        this.pendingRequest.resolve(command);
+        this.pendingRequest?.resolve(command);
         this._clearPendingRequest();
     }
 
     // Handle driver request
-    _shouldResolveCurrentDriverTask (driverStatus) {
+    private _shouldResolveCurrentDriverTask (driverStatus: DriverStatus): boolean {
         const currentCommand = this.currentDriverTask.command;
 
         const isExecutingObservationCommand = currentCommand instanceof observationCommands.ExecuteSelectorCommand ||
@@ -580,7 +714,7 @@ export default class TestRun extends AsyncEventEmitter {
         return !shouldExecuteCurrentCommand;
     }
 
-    _fulfillCurrentDriverTask (driverStatus) {
+    private _fulfillCurrentDriverTask (driverStatus: DriverStatus): void {
         if (!this.currentDriverTask)
             return;
 
@@ -590,7 +724,7 @@ export default class TestRun extends AsyncEventEmitter {
             this._resolveCurrentDriverTask(driverStatus.result);
     }
 
-    _handlePageErrorStatus (pageError) {
+    private _handlePageErrorStatus (pageError: Error): boolean {
         if (this.currentDriverTask && isCommandRejectableByPageError(this.currentDriverTask.command)) {
             this._rejectCurrentDriverTask(pageError);
             this.pendingPageError = null;
@@ -603,7 +737,7 @@ export default class TestRun extends AsyncEventEmitter {
         return false;
     }
 
-    _handleDriverRequest (driverStatus) {
+    private _handleDriverRequest (driverStatus: DriverStatus): Command | null | string {
         const isTestDone                 = this.currentDriverTask && this.currentDriverTask.command.type ===
                                            COMMAND_TYPE.testDone;
         const pageError                  = this.pendingPageError || driverStatus.pageError;
@@ -627,22 +761,22 @@ export default class TestRun extends AsyncEventEmitter {
         return this._getCurrentDriverTaskCommand();
     }
 
-    _getCurrentDriverTaskCommand () {
+    private _getCurrentDriverTaskCommand (): Command | null {
         if (!this.currentDriverTask)
             return null;
 
         const command = this.currentDriverTask.command;
 
-        if (command.type === COMMAND_TYPE.navigateTo && command.stateSnapshot)
-            this.session.useStateSnapshot(JSON.parse(command.stateSnapshot));
+        if (command.type === COMMAND_TYPE.navigateTo && (command as any).stateSnapshot)
+            this.session.useStateSnapshot(JSON.parse((command as any).stateSnapshot));
 
         return command;
     }
 
     // Execute command
-    _executeJsExpression (command) {
-        const resultVariableName = command.resultVariableName;
-        let expression           = command.expression;
+    private _executeJsExpression (command: Command): unknown {
+        const resultVariableName = (command as any).resultVariableName;
+        let expression           = (command as any).expression;
 
         if (resultVariableName)
             expression = `${resultVariableName} = ${expression}, ${resultVariableName}`;
@@ -650,20 +784,19 @@ export default class TestRun extends AsyncEventEmitter {
         return executeJsExpression(expression, this, { skipVisibilityCheck: false });
     }
 
-    async _executeAssertion (command, callsite) {
-        const assertionTimeout = command.options.timeout ===
-                                 void 0 ? this.opts.assertionTimeout : command.options.timeout;
+    private async _executeAssertion (command: AssertionCommand, callsite: CallsiteRecord): Promise<void> {
+        const assertionTimeout = getAssertionTimeout(command, this.opts);
         const executor         = new AssertionExecutor(command, assertionTimeout, callsite);
 
-        executor.once('start-assertion-retries', timeout => this.executeCommand(new serviceCommands.ShowAssertionRetriesStatusCommand(timeout)));
-        executor.once('end-assertion-retries', success => this.executeCommand(new serviceCommands.HideAssertionRetriesStatusCommand(success)));
+        executor.once('start-assertion-retries', (timeout: number) => this.executeCommand(new serviceCommands.ShowAssertionRetriesStatusCommand(timeout)));
+        executor.once('end-assertion-retries', (success: boolean) => this.executeCommand(new serviceCommands.HideAssertionRetriesStatusCommand(success)));
 
         const executeFn = this.decoratePreventEmitActionEvents(() => executor.run(), { prevent: true });
 
         return await executeFn();
     }
 
-    _adjustConfigurationWithCommand (command) {
+    private _adjustConfigurationWithCommand (command: Command): void {
         if (command.type === COMMAND_TYPE.testDone) {
             this.testDoneCommandQueued = true;
             if (this.debugLogger)
@@ -671,25 +804,25 @@ export default class TestRun extends AsyncEventEmitter {
         }
 
         else if (command.type === COMMAND_TYPE.setNativeDialogHandler)
-            this.activeDialogHandler = command.dialogHandler;
+            this.activeDialogHandler = (command as any).dialogHandler;
 
         else if (command.type === COMMAND_TYPE.switchToIframe)
-            this.activeIframeSelector = command.selector;
+            this.activeIframeSelector = (command as any).selector;
 
         else if (command.type === COMMAND_TYPE.switchToMainWindow)
             this.activeIframeSelector = null;
 
         else if (command.type === COMMAND_TYPE.setTestSpeed)
-            this.speed = command.speed;
+            this.speed = (command as any).speed;
 
         else if (command.type === COMMAND_TYPE.setPageLoadTimeout)
-            this.pageLoadTimeout = command.duration;
+            this.pageLoadTimeout = (command as any).duration;
 
         else if (command.type === COMMAND_TYPE.debug)
             this.debugging = true;
     }
 
-    async _adjustScreenshotCommand (command) {
+    private async _adjustScreenshotCommand (command: TakeScreenshotBaseCommand): Promise<void> {
         const browserId                    = this.browserConnection.id;
         const { hasChromelessScreenshots } = await this.browserConnection.provider.hasCustomActionForBrowser(browserId);
 
@@ -697,19 +830,19 @@ export default class TestRun extends AsyncEventEmitter {
             command.generateScreenshotMark();
     }
 
-    async _adjustCommandOptions (command) {
-        if (command.options?.confidential !== void 0)
+    public async _adjustCommandOptions (command: Command): Promise<void> {
+        if ((command as any).options?.confidential !== void 0)
             return;
 
         if (command.type === COMMAND_TYPE.typeText) {
-            const result = await this.executeCommand(command.selector);
+            const result = await this.executeCommand((command as any).selector);
 
             if (!result)
                 return;
 
             const node = this.replicator.decode(result);
 
-            command.options.confidential = isPasswordInput(node);
+            (command as any).options.confidential = isPasswordInput(node);
         }
 
         else if (command.type === COMMAND_TYPE.pressKey) {
@@ -720,16 +853,16 @@ export default class TestRun extends AsyncEventEmitter {
 
             const node = this.replicator.decode(result);
 
-            command.options.confidential = isPasswordInput(node);
+            (command as any).options.confidential = isPasswordInput(node);
         }
     }
 
-    async _setBreakpointIfNecessary (command, callsite) {
+    public async _setBreakpointIfNecessary (command: Command, callsite?: CallsiteRecord): Promise<void> {
         if (!this.disableDebugBreakpoints && this.debugging && canSetDebuggerBreakpointBeforeCommand(command))
             await this._enqueueSetBreakpointCommand(callsite);
     }
 
-    async executeAction (apiActionName, command, callsite) {
+    public async executeAction (apiActionName: string, command: Command, callsite: CallsiteRecord): Promise<unknown> {
         const actionArgs = { apiActionName, command };
 
         let errorAdapter = null;
@@ -740,7 +873,7 @@ export default class TestRun extends AsyncEventEmitter {
 
         await this.emitActionEvent('action-start', actionArgs);
 
-        const start = new Date();
+        const start = new Date().getTime();
 
         try {
             result = await this.executeCommand(command, callsite);
@@ -749,7 +882,7 @@ export default class TestRun extends AsyncEventEmitter {
             error = err;
         }
 
-        const duration = new Date() - start;
+        const duration = new Date().getTime() - start;
 
         if (error) {
             // NOTE: check if error is TestCafeErrorList is specific for the `useRole` action
@@ -776,7 +909,7 @@ export default class TestRun extends AsyncEventEmitter {
         return result;
     }
 
-    async executeCommand (command, callsite) {
+    public async executeCommand (command: Command, callsite?: CallsiteRecord): Promise<unknown> {
         this.debugLog.command(command);
 
         if (this.pendingPageError && isCommandRejectableByPageError(command))
@@ -796,7 +929,7 @@ export default class TestRun extends AsyncEventEmitter {
                 return null;
             }
 
-            await this._adjustScreenshotCommand(command);
+            await this._adjustScreenshotCommand(command as TakeScreenshotBaseCommand);
         }
 
         if (isBrowserManipulationCommand(command)) {
@@ -807,7 +940,7 @@ export default class TestRun extends AsyncEventEmitter {
         }
 
         if (command.type === COMMAND_TYPE.wait)
-            return delay(command.timeout);
+            return delay((command as any).timeout);
 
         if (command.type === COMMAND_TYPE.setPageLoadTimeout)
             return null;
@@ -816,7 +949,7 @@ export default class TestRun extends AsyncEventEmitter {
             return await this._enqueueSetBreakpointCommand(callsite);
 
         if (command.type === COMMAND_TYPE.useRole) {
-            let fn = () => this._useRole(command.role, callsite);
+            let fn = (): Promise<void> => this._useRole((command as any).role, callsite as CallsiteRecord);
 
             fn = this.decoratePreventEmitActionEvents(fn, { prevent: true });
             fn = this.decorateDisableDebugBreakpoints(fn, { disable: true });
@@ -825,45 +958,46 @@ export default class TestRun extends AsyncEventEmitter {
         }
 
         if (command.type === COMMAND_TYPE.assertion)
-            return this._executeAssertion(command, callsite);
+            return this._executeAssertion(command as AssertionCommand, callsite as CallsiteRecord);
 
         if (command.type === COMMAND_TYPE.executeExpression)
-            return await this._executeJsExpression(command, callsite);
+            return await this._executeJsExpression(command);
 
         if (command.type === COMMAND_TYPE.executeAsyncExpression)
-            return await executeAsyncJsExpression(command.expression, this, callsite);
+            return await executeAsyncJsExpression((command as any).expression, this, callsite);
 
         if (command.type === COMMAND_TYPE.getBrowserConsoleMessages)
-            return await this._enqueueBrowserConsoleMessagesCommand(command, callsite);
+            return await this._enqueueBrowserConsoleMessagesCommand(command, callsite as CallsiteRecord);
 
         if (command.type === COMMAND_TYPE.switchToPreviousWindow)
-            command.windowId = this.browserConnection.previousActiveWindowId;
+            (command as any).windowId = this.browserConnection.previousActiveWindowId;
 
         if (command.type === COMMAND_TYPE.switchToWindowByPredicate)
-            return this._switchToWindowByPredicate(command);
+            return this._switchToWindowByPredicate(command as SwitchToWindowByPredicateCommand);
 
-
-        return this._enqueueCommand(command, callsite);
+        return this._enqueueCommand(command, callsite as CallsiteRecord);
     }
 
-    _rejectCommandWithPageError (callsite) {
+    private _rejectCommandWithPageError (callsite?: CallsiteRecord): Promise<Error> {
         const err = this.pendingPageError;
 
+        // @ts-ignore
         err.callsite          = callsite;
         this.pendingPageError = null;
 
         return Promise.reject(err);
     }
 
-    async _makeScreenshotOnFail () {
+    public async _makeScreenshotOnFail (): Promise<void> {
         const { screenshots } = this.opts;
 
-        if (!this.errScreenshotPath && screenshots && screenshots.takeOnFails)
-            this.errScreenshotPath = await this.executeCommand(new browserManipulationCommands.TakeScreenshotOnFailCommand());
+        if (!this.errScreenshotPath && (screenshots as ScreenshotOptionValue)?.takeOnFails)
+            this.errScreenshotPath = await this.executeCommand(new browserManipulationCommands.TakeScreenshotOnFailCommand()) as string;
     }
 
-    _decorateWithFlag (fn, flagName, value) {
+    private _decorateWithFlag (fn: Function, flagName: string, value: boolean): () => Promise<void> {
         return async () => {
+            // @ts-ignore
             this[flagName] = value;
 
             try {
@@ -873,29 +1007,30 @@ export default class TestRun extends AsyncEventEmitter {
                 throw err;
             }
             finally {
+                // @ts-ignore
                 this[flagName] = !value;
             }
         };
     }
 
-    decoratePreventEmitActionEvents (fn, { prevent }) {
+    public decoratePreventEmitActionEvents (fn: Function, { prevent }: { prevent: boolean }): () => Promise<void> {
         return this._decorateWithFlag(fn, 'preventEmitActionEvents', prevent);
     }
 
-    decorateDisableDebugBreakpoints (fn, { disable }) {
+    public decorateDisableDebugBreakpoints (fn: Function, { disable }: { disable: boolean }): () => Promise<void> {
         return this._decorateWithFlag(fn, 'disableDebugBreakpoints', disable);
     }
 
     // Role management
-    async getStateSnapshot () {
+    public async getStateSnapshot (): Promise<StateSnapshot> {
         const state = this.session.getStateSnapshot();
 
-        state.storages = await this.executeCommand(new serviceCommands.BackupStoragesCommand());
+        state.storages = await this.executeCommand(new serviceCommands.BackupStoragesCommand()) as StoragesSnapshot;
 
         return state;
     }
 
-    async switchToCleanRun (url) {
+    public async switchToCleanRun (url: string): Promise<void> {
         this.ctx             = Object.create(null);
         this.fixtureCtx      = Object.create(null);
         this.consoleMessages = new BrowserConsoleMessages();
@@ -923,16 +1058,16 @@ export default class TestRun extends AsyncEventEmitter {
         }
     }
 
-    async navigateToUrl (url, forceReload, stateSnapshot) {
+    public async navigateToUrl (url: string, forceReload: boolean, stateSnapshot?: StateSnapshot): Promise<void> {
         const navigateCommand = new actionCommands.NavigateToCommand({ url, forceReload, stateSnapshot });
 
         await this.executeCommand(navigateCommand);
     }
 
-    async _getStateSnapshotFromRole (role) {
+    private async _getStateSnapshotFromRole (role: Role): Promise<StateSnapshot> {
         const prevPhase = this.phase;
 
-        this.phase = PHASE.inRoleInitializer;
+        this.phase = TestRunPhase.inRoleInitializer;
 
         if (role.phase === ROLE_PHASE.uninitialized)
             await role.initialize(this);
@@ -948,8 +1083,8 @@ export default class TestRun extends AsyncEventEmitter {
         return role.stateSnapshot;
     }
 
-    async _useRole (role, callsite) {
-        if (this.phase === PHASE.inRoleInitializer)
+    private async _useRole (role: Role, callsite: CallsiteRecord): Promise<void> {
+        if (this.phase === TestRunPhase.inRoleInitializer)
             throw new RoleSwitchInRoleInitializerError(callsite);
 
         const bookmark = new TestRunBookmark(this, role);
@@ -968,7 +1103,7 @@ export default class TestRun extends AsyncEventEmitter {
         await bookmark.restore(callsite, stateSnapshot);
     }
 
-    async getCurrentUrl () {
+    public async getCurrentUrl (): Promise<string> {
         const builder = new ClientFunctionBuilder(() => {
             /* eslint-disable no-undef */
             return window.location.href;
@@ -980,14 +1115,14 @@ export default class TestRun extends AsyncEventEmitter {
         return await getLocation();
     }
 
-    async _switchToWindowByPredicate (command) {
-        const currentWindows = await this.executeCommand(new GetCurrentWindowsCommand({}, this));
+    private async _switchToWindowByPredicate (command: SwitchToWindowByPredicateCommand): Promise<void> {
+        const currentWindows = await this.executeCommand(new GetCurrentWindowsCommand({}, this)) as OpenedWindowInformation[];
 
         const windows = currentWindows.filter(wnd => {
             try {
                 const url = new URL(wnd.url);
 
-                return command.findWindow({ url, title: wnd.title });
+                return (command as any).findWindow({ url, title: wnd.title });
             }
             catch (e) {
                 throw new SwitchToWindowPredicateError(e.message);
@@ -1000,10 +1135,10 @@ export default class TestRun extends AsyncEventEmitter {
         if (windows.length > 1)
             this.warningLog.addWarning(WARNING_MESSAGE.multipleWindowsFoundByPredicate);
 
-        await this.executeCommand(new SwitchToWindowCommand({ windowId: windows[0].id }), this);
+        await this.executeCommand(new SwitchToWindowCommand({ windowId: windows[0].id }, this));
     }
 
-    _disconnect (err) {
+    private _disconnect (err: Error): void {
         this.disconnected = true;
 
         if (this.currentDriverTask)
@@ -1014,18 +1149,19 @@ export default class TestRun extends AsyncEventEmitter {
         delete testRunTracker.activeTestRuns[this.session.id];
     }
 
-    async emitActionEvent (eventName, args) {
+    public async emitActionEvent (eventName: string, args: unknown): Promise<void> {
+        // @ts-ignore
         if (!this.preventEmitActionEvents)
             await this.emit(eventName, args);
     }
 
-    static isMultipleWindowsAllowed (testRun) {
+    public static isMultipleWindowsAllowed (testRun: TestRun): boolean {
         const { disableMultipleWindows, test, browserConnection } = testRun;
 
-        return !disableMultipleWindows && !test.isLegacy && !!browserConnection.activeWindowId;
+        return !disableMultipleWindows && !(test as LegacyTestRun).isLegacy && !!browserConnection.activeWindowId;
     }
 
-    async initialize () {
+    public async initialize (): Promise<void> {
         if (!this.compilerService)
             return;
 
@@ -1034,67 +1170,64 @@ export default class TestRun extends AsyncEventEmitter {
             testId:    this.test.id
         });
     }
-}
 
-// Service message handlers
-const ServiceMessages = TestRun.prototype;
+    // NOTE: this function is time-critical and must return ASAP to avoid client disconnection
+    private async [CLIENT_MESSAGES.ready] (msg: DriverMessage): Promise<unknown> {
+        this.debugLog.driverMessage(msg);
 
-// NOTE: this function is time-critical and must return ASAP to avoid client disconnection
-ServiceMessages[CLIENT_MESSAGES.ready] = function (msg) {
-    this.debugLog.driverMessage(msg);
+        if (this.disconnected)
+            return Promise.reject(new GeneralError(RUNTIME_ERRORS.testRunRequestInDisconnectedBrowser, this.browserConnection.browserInfo.alias));
 
-    if (this.disconnected)
-        return Promise.reject(new GeneralError(RUNTIME_ERRORS.testRunRequestInDisconnectedBrowser, this.browserConnection.browserInfo.alias));
+        this.emit('connected');
 
-    this.emit('connected');
+        this._clearPendingRequest();
 
-    this._clearPendingRequest();
+        // NOTE: the driver sends the status for the second time if it didn't get a response at the
+        // first try. This is possible when the page was unloaded after the driver sent the status.
+        if (msg.status.id === this.lastDriverStatusId)
+            return this.lastDriverStatusResponse;
 
-    // NOTE: the driver sends the status for the second time if it didn't get a response at the
-    // first try. This is possible when the page was unloaded after the driver sent the status.
-    if (msg.status.id === this.lastDriverStatusId)
-        return this.lastDriverStatusResponse;
+        this.lastDriverStatusId       = msg.status.id;
+        this.lastDriverStatusResponse = this._handleDriverRequest(msg.status);
 
-    this.lastDriverStatusId       = msg.status.id;
-    this.lastDriverStatusResponse = this._handleDriverRequest(msg.status);
+        if (this.lastDriverStatusResponse || msg.status.isPendingWindowSwitching)
+            return this.lastDriverStatusResponse;
 
-    if (this.lastDriverStatusResponse || msg.status.isPendingWindowSwitching)
-        return this.lastDriverStatusResponse;
+        // NOTE: we send an empty response after the MAX_RESPONSE_DELAY timeout is exceeded to keep connection
+        // with the client and prevent the response timeout exception on the client side
+        const responseTimeout = setTimeout(() => this._resolvePendingRequest(null), MAX_RESPONSE_DELAY);
 
-    // NOTE: we send an empty response after the MAX_RESPONSE_DELAY timeout is exceeded to keep connection
-    // with the client and prevent the response timeout exception on the client side
-    const responseTimeout = setTimeout(() => this._resolvePendingRequest(null), MAX_RESPONSE_DELAY);
-
-    return new Promise((resolve, reject) => {
-        this.pendingRequest = { resolve, reject, responseTimeout };
-    });
-};
-
-ServiceMessages[CLIENT_MESSAGES.readyForBrowserManipulation] = async function (msg) {
-    this.debugLog.driverMessage(msg);
-
-    let result = null;
-    let error  = null;
-
-    try {
-        result = await this.browserManipulationQueue.executePendingManipulation(msg);
-    }
-    catch (err) {
-        error = err;
+        return new Promise((resolve, reject) => {
+            this.pendingRequest = { resolve, reject, responseTimeout };
+        });
     }
 
-    return { result, error };
-};
+    private async [CLIENT_MESSAGES.readyForBrowserManipulation] (msg: DriverMessage): Promise<BrowserManipulationResult> {
+        this.debugLog.driverMessage(msg);
 
-ServiceMessages[CLIENT_MESSAGES.waitForFileDownload] = function (msg) {
-    this.debugLog.driverMessage(msg);
+        let result = null;
+        let error  = null;
 
-    return new Promise(resolve => {
-        if (this.fileDownloadingHandled) {
-            this.fileDownloadingHandled = false;
-            resolve(true);
+        try {
+            result = await this.browserManipulationQueue.executePendingManipulation(msg);
         }
-        else
-            this.resolveWaitForFileDownloadingPromise = resolve;
-    });
-};
+        catch (err) {
+            error = err;
+        }
+
+        return { result, error };
+    }
+
+    private async [CLIENT_MESSAGES.waitForFileDownload] (msg: DriverMessage): Promise<boolean> {
+        this.debugLog.driverMessage(msg);
+
+        return new Promise(resolve => {
+            if (this.fileDownloadingHandled) {
+                this.fileDownloadingHandled = false;
+                resolve(true);
+            }
+            else
+                this.resolveWaitForFileDownloadingPromise = resolve;
+        });
+    }
+}

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -929,7 +929,7 @@ export default class TestRun extends AsyncEventEmitter {
                 return null;
             }
 
-            await this._adjustScreenshotCommand(command as TakeScreenshotBaseCommand);
+            await this._adjustScreenshotCommand(command as unknown as TakeScreenshotBaseCommand);
         }
 
         if (isBrowserManipulationCommand(command)) {
@@ -973,7 +973,7 @@ export default class TestRun extends AsyncEventEmitter {
             (command as any).windowId = this.browserConnection.previousActiveWindowId;
 
         if (command.type === COMMAND_TYPE.switchToWindowByPredicate)
-            return this._switchToWindowByPredicate(command as SwitchToWindowByPredicateCommand);
+            return this._switchToWindowByPredicate(command as unknown as SwitchToWindowByPredicateCommand);
 
         return this._enqueueCommand(command, callsite as CallsiteRecord);
     }
@@ -1116,7 +1116,7 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     private async _switchToWindowByPredicate (command: SwitchToWindowByPredicateCommand): Promise<void> {
-        const currentWindows = await this.executeCommand(new GetCurrentWindowsCommand({}, this)) as OpenedWindowInformation[];
+        const currentWindows = await this.executeCommand(new GetCurrentWindowsCommand({}, this) as unknown as Command) as OpenedWindowInformation[];
 
         const windows = currentWindows.filter(wnd => {
             try {
@@ -1135,7 +1135,7 @@ export default class TestRun extends AsyncEventEmitter {
         if (windows.length > 1)
             this.warningLog.addWarning(WARNING_MESSAGE.multipleWindowsFoundByPredicate);
 
-        await this.executeCommand(new SwitchToWindowCommand({ windowId: windows[0].id }, this));
+        await this.executeCommand(new SwitchToWindowCommand({ windowId: windows[0].id }, this) as unknown as Command);
     }
 
     private _disconnect (err: Error): void {

--- a/src/test-run/marker-symbol.ts
+++ b/src/test-run/marker-symbol.ts
@@ -1,6 +1,6 @@
-/*global Symbol*/
-
 // HACK: used to validate that ClientFunction `boundTestRun` option value
 // is a TestRun. With the marker symbol approach we can safely use
 // ClientFunctionBuilder in TestRun without circular reference.
-export default Symbol('testRun');
+const testRunSymbol = Symbol('testRun');
+
+export default testRunSymbol;

--- a/src/utils/get-options/get-assertion-timeout.ts
+++ b/src/utils/get-options/get-assertion-timeout.ts
@@ -2,8 +2,7 @@ import AssertionCommand from '../../test-run/commands/assertion';
 import { Dictionary } from '../../configuration/interfaces';
 
 export default function getAssertionTimeout (command: AssertionCommand, options: Dictionary<OptionValue>): number {
-    // @ts-ignore
-    const { timeout: commandTimeout } = command.options;
+    const commandTimeout = command.options?.timeout;
 
     return commandTimeout === void 0
         ? options.assertionTimeout

--- a/src/utils/get-options/get-assertion-timeout.ts
+++ b/src/utils/get-options/get-assertion-timeout.ts
@@ -1,0 +1,11 @@
+import AssertionCommand from '../../test-run/commands/assertion';
+import { Dictionary } from '../../configuration/interfaces';
+
+export default function getAssertionTimeout (command: AssertionCommand, options: Dictionary<OptionValue>): number {
+    // @ts-ignore
+    const { timeout: commandTimeout } = command.options;
+
+    return commandTimeout === void 0
+        ? options.assertionTimeout
+        : commandTimeout;
+}

--- a/src/utils/prerender-callsite.ts
+++ b/src/utils/prerender-callsite.ts
@@ -1,9 +1,15 @@
-import { renderers } from 'callsite-record';
+import { CallsiteRecord, renderers } from 'callsite-record';
 import renderCallsiteSync from './render-callsite-sync';
 import createStackFilter from '../errors/create-stack-filter';
 
+export interface RenderedCallsite {
+    prerendered: boolean;
+    default: string;
+    html: string;
+    noColor: string;
+}
 
-export default function prerenderCallsite (callsite) {
+export default function prerenderCallsite (callsite: CallsiteRecord): RenderedCallsite {
     const stackFilter = createStackFilter(Error.stackTraceLimit);
 
     return {


### PR DESCRIPTION
Changes:
* rewrite `TestRun` to TypeScript
* move the `testClient` function and test client settings from the `Gulpfile.js`
* more strict types