### PR TITLE
Pseudo-element selector

### DIFF
--- a/pseudo-test/fixture.ts
+++ b/pseudo-test/fixture.ts
@@ -7,5 +7,8 @@ test('pseudo', async t => {
     //await t.click('#popUp::after', { speed: 0.1 });
     //await t.rightClick('#popUp::after', { speed: 0.1 });
     //await t.doubleClick('#popUp::after');
-    await t.hover('#popUp::after', { speed: 0.1 });
+    //await t.hover('#popUp::after', { speed: 0.1 });
+    //await t.drag('#timeline_drag::after', 300, 0,{ speed: 0.1 });
+    //await t.dragToElement('#timeline_drag::after', '#timeline::after', { speed: 0.1 });
+    //await t.takeElementScreenshot('#popUp::after', './screenshots');
 });

--- a/pseudo-test/fixture.ts
+++ b/pseudo-test/fixture.ts
@@ -1,0 +1,8 @@
+import {t, Selector } from 'testcafe';
+
+fixture `Pseudo-element-click`
+    .page `./index.html`;
+
+test('pseudo', async t => {
+    await t.click('#popUp::after', { speed: 0.10/*, offsetX: 250, offsetY: -250*/ });
+});

--- a/pseudo-test/fixture.ts
+++ b/pseudo-test/fixture.ts
@@ -4,5 +4,6 @@ fixture `Pseudo-element-click`
     .page `./index.html`;
 
 test('pseudo', async t => {
-    await t.click('#popUp::after', { speed: 0.10/*, offsetX: 250, offsetY: -250*/ });
+    //await t.click('#popUp::after', { speed: 0.1 });
+    await t.rightClick('#popUp::after', { speed: 0.1 });
 });

--- a/pseudo-test/fixture.ts
+++ b/pseudo-test/fixture.ts
@@ -5,5 +5,7 @@ fixture `Pseudo-element-click`
 
 test('pseudo', async t => {
     //await t.click('#popUp::after', { speed: 0.1 });
-    await t.rightClick('#popUp::after', { speed: 0.1 });
+    //await t.rightClick('#popUp::after', { speed: 0.1 });
+    //await t.doubleClick('#popUp::after');
+    await t.hover('#popUp::after', { speed: 0.1 });
 });

--- a/pseudo-test/func.js
+++ b/pseudo-test/func.js
@@ -1,0 +1,7 @@
+$(document).ready(() => {
+    $('#popUp').click(function (e) {
+        $('#boop').show();
+        if (this.offsetWidth - e.offsetX < 0)
+            $('#popUp').addClass('close');
+    });
+});

--- a/pseudo-test/func.js
+++ b/pseudo-test/func.js
@@ -4,36 +4,25 @@ $(document).ready(() => {
         if (this.offsetWidth - e.offsetX < 0)
             $('#popUp').addClass('close');
     });
-});
 
-let timeline = document.getElementsByClassName('timeline')[0],
-    timelineProgress = document.getElementsByClassName('timeline__progress')[0],
-    drag = document.getElementsByClassName('timeline__drag')[0];
+    $('#timeline_drag').mousedown(dragMouseDown);
 
-// Make the timeline draggable
-Draggable.create(drag, {
-    type: 'x',
-    trigger: timeline,
-    bounds: timeline,
-    onPress: function(e) {
-        video.currentTime = this.x / this.maxX * video.duration;
-        TweenMax.set(this.target, {
-            x: this.pointerX - timeline.getBoundingClientRect().left
-        });
-        this.update();
-        var progress = this.x / timeline.offsetWidth;
-        TweenMax.set(timelineProgress, {
-            scaleX: progress
-        });
-    },
-    onDrag: function() {
-        video.currentTime = this.x / this.maxX * video.duration;
-        var progress = this.x / timeline.offsetWidth;
-        TweenMax.set(timelineProgress, {
-            scaleX: progress
-        });
-    },
-    onRelease: function(e) {
-        e.preventDefault();
+    function dragMouseDown(e) {
+        document.onmouseup = closeDragElement;
+        document.onmousemove = elementDrag;
+    }
+
+    function elementDrag(e) {
+        const drag = $('#timeline_drag');
+        const timeline = $('#timeline');
+        const position = e.clientX - timeline.offset().left - 10;
+
+        if(position >= -1 && position <= 290)
+            drag.css('left', position + 'px');
+    }
+
+    function closeDragElement() {
+        document.onmouseup = null;
+        document.onmousemove = null;
     }
 });

--- a/pseudo-test/func.js
+++ b/pseudo-test/func.js
@@ -5,3 +5,35 @@ $(document).ready(() => {
             $('#popUp').addClass('close');
     });
 });
+
+let timeline = document.getElementsByClassName('timeline')[0],
+    timelineProgress = document.getElementsByClassName('timeline__progress')[0],
+    drag = document.getElementsByClassName('timeline__drag')[0];
+
+// Make the timeline draggable
+Draggable.create(drag, {
+    type: 'x',
+    trigger: timeline,
+    bounds: timeline,
+    onPress: function(e) {
+        video.currentTime = this.x / this.maxX * video.duration;
+        TweenMax.set(this.target, {
+            x: this.pointerX - timeline.getBoundingClientRect().left
+        });
+        this.update();
+        var progress = this.x / timeline.offsetWidth;
+        TweenMax.set(timelineProgress, {
+            scaleX: progress
+        });
+    },
+    onDrag: function() {
+        video.currentTime = this.x / this.maxX * video.duration;
+        var progress = this.x / timeline.offsetWidth;
+        TweenMax.set(timelineProgress, {
+            scaleX: progress
+        });
+    },
+    onRelease: function(e) {
+        e.preventDefault();
+    }
+});

--- a/pseudo-test/index.html
+++ b/pseudo-test/index.html
@@ -16,9 +16,9 @@
         POPUP
     </div>
 
-    <div class="timeline">
-        <div class="timeline_drag"></div>
-        <span class="timeline_progress"></span>
+    <div id="timeline">
+        <div id="timeline_drag"></div>
+        <div id="timeline_finish"></div>
     </div>
 </body>
 </html>

--- a/pseudo-test/index.html
+++ b/pseudo-test/index.html
@@ -14,9 +14,11 @@
 
     <div id="popUp">
         POPUP
-<!--        <div id="newClose">-->
-<!--            ЗАКРЫТЬ-->
-<!--        </div>-->
+    </div>
+
+    <div class="timeline">
+        <div class="timeline_drag"></div>
+        <span class="timeline_progress"></span>
     </div>
 </body>
 </html>

