### PR TITLE
fix focus if activeElement has negative tabIndex (closes #4848)

### DIFF
--- a/src/client/automation/playback/press/utils.js
+++ b/src/client/automation/playback/press/utils.js
@@ -153,8 +153,12 @@ export function getNextFocusableElement (element, reverse, skipRadioGroups) {
     const currentIndex         = arrayUtils.indexOf(allFocusable, element);
     const isLastElementFocused = reverse ? currentIndex === 0 : currentIndex === allFocusable.length - 1;
 
-    if (isLastElementFocused)
+    if (isLastElementFocused) {
+        if (!reverse && element.tabIndex < 0)
+            return allFocusable.find(el => el.tabIndex === 0);
+
         return skipRadioGroups || !isRadioInput ? document.body : allFocusable[allFocusable.length - 1 - currentIndex];
+    }
 
     if (reverse && currentIndex === -1)
         return allFocusable[allFocusable.length - 1];

--- a/src/client/automation/playback/press/utils.js
+++ b/src/client/automation/playback/press/utils.js
@@ -155,7 +155,7 @@ export function getNextFocusableElement (element, reverse, skipRadioGroups) {
 
     if (isLastElementFocused) {
         if (!reverse && element.tabIndex < 0)
-            return allFocusable.find(el => el.tabIndex === 0);
+            return arrayUtils.find(allFocusable, el => el.tabIndex === 0);
 
         return skipRadioGroups || !isRadioInput ? document.body : allFocusable[allFocusable.length - 1 - currentIndex];
     }

--- a/test/functional/fixtures/regression/gh-4848/pages/index.html
+++ b/test/functional/fixtures/regression/gh-4848/pages/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>gh-4848</title>
+</head>
+<body>
+    <button id="ft5" tabindex="-1">Focus "target 5"</button>
+    <button id="ft1" tabindex="-1">Focus "target 1"</button>
+    <div id="target1" tabindex="0">target 1</div>
+    <div id="target2" tabindex="-1">target 2</div>
+    <div id="target3">target 3</div>
+    <a href="http://example.com">test</a>
+    <div id="target4" tabindex="2">target 4</div>
+    <div id="target5" tabindex="-1">target 5</div>
+
+    <script>
+        document.querySelector('#target2').focus();
+
+        document.querySelector('#ft5').addEventListener('click', function () {
+            document.querySelector('#target5').focus();
+        });
+
+        document.querySelector('#ft1').addEventListener('click', function () {
+            var t1 = document.querySelector('#target1');
+
+            t1.setAttribute('tabindex', '-1');
+            t1.focus();
+        });
+    </script>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-4848/test.js
+++ b/test/functional/fixtures/regression/gh-4848/test.js
@@ -1,0 +1,25 @@
+describe('[Regression](GH-4848) - Should focus next element if current element has negative tabIndex', function () {
+    it('Straight order. Middle', function () {
+        return runTests('testcafe-fixtures/index.js', 'Straight order. Middle');
+    });
+
+    it('Reversed order. Middle', function () {
+        return runTests('testcafe-fixtures/index.js', 'Reversed order. Middle');
+    });
+
+    it('Reversed order. First', function () {
+        return runTests('testcafe-fixtures/index.js', 'Reversed order. First');
+    });
+
+    it('Reversed order. Last', function () {
+        return runTests('testcafe-fixtures/index.js', 'Reversed order. Last');
+    });
+
+    it('Straight order. First', function () {
+        return runTests('testcafe-fixtures/index.js', 'Straight order. First');
+    });
+
+    it('Straight order. Last', function () {
+        return runTests('testcafe-fixtures/index.js', 'Straight order. Last');
+    });
+});

--- a/test/functional/fixtures/regression/gh-4848/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-4848/testcafe-fixtures/index.js
@@ -1,0 +1,48 @@
+import { Selector } from 'testcafe';
+
+fixture `[Regression](GH-4848) - Should focus next element if current element has negative tabIndex`
+    .page `http://localhost:3000/fixtures/regression/gh-4848/pages/index.html`;
+
+const body = Selector('body');
+const ft1  = Selector('#ft1');
+const ft5  = Selector('#ft5');
+const a    = Selector('a');
+
+test(`Straight order. Middle`, async t => {
+    await t.pressKey('tab');
+    await t.expect(Selector(a).focused).eql(true);
+});
+
+test(`Reversed order. Middle`, async t => {
+    await t.pressKey('shift+tab');
+    await t.expect(Selector('#target1').focused).eql(true);
+});
+
+test(`Reversed order. Last`, async t => {
+    await t.click(ft5);
+    await t.pressKey('shift+tab');
+    await t.expect(Selector('#target4').focused).eql(true);
+});
+
+test(`Straight order. First`, async t => {
+    await t.click(ft1);
+    await t.pressKey('tab');
+    await t.expect(a.focused).eql(true);
+});
+
+test(`Reversed order. First`, async t => {
+    await t.click(ft1);
+    await t.pressKey('shift+tab');
+    await t.expect(body.focused).eql(true);
+});
+
+test(`Straight order. Last`, async t => {
+    await t.click(ft5);
+    await t.pressKey('tab');
+    await t.expect(Selector('#target1').focused).eql(true);
+
+    await t.click(ft1); // NOTE: make tabIndex of `target1` to -1
+    await t.click(ft5);
+    await t.pressKey('tab');
+    await t.expect(Selector(a).focused).eql(true);
+});


### PR DESCRIPTION
This PR fixes special case when the current active element has `tabIndex` < 0.
In this case we should not sort all possible focus targets by tabIndex, but just need to focus next/previous sibling.

There is a specific case if the element with `tabIndex` < 0 is last element of all focusable elements. In this case we need to focus first element which does not have specified tabIndex.