### PR TITLE
perf(compiler/babel): load configuration only once

### DIFF
--- a/src/compiler/babel/load-libs.js
+++ b/src/compiler/babel/load-libs.js
@@ -49,9 +49,11 @@ function getPresetReact () {
     return presetReact;
 }
 
+let loadedLibs = null;
+
 // NOTE: lazy load heavy dependencies
 export default function loadLibs () {
-    return {
+    loadedLibs = loadedLibs || {
         babel:                      require('@babel/core'),
         presetStage2:               require('./preset-stage-2'),
         presetFlow:                 require('@babel/preset-flow'),
@@ -64,4 +66,6 @@ export default function loadLibs () {
         proposalPrivateMethods:     [require('@babel/plugin-proposal-private-methods'), { loose: true }],
         proposalClassProperties:    [require('@babel/plugin-proposal-class-properties'), { loose: true }]
     };
+
+    return loadedLibs;
 }

--- a/src/compiler/compile-client-function.js
+++ b/src/compiler/compile-client-function.js
@@ -17,18 +17,24 @@ const ASYNC_TO_GENERATOR_OUTPUT_CODE = formatBabelProducedCode(asyncToGenerator(
 const CLIENT_FUNCTION_BODY_WRAPPER = code => `const func = (${code});`;
 const CLIENT_FUNCTION_WRAPPER      = ({ code, dependencies }) => `(function(){${dependencies} ${code} return func;})();`;
 
-function getBabelOptions () {
-    const { presetEnvForClientFunction, transformForOfAsArray } = loadBabelLibs();
+let babelOptions = null;
 
-    return Object.assign({}, BASE_BABEL_OPTIONS, {
-        presets: [{ plugins: [transformForOfAsArray] }, presetEnvForClientFunction]
-    });
+function getBabelOptions (babel) {
+    if (!babelOptions) {
+        const { presetEnvForClientFunction, transformForOfAsArray } = loadBabelLibs();
+
+        babelOptions = babel.loadOptions(Object.assign({}, BASE_BABEL_OPTIONS, {
+            presets: [{ plugins: [transformForOfAsArray] }, presetEnvForClientFunction]
+        }));
+    }
+
+    return babelOptions;
 }
 
 function downgradeES (fnCode) {
     const { babel } = loadBabelLibs();
 
-    const opts     = getBabelOptions();
+    const opts     = getBabelOptions(babel);
     const compiled = babel.transform(fnCode, opts);
 
     return compiled.code


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Loading the Babel configuration is an expensive operation. Since the configuration file doesn't change during the compilation it should only be read once. Currently it is read each time a client function is transpiled (in `downgradeES`). Profiling has shown that for small selectors the loading of the configuration file takes significantly (up to 5 times) more than the transpilation of the code.

![image](https://user-images.githubusercontent.com/2109702/121353700-6e3b7100-c92e-11eb-9fca-8db651f1483c.png)

## Approach
This patch introduces caching of the configuration file, resulting in a ~33% reduction of the duration of the compilation for certain use cases and lower memory usage. While the addition of the caching is a bit ad-hoc (as opposed to a more systematic approach where a caching layer is introduced), we consider that the performance improvement (which can easily translate to tens of seconds for large test suites) is worth the small decrease in code readability (and consistency).

## References
Closes https://github.com/DevExpress/testcafe/issues/6284.

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