--- a/pseudo-test/index.html
+++ b/pseudo-test/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Pseudo</title>
+    <link rel="stylesheet" type="text/css" href="./style.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script src="func.js"></script>
+</head>
+<body>
+    <div id="boop">
+        ASDASD
+    </div>
+
+    <div id="popUp">
+        POPUP
+<!--        <div id="newClose">-->
+<!--            ЗАКРЫТЬ-->
+<!--        </div>-->
+    </div>
+</body>
+</html>

--- a/pseudo-test/runner.js
+++ b/pseudo-test/runner.js
@@ -1,0 +1,16 @@
+const createTestCafe = require('./..');
+let runner; let testcafe;
+
+createTestCafe( 'localhost', '', '')
+    .then(testcafeInstance => {
+        runner = testcafeInstance.createRunner();
+        testcafe = testcafeInstance;
+    })
+    .then(() => {
+        return runner
+            .src('./pseudo-test/fixture.ts')
+            .browsers('chrome')
+            .run({ debugMode: true });
+    }).then(() => {
+        testcafe.close();
+    });

--- a/pseudo-test/style.css
+++ b/pseudo-test/style.css
@@ -23,6 +23,7 @@ body,html {width:100%;height:100%;margin:0px;padding:0px;}
     font:10px arial;
     color:#ff0000;
     cursor:pointer;
+    z-index: 1;
 }
 
 #boop {

--- a/pseudo-test/style.css
+++ b/pseudo-test/style.css
@@ -1,0 +1,39 @@
+body,html {width:100%;height:100%;margin:0px;padding:0px;}
+
+#popUp {
+    position:absolute;
+    top:50%;
+    left:50%;
+    transform: translate(-50%,-50%);
+    background:#aaaaaa;
+    padding:20px;
+    text-align:center;
+    font:50px /200px arial;
+    color:#ffffff;
+}
+
+#popUp.close {
+    display:none;
+}
+#popUp:after {
+    content:'Закрыть';
+    position: absolute;
+    top:-20px;
+    right:-50px;
+    font:10px arial;
+    color:#ff0000;
+    cursor:pointer;
+}
+
+#boop {
+    position:absolute;
+    top:20%;
+    left:20%;
+    transform: translate(-50%,-50%);
+    background:#0aa;
+    padding:20px;
+    text-align:center;
+    font:50px /200px arial;
+    color:#fff;
+    display: none;
+}

--- a/pseudo-test/style.css
+++ b/pseudo-test/style.css
@@ -5,24 +5,24 @@ body,html {width:100%;height:100%;margin:0px;padding:0px;}
     top:50%;
     left:50%;
     transform: translate(-50%,-50%);
-    background:#aaaaaa;
+    background:#fd8;
     padding:20px;
     text-align:center;
     font:50px /200px arial;
     color:#ffffff;
 }
-
 #popUp.close {
     display:none;
 }
 #popUp:after {
     content:'Закрыть';
     position: absolute;
-    top:-20px;
-    right:-50px;
+    top:-30px;
+    right:-75px;
     font:10px arial;
     color:#ff0000;
     cursor:pointer;
+    font-size: 20px;
     z-index: 1;
 }
 
@@ -37,4 +37,45 @@ body,html {width:100%;height:100%;margin:0px;padding:0px;}
     font:50px /200px arial;
     color:#fff;
     display: none;
+}
+
+.timeline {
+    position: absolute;
+    top: 80%;
+    left: 5%;
+
+    max-width: 50em;
+    width: 100%;
+    height: 20px;
+    background-color: grey;
+    cursor: pointer;
+    position: relative;
+}
+
+.timeline_drag {
+    width: 20px;
+    height: 40px;
+    background-color: red;
+    z-index: 2;
+    transform-origin: 0 0;
+}
+
+.timeline_drag::after {
+    position:absolute;
+    width: 100px;
+    height: 100px;
+    top: 50%;
+    left: 50%;
+    z-index: 2;
+    transform-origin: 0 0;
+}
+
+.timeline_progress {
+    display: block;
+    width: 100%;
+    height: 100%;
+    background-color: green;
+    transform: scaleX(0);
+    transform-origin: 0 0;
+    z-index: 1;
 }

--- a/pseudo-test/style.css
+++ b/pseudo-test/style.css
@@ -19,10 +19,8 @@ body,html {width:100%;height:100%;margin:0px;padding:0px;}
     position: absolute;
     top:-30px;
     right:-75px;
-    font:10px arial;
+    font:20px arial;
     color:#ff0000;
-    cursor:pointer;
-    font-size: 20px;
     z-index: 1;
 }
 
@@ -39,43 +37,39 @@ body,html {width:100%;height:100%;margin:0px;padding:0px;}
     display: none;
 }
 
-.timeline {
+#timeline {
     position: absolute;
     top: 80%;
     left: 5%;
 
-    max-width: 50em;
-    width: 100%;
+    width: 300px;
     height: 20px;
     background-color: grey;
     cursor: pointer;
-    position: relative;
 }
-
-.timeline_drag {
-    width: 20px;
+#timeline::after {
+    content:'_';
+    position: absolute;
+    top:-10px;
+    right: 5px;
     height: 40px;
+    width: 10px;
+    background-color: #ffdd88;
+    color:#ffdd88;
+    z-index: 1;
+}
+#timeline_drag {
+    position: relative;
+    width: 0px;
+    height: 0px;
     background-color: red;
     z-index: 2;
-    transform-origin: 0 0;
 }
-
-.timeline_drag::after {
-    position:absolute;
-    width: 100px;
-    height: 100px;
-    top: 50%;
-    left: 50%;
-    z-index: 2;
-    transform-origin: 0 0;
-}
-
-.timeline_progress {
-    display: block;
-    width: 100%;
-    height: 100%;
-    background-color: green;
-    transform: scaleX(0);
-    transform-origin: 0 0;
+#timeline_drag::after {
+    content:'_';
+    position: absolute;
+    top:-10px;
+    background-color: red;
+    color:red;
     z-index: 1;
 }

--- a/src/client-functions/selectors/selector-builder.js
+++ b/src/client-functions/selectors/selector-builder.js
@@ -104,6 +104,18 @@ export default class SelectorBuilder extends ClientFunctionBuilder {
                         pseudoStyles.getPropertyPriority(pseudoStyle))
                 );
 
