### PR TITLE
fix: experimental option parsing in cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "chalk": "^2.3.0",
     "chrome-remote-interface": "^0.30.0",
     "coffeescript": "^2.3.1",
-    "commander": "^2.8.1",
+    "commander": "^7.2.0",
     "debug": "^4.3.1",
     "dedent": "^0.4.0",
     "del": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "chalk": "^2.3.0",
     "chrome-remote-interface": "^0.30.0",
     "coffeescript": "^2.3.1",
-    "commander": "^7.2.0",
+    "commander": "^8.0.0",
     "debug": "^4.3.1",
     "dedent": "^0.4.0",
     "del": "^3.0.0",

--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -86,8 +86,7 @@ export default class CLIArgumentParser {
     public args: string[];
 
     public constructor (cwd: string) {
-        // NOTE: https://github.com/tj/commander.js/issues/1465
-        this.program      = new Command('testcafe') as Command;
+        this.program      = new Command('testcafe');
         this.cwd          = cwd || process.cwd();
         this.remoteCount  = 0;
         this.opts         = {};
@@ -162,13 +161,13 @@ export default class CLIArgumentParser {
             .option('--disable-screenshots', 'disable screenshots')
             .option('--screenshots-full-page', 'enable full-page screenshots')
             .option('--compiler-options <option=value[,...]>', 'specify test file compiler options')
+            .option('--disable-multiple-windows', 'disable multiple windows mode')
 
             // NOTE: these options will be handled by chalk internally
             .option('--color', 'force colors in command line')
             .option('--no-color', 'disable colors in command line')
 
             // NOTE: temporary hide experimental options from --help command
-            .addOption(new Option('--disable-multiple-windows', 'disable multiple windows mode').hideHelp())
             .addOption(new Option('--experimental-compiler-service', 'run compiler in a separate process').hideHelp())
             .addOption(new Option('--cache', 'cache web assets between test runs').hideHelp());
     }

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -790,7 +790,7 @@ describe('CLI argument parser', function () {
         ];
 
         const parser  = new CliArgumentParser('');
-        const options = [ ...parser.program.options, ...parser.experimental.options];
+        const options = parser.program.options;
 
         expect(options.length).eql(EXPECTED_OPTIONS.length, CHANGE_CLI_WARNING);
 


### PR DESCRIPTION
Changes:
* remove `experimental` options group
* mark the `--disable-multiple-windows` option as regular because it is described as regular in the [documentation](https://testcafe.io/documentation/402639/reference/command-line-interface#--disable-multiple-windows).

We used the `experimental` options group to hide them from the `testcafe --help` command. The `commander` module has a problem with parsing `experimental` options. We fix the problem using another approach to hide `experimental` options from help - `Option.hideHelp()` method. The test is not necessary since we remove the code that causes the problem.