### PR TITLE
fix focusing of svg element with tabIndex

### DIFF
--- a/src/client/core/utils/dom.js
+++ b/src/client/core/utils/dom.js
@@ -246,7 +246,7 @@ function getInvisibleElements (elements) {
 }
 
 function getTabIndexAttributeIntValue (el) {
-    let tabIndex = el.getAttribute('tabindex');
+    let tabIndex = nativeMethods.getAttribute.call(el, 'tabindex');
 
     if (tabIndex !== null) {
         tabIndex = parseInt(tabIndex, 10);

--- a/src/client/core/utils/dom.js
+++ b/src/client/core/utils/dom.js
@@ -246,7 +246,7 @@ function getInvisibleElements (elements) {
 }
 
 function getTabIndexAttributeIntValue (el) {
-    let tabIndex = el.getAttribute('tabIndex');
+    let tabIndex = el.getAttribute('tabindex');
 
     if (tabIndex !== null) {
         tabIndex = parseInt(tabIndex, 10);

--- a/test/client/fixtures/automation/press-test.js
+++ b/test/client/fixtures/automation/press-test.js
@@ -159,6 +159,46 @@ $(document).ready(function () {
             });
     });
 
+    asyncTest('press tab to focus svg', function () {
+        const div = document.createElement('div');
+
+        div.innerHTML = '<button id="btn_prev_svg" tabindex="100">button 1</button>' +
+                        '<svg id="svg_target" tabindex="101"><text x="0" y="15" fill="red">svg</text></svg>' +
+                        '<button id="btn_after_svg" tabindex="102">button 2</button>';
+
+        const btn1 = div.querySelector('#btn_prev_svg');
+        const svg  = div.querySelector('#svg_target');
+        const btn2 = div.querySelector('#btn_after_svg');
+
+        document.body.appendChild(div);
+
+        btn1.focus();
+        ok(btn1 === document.activeElement);
+
+        let press = new PressAutomation(parseKeySequence('tab').combinations, {});
+
+        press
+            .run()
+            .then(function () {
+                ok(svg === document.activeElement);
+
+                btn2.focus();
+                ok(btn2 === document.activeElement);
+
+                press = new PressAutomation(parseKeySequence('shift+tab').combinations, {});
+
+                return press
+                    .run();
+            })
+            .then(function () {
+                ok(svg === document.activeElement);
+
+                document.body.removeChild(div);
+
+                start();
+            });
+    });
+
     module('regression tests');
 
     asyncTest('T334620, GH-3282 - Wrong "key" property in keyEvent objects (press)', function () {

--- a/test/client/fixtures/automation/press-test.js
+++ b/test/client/fixtures/automation/press-test.js
@@ -159,45 +159,47 @@ $(document).ready(function () {
             });
     });
 
-    asyncTest('press tab to focus svg', function () {
-        const div = document.createElement('div');
+    if (!browserUtils.isIE11) {
+        asyncTest('press tab to focus svg', function () {
+            const div = document.createElement('div');
 
-        div.innerHTML = '<button id="btn_prev_svg" tabindex="100">button 1</button>' +
-                        '<svg id="svg_target" tabindex="101"><text x="0" y="15" fill="red">svg</text></svg>' +
-                        '<button id="btn_after_svg" tabindex="102">button 2</button>';
+            div.innerHTML = '<button id="btn_prev_svg" tabindex="100">button 1</button>' +
+                            '<svg id="svg_target" tabindex="101"><text x="0" y="15" fill="red">svg</text></svg>' +
+                            '<button id="btn_after_svg" tabindex="102">button 2</button>';
 
-        const btn1 = div.querySelector('#btn_prev_svg');
-        const svg  = div.querySelector('#svg_target');
-        const btn2 = div.querySelector('#btn_after_svg');
+            const btn1 = div.querySelector('#btn_prev_svg');
+            const svg  = div.querySelector('#svg_target');
+            const btn2 = div.querySelector('#btn_after_svg');
 
-        document.body.appendChild(div);
+            document.body.appendChild(div);
 
-        btn1.focus();
-        ok(btn1 === document.activeElement);
+            btn1.focus();
+            ok(btn1 === document.activeElement, document.activeElement.id + ' is focused');
 
-        let press = new PressAutomation(parseKeySequence('tab').combinations, {});
+            let press = new PressAutomation(parseKeySequence('tab').combinations, {});
 
-        press
-            .run()
-            .then(function () {
-                ok(svg === document.activeElement);
+            press
+                .run()
+                .then(function () {
+                    ok(svg === document.activeElement, document.activeElement.id + ' is focused');
 
-                btn2.focus();
-                ok(btn2 === document.activeElement);
+                    btn2.focus();
+                    ok(btn2 === document.activeElement, document.activeElement.id + ' is focused');
 
-                press = new PressAutomation(parseKeySequence('shift+tab').combinations, {});
+                    press = new PressAutomation(parseKeySequence('shift+tab').combinations, {});
 
-                return press
-                    .run();
-            })
-            .then(function () {
-                ok(svg === document.activeElement);
+                    return press
+                        .run();
+                })
+                .then(function () {
+                    ok(svg === document.activeElement, document.activeElement.id + ' is focused');
 
-                document.body.removeChild(div);
+                    document.body.removeChild(div);
 
-                start();
-            });
-    });
+                    start();
+                });
+        });
+    }
 
     module('regression tests');
 


### PR DESCRIPTION
for some reason `getAttribute('tabIndex')` does not work for svg elements in Chrome/FF (without TestCafe as well).
However, if we change `tabIndex` to `tabindex` it works as expected.
This case can be reproduced only if the `tabIndex` attribute is set declaratively in HTML markup.
In we set attribute using the `setAttribute` method, then `getAttribute('tabIndex')` works as well.

APPROACH:
change `getAttribute('tabIndex')` to `getAttribute('tabindex')`

In tests I create svg element using the `innerHTML` property of parent div element intentionally, because of the problem I described above.

NOTE:
IE11 does not allow to focus SVG even with tabIndex