### PR TITLE
fix: hangs in an iframe when it redirects to a cross-domain site

### DIFF
--- a/src/client/driver/driver-link/iframe/parent.js
+++ b/src/client/driver/driver-link/iframe/parent.js
@@ -1,5 +1,9 @@
 import { eventSandbox } from '../../deps/hammerhead';
-import { EstablishConnectionMessage, CommandExecutedMessage } from '../messages';
+import {
+    EstablishConnectionMessage,
+    CommandExecutedMessage,
+    HasPendingActionFlagsMessage
+} from '../messages';
 import { CurrentIframeIsNotLoadedError } from '../../../../shared/errors';
 import sendMessageToDriver from '../send-message-to-driver';
 import { WAIT_FOR_IFRAME_DRIVER_RESPONSE_TIMEOUT } from '../timeouts';
@@ -28,5 +32,16 @@ export default class ParentIframeDriverLink {
         const msg = new CommandExecutedMessage(status);
 
         eventSandbox.message.sendServiceMsg(msg, this.driverWindow);
+    }
+
+    async hasPendingActionFlags () {
+        const response = await sendMessageToDriver(
+            new HasPendingActionFlagsMessage(),
+            this.driverWindow,
+            WAIT_FOR_IFRAME_DRIVER_RESPONSE_TIMEOUT,
+            CurrentIframeIsNotLoadedError
+        );
+
+        return response.result;
     }
 }

