### PR TITLE
test: rewrite the "Events initiated by scroll should have valid properties" test

### DIFF
--- a/test/functional/fixtures/api/es-next/scroll/pages/event-properties.html
+++ b/test/functional/fixtures/api/es-next/scroll/pages/event-properties.html
@@ -15,9 +15,9 @@
     </style>
 </head>
 <body>
-    <div id="item1" class="space"></div>
-    <div id="item2" class="item"></div>
-    <div id="item3" class="space"></div>
+    <div id="space-before" class="space"></div>
+    <div id="target" class="item"></div>
+    <div id="space-after" class="space"></div>
     <div>
         <span id="emittedEvents"></span>
         <span id="emittedEventDetails"></span>

--- a/test/functional/fixtures/api/es-next/scroll/testcafe-fixtures/event-properties.js
+++ b/test/functional/fixtures/api/es-next/scroll/testcafe-fixtures/event-properties.js
@@ -10,9 +10,17 @@ const getElementClassFromPoint = ClientFunction((x, y) => {
 });
 
 test('test', async t => {
+    const target = Selector('#target');
+
+    const targetBounds = await target.boundingClientRect;
+
+    // NOTE: All actions should be aligned vertically at the center of the target to prevent MouseMove actions and force the Scroll action to raise mouseenter/mouseleave events
+    const offsetX = 0.5 * (targetBounds.left + targetBounds.right);
+
     await t
-        .hover('#item2')
-        .click('#item3')
+        .click('#space-before', { offsetX })
+        .hover('#target', { offsetX })
+        .click('#space-after',  { offsetX })
         .expect(Selector('#emittedEvents').textContent).eql('mouseenter;mouseleave;');
 
     const emittedEventDetails = await Selector('#emittedEventDetails').textContent;
@@ -27,7 +35,7 @@ test('test', async t => {
         .expect(mouseenterEventProperties.alt).eql(false)
         .expect(mouseenterEventProperties.shift).eql(false)
         .expect(mouseenterEventProperties.meta).eql(false)
-        .expect(mouseenterEventProperties.relatedTarget).eql('html')
+        .expect(mouseenterEventProperties.relatedTarget).eql('space')
         .expect(mouseenterEventProperties.target).eql('item')
         .expect(getElementClassFromPoint(mouseenterEventProperties.clientX, mouseenterEventProperties.clientY)).eql('space')
 

--- a/test/functional/fixtures/api/es-next/scroll/testcafe-fixtures/event-properties.js
+++ b/test/functional/fixtures/api/es-next/scroll/testcafe-fixtures/event-properties.js
@@ -20,7 +20,7 @@ test('test', async t => {
     await t
         .click('#space-before', { offsetX })
         .hover('#target', { offsetX })
-        .click('#space-after',  { offsetX })
+        .click('#space-after', { offsetX })
         .expect(Selector('#emittedEvents').textContent).eql('mouseenter;mouseleave;');
 
     const emittedEventDetails = await Selector('#emittedEventDetails').textContent;


### PR DESCRIPTION
The previous version of the test was flaky due to a scroll lag (most likely). Moreover, it didn't test events initiated by the scroll action, since the cursor wasn't properly positioned and all events in the tests were actually raised by the `MouseMove` action. 

I forced the vertical cursor alignment by using an additional first step and the `offsetX` option. It should fix both issues.