### PR TITLE
perf: speed up Babel compilation (close #6284)

### DIFF
--- a/src/compiler/compile-client-function.js
+++ b/src/compiler/compile-client-function.js
@@ -17,6 +17,8 @@ const ASYNC_TO_GENERATOR_OUTPUT_CODE = formatBabelProducedCode(asyncToGenerator(
 const CLIENT_FUNCTION_BODY_WRAPPER = code => `const func = (${code});`;
 const CLIENT_FUNCTION_WRAPPER      = ({ code, dependencies }) => `(function(){${dependencies} ${code} return func;})();`;
 
+let loadedBabelOptions = null;
+
 function getBabelOptions () {
     const { presetEnvForClientFunction, transformForOfAsArray } = loadBabelLibs();
 
@@ -25,11 +27,21 @@ function getBabelOptions () {
     });
 }
 
+function ensureLoadedBabelOptions () {
+    if (!loadedBabelOptions) {
+        const { babel } = loadBabelLibs();
+        const opts      = getBabelOptions();
+
+        loadedBabelOptions = babel.loadOptions(opts);
+    }
+
+    return loadedBabelOptions;
+}
+
 function downgradeES (fnCode) {
     const { babel } = loadBabelLibs();
-
-    const opts     = getBabelOptions();
-    const compiled = babel.transform(fnCode, opts);
+    const opts      = ensureLoadedBabelOptions();
+    const compiled  = babel.transform(fnCode, opts);
 
     return compiled.code
         .replace(USE_STRICT_RE, '')

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -815,6 +815,18 @@ describe('Compiler', function () {
             return testClientFnCompilation('basic');
         });
 
+        it('Performance (GH-6284)', async function () {
+            this.timeout(20000);
+
+            const start           = new Date().getTime();
+            const compiled        = await compile('test/server/data/client-fn-compilation/performance/index.js');
+            const compilationTime = new Date().getTime() - start;
+
+            expect(compilationTime).below(5000);
+            expect(compiled.tests.length).eql(1);
+            expect(compiled.fixtures.length).eql(1);
+        });
+
         describe('Regression', function () {
             it('Should compile ES6 object method (GH-1279)', function () {
                 return testClientFnCompilation('gh1279');

--- a/test/server/data/client-fn-compilation/performance/index.js
+++ b/test/server/data/client-fn-compilation/performance/index.js
@@ -1,0 +1,13 @@
+import { Selector } from 'testcafe';
+
+const selectors = [];
+
+for (let i = 0; i < 300; i++) {
+    const str = i.toString();
+
+    selectors.push(Selector(str).withAttribute(str).find(str));
+}
+
+fixture ('Fixture');
+
+test('test', async t => { });


### PR DESCRIPTION
Based on https://github.com/DevExpress/testcafe/pull/6290

Changes:
* load babel configuration for the `compileClientFunction` function only 1 time.
* add a performance test (before it takes 15 sec, after - 3 sec).