+                // NOTE: the new element should be above the pseudo, because
+                // action will look at the top element
+                const pseudoZIndex = pseudoStyles.getPropertyValue('z-index');
+                console.log('pseudoZIndex', typeof pseudoZIndex, pseudoZIndex);
+                if(pseudoZIndex === 'auto' || pseudoZIndex === 'inherit') {
+                    realPseudo.style.setProperty('z-index', '99');
+                }
+                else {
+                    const realZIndex = parseInt(pseudoZIndex) + 1;
+                    realPseudo.style.setProperty('z-index', '' + realZIndex);
+                }
+
                 // NOTE: css-content returns value with quotation marks on borders
                 if(pseudoStyles.content) realPseudo.textContent = pseudoStyles.content.substring(1, pseudoStyles.content.length - 1);
                 parent.append(realPseudo);

--- a/src/client-functions/selectors/selector-builder.js
+++ b/src/client-functions/selectors/selector-builder.js
@@ -107,7 +107,6 @@ export default class SelectorBuilder extends ClientFunctionBuilder {
                 // NOTE: the new element should be above the pseudo, because
                 // action will look at the top element
                 const pseudoZIndex = pseudoStyles.getPropertyValue('z-index');
-                console.log('pseudoZIndex', typeof pseudoZIndex, pseudoZIndex);
                 if(pseudoZIndex === 'auto' || pseudoZIndex === 'inherit') {
                     realPseudo.style.setProperty('z-index', '99');
                 }

--- a/src/client-functions/selectors/selector-builder.js
+++ b/src/client-functions/selectors/selector-builder.js
@@ -87,11 +87,12 @@ export default class SelectorBuilder extends ClientFunctionBuilder {
         return null;
     }
 
-    _selectorToFunction(selector) {
-        const pseudoelementKeywords =['::after', '::before', '::cue', '::first-letter', '::first-line', '::selection', '::slotted'];
+    _selectorToFunction (selector) {
+        const pseudoelementKeywords = ['::after', '::before', '::cue', '::first-letter', '::first-line', '::selection', '::slotted'];
 
-        if(this._hasPseudo(selector, pseudoelementKeywords)) {
+        if (this._hasPseudo(selector, pseudoelementKeywords)) {
             const { parentSelector, pseudoSelector } = this._parsePseudoelementTags(selector, pseudoelementKeywords);
+
             return `(function() {
                 const parent = document.querySelectorAll(${JSON.stringify(parentSelector)})[0];
                 const pseudoStyles = window.getComputedStyle(parent, ${JSON.stringify(pseudoSelector)});
@@ -110,28 +111,27 @@ export default class SelectorBuilder extends ClientFunctionBuilder {
                 return realPseudo;
             })`;
         }
+
         return `(function() { return document.querySelectorAll(${JSON.stringify(selector)}); });`;
     }
 
-    _hasPseudo(selector, pseudoelementKeywords) {
+    _hasPseudo (selector, pseudoelementKeywords) {
         let hasPseudo = false;
 
         pseudoelementKeywords.forEach(keyword => {
-            if (selector.includes(keyword)) {
+            if (selector.includes(keyword))
                 hasPseudo = true;
-            }
         });
 
         return hasPseudo;
     }
 
-    _parsePseudoelementTags(selector, pseudoelementKeywords) {
-        // TODO: КАК-ТО АДАПТИРУЙСЯ ПОД СЛОЖНЫЕ СОСТАВНЫЕ СЕЛЕКТОРЫ
+    _parsePseudoelementTags (selector, pseudoelementKeywords) {
         let parentSelector = selector;
         let pseudoSelector = '';
 
         pseudoelementKeywords.forEach(keyword => {
-            if(parentSelector.includes(keyword)) {
+            if (parentSelector.includes(keyword)) {
                 pseudoSelector = keyword;
                 parentSelector = parentSelector.replace(keyword, '');
             }

--- a/src/client-functions/selectors/selector-builder.js
+++ b/src/client-functions/selectors/selector-builder.js
@@ -104,16 +104,16 @@ export default class SelectorBuilder extends ClientFunctionBuilder {
                         pseudoStyles.getPropertyPriority(pseudoStyle))
                 );
 
-                // NOTE: the new element should be above the pseudo, because
-                // action will look at the top element
-                const pseudoZIndex = pseudoStyles.getPropertyValue('z-index');
-                if(pseudoZIndex === 'auto' || pseudoZIndex === 'inherit') {
-                    realPseudo.style.setProperty('z-index', '99');
-                }
-                else {
-                    const realZIndex = parseInt(pseudoZIndex) + 1;
-                    realPseudo.style.setProperty('z-index', '' + realZIndex);
-                }
+                // // NOTE: the new element should be above the pseudo, because
+                // // action will look at the top element
+                // const pseudoZIndex = pseudoStyles.getPropertyValue('z-index');
+                // if(pseudoZIndex === 'auto' || pseudoZIndex === 'inherit') {
+                //     realPseudo.style.setProperty('z-index', '99');
+                // }
+                // else {
+                //     const realZIndex = parseInt(pseudoZIndex) + 1;
+                //     realPseudo.style.setProperty('z-index', '' + realZIndex);
+                // }
 
                 // NOTE: css-content returns value with quotation marks on borders
                 if(pseudoStyles.content) realPseudo.textContent = pseudoStyles.content.substring(1, pseudoStyles.content.length - 1);

--- a/src/client-functions/selectors/selector-builder.js
+++ b/src/client-functions/selectors/selector-builder.js
@@ -88,7 +88,7 @@ export default class SelectorBuilder extends ClientFunctionBuilder {
     }
 
     _selectorToFunction(selector) {
-        const pseudoelementKeywords =['::after', '::before', '::cue', '::first-letter', '::first-line', '::selection', '::slotted'];
+        const pseudoelementKeywords =[':after', ':before', ':cue', ':first-letter', ':first-line', ':selection', ':slotted'];
 
         if(this._hasPseudo(selector, pseudoelementKeywords)) {
             const { parentSelector, pseudoSelector } = this._parsePseudoelementTags(selector, pseudoelementKeywords);

--- a/src/client-functions/selectors/selector-builder.js
+++ b/src/client-functions/selectors/selector-builder.js
@@ -88,7 +88,7 @@ export default class SelectorBuilder extends ClientFunctionBuilder {
     }
 
     _selectorToFunction(selector) {
-        const pseudoelementKeywords =[':after', ':before', ':cue', ':first-letter', ':first-line', ':selection', ':slotted'];
+        const pseudoelementKeywords =['::after', '::before', '::cue', '::first-letter', '::first-line', '::selection', '::slotted'];
 
         if(this._hasPseudo(selector, pseudoelementKeywords)) {
             const { parentSelector, pseudoSelector } = this._parsePseudoelementTags(selector, pseudoelementKeywords);
@@ -103,17 +103,6 @@ export default class SelectorBuilder extends ClientFunctionBuilder {
                         pseudoStyles.getPropertyValue(pseudoStyle),
                         pseudoStyles.getPropertyPriority(pseudoStyle))
                 );
-
-                // // NOTE: the new element should be above the pseudo, because
-                // // action will look at the top element
-                // const pseudoZIndex = pseudoStyles.getPropertyValue('z-index');
-                // if(pseudoZIndex === 'auto' || pseudoZIndex === 'inherit') {
-                //     realPseudo.style.setProperty('z-index', '99');
-                // }
-                // else {
-                //     const realZIndex = parseInt(pseudoZIndex) + 1;
-                //     realPseudo.style.setProperty('z-index', '' + realZIndex);
-                // }
 
                 // NOTE: css-content returns value with quotation marks on borders
                 if(pseudoStyles.content) realPseudo.textContent = pseudoStyles.content.substring(1, pseudoStyles.content.length - 1);

--- a/src/client/automation/playback/click/index.js
+++ b/src/client/automation/playback/click/index.js
@@ -20,8 +20,8 @@ const arrayUtils = testCafeCore.arrayUtils;
 const delay      = testCafeCore.delay;
 
 export default class ClickAutomation extends VisibleElementAutomation {
-    constructor (element, clickOptions) {
-        super(element, clickOptions);
+    constructor (element, clickOptions, hasPseudo) {
+        super(element, clickOptions, hasPseudo);
 
         this.modifiers = clickOptions.modifiers;
         this.caretPos  = clickOptions.caretPos;

--- a/src/client/automation/playback/dblclick.js
+++ b/src/client/automation/playback/dblclick.js
@@ -15,8 +15,8 @@ const delay      = testCafeCore.delay;
 const FIRST_CLICK_DELAY = featureDetection.isTouchDevice ? 0 : 160;
 
 export default class DblClickAutomation extends VisibleElementAutomation {
-    constructor (element, clickOptions) {
-        super(element, clickOptions);
+    constructor (element, clickOptions, hasPseudo) {
+        super(element, clickOptions, hasPseudo);
 
         this.modifiers = clickOptions.modifiers;
         this.caretPos  = clickOptions.caretPos;
@@ -40,7 +40,7 @@ export default class DblClickAutomation extends VisibleElementAutomation {
 
         clickOptions.speed = 1;
 
-        const clickAutomation = new ClickAutomation(this.element, clickOptions);
+        const clickAutomation = new ClickAutomation(this.element, clickOptions, this.hasPseudo);
 
         clickAutomation.on(clickAutomation.TARGET_ELEMENT_FOUND_EVENT, e => this.emit(this.TARGET_ELEMENT_FOUND_EVENT, e));
 
@@ -63,7 +63,7 @@ export default class DblClickAutomation extends VisibleElementAutomation {
             speed:     1
         });
 
-        const clickAutomation = new ClickAutomation(document.documentElement, clickOptions);
+        const clickAutomation = new ClickAutomation(document.documentElement, clickOptions, this.hasPseudo);
 
         return clickAutomation.run()
             .then(clickEventArgs => {

--- a/src/client/automation/playback/drag/base.js
+++ b/src/client/automation/playback/drag/base.js
@@ -21,8 +21,8 @@ const focusBlurSandbox = hammerhead.eventSandbox.focusBlur;
 
 
 export default class DragAutomationBase extends VisibleElementAutomation {
-    constructor (element, mouseOptions) {
-        super(element, mouseOptions);
+    constructor (element, mouseOptions, hasPseudo) {
+        super(element, mouseOptions, hasPseudo);
 
         this.modifiers = mouseOptions.modifiers;
         this.speed     = mouseOptions.speed;

--- a/src/client/automation/playback/drag/to-element.js
+++ b/src/client/automation/playback/drag/to-element.js
@@ -6,8 +6,8 @@ const positionUtils = testCafeCore.positionUtils;
 
 
 export default class DragToElementAutomation extends DragAutomationBase {
-    constructor (element, destinationElement, dragToElementOptions) {
-        super(element, dragToElementOptions);
+    constructor (element, destinationElement, dragToElementOptions, hasPseudo) {
+        super(element, dragToElementOptions, hasPseudo);
 
         this.destinationElement = destinationElement;
         this.destinationOffsetX = dragToElementOptions.destinationOffsetX;

--- a/src/client/automation/playback/drag/to-offset.js
+++ b/src/client/automation/playback/drag/to-offset.js
@@ -6,8 +6,8 @@ const styleUtils = testCafeCore.styleUtils;
 
 
 export default class DragToOffsetAutomation extends DragAutomationBase {
-    constructor (element, offsetX, offsetY, mouseOptions) {
-        super(element, mouseOptions);
+    constructor (element, offsetX, offsetY, mouseOptions, hasPseudo) {
+        super(element, mouseOptions, hasPseudo);
 
         this.dragOffsetX = offsetX;
         this.dragOffsetY = offsetY;

--- a/src/client/automation/playback/hover.js
+++ b/src/client/automation/playback/hover.js
@@ -2,8 +2,8 @@ import VisibleElementAutomation from './visible-element-automation';
 
 
 export default class HoverAutomation extends VisibleElementAutomation {
-    constructor (element, hoverOptions) {
-        super(element, hoverOptions);
+    constructor (element, hoverOptions, hasPseudo) {
+        super(element, hoverOptions, hasPseudo);
     }
 
     run (useStrictElementCheck) {

--- a/src/client/automation/playback/rclick.js
+++ b/src/client/automation/playback/rclick.js
@@ -14,8 +14,8 @@ const eventSimulator = hammerhead.eventSandbox.eventSimulator;
 const { domUtils, eventUtils, delay } = testCafeCore;
 
 export default class RClickAutomation extends VisibleElementAutomation {
-    constructor (element, clickOptions) {
-        super(element, clickOptions);
+    constructor (element, clickOptions, hasPseudo) {
+        super(element, clickOptions, hasPseudo);
 
         this.modifiers = clickOptions.modifiers;
         this.caretPos  = clickOptions.caretPos;

--- a/src/client/automation/playback/scroll-into-view.ts
+++ b/src/client/automation/playback/scroll-into-view.ts
@@ -3,8 +3,8 @@ import { OffsetOptions } from '../../../test-run/commands/options';
 
 
 export default class ScrollIntoViewAutomation extends VisibleElementAutomation {
-    public constructor (element: HTMLElement, offsetOptions: OffsetOptions) {
-        super(element, offsetOptions);
+    public constructor (element: HTMLElement, offsetOptions: OffsetOptions, hasPseudo: boolean) {
+        super(element, offsetOptions, hasPseudo);
     }
 
     public run (useStrictElementCheck: boolean): Promise<unknown> {

--- a/src/client/automation/playback/set-scroll.ts
+++ b/src/client/automation/playback/set-scroll.ts
@@ -38,8 +38,8 @@ export default class SetScrollAutomation extends VisibleElementAutomation {
     private scrollLeft: number;
     private scrollTop: number;
 
-    public constructor (element: HTMLElement, { x, y, position, byX, byY }: SetScrollAutomationOptions, offsetOptions: OffsetOptions) {
-        super(element, offsetOptions);
+    public constructor (element: HTMLElement, { x, y, position, byX, byY }: SetScrollAutomationOptions, offsetOptions: OffsetOptions, hasPseudo: boolean) {
+        super(element, offsetOptions, hasPseudo);
 
         if (position)
             [x, y] = calculatePosition(element, position);

--- a/src/client/automation/playback/visible-element-automation.js
+++ b/src/client/automation/playback/visible-element-automation.js
@@ -32,17 +32,19 @@ class ElementState {
         this.isTarget    = isTarget;
         this.inMoving    = inMoving;
         this.devicePoint = getDevicePoint(clientPoint);
+        this.hasPseudo   = true;
     }
 }
 
 export default class VisibleElementAutomation extends serviceUtils.EventEmitter {
-    constructor (element, offsetOptions) {
+    constructor (element, offsetOptions, hasPseudo) {
         super();
 
         this.TARGET_ELEMENT_FOUND_EVENT = 'automation|target-element-found-event';
 
         this.element            = element;
         this.options            = offsetOptions;
+        this.hasPseudo          = hasPseudo;
         this.automationSettings = new AutomationSettings(offsetOptions.speed);
     }
 
@@ -142,6 +144,10 @@ export default class VisibleElementAutomation extends serviceUtils.EventEmitter 
                         if (!isTarget) {
                             // NOTE: perform an operation with searching in dom only if necessary
                             isTarget = arrayUtils.indexOf(domUtils.getParents(foundElement), this.element) > -1;
+                        }
+
+                        if (!isTarget && this.hasPseudo) {
+                            isTarget = arrayUtils.indexOf(domUtils.getParents(this.element), foundElement) > -1;
                         }
 
                         const offsetPositionChanged = screenPointBeforeAction.x !== screenPointAfterAction.x ||

--- a/src/client/automation/playback/visible-element-automation.js
+++ b/src/client/automation/playback/visible-element-automation.js
@@ -32,7 +32,6 @@ class ElementState {
         this.isTarget    = isTarget;
         this.inMoving    = inMoving;
         this.devicePoint = getDevicePoint(clientPoint);
-        this.hasPseudo   = true;
     }
 }
 
@@ -45,6 +44,10 @@ export default class VisibleElementAutomation extends serviceUtils.EventEmitter 
         this.element            = element;
         this.options            = offsetOptions;
         this.hasPseudo          = hasPseudo;
+
+        console.log('HAS PSEUDO:', hasPseudo);
+        debugger;
+
         this.automationSettings = new AutomationSettings(offsetOptions.speed);
     }
 

--- a/src/client/automation/playback/visible-element-automation.js
+++ b/src/client/automation/playback/visible-element-automation.js
@@ -45,9 +45,6 @@ export default class VisibleElementAutomation extends serviceUtils.EventEmitter 
         this.options            = offsetOptions;
         this.hasPseudo          = hasPseudo;
 
-        console.log('HAS PSEUDO:', hasPseudo);
-        debugger;
-
         this.automationSettings = new AutomationSettings(offsetOptions.speed);
     }
 
@@ -149,9 +146,9 @@ export default class VisibleElementAutomation extends serviceUtils.EventEmitter 
                             isTarget = arrayUtils.indexOf(domUtils.getParents(foundElement), this.element) > -1;
                         }
 
-                        if (!isTarget && this.hasPseudo) {
+                        if (!isTarget && this.hasPseudo)
                             isTarget = arrayUtils.indexOf(domUtils.getParents(this.element), foundElement) > -1;
-                        }
+
 
                         const offsetPositionChanged = screenPointBeforeAction.x !== screenPointAfterAction.x ||
                                                     screenPointBeforeAction.y !== screenPointAfterAction.y;

--- a/src/client/driver/command-executors/execute-action.js
+++ b/src/client/driver/command-executors/execute-action.js
@@ -180,7 +180,7 @@ class ActionExecutor {
     }
 
     _hasPseudo(command) {
-        const pseudoelementKeywords =['::after', '::before', '::cue', '::first-letter', '::first-line', '::selection', '::slotted'];
+        const pseudoelementKeywords =[':after', ':before', ':cue', ':first-letter', ':first-line', ':selection', ':slotted'];
         const selectorText = command.selector.apiFnChain[0];
 
         let hasPseudo = false;
@@ -223,22 +223,22 @@ class ActionExecutor {
                 return new DragToOffsetAutomation(this.elements[0], this.command.dragOffsetX, this.command.dragOffsetY, this.command.options, hasPseudo);
 
             case COMMAND_TYPE.dragToElement :
-                return new DragToElementAutomation(this.elements[0], this.elements[1], this.command.options);
+                return new DragToElementAutomation(this.elements[0], this.elements[1], this.command.options, hasPseudo);
 
             case COMMAND_TYPE.scroll: {
                 const { x, y, position, options } = this.command;
 
-                return new SetScrollAutomation(this.elements[0], { x, y, position }, options);
+                return new SetScrollAutomation(this.elements[0], { x, y, position }, options, hasPseudo);
             }
 
             case COMMAND_TYPE.scrollBy: {
                 const { byX, byY, options } = this.command;
 
-                return new SetScrollAutomation(this.elements[0], { byX, byY }, options);
+                return new SetScrollAutomation(this.elements[0], { byX, byY }, options, hasPseudo);
             }
 
             case COMMAND_TYPE.scrollIntoView: {
-                return new ScrollIntoViewAutomation(this.elements[0], this.command.options);
+                return new ScrollIntoViewAutomation(this.elements[0], this.command.options, hasPseudo);
             }
 
             case COMMAND_TYPE.typeText:

--- a/src/client/driver/command-executors/execute-action.js
+++ b/src/client/driver/command-executors/execute-action.js
@@ -179,16 +179,15 @@ class ActionExecutor {
             ensureOffsetOptions(this.elements[0], this.command.options);
     }
 
-    _hasPseudo(command) {
-        const pseudoelementKeywords =[':after', ':before', ':cue', ':first-letter', ':first-line', ':selection', ':slotted'];
+    _hasPseudo (command) {
+        const pseudoelementKeywords = ['::after', '::before', '::cue', '::first-letter', '::first-line', '::selection', '::slotted'];
         const selectorText = command.selector.apiFnChain[0];
 
         let hasPseudo = false;
 
         pseudoelementKeywords.forEach(keyword => {
-            if (selectorText.includes(keyword)) {
+            if (selectorText.includes(keyword))
                 hasPseudo = true;
-            }
         });
 
         return hasPseudo;

--- a/src/client/driver/command-executors/execute-action.js
+++ b/src/client/driver/command-executors/execute-action.js
@@ -179,8 +179,24 @@ class ActionExecutor {
             ensureOffsetOptions(this.elements[0], this.command.options);
     }
 
+    _hasPseudo(command) {
+        const pseudoelementKeywords =['::after', '::before', '::cue', '::first-letter', '::first-line', '::selection', '::slotted'];
+        const selectorText = command.selector.apiFnChain[0];
+
+        let hasPseudo = false;
+
+        pseudoelementKeywords.forEach(keyword => {
+            if (selectorText.includes(keyword)) {
+                hasPseudo = true;
+            }
+        });
+
+        return hasPseudo;
+    }
+
     _createAutomation () {
         let selectArgs = null;
+        const hasPseudo = this._hasPseudo(this.command);
 
         switch (this.command.type) {
             case COMMAND_TYPE.dispatchEvent:
@@ -192,10 +208,10 @@ class ActionExecutor {
                 if (/option|optgroup/.test(domUtils.getTagName(this.elements[0])))
                     return new SelectChildClickAutomation(this.elements[0], this.command.options);
 
-                return new ClickAutomation(this.elements[0], this.command.options);
+                return new ClickAutomation(this.elements[0], this.command.options, hasPseudo);
 
             case COMMAND_TYPE.rightClick :
-                return new RClickAutomation(this.elements[0], this.command.options);
+                return new RClickAutomation(this.elements[0], this.command.options, hasPseudo);
 
             case COMMAND_TYPE.doubleClick :
                 return new DblClickAutomation(this.elements[0], this.command.options);

--- a/src/client/driver/command-executors/execute-action.js
+++ b/src/client/driver/command-executors/execute-action.js
@@ -180,6 +180,8 @@ class ActionExecutor {
     }
 
     _hasPseudo (command) {
+        if (!command.selector) return false;
+
         const pseudoelementKeywords = ['::after', '::before', '::cue', '::first-letter', '::first-line', '::selection', '::slotted'];
         const selectorText = command.selector.apiFnChain[0];
 

--- a/src/client/driver/command-executors/execute-action.js
+++ b/src/client/driver/command-executors/execute-action.js
@@ -187,10 +187,11 @@ class ActionExecutor {
 
         let hasPseudo = false;
 
-        pseudoelementKeywords.forEach(keyword => {
-            if (selectorText.includes(keyword))
+        // NOTE: IE doesn't support "foreach" syntax and Array.includes() method
+        for (let i = 0; i < pseudoelementKeywords.length; i++) {
+            if (selectorText.indexOf(pseudoelementKeywords[i]) > -1)
                 hasPseudo = true;
-        });
+        }
 
         return hasPseudo;
     }

--- a/src/client/driver/command-executors/execute-action.js
+++ b/src/client/driver/command-executors/execute-action.js
@@ -214,13 +214,13 @@ class ActionExecutor {
                 return new RClickAutomation(this.elements[0], this.command.options, hasPseudo);
 
             case COMMAND_TYPE.doubleClick :
-                return new DblClickAutomation(this.elements[0], this.command.options);
+                return new DblClickAutomation(this.elements[0], this.command.options, hasPseudo);
 
             case COMMAND_TYPE.hover :
-                return new HoverAutomation(this.elements[0], this.command.options);
+                return new HoverAutomation(this.elements[0], this.command.options, hasPseudo);
 
             case COMMAND_TYPE.drag :
-                return new DragToOffsetAutomation(this.elements[0], this.command.dragOffsetX, this.command.dragOffsetY, this.command.options);
+                return new DragToOffsetAutomation(this.elements[0], this.command.dragOffsetX, this.command.dragOffsetY, this.command.options, hasPseudo);
 
             case COMMAND_TYPE.dragToElement :
                 return new DragToElementAutomation(this.elements[0], this.elements[1], this.command.options);

--- a/src/utils/browser-connection-timeouts.js
+++ b/src/utils/browser-connection-timeouts.js
@@ -3,7 +3,7 @@
 // Do not use any browser or node-specific API!
 // -------------------------------------------------------------
 
-export const HEARTBEAT_TIMEOUT       = 20 * 60 * 1000;
+export const HEARTBEAT_TIMEOUT       = 2 * 60 * 1000;
 export const BROWSER_RESTART_TIMEOUT = 60 * 1000;
 export const BROWSER_CLOSE_TIMEOUT   = BROWSER_RESTART_TIMEOUT / 2;
 

--- a/src/utils/browser-connection-timeouts.js
+++ b/src/utils/browser-connection-timeouts.js
@@ -3,7 +3,7 @@
 // Do not use any browser or node-specific API!
 // -------------------------------------------------------------
 
-export const HEARTBEAT_TIMEOUT       = 2 * 60 * 1000;
+export const HEARTBEAT_TIMEOUT       = 20 * 60 * 1000;
 export const BROWSER_RESTART_TIMEOUT = 60 * 1000;
 export const BROWSER_CLOSE_TIMEOUT   = BROWSER_RESTART_TIMEOUT / 2;
 

--- a/test/functional/utils/pseudoelement-selector/func.js
+++ b/test/functional/utils/pseudoelement-selector/func.js
@@ -1,0 +1,50 @@
+$(document).ready(() => {
+    $('#left-click').click(function (e) {
+        if (this.offsetWidth - e.offsetX < 0)
+            $('#left-click').css('background-color', '#8d8');
+    });
+
+    $('#right-click').mousedown(function (e) {
+        if(e.button !== 2) return true;
+
+        if (this.offsetWidth - e.offsetX < 0)
+            $('#right-click').css('background-color', '#8d8');
+    });
+
+    $('#double-click').dblclick(function (e) {
+        if (this.offsetWidth - e.offsetX < 0)
+            $('#double-click').css('background-color', '#8d8');
+    });
+
+    $('#hover').hover(function (e) {
+        if (this.offsetWidth - e.offsetX < 0)
+            $('#hover').css('background-color', '#8d8');
+    });
+
+    $('#D').click(function (e) {
+        console.log('IT TWORKS');
+        if (this.offsetWidth - e.offsetX < 0)
+            $('#D').css('background-color', '#8d8');
+    });
+
+    $('#drag').mousedown(dragMouseDown);
+
+    function dragMouseDown(e) {
+        document.onmouseup = closeDragElement;
+        document.onmousemove = elementDrag;
+    }
+
+    function elementDrag(e) {
+        const drag = $('#drag');
+        const timeline = $('#timeline');
+        const position = e.clientX - timeline.offset().left - 10;
+
+        if(position >= -1 && position <= 290)
+            drag.css('left', position + 'px');
+    }
+
+    function closeDragElement() {
+        document.onmouseup = null;
+        document.onmousemove = null;
+    }
+});

--- a/test/functional/utils/pseudoelement-selector/func.js
+++ b/test/functional/utils/pseudoelement-selector/func.js
@@ -2,48 +2,59 @@ $(document).ready(() => {
     $('#left-click').click(function (e) {
         if (this.offsetWidth - e.offsetX < 0)
             $('#left-click').css('background-color', '#8d8');
+
+        return true;
     });
 
     $('#right-click').mousedown(function (e) {
-        if(e.button !== 2) return true;
+        if (e.button !== 2) return true;
 
         if (this.offsetWidth - e.offsetX < 0)
             $('#right-click').css('background-color', '#8d8');
+
+        return true;
     });
 
     $('#double-click').dblclick(function (e) {
         if (this.offsetWidth - e.offsetX < 0)
             $('#double-click').css('background-color', '#8d8');
+
+        return true;
     });
 
     $('#hover').hover(function (e) {
         if (this.offsetWidth - e.offsetX < 0)
             $('#hover').css('background-color', '#8d8');
+
+        return true;
     });
 
     $('#D').click(function (e) {
-        console.log('IT TWORKS');
         if (this.offsetWidth - e.offsetX < 0)
             $('#D').css('background-color', '#8d8');
+
+        return true;
     });
 
     $('#drag').mousedown(dragMouseDown);
 
-    function dragMouseDown(e) {
+    function dragMouseDown () {
         document.onmouseup = closeDragElement;
         document.onmousemove = elementDrag;
+
+        return true;
     }
 
-    function elementDrag(e) {
+    function elementDrag (e) {
         const drag = $('#drag');
         const timeline = $('#timeline');
         const position = e.clientX - timeline.offset().left - 10;
 
-        if(position >= -1 && position <= 290)
+        if (position >= -1 && position <= 290)
             drag.css('left', position + 'px');
     }
 
-    function closeDragElement() {
+    function closeDragElement () {
         document.onmouseup = null;
         document.onmousemove = null;
     }

--- a/test/functional/utils/pseudoelement-selector/index.html
+++ b/test/functional/utils/pseudoelement-selector/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Pseudo</title>
+    <link rel="stylesheet" type="text/css" href="style.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script src="func.js"></script>
+</head>
+<body>
+    <div class="mouse-block" id="left-click">
+        L-CLICK
+    </div>
+    <div class="mouse-block" id="right-click">
+        R-CLICK
+    </div>
+    <div class="mouse-block" id="double-click">
+        DOUBLE<br>CLICK
+    </div>
+    <div class="mouse-block" id="hover">
+        HOVER
+    </div>
+
+    <div id="A">
+        <div id="B">
+            <div id="C">
+                <div id="D">
+                    COMBINE<br>CLICK
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div id="timeline">
+        <div id="drag"></div>
+    </div>
+    <div id="drag-title">DRAG</div>
+</body>
+</html>

--- a/test/functional/utils/pseudoelement-selector/style.css
+++ b/test/functional/utils/pseudoelement-selector/style.css
@@ -1,0 +1,156 @@
+body,html {width:100%;height:100%;margin:0px;padding:0px;}
+
+.close {
+    display:none;
+}
+
+.mouse-block {
+    position:absolute;
+    top:200px;
+    background:#fd8;
+    padding:30px;
+    text-align:center;
+    font:30px arial;
+    color:#ffffff;
+}
+
+#left-click {
+    left:50px;
+}
+#left-click:after {
+    content:'X';
+    position: absolute;
+    top:-30px;
+    right: -20px;
+    font:20px arial;
+    color:#ff0000;
+    z-index: 1;
+}
+
+#right-click {
+    left:250px;
+}
+#right-click:after {
+    content:'X';
+    position: absolute;
+    top:-30px;
+    right: -20px;
+    font:20px arial;
+    color:#ff0000;
+    z-index: 1;
+}
+
+#double-click {
+    left:460px;
+}
+#double-click:after {
+    content:'X';
+    position: absolute;
+    top:-30px;
+    right: -20px;
+    font:20px arial;
+    color:#ff0000;
+    z-index: 1;
+}
+
+#hover {
+    left:670px;
+}
+#hover:after {
+    content:'X';
+    position: absolute;
+    top:-30px;
+    right: -20px;
+    font:20px arial;
+    color:#ff0000;
+    z-index: 1;
+}
+
+#A {
+    position: absolute;
+    top: 400px;
+    left: 350px;
+    width: 200px;
+    height: 125px;
+    background-color: #940;
+}
+#B {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    width: 180px;
+    height: 105px;
+    background-color: #c70;
+}
+#C {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    width: 160px;
+    height: 85px;
+    background-color: #fa0;
+}
+#D {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    width: 140px;
+    height: 65px;
+    background-color:#fd8;
+    text-align:center;
+    font:30px arial;
+    color:#ffffff;
+}
+#D:after {
+    content:'X';
+    position: absolute;
+    top:-30px;
+    right: -20px;
+    font:20px arial;
+    color:#ff0000;
+    z-index: 1;
+}
+
+#timeline {
+    position: absolute;
+    top: 700px;
+    left: 50px;
+
+    width: 300px;
+    height: 20px;
+    background-color: grey;
+    cursor: pointer;
+}
+#timeline::after {
+    content:'_';
+    position: absolute;
+    top:-10px;
+    right: 5px;
+    height: 40px;
+    width: 10px;
+    background-color: #ffdd88;
+    color:#ffdd88;
+    z-index: 1;
+}
+#drag {
+    position: relative;
+    width: 0px;
+    height: 0px;
+    background-color: red;
+    z-index: 2;
+}
+#drag::after {
+    content:'_';
+    position: absolute;
+    top:-10px;
+    background-color: red;
+    color:red;
+    z-index: 1;
+}
+
+#drag-title {
+    position: absolute;
+    top: 730px;
+    left: 150px;
+    font:30px arial;
+}

--- a/test/functional/utils/pseudoelement-selector/test.js
+++ b/test/functional/utils/pseudoelement-selector/test.js
@@ -1,0 +1,27 @@
+const createTestCafe = require('../../../..');
+const assert = require('assert');
+
+describe('Actions with pseudoelement selectors', () => {
+    it('Should work', async function () {
+        this.timeout(30000);
+
+        let runner;
+        let testcafe;
+
+        return await createTestCafe('localhost', '', '')
+            .then(testcafeInstance => {
+                runner = testcafeInstance.createRunner();
+                testcafe = testcafeInstance;
+            })
+            .then(() => {
+                return runner
+                    .src('test/functional/utils/pseudoelement-selector/testcafe-fixture.js')
+                    .browsers('chrome')
+                    .run();
+            })
+            .then(async testResult => {
+                assert.deepStrictEqual(testResult, 0);
+                await testcafe.close();
+            });
+    });
+});

--- a/test/functional/utils/pseudoelement-selector/testcafe-fixture.js
+++ b/test/functional/utils/pseudoelement-selector/testcafe-fixture.js
@@ -1,0 +1,50 @@
+import {Selector} from "testcafe";
+
+fixture `Pseudoelement actions`
+    .page `./index.html`;
+
+const successMouseStyle = 'background-color: rgb(136, 221, 136);'
+
+test('Сlick on a pseudoelement should works', async t => {
+    await t.click('#left-click::after');
+    const objectAttributes = await Selector('#left-click').attributes;
+    await t.expect(objectAttributes.style).eql(successMouseStyle);
+});
+
+test('Right click on a pseudoelement should works', async t => {
+    await t.rightClick('#right-click::after');
+    const objectAttributes = await Selector('#right-click').attributes;
+    await t.expect(objectAttributes.style).eql(successMouseStyle);
+});
+
+test('Double click on a pseudoelement should works', async t => {
+    await t.doubleClick('#double-click::after');
+    const objectAttributes = await Selector('#double-click').attributes;
+    await t.expect(objectAttributes.style).eql(successMouseStyle);
+});
+
+test('Hovering over a pseudoelement should work', async t => {
+    await t.hover('#hover::after');
+    const objectAttributes = await Selector('#hover').attributes;
+    await t.expect(objectAttributes.style).eql(successMouseStyle);
+});
+
+test('Drag a pseudoelement should works', async t => {
+    await t.drag('#drag::after', 250, 0);
+    const objectAttributes = await Selector('#drag').attributes;
+    const leftOffset = parseInt(objectAttributes.style.replace(/\D+/, ''));
+    await t.expect(leftOffset).within(200, 300);
+});
+
+test('Drag a pseudoelement to another pseudoelement should works', async t => {
+    await t.dragToElement('#drag::after', '#timeline::after');
+    const objectAttributes = await Selector('#drag').attributes;
+    const leftOffset = parseInt(objectAttributes.style.replace(/\D/g, ''));
+    await t.expect(leftOffset).within(200, 300);
+});
+
+test('Сlick on a pseudoelement with complex selector should works', async t => {
+    await t.click('#A > #B > #C > #D::after');
+    const objectAttributes = await Selector('#A > #B > #C > #D').attributes;
+    await t.expect(objectAttributes.style).eql(successMouseStyle);
+});

--- a/test/functional/utils/pseudoelement-selector/testcafe-fixture.js
+++ b/test/functional/utils/pseudoelement-selector/testcafe-fixture.js
@@ -1,50 +1,65 @@
-import {Selector} from "testcafe";
+import { Selector } from 'testcafe';
 
+// eslint-disable-next-line no-undef,no-unused-expressions
 fixture `Pseudoelement actions`
     .page `./index.html`;
 
-const successMouseStyle = 'background-color: rgb(136, 221, 136);'
+const successMouseStyle = 'background-color: rgb(136, 221, 136);';
 
 test('Сlick on a pseudoelement should works', async t => {
     await t.click('#left-click::after');
+
     const objectAttributes = await Selector('#left-click').attributes;
+
     await t.expect(objectAttributes.style).eql(successMouseStyle);
 });
 
 test('Right click on a pseudoelement should works', async t => {
     await t.rightClick('#right-click::after');
+
     const objectAttributes = await Selector('#right-click').attributes;
+
     await t.expect(objectAttributes.style).eql(successMouseStyle);
 });
 
 test('Double click on a pseudoelement should works', async t => {
     await t.doubleClick('#double-click::after');
+
     const objectAttributes = await Selector('#double-click').attributes;
+
     await t.expect(objectAttributes.style).eql(successMouseStyle);
 });
 
 test('Hovering over a pseudoelement should work', async t => {
     await t.hover('#hover::after');
+
     const objectAttributes = await Selector('#hover').attributes;
+
     await t.expect(objectAttributes.style).eql(successMouseStyle);
 });
 
 test('Drag a pseudoelement should works', async t => {
     await t.drag('#drag::after', 250, 0);
+
     const objectAttributes = await Selector('#drag').attributes;
-    const leftOffset = parseInt(objectAttributes.style.replace(/\D+/, ''));
+    const leftOffset = parseInt(objectAttributes.style.replace(/\D+/, ''), 10);
+
     await t.expect(leftOffset).within(200, 300);
 });
 
 test('Drag a pseudoelement to another pseudoelement should works', async t => {
     await t.dragToElement('#drag::after', '#timeline::after');
+
     const objectAttributes = await Selector('#drag').attributes;
-    const leftOffset = parseInt(objectAttributes.style.replace(/\D/g, ''));
+    const leftOffset = parseInt(objectAttributes.style.replace(/\D/g, ''), 10);
+
     await t.expect(leftOffset).within(200, 300);
 });
 
 test('Сlick on a pseudoelement with complex selector should works', async t => {
     await t.click('#A > #B > #C > #D::after');
+
     const objectAttributes = await Selector('#A > #B > #C > #D').attributes;
+
     await t.expect(objectAttributes.style).eql(successMouseStyle);
 });


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Testcafe now can work with pseudoelement ('::after', '::before'...). 
Test for that feature

## Approach
The standard selector uses the querySelectorAll function.
A handler has been created for the pseudo-element, which receives the parent element from the pseudo-element, creates a child element for it, and sets the CSS properties of the pseudo-element to the new element. Testcafe can work with the new element. 
When trying to work with a pseudo-element in this way, there was a delay, due to checking "whether the desired element is located at the specified coordinates" (VisibleElementAutomation::_wrapAction)
To solve this problem, was implemented the "hasPseudo" flag, which is used for an additional check - "if there is a pseudo-element in the request, can the coordinates contain a pseudo-element that is perceived as the parent?" - if so, then this is where the action was supposed to be
Tests for click, right-click, double-click, hover, drag, dragToElement and for combined selector are written

## References
https://github.com/DevExpress/testcafe/issues/2813

## Pre-Merge TODO
- [ ] Make sure that existing tests do not fail
