### PR TITLE
fix: changed context for calling _hasLocalBrowsers in _checkRequiredPermissions

### DIFF
--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -497,7 +497,7 @@ export default class Runner extends EventEmitter {
     }
 
     async _checkRequiredPermissions (browserInfo) {
-        const hasLocalBrowsers = await Bootstrapper._hasLocalBrowsers(browserInfo);
+        const hasLocalBrowsers = await this._hasLocalBrowsers(browserInfo);
 
         const { error } = await authenticationHelper(
             () => findWindow(''),


### PR DESCRIPTION
## Purpose
Fix error when running on MacOs. The error occurs when trying to run the browser check.

## Approach
Change context for calling _hasLocalBrowsers in _checkRequiredPermissions

## References
https://github.com/DevExpress/testcafe/issues/6244

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
