### PR TITLE
fix: ExternalAssertionLibraryError when assertion gets failed in testcafe (close #4613)

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "semver": "^5.6.0",
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
-    "testcafe-browser-tools": "2.0.15",
+    "testcafe-browser-tools": "2.0.16",
     "testcafe-hammerhead": "24.3.1",
     "testcafe-legacy-api": "5.0.2",
     "testcafe-reporter-json": "^2.1.0",

--- a/src/notifications/warning-message.ts
+++ b/src/notifications/warning-message.ts
@@ -47,5 +47,6 @@ export default {
     browserProviderDropOfPerformance:   'We detected \'{browserName}\' runs slowly. Try to free up or allocate more system resources on its host machine.',
     testsCompilationTakesTooLong:       'Tests took too long to compile ({compileTime}). Ensure the test code has no excessive imports.',
     deprecatedAPI:                      '{API} is deprecated and will be removed in the next major release. Use {replacement} instead.',
+    unawaitedMethodWithAssertion:       "An asynchronous method that you do not await includes an assertion. Inspect that method's execution chain and add the 'await' keyword where necessary.",
 };
 

--- a/src/test-run/phase.ts
+++ b/src/test-run/phase.ts
@@ -8,7 +8,8 @@ enum TestRunPhase {
     inFixtureAfterEachHook = 'inFixtureAfterEachHook',
     inFixtureAfterHook = 'inFixtureAfterHook',
     inRoleInitializer = 'inRoleInitializer',
-    inBookmarkRestore = 'inBookmarkRestore'
+    inBookmarkRestore = 'inBookmarkRestore',
+    pendingFinalization = 'pendingFinalization'
 }
 
 export default TestRunPhase;

--- a/test/functional/fixtures/api/es-next/assertions/test.js
+++ b/test/functional/fixtures/api/es-next/assertions/test.js
@@ -343,8 +343,8 @@ describe('[API] Assertions', function () {
             only:       'chrome',
         })
             .catch(function (errs) {
-                expect(errs[1]).contains('A call to an async function is not awaited.');
-                expect(errs[1]).contains('> 136 |    t.expect(42).eql(43); 137 |});');
+                expect(errs[0]).contains('A call to an async function is not awaited.');
+                expect(errs[0]).contains('> 136 |    t.expect(42).eql(43); 137 |});');
             });
     });
 

--- a/test/functional/fixtures/regression/gh-4613/common/method-with-failed-assertion.js
+++ b/test/functional/fixtures/regression/gh-4613/common/method-with-failed-assertion.js
@@ -1,0 +1,5 @@
+import { t } from 'testcafe';
+
+export default async function methodWithFailedAssertion () {
+    await t.expect(1).eql(2);
+}

--- a/test/functional/fixtures/regression/gh-4613/executed-test-info.js
+++ b/test/functional/fixtures/regression/gh-4613/executed-test-info.js
@@ -1,0 +1,37 @@
+const { expect } = require('chai');
+
+const EXPECTED_EXECUTED_TEST_NAMES = ['1', '2', '3'];
+
+module.exports = class ExecutedTestInfo {
+    constructor () {
+        this.clear();
+    }
+
+    clear () {
+        this.testNames = [];
+        this.errs      = [];
+        this.warnings  = [];
+    }
+
+    onTestDone (name, testRunInfo) {
+        this.testNames.push(name);
+        this.errs.push(...testRunInfo.errs);
+    }
+
+    onTaskDone (warnings) {
+        this.warnings.push(...warnings);
+    }
+
+    check () {
+        expect(this.testNames).eql(EXPECTED_EXECUTED_TEST_NAMES);
+        expect(this.errs.length).eql(0);
+        expect(this.warnings[0]).contain(
+            "An asynchronous method that you do not await includes an assertion. Inspect that method's execution chain and add the 'await' keyword where necessary." + '\n\n' +
+            '   1 |import { t } from \'testcafe\';' + '\n' +
+            '   2 |' + '\n' +
+            '   3 |export default async function methodWithFailedAssertion () {' + '\n' +
+            ' > 4 |    await t.expect(1).eql(2);' + '\n' +
+            '   5 |}' + '\n' +
+            '   6 |');
+    }
+};

--- a/test/functional/fixtures/regression/gh-4613/test.js
+++ b/test/functional/fixtures/regression/gh-4613/test.js
@@ -1,0 +1,36 @@
+const { createReporter } = require('../../../utils/reporter');
+const ExecutedTestInfo   = require('./executed-test-info');
+
+const executedTestInfo = new ExecutedTestInfo();
+
+const reporter = createReporter({
+    reportTestDone (name, testRunInfo) {
+        executedTestInfo.onTestDone(name, testRunInfo);
+    },
+
+    reportTaskDone (endTime, passed, warnings) {
+        executedTestInfo.onTaskDone(warnings);
+    },
+});
+
+describe('Should not interrupt test execution after unawaited method with assertion (GH-4613)', () => {
+    beforeEach(() => {
+        executedTestInfo.clear();
+    });
+
+    afterEach(() => {
+        executedTestInfo.check();
+    });
+
+    it('the test with the unawaited method is first', () => {
+        return runTests('./testcafe-fixtures/first.js', null, { reporter });
+    });
+
+    it('the test with the unawaited method is middle', () => {
+        return runTests('./testcafe-fixtures/middle.js', null, { reporter });
+    });
+
+    it('the test with the unawaited method is last', () => {
+        return runTests('./testcafe-fixtures/last.js', null, { reporter });
+    });
+});

--- a/test/functional/fixtures/regression/gh-4613/testcafe-fixtures/first.js
+++ b/test/functional/fixtures/regression/gh-4613/testcafe-fixtures/first.js
@@ -1,0 +1,15 @@
+import methodWithFailedAssertion from '../common/method-with-failed-assertion';
+
+fixture `First`;
+
+test('1', async () => {
+    methodWithFailedAssertion();
+});
+
+test('2', async t => {
+    await t.wait(2000);
+});
+
+test('3', async t => {
+    await t.wait(2000);
+});

--- a/test/functional/fixtures/regression/gh-4613/testcafe-fixtures/last.js
+++ b/test/functional/fixtures/regression/gh-4613/testcafe-fixtures/last.js
@@ -1,0 +1,15 @@
+import methodWithFailedAssertion from '../common/method-with-failed-assertion';
+
+fixture `Last`;
+
+test('1', async t => {
+    await t.wait(2000);
+});
+
+test('2', async t => {
+    await t.wait(2000);
+});
+
+test('3', async () => {
+    methodWithFailedAssertion();
+});

--- a/test/functional/fixtures/regression/gh-4613/testcafe-fixtures/middle.js
+++ b/test/functional/fixtures/regression/gh-4613/testcafe-fixtures/middle.js
@@ -1,0 +1,15 @@
+import methodWithFailedAssertion from '../common/method-with-failed-assertion';
+
+fixture `Middle`;
+
+test('1', async t => {
+    await t.wait(2000);
+});
+
+test('2', async () => {
+    methodWithFailedAssertion();
+});
+
+test('3', async t => {
+    await t.wait(2000);
+});


### PR DESCRIPTION
Changes:
* don't raise an error if it occurred after test function execution.
* add a warning message about assertion placed into the unawaited method