### PR TITLE
fix: fixed a parsing issue that caused by empty quarantine mode arguments (closes #6231)

### DIFF
--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -120,7 +120,7 @@ export default class CLIArgumentParser {
             .option('-s, --screenshots <option=value[,...]>', 'specify screenshot options')
             .option('-S, --screenshots-on-fails', 'take a screenshot whenever a test fails')
             .option('-p, --screenshot-path-pattern <pattern>', 'use patterns to compose screenshot file names and paths: ${BROWSER}, ${BROWSER_VERSION}, ${OS}, etc.')
-            .option('-q, --quarantine-mode', 'enable the quarantine mode, optionally number of retries and pass threshold')
+            .option('-q, --quarantine-mode [option=value,...]', 'enable the quarantine mode, optionally number of retries and pass threshold')
             .option('-d, --debug-mode', 'execute test steps one by one pausing the test after each step')
             .option('-e, --skip-js-errors', 'make tests not fail when a JS error happens on a page')
             .option('-u, --skip-uncaught-errors', 'ignore uncaught errors and unhandled promise rejections, which occur during test execution')
@@ -295,7 +295,7 @@ export default class CLIArgumentParser {
     }
 
     private _parseBrowsersFromArgs (): void {
-        const browsersArg = this.program.args[0] || '';
+        const browsersArg = this.args[0] || '';
 
         this.opts.browsers = splitQuotedText(browsersArg, ',')
             .filter(browser => browser && this._checkAndCountRemotes(browser));
@@ -323,7 +323,7 @@ export default class CLIArgumentParser {
     }
 
     private _parseFileList (): void {
-        this.opts.src = this.program.args.slice(1);
+        this.opts.src = this.args.slice(1);
     }
 
     private async _parseScreenshotOptions (): Promise<void> {
@@ -378,6 +378,13 @@ export default class CLIArgumentParser {
         this.args = this.program.args;
 
         this.opts = { ...this.experimental.opts(), ...this.program.opts() };
+
+        // NOTE: GH-6231
+        // @ts-ignore
+        if (this.opts.quarantineMode && typeof this.opts.quarantineMode === 'string' && !['retryCount', 'passCount'].some(opt => this.opts.quarantineMode.startsWith(opt))) {
+            this.args.unshift(this.opts.quarantineMode);
+            this.opts.quarantineMode = true;
+        }
 
         this._parseListBrowsers();
 

--- a/src/errors/runtime/templates.js
+++ b/src/errors/runtime/templates.js
@@ -39,7 +39,7 @@ export default {
     [RUNTIME_ERRORS.multipleSameStreamReporters]:                        'The following reporters attempted to write to the same output stream: "{reporters}". Only one reporter can write to a stream.',
     [RUNTIME_ERRORS.optionValueIsNotValidRegExp]:                        'The "{optionName}" option value is not a valid regular expression.',
     [RUNTIME_ERRORS.optionValueIsNotValidKeyValue]:                      'The "{optionName}" option value is not a valid key-value pair.',
-    [RUNTIME_ERRORS.invalidQuarantineOption]:                            'The "{optionName}" option should be empty, otherwise one of "retryCount" or "passCount".',
+    [RUNTIME_ERRORS.invalidQuarantineOption]:                            'The "{optionName}" option should be one of "retryCount" or "passCount" if you specify custom quarantine mode settings.',
     [RUNTIME_ERRORS.invalidRetryCountValue]:                             'The "retryCount" value should be greater or equal to "passCount" ({passCount}).',
     [RUNTIME_ERRORS.invalidSpeedValue]:                                  'Speed should be a number between 0.01 and 1.',
     [RUNTIME_ERRORS.invalidConcurrencyFactor]:                           'The concurrency factor should be an integer greater or equal to 1.',

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -389,7 +389,7 @@ export default class Runner extends EventEmitter {
         const quarantineMode = this.configuration.getOption(OPTION_NAMES.quarantineMode);
 
         if (typeof quarantineMode === 'object')
-            validateQuarantineOptions(quarantineMode, 'quarantineMode');
+            validateQuarantineOptions(quarantineMode, OPTION_NAMES.quarantineMode);
     }
 
     async _validateRunOptions () {

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -35,6 +35,7 @@ import CustomizableCompilers from '../configuration/customizable-compilers';
 import { getConcatenatedValuesString, getPluralSuffix } from '../utils/string';
 import isLocalhost from '../utils/is-localhost';
 import WarningLog from '../notifications/warning-log';
+import { validateQuarantineOptions } from '../utils/get-options/quarantine';
 
 const DEBUG_LOGGER = debug('testcafe:runner');
 
@@ -384,6 +385,13 @@ export default class Runner extends EventEmitter {
         throw new GeneralError(RUNTIME_ERRORS.cannotEnableRetryTestPagesOption);
     }
 
+    _validateQuarantineOptions () {
+        const quarantineMode = this.configuration.getOption(OPTION_NAMES.quarantineMode);
+
+        if (typeof quarantineMode === 'object')
+            validateQuarantineOptions(quarantineMode, 'quarantineMode');
+    }
+
     async _validateRunOptions () {
         this._validateDebugLogger();
         this._validateScreenshotOptions();
@@ -395,6 +403,7 @@ export default class Runner extends EventEmitter {
         this._validateRetryTestPagesOption();
         this._validateRequestTimeoutOption(OPTION_NAMES.pageRequestTimeout);
         this._validateRequestTimeoutOption(OPTION_NAMES.ajaxRequestTimeout);
+        this._validateQuarantineOptions();
     }
 
     _createRunnableConfiguration () {

--- a/src/utils/get-options/quarantine.ts
+++ b/src/utils/get-options/quarantine.ts
@@ -12,7 +12,10 @@ function _isQuarantineOption (option: string): option is QUARANTINE_OPTION_NAMES
     return Object.values(QUARANTINE_OPTION_NAMES).includes(option as QUARANTINE_OPTION_NAMES);
 }
 
-function _validateQuarantineOptions (options: Dictionary<string | number> ): void {
+export function validateQuarantineOptions (options: Dictionary<string | number>, optionName: string): void {
+    if (Object.keys(options).some(key => !_isQuarantineOption(key)))
+        throw new GeneralError(RUNTIME_ERRORS.invalidQuarantineOption, optionName);
+
     const retryCount = options.retryCount || DEFAULT_TEST_RUN_THRESHOLD;
     const passCount  = options.passCount || DEFAULT_QUARANTINE_THRESHOLD;
 
@@ -35,10 +38,7 @@ export async function getQuarantineOptions (optionName: string, options: string 
         }
     });
 
-    if (Object.keys(parsedOptions).some(key => !_isQuarantineOption(key)))
-        throw new GeneralError(RUNTIME_ERRORS.invalidQuarantineOption, optionName);
-
-    _validateQuarantineOptions(parsedOptions);
+    validateQuarantineOptions(parsedOptions, optionName);
 
     return parsedOptions;
 }

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -644,49 +644,57 @@ describe('CLI argument parser', function () {
             });
     });
 
-    // TODO: enable tests back after eliminating a breaking change in -q <browser> and -q <test.js> behavior
-    describe.skip('Quarantine Options', function () {
+    describe('Quarantine Option', function () {
         it('Should parse quarantine arguments', async () => {
-            const parser = await parse('-q retryCount=5,passCount=1');
+            async function checkCliArgs (argsString) {
+                const parser = await parse(argsString);
 
-            expect(parser.opts.quarantineMode).to.be.ok;
-            expect(parser.opts.quarantineMode.retryCount).equal(5);
-            expect(parser.opts.quarantineMode.passCount).equal(1);
-        });
+                expect(parser.opts.quarantineMode).to.be.ok;
+                expect(parser.opts.quarantineMode.retryCount).equal(5);
+                expect(parser.opts.quarantineMode.passCount).equal(1);
+            }
 
-        it('Should parse quarantine-mode arguments', async () => {
-            const parser = await parse('--quarantine-mode retryCount=5,passCount=1');
-
-            expect(parser.opts.quarantineMode).to.be.ok;
-            expect(parser.opts.quarantineMode.retryCount).equal(5);
-            expect(parser.opts.quarantineMode.passCount).equal(1);
+            await checkCliArgs('-q retryCount=5,passCount=1');
+            await checkCliArgs('--quarantine-mode retryCount=5,passCount=1');
         });
 
         it('Should pass if only "passCount" is provided', async () => {
-            const parser = await parse('--quarantine-mode passCount=1');
+            async function checkCliArgs (argsString) {
+                const parser = await parse(argsString);
 
-            expect(parser.opts.quarantineMode).to.be.ok;
-            expect(parser.opts.quarantineMode.passCount).equal(1);
+                expect(parser.opts.quarantineMode).to.be.ok;
+                expect(parser.opts.quarantineMode.passCount).equal(1);
+            }
+
+            await checkCliArgs('-q passCount=1');
+            await checkCliArgs('--quarantine-mode passCount=1');
         });
 
-        it('Should fail if threshold value not specified', async () => {
-            return assertRaisesError('--quarantine-mode retryCount=', 'The "--quarantine-mode" option value is not a valid key-value pair.');
-        });
-
-        it('Should fail if threshold keys not specified', async () => {
-            return assertRaisesError('--quarantine-mode 1', 'The "--quarantine-mode" option value is not a valid key-value pair.');
-        });
-
-        it('Should fail if invalid option is specified', async () => {
-            return assertRaisesError('--quarantine-mode test=fake', 'The "--quarantine-mode" option should be empty, otherwise one of "retryCount" or "passCount".');
+        it('Should fail if the argument value is not specified', async () => {
+            await assertRaisesError('-q retryCount=', 'The "--quarantine-mode" option value is not a valid key-value pair.');
+            await assertRaisesError('--quarantine-mode retryCount=', 'The "--quarantine-mode" option value is not a valid key-value pair.');
         });
 
         it('Should fail if "retryCount" is greater than "passCount"', async () => {
-            return assertRaisesError('--quarantine-mode retryCount=1,passCount=2', 'The "retryCount" value should be greater or equal to "passCount" (2).');
+            await assertRaisesError('-q retryCount=1,passCount=2', 'The "retryCount" value should be greater or equal to "passCount" (2).');
+            await assertRaisesError('--quarantine-mode retryCount=1,passCount=2', 'The "retryCount" value should be greater or equal to "passCount" (2).');
         });
 
         it('Should fail if "retryCount" is less than 3', async () => {
-            return assertRaisesError('--quarantine-mode retryCount=1', 'The "retryCount" value should be greater or equal to "passCount" (3).');
+            await assertRaisesError('-q retryCount=1', 'The "retryCount" value should be greater or equal to "passCount" (3).');
+            await assertRaisesError('--quarantine-mode retryCount=1', 'The "retryCount" value should be greater or equal to "passCount" (3).');
+        });
+
+        it('Should not fail if the quarantine option is not the latest option and don\'t specify Quarantine Mode arguments ', async () => {
+            async function checkCliArgs (argsString) {
+                const parser = await parse(argsString);
+
+                expect(parser.opts.quarantineMode).to.be.ok;
+                expect(parser.opts.browsers).eql(['chrome']);
+            }
+
+            await checkCliArgs('-q chrome');
+            await checkCliArgs('--quarantine-mode chrome');
         });
     });
 

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -685,7 +685,7 @@ describe('CLI argument parser', function () {
             await assertRaisesError('--quarantine-mode retryCount=1', 'The "retryCount" value should be greater or equal to "passCount" (3).');
         });
 
-        it('Should not fail if the quarantine option is not the latest option and don\'t specify Quarantine Mode arguments ', async () => {
+        it('Should not fail if the quarantine option is not the latest option and no quarantine mode arguments are specified', async () => {
             async function checkCliArgs (argsString) {
                 const parser = await parse(argsString);
 

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -691,10 +691,13 @@ describe('CLI argument parser', function () {
 
                 expect(parser.opts.quarantineMode).to.be.ok;
                 expect(parser.opts.browsers).eql(['chrome']);
+                expect(parser.opts.src).eql(['test.js']);
             }
 
-            await checkCliArgs('-q chrome');
-            await checkCliArgs('--quarantine-mode chrome');
+            await checkCliArgs('-q chrome test.js');
+            await checkCliArgs('--quarantine-mode chrome test.js');
+            await checkCliArgs('chrome -q test.js');
+            await checkCliArgs('chrome --quarantine-mode test.js');
         });
     });
 

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -917,6 +917,27 @@ describe('Runner', () => {
 
             expect(errorCount).eql(4);
         });
+
+        it('Should raise an error if the Quarantine Mode is represented by invalid arguments', async () => {
+            let errorCount = 0;
+
+            const checkQuarantineOptions = (quarantineOptions, expectedErrorMessage) => {
+                return runner
+                    .run(quarantineOptions)
+                    .catch(err => {
+                        errorCount++;
+
+                        expect(err.message).eql(expectedErrorMessage);
+
+                        delete runner.configuration._options[OptionNames.quarantineMode];
+                    });
+            };
+
+            await checkQuarantineOptions({ quarantineMode: { retryCount: 5, passCount: 10 } }, 'The "retryCount" value should be greater or equal to "passCount" (10).');
+            await checkQuarantineOptions({ quarantineMode: { test: '1' } }, 'The "quarantineMode" option should be one of "retryCount" or "passCount" if you specify custom quarantine mode settings.');
+
+            expect(errorCount).eql(2);
+        });
     });
 
     describe('.clientScripts', () => {

--- a/ts-defs-src/runner-api/runner-api.d.ts
+++ b/ts-defs-src/runner-api/runner-api.d.ts
@@ -296,7 +296,7 @@ interface RunOptions {
      */
     skipUncaughtErrors: boolean;
     /**
-     * Defines whether to enable the quarantine mode.
+     * Defines whether to enable the quarantine mode. Optionally specifies the custom quarantine mode options.
      */
     quarantineMode: boolean | Record<string, string>;
     /**


### PR DESCRIPTION
## Purpose
Fix parsing CLI issue: `testcafe -q chrome test.js`, `testcafe chrome -q test.js`.

## Approach
Modifying CLI arguments before parsing. Additional changes: added quarantine option validation to non-CLI interfaces.

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
