### PR TITLE
support focus for elements inside shadowDom (closes #4988)

### DIFF
--- a/src/client/automation/playback/press/utils.js
+++ b/src/client/automation/playback/press/utils.js
@@ -13,7 +13,7 @@ const browserUtils     = hammerhead.utils.browser;
 const focusBlurSandbox = hammerhead.eventSandbox.focusBlur;
 const Promise          = hammerhead.Promise;
 
-const { findDocument, isRadioButtonElement, getActiveElement } = domUtils;
+const { isRadioButtonElement, getActiveElement, getTabIndexAttributeIntValue } = domUtils;
 
 export function changeLetterCase (letter) {
     const isLowCase = letter === letter.toLowerCase();
@@ -143,9 +143,18 @@ function correctFocusableElement (elements, element, skipRadioGroups) {
     return checkedRadioButtonElementWithSameName || element;
 }
 
+function activeElementHasNegativeTabIndex (doc) {
+    const activeElement         = nativeMethods.documentActiveElementGetter.call(doc);
+    const activeElementTabIndex = activeElement && getTabIndexAttributeIntValue(activeElement);
+
+    return activeElement && activeElementTabIndex < 0;
+}
+
 export function getNextFocusableElement (element, reverse, skipRadioGroups) {
     const offset     = reverse ? -1 : 1;
-    let allFocusable = domUtils.getFocusableElements(findDocument(element), true);
+    const doc        = domUtils.getTopSameDomainWindow(window).document;
+    const sort       = !activeElementHasNegativeTabIndex(doc);
+    let allFocusable = domUtils.getFocusableElements(doc, sort);
 
     allFocusable = filterFocusableElements(allFocusable, element, skipRadioGroups);
 

--- a/src/client/core/utils/dom.js
+++ b/src/client/core/utils/dom.js
@@ -59,107 +59,12 @@ export const findParent                             = hammerhead.utils.dom.findP
 export const getTopSameDomainWindow                 = hammerhead.utils.dom.getTopSameDomainWindow;
 export const getParentExceptShadowRoot              = hammerhead.utils.dom.getParentExceptShadowRoot;
 
-function getElementsWithTabIndex (elements) {
-    return arrayUtils.filter(elements, el => el.tabIndex > 0);
-}
+function canFocus (element, parent, tabIndex) {
+    let activeElement = null;
 
-function getElementsWithoutTabIndex (elements) {
-    return arrayUtils.filter(elements, el => el.tabIndex <= 0);
-}
+    if (parent.nodeType === Node.DOCUMENT_NODE)
+        activeElement = nativeMethods.documentActiveElementGetter.call(parent);
 
-function sortElementsByFocusingIndex (elements) {
-    if (!elements || !elements.length)
-        return [];
-
-    let elementsWithTabIndex = getElementsWithTabIndex(elements);
-
-    //iframes
-    const iframes = arrayUtils.filter(elements, el => isIframeElement(el));
-
-    if (!elementsWithTabIndex.length) {
-        if (iframes.length)
-            elements = insertIframesContentElements(elements, iframes);
-
-        return elements;
-    }
-
-    elementsWithTabIndex          = elementsWithTabIndex.sort(sortBy('tabIndex'));
-    const elementsWithoutTabIndex = getElementsWithoutTabIndex(elements);
-
-    if (iframes.length)
-        return insertIframesContentElements(elementsWithTabIndex, iframes).concat(insertIframesContentElements(elementsWithoutTabIndex, iframes));
-
-    return elementsWithTabIndex.concat(elementsWithoutTabIndex);
-}
-
-function insertIframesContentElements (elements, iframes) {
-    const sortedIframes       = sortElementsByTabIndex(iframes);
-    let results               = [];
-    const iframesElements     = [];
-    let iframeFocusedElements = [];
-    let i                     = 0;
-
-    for (i = 0; i < sortedIframes.length; i++) {
-        //NOTE: We can get elements of the same domain iframe only
-        try {
-            iframeFocusedElements = getFocusableElements(nativeMethods.contentDocumentGetter.call(sortedIframes[i]));
-        }
-        catch (e) {
-            iframeFocusedElements = [];
-        }
-
-        iframesElements.push(sortElementsByFocusingIndex(iframeFocusedElements));
-    }
-
-    for (i = 0; i < elements.length; i++) {
-        results.push(elements[i]);
-
-        if (isIframeElement(elements[i])) {
-            if (browserUtils.isIE) {
-                results.pop();
-
-                const iFrameElements               = iframesElements[arrayUtils.indexOf(iframes, elements[i])];
-                let elementsWithTabIndex           = getElementsWithTabIndex(iFrameElements);
-                const elementsWithoutTabIndexArray = getElementsWithoutTabIndex(iFrameElements);
-
-                elementsWithTabIndex = elementsWithTabIndex.sort(sortBy('tabIndex'));
-                results              = results.concat(elementsWithTabIndex);
-                results.push(elements[i]);
-                results = results.concat(elementsWithoutTabIndexArray);
-            }
-            else {
-                if (browserUtils.isWebKit && iframesElements[arrayUtils.indexOf(iframes, elements[i])].length)
-                    results.pop();
-
-                results = results.concat(iframesElements[arrayUtils.indexOf(iframes, elements[i])]);
-            }
-        }
-    }
-
-    return results;
-}
-
-function sortElementsByTabIndex (elements) {
-    const elementsWithTabIndex = getElementsWithTabIndex(elements);
-
-    if (!elementsWithTabIndex.length)
-        return elements;
-
-    return elementsWithTabIndex.sort(sortBy('tabIndex')).concat(getElementsWithoutTabIndex(elements));
-}
-
-function sortBy (property) {
-    return function (a, b) {
-        if (a[property] < b[property])
-            return -1;
-        if (a[property] > b[property])
-            return 1;
-
-        return 0;
-    };
-}
-
-function canFocus (element, activeElement, tabIndex) {
     if (element === activeElement)
         return true;
 
@@ -178,12 +83,41 @@ function canFocus (element, activeElement, tabIndex) {
     return true;
 }
 
-export function getFocusableElements (doc, sort = false) {
+function wrapElement (el) {
+    return {
+        el:       el,
+        skip:     el.shadowRoot && el.tabIndex < 0,
+        children: {}
+    };
+}
+
+function buildFocusableTree (parent, sort) {
+    const node = wrapElement(parent);
+
+    parent = parent.shadowRoot || parent;
+
+    if (isIframeElement(parent))
+        parent = nativeMethods.contentDocumentGetter.call(parent);
+
+    if (parent.nodeType === Node.DOCUMENT_FRAGMENT_NODE || parent.nodeType === Node.DOCUMENT_NODE) {
+        const elements = filterFocusableElements(parent);
+
+        for (const el of elements) {
+            const key = !sort || el.tabIndex <= 0 ? -1 : el.tabIndex;
+
+            node.children[key] = node.children[key] || [];
+
+            node.children[key].push(buildFocusableTree(el, sort));
+        }
+    }
+
+    return node;
+}
+
+function filterFocusableElements (parent) {
     // NOTE: We don't take into account the case of embedded contentEditable
     // elements and specify the contentEditable attribute for focusable elements
-    const allElements           = doc.querySelectorAll('*');
-    const activeElement         = nativeMethods.documentActiveElementGetter.call(doc);
-    const activeElementTabIndex = getTabIndexAttributeIntValue(activeElement);
+    const allElements           = parent.querySelectorAll('*');
     const invisibleElements     = getInvisibleElements(allElements);
     const inputElementsRegExp   = /^(input|button|select|textarea)$/;
     const focusableElements     = [];
@@ -200,13 +134,15 @@ export function getFocusableElements (doc, sort = false) {
         tabIndex = getTabIndexAttributeIntValue(element);
         needPush = false;
 
-        if (!canFocus(element, activeElement, tabIndex))
+        if (!canFocus(element, parent, tabIndex))
             continue;
 
         if (inputElementsRegExp.test(tagName))
             needPush = true;
-        else if (browserUtils.isIE && isIframeElement(element))
-            focusableElements.push(element);
+        else if (element.shadowRoot)
+            needPush = true;
+        else if (isIframeElement(element))
+            needPush = true;
         else if (isAnchorElement(element) && element.hasAttribute('href'))
             needPush = element.getAttribute('href') !== '' || !browserUtils.isIE || tabIndex !== null;
 
@@ -223,15 +159,28 @@ export function getFocusableElements (doc, sort = false) {
     }
 
     //NOTE: remove children of invisible elements
-    let result = arrayUtils.filter(focusableElements, el => !containsElement(invisibleElements, el));
+    return arrayUtils.filter(focusableElements, el => !containsElement(invisibleElements, el));
+}
 
-    if (activeElementTabIndex && activeElementTabIndex < 0)
-        sort = false;
+function flattenFocusableTree (node) {
+    const result = [];
 
-    if (sort)
-        result = sortElementsByFocusingIndex(result);
+    if (!node.skip && node.el.nodeType !== Node.DOCUMENT_NODE && !isIframeElement(node.el))
+        result.push(node.el);
+
+    for (const prop in node.children) {
+        for (const childNode of node.children[prop])
+            result.push(...flattenFocusableTree(childNode));
+    }
 
     return result;
+}
+
+
+export function getFocusableElements (doc, sort = false) {
+    const root = buildFocusableTree(doc, sort);
+
+    return flattenFocusableTree(root);
 }
 
 function getInvisibleElements (elements) {
@@ -245,7 +194,7 @@ function getInvisibleElements (elements) {
     return invisibleElements;
 }
 
-function getTabIndexAttributeIntValue (el) {
+export function getTabIndexAttributeIntValue (el) {
     let tabIndex = nativeMethods.getAttribute.call(el, 'tabindex');
 
     if (tabIndex !== null) {

--- a/src/client/core/utils/dom.js
+++ b/src/client/core/utils/dom.js
@@ -87,7 +87,7 @@ function wrapElement (el) {
     return {
         el:       el,
         skip:     el.shadowRoot && el.tabIndex < 0,
-        children: {}
+        children: {},
     };
 }
 

--- a/test/client/fixtures/automation/tab-emulation-test.js
+++ b/test/client/fixtures/automation/tab-emulation-test.js
@@ -222,4 +222,107 @@ $(document).ready(function () {
 
         pressShiftTabRecursive();
     });
+
+    if (!browserUtils.isIE11) {
+        module('shadow root');
+
+        asyncTest('tab', function () {
+            const btn1 = document.createElement('button'); // <button>not shadow - no tabIndex</button>
+            const btn2 = document.createElement('button'); // <button tabindex="1">not shadow - tabIndex === 1</button>
+            const div1 = document.createElement('div'); // <div style="width: 100px; height: 100px; border: 1px solid black;"></div>
+            const div2 = document.createElement('div'); // <div tabindex="4"></div>
+            const btn3 = document.createElement('button'); // <button tabindex="3">not shadow - tabIndex === 3</button>
+            const btn4 = document.createElement('button'); // <button>not shadow - no tabIndex</button>
+
+            btn1.innerHTML = 'not shadow - no tabIndex';
+            btn2.innerHTML = 'not shadow - tabIndex === 1';
+            btn3.innerHTML = 'not shadow - tabIndex === 3';
+            btn4.innerHTML = 'not shadow - no tabIndex';
+
+            div1.style.width = '100px;';
+            div1.style.height = '100px;';
+            div1.style.border = '1px solid black';
+
+            btn2.setAttribute('tabindex', '1');
+            btn3.setAttribute('tabindex', '3');
+            div2.setAttribute('tabindex', '4');
+
+            // shadow root for non tabIndex div1
+            const btn5 = document.createElement('button');
+            const btn6 = document.createElement('button');
+
+            btn5.innerHTML = 'shadow - no tabIndex';
+            btn5.id        = 'btnShadow_on_tabIndex_c2';
+
+            btn6.innerHTML = 'shadow - tabIndex === 2';
+            btn6.id        = 'btnShadow_tabIndex2_c2';
+
+            btn6.setAttribute('tabindex', 2);
+
+            div1.attachShadow({ mode: 'open' });
+            div1.shadowRoot.appendChild(btn5);
+            div1.shadowRoot.appendChild(btn6);
+
+            // shadow root for tabIndex div2
+
+            const btn7 = document.createElement('button');
+            const btn8 = document.createElement('button');
+
+            btn7.innerHTML = 'shadow - no tabIndex';
+            btn8.innerHTML = 'shadow - tabIndex === 2';
+
+            btn8.setAttribute('tabindex', 2);
+
+            div2.attachShadow({ mode: 'open' });
+            div2.shadowRoot.appendChild(btn7);
+            div2.shadowRoot.appendChild(btn8);
+
+            document.body.appendChild(btn1);
+            document.body.appendChild(btn2);
+            document.body.appendChild(div1);
+            document.body.appendChild(div2);
+            document.body.appendChild(btn3);
+            document.body.appendChild(btn4);
+
+            function pressTabAndAssert (el1, el2) {
+                const pressAutomation = new PressAutomation(parseKeySequence('tab').combinations, {});
+
+                return pressAutomation
+                    .run()
+                    .then(function () {
+                        equal(document.activeElement, el1);
+
+                        if (el2)
+                            equal(el1.shadowRoot.activeElement, el2);
+                    });
+            }
+
+            pressTabAndAssert(btn2)
+                .then(function () {
+                    return pressTabAndAssert(btn3);
+                })
+                .then(function () {
+                    return pressTabAndAssert(div2);
+                })
+                .then(function () {
+                    return pressTabAndAssert(div2, btn8);
+                })
+                .then(function () {
+                    return pressTabAndAssert(div2, btn7);
+                })
+                .then(function () {
+                    return pressTabAndAssert(btn1);
+                })
+                .then(function () {
+                    return pressTabAndAssert(div1, btn6);
+                })
+                .then(function () {
+                    return pressTabAndAssert(div1, btn5);
+                })
+                .then(function () {
+                    return pressTabAndAssert(btn4);
+                })
+                .then(start);
+        });
+    }
 });

--- a/test/functional/fixtures/regression/gh-4988/pages/frame1.html
+++ b/test/functional/fixtures/regression/gh-4988/pages/frame1.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+    <button id='btn3'>#btn3 not set</button>
+    <button id='btn4' tabindex='2'>#btn4 2</button>
+    <button id='btn5' tabindex='1'>#btn5 1</button>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-4988/pages/frame2.html
+++ b/test/functional/fixtures/regression/gh-4988/pages/frame2.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+    <button id='btn7'>#btn7 not set</button>
+    <button id='btn8' tabindex='2'>#btn8 2</button>
+    <button id='btn9' tabindex='1'>#btn9 1</button>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-4988/pages/index.html
+++ b/test/functional/fixtures/regression/gh-4988/pages/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>gh-4988 (iframe part)</title>
+</head>
+<body>
+    <button id="btn1">#btn1 no set</button>
+    <button id="btn2" tabindex="2">#btn2 2</button>
+    <iframe id="iframe1" src="./frame1.html"></iframe>
+    <button id="btn6" tabindex="1">#btn6 1</button>
+    <iframe tabindex="3" id="iframe2" src="./frame2.html"></iframe>
+    <button id="btn10">#btn10 no set</button>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-4988/test.js
+++ b/test/functional/fixtures/regression/gh-4988/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-4988) - improved algo for shadow/iframe elements', function () {
+    it('improved algo for shadow/iframe elements', function () {
+        return runTests('testcafe-fixtures/index.js');
+    });
+});

--- a/test/functional/fixtures/regression/gh-4988/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-4988/testcafe-fixtures/index.js
@@ -1,0 +1,42 @@
+import { Selector } from 'testcafe';
+
+const btn1  = Selector('#btn1');
+const btn2  = Selector('#btn2');
+const btn3  = Selector('#btn3');
+const btn4  = Selector('#btn4');
+const btn5  = Selector('#btn5');
+const btn6  = Selector('#btn6');
+const btn7  = Selector('#btn7');
+const btn8  = Selector('#btn8');
+const btn9  = Selector('#btn9');
+const btn10 = Selector('#btn10');
+const frm1  = Selector('#iframe1');
+const frm2  = Selector('#iframe2');
+
+async function assert (t, expectedElement, iframeElement) {
+    await t.pressKey('tab');
+
+    if (iframeElement)
+        await t.switchToIframe(iframeElement);
+
+    await t.expect(expectedElement.focused).eql(true);
+
+    if (iframeElement)
+        await t.switchToMainWindow();
+}
+
+fixture `GH-4988 - improved algo for shadow/iframe elements`
+    .page `http://localhost:3000/fixtures/regression/gh-4988/pages/index.html`;
+
+test('iframe', async t => {
+    await assert(t, btn6);
+    await assert(t, btn2);
+    await assert(t, btn9, frm2);
+    await assert(t, btn8, frm2);
+    await assert(t, btn7, frm2);
+    await assert(t, btn1);
+    await assert(t, btn5, frm1);
+    await assert(t, btn4, frm1);
+    await assert(t, btn3, frm1);
+    await assert(t, btn10);
+});


### PR DESCRIPTION
- support of shadow dom elements.
- modification of the elements sorting algorithm
- fix focusing elements inside the iframes

I build the tree of focusable elements, where child nodes are grouped by tabIndex.
See the `buildFocusableTree` and the `flattenFocusableTree` methods.

I completely removed the `sortElementsByFocusingIndex` method, because the focusable tree approach does not need this.

I added client test for focusing shadow dom elements.
Moreover, I added functional test for focusing iframe elements. It looks like this case did not work and unfortunatelly we do not have enough tests to test iframe focusing.