--- a/src/client/driver/driver-link/messages.js
+++ b/src/client/driver/driver-link/messages.js
@@ -16,7 +16,8 @@ export const TYPE = {
     startToRestoreChildLink:     'driver|start-to-restore-child-link',
     restoreChildLink:            'driver|restore-child-link',
     childWindowIsLoadedInIFrame: 'driver|child-window-is-loaded-in-iframe',
-    childWindowIsOpenedInIFrame: 'driver|child-window-is-opened-in-iframe'
+    childWindowIsOpenedInIFrame: 'driver|child-window-is-opened-in-iframe',
+    hasPendingActionFlags:       'driver|has-pending-action-flags'
 };
 
 class InterDriverMessage {
@@ -146,5 +147,11 @@ export class ChildWindowIsLoadedInFrameMessage extends InterDriverMessage {
 export class ChildWindowIsOpenedInFrameMessage extends InterDriverMessage {
     constructor () {
         super(TYPE.childWindowIsOpenedInIFrame);
+    }
+}
+
+export class HasPendingActionFlagsMessage extends InterDriverMessage {
+    constructor () {
+        super(TYPE.hasPendingActionFlags);
     }
 }

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -757,6 +757,16 @@ export default class Driver extends serviceUtils.EventEmitter {
         this.parentWindowDriverLink.restoreChild(this._getCurrentWindowId());
     }
 
+    _handleHasPendingActionFlags (msg, window) {
+        const result = this._hasPendingActionFlags(this.contextStorage);
+
+        sendConfirmationMessage({
+            requestMsgId: msg.id,
+            window,
+            result
+        });
+    }
+
     _handleRestoreChildLink (msg, wnd) {
         if (this._stopRespondToChildren)
             return;
@@ -839,6 +849,9 @@ export default class Driver extends serviceUtils.EventEmitter {
                     break;
                 case MESSAGE_TYPE.startToRestoreChildLink:
                     this._handleStartToRestoreChildLinkMessage();
+                    break;
+                case MESSAGE_TYPE.hasPendingActionFlags:
+                    this._handleHasPendingActionFlags(msg, window);
                     break;
                 case MESSAGE_TYPE.restoreChildLink:
                     this._handleRestoreChildLink(msg, window);

--- a/src/client/driver/iframe-driver.js
+++ b/src/client/driver/iframe-driver.js
@@ -87,9 +87,10 @@ export default class IframeDriver extends Driver {
         if (this._failIfClientCodeExecutionIsInterrupted())
             return;
 
-        const inCommandExecution = inCrossDomainIframe(window) ?
-            await this.parentDriverLink.hasPendingActionFlags() :
-            this._hasPendingActionFlags(this.contextStorage);
+        let inCommandExecution = this._hasPendingActionFlags(this.contextStorage);
+
+        if (inCrossDomainIframe(window))
+            inCommandExecution = await this.parentDriverLink.hasPendingActionFlags();
 
         if (inCommandExecution) {
             this.contextStorage.setItem(this.COMMAND_EXECUTING_FLAG, false);

--- a/src/client/driver/iframe-driver.js
+++ b/src/client/driver/iframe-driver.js
@@ -1,4 +1,9 @@
-import { Promise, eventSandbox, utils } from './deps/hammerhead';
+import {
+    Promise,
+    eventSandbox,
+    utils
+} from './deps/hammerhead';
+
 import { pageUnloadBarrier } from './deps/testcafe-core';
 import { IframeStatusBar } from './deps/testcafe-ui';
 import Driver from './driver';

--- a/src/utils/in-cross-domain-iframe.ts
+++ b/src/utils/in-cross-domain-iframe.ts
@@ -1,0 +1,8 @@
+export default function inCrossDomainIframe (window: Window): boolean {
+    try {
+        return !window.top.document;
+    }
+    catch (e) {
+        return true;
+    }
+}

--- a/src/utils/in-cross-domain-iframe.ts
+++ b/src/utils/in-cross-domain-iframe.ts
@@ -1,8 +1,0 @@
-export default function inCrossDomainIframe (window: Window): boolean {
-    try {
-        return !window.parent.document;
-    }
-    catch (e) {
-        return true;
-    }
-}

--- a/src/utils/in-cross-domain-iframe.ts
+++ b/src/utils/in-cross-domain-iframe.ts
@@ -1,6 +1,6 @@
 export default function inCrossDomainIframe (window: Window): boolean {
     try {
-        return !window.top.document;
+        return !window.parent.document;
     }
     catch (e) {
         return true;

--- a/test/functional/fixtures/regression/gh-4232/pages/cross-domain-page.html
+++ b/test/functional/fixtures/regression/gh-4232/pages/cross-domain-page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>GH-4232</title>
+</head>
+<body>
+    <h1>Cross-domain page</h1>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-4232/pages/iframe.html
+++ b/test/functional/fixtures/regression/gh-4232/pages/iframe.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>GH-4232</title>
+</head>
+<body>
+<input id="submit-btn" type="submit" value="Submit">
+<script>
+    var submitBtn = document.getElementById('submit-btn');
+    
+    submitBtn.onclick = function () {
+        document.location = 'http://localhost:3001/fixtures/regression/gh-4232/pages/cross-domain-page.html';
+    };
+</script>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-4232/pages/index.html
+++ b/test/functional/fixtures/regression/gh-4232/pages/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>GH-4232</title>
+</head>
+<body>
+<iframe id="same-domain-iframe" src="iframe.html"></iframe>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-4232/test.js
+++ b/test/functional/fixtures/regression/gh-4232/test.js
@@ -1,5 +1,5 @@
 describe('[Regression](GH-4232)', function () {
-    it('Should not hang after submitting button in an iframe which redirects to a page on a different domain', function () { // eslint-disable-line
+    it('Should not hang after submitting button in an iframe which redirects to a page on a different domain', function () {
         return runTests(
             'testcafe-fixtures/index-test.js',
             'Click on submit button in an iframe when the click redirecting to a page on a different domain'

--- a/test/functional/fixtures/regression/gh-4232/test.js
+++ b/test/functional/fixtures/regression/gh-4232/test.js
@@ -1,0 +1,8 @@
+describe('[Regression](GH-4232)', function () {
+    it('Should not hang after submitting button in an iframe which redirects to a page on a different domain', function () { // eslint-disable-line
+        return runTests(
+            'testcafe-fixtures/index-test.js',
+            'Click on submit button in an iframe when the click redirecting to a page on a different domain'
+        );
+    });
+});

--- a/test/functional/fixtures/regression/gh-4232/test.js
+++ b/test/functional/fixtures/regression/gh-4232/test.js
@@ -1,8 +1,5 @@
 describe('[Regression](GH-4232)', function () {
     it('Should not hang after submitting button in an iframe which redirects to a page on a different domain', function () {
-        return runTests(
-            'testcafe-fixtures/index-test.js',
-            'Click on submit button in an iframe when the click redirecting to a page on a different domain'
-        );
+        return runTests('testcafe-fixtures/index-test.js');
     });
 });

--- a/test/functional/fixtures/regression/gh-4232/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/regression/gh-4232/testcafe-fixtures/index-test.js
@@ -1,0 +1,13 @@
+import { Selector } from 'testcafe';
+
+fixture `gh-4232`
+    .page `http://localhost:3000/fixtures/regression/gh-4232/pages/index.html`;
+
+test('Click on submit button in an iframe when the click redirecting to a page on a different domain', async t => {
+    const iframe = Selector('#same-domain-iframe');
+
+    await t
+        .switchToIframe(iframe)
+        .click('input')
+        .expect(Selector('h1').innerText).eql('Cross-domain page');
+});

--- a/test/functional/fixtures/regression/gh-4232/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/regression/gh-4232/testcafe-fixtures/index-test.js
@@ -4,7 +4,7 @@ fixture `gh-4232`
     .page `http://localhost:3000/fixtures/regression/gh-4232/pages/index.html`;
 
 test('Click on submit button in an iframe when the click redirecting to a page on a different domain', async t => {
-    const iframe = Selector('#same-domain-iframe');
+    const iframe = Selector('#same-domain-iframe', { timeout: 10000 });
 
     await t
         .switchToIframe(iframe)


### PR DESCRIPTION
## Purpose
TestCafe hangs when click in an iframe redirects to a page on a different domain. It occurs due to the cross-origin iframe's driver not able to read the pending actions from the `ContextStorage` of its parent and because of that the driver doesn't send the "ready" driver status and TestCafe hangs.

## Approach
In the cross-domain iframe we should check that the parent doesn't have pending actions as well. Because the iframe and its parent with different origins doesn't share a common `sessionStorage` (its used under the hood of `ContextStorage`), we should send the message to check if there're some pending actions in the parent's driver.

## References
Fixes #4232 

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
