### PR TITLE
test: typeText should work with the DX Lookup search field

### DIFF
--- a/test/functional/fixtures/regression/gh-4472/pages/index.html
+++ b/test/functional/fixtures/regression/gh-4472/pages/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>gh-4472</title>
+</head>
+<body>
+    <div id="targetInputWrapper">
+        <input type="text" id="targetInput" tabindex="0"></input>
+    </div>
+    <script>
+        var input = document.getElementById('targetInput');
+        var div   = document.getElementById('targetInputWrapper');
+
+        input.onclick = function () {
+            div.focus();
+        };
+    </script>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-4472/test.js
+++ b/test/functional/fixtures/regression/gh-4472/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-4472)', function () {
+    it('Input should not lose focus after the focus method was called on a not focusable element', function () {
+        return runTests('testcafe-fixtures/index.js');
+    });
+});

--- a/test/functional/fixtures/regression/gh-4472/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-4472/testcafe-fixtures/index.js
@@ -1,0 +1,11 @@
+import { Selector } from 'testcafe';
+
+fixture `GH-4472`
+    .page `http://localhost:3000/fixtures/regression/gh-4472/pages/index.html`;
+
+test(`Should not lose the focus on input`, async t => {
+    const input = Selector('#targetInput');
+
+    await t.typeText(input, 'text');
+    await t.expect(input.value).eql('text');
+});


### PR DESCRIPTION
## Purpose
The DX Lookup search field loses focus and stays empty because the `focus` method is called on a not focusable element and HH sends an extra `blur` event to an active element (input).

## Approach
Add functional test for the fix on HH side (https://github.com/DevExpress/testcafe-hammerhead/pull/2635)

## References
#4472 

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
