### PR TITLE
refactor: support raw api and other subsystems in the compiler service mode (close #6335)

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -35,7 +35,6 @@ const {
     LEGACY_TESTS_GLOB,
     MULTIPLE_WINDOWS_TESTS_GLOB,
     MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB,
-    COMPILER_SERVICE_TESTS_GLOB,
 } = require('./gulp/constants/functional-test-globs');
 
 const {
@@ -263,6 +262,10 @@ gulp.task('build', process.env.DEV_MODE === 'true' ? gulp.registry().get('fast-b
 gulp.step('prepare-tests', gulp.registry().get(SKIP_BUILD ? 'lint' : 'build'));
 
 gulp.step('test-server-run', () => {
+    const chai = require('chai');
+
+    chai.use(require('chai-string'));
+
     // HACK: We have to exit from all Gulp's error domains to avoid conflicts with error handling inside mocha tests
     const domains = exitDomains();
 
@@ -407,7 +410,7 @@ gulp.step('test-functional-local-multiple-windows-run', () => {
 gulp.task('test-functional-local-multiple-windows', gulp.series('prepare-tests', 'test-functional-local-multiple-windows-run'));
 
 gulp.step('test-functional-local-compiler-service-run', () => {
-    return testFunctional(MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB.concat(COMPILER_SERVICE_TESTS_GLOB), functionalTestConfig.testingEnvironmentNames.localHeadlessChrome, { experimentalCompilerService: true });
+    return testFunctional(MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB, functionalTestConfig.testingEnvironmentNames.localHeadlessChrome, { experimentalCompilerService: true });
 });
 
 gulp.task('test-functional-local-compiler-service', gulp.series('prepare-tests', 'test-functional-local-compiler-service-run'));

--- a/gulp/constants/functional-test-globs.js
+++ b/gulp/constants/functional-test-globs.js
@@ -1,25 +1,27 @@
 const MULTIPLE_WINDOWS_TESTS_GLOB = 'test/functional/fixtures/multiple-windows/test.js';
 const COMPILER_SERVICE_TESTS_GLOB = 'test/functional/fixtures/compiler-service/test.js';
 const LEGACY_TESTS_GLOB           = 'test/functional/legacy-fixtures/**/test.js';
+const BASIC_TESTS_GLOB            = 'test/functional/fixtures/**/test.js';
 
 const TESTS_GLOB = [
-    'test/functional/fixtures/**/test.js',
+    BASIC_TESTS_GLOB,
     `!${MULTIPLE_WINDOWS_TESTS_GLOB}`,
     `!${COMPILER_SERVICE_TESTS_GLOB}`,
 ];
 
 const MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB = [
-    'test/functional/fixtures/app-command/test.js',
-    'test/functional/fixtures/driver/test.js',
-    'test/functional/fixtures/concurrency/test.js',
-    'test/functional/fixtures/driver/test.js',
-    'test/functional/fixtures/hammerhead/gh-2418/test.js',
-    'test/functional/fixtures/hammerhead/gh-2622/test.js',
-    'test/functional/fixtures/live/test.js',
-    'test/functional/fixtures/reporter/test.js',
-    'test/functional/fixtures/api/es-next/roles/test.js',
-    'test/functional/fixtures/api/es-next/hooks/test.js',
-    'test/functional/fixtures/api/es-next/request-hooks/test.js',
+    BASIC_TESTS_GLOB,
+    COMPILER_SERVICE_TESTS_GLOB,
+    '!test/functional/fixtures/multiple-windows/test.js',
+    '!test/functional/fixtures/browser-provider/browser-reconnect/test.js',
+    '!test/functional/fixtures/api/es-next/assertions/test.js',
+    '!test/functional/fixtures/regression/gh-2546/test.js',
+    '!test/functional/fixtures/regression/gh-2846/test.js',
+    '!test/functional/fixtures/regression/gh-2861/test.js',
+    '!test/functional/fixtures/regression/gh-2968/test.js',
+    '!test/functional/fixtures/regression/gh-3021/test.js',
+    '!test/functional/fixtures/regression/gh-3298/test.js',
+    '!test/functional/fixtures/regression/gh-4516/test.js',
 ];
 
 module.exports = {

--- a/gulp/helpers/test-functional.js
+++ b/gulp/helpers/test-functional.js
@@ -2,8 +2,12 @@ const gulp           = require('gulp');
 const mocha          = require('gulp-mocha-simple');
 const { castArray }  = require('lodash');
 const getTimeout     = require('./get-timeout');
-const { TESTS_GLOB } = require('../constants/functional-test-globs');
 const chai           = require('chai');
+
+const {
+    TESTS_GLOB,
+    MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB,
+} = require('../constants/functional-test-globs');
 
 chai.use(require('chai-string'));
 
@@ -14,6 +18,10 @@ const SCREENSHOT_TESTS_GLOB = [
     'test/functional/fixtures/api/es-next/take-screenshot/test.js',
     'test/functional/fixtures/screenshots-on-fails/test.js',
 ];
+
+function shouldAddTakeScreenshotTestGlob (glob) {
+    return [TESTS_GLOB, MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB].includes(glob);
+}
 
 module.exports = function testFunctional (src, testingEnvironmentName, { experimentalCompilerService, isProxyless } = {}) {
     process.env.TESTING_ENVIRONMENT       = testingEnvironmentName;
@@ -31,7 +39,7 @@ module.exports = function testFunctional (src, testingEnvironmentName, { experim
     let tests = castArray(src);
 
     // TODO: Run takeScreenshot tests first because other tests heavily impact them
-    if (src === TESTS_GLOB)
+    if (shouldAddTakeScreenshotTestGlob(src))
         tests = SCREENSHOT_TESTS_GLOB.concat(tests);
 
     tests.unshift(SETUP_TESTS_GLOB);

--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -12,7 +12,6 @@ import ClientFunctionBuilder from '../../client-functions/client-function-builde
 import Assertion from './assertion';
 import { getDelegatedAPIList, delegateAPI } from '../../utils/delegated-api';
 import WARNING_MESSAGE from '../../notifications/warning-message';
-import getBrowser from '../../utils/get-browser';
 import addWarning from '../../notifications/add-rendered-warning';
 import { getCallsiteId, getCallsiteStackFrameString } from '../../utils/callsite';
 import { getDeprecationMessage, DEPRECATED } from '../../notifications/deprecated';
@@ -189,7 +188,7 @@ export default class TestController {
     }
 
     _browser$getter () {
-        return getBrowser(this.testRun.browserConnection);
+        return this.testRun.browser;
     }
 
     _dispatchEvent$ (selector, eventName, options = {}) {

--- a/src/errors/test-run/render-error-template/index.js
+++ b/src/errors/test-run/render-error-template/index.js
@@ -1,25 +1,18 @@
-import { renderers } from 'callsite-record';
-import { TEST_RUN_ERRORS } from '../types';
-import {
-    markup,
-    shouldSkipCallsite,
-    formatExpressionMessage,
-} from './utils';
+import { TEST_RUN_ERRORS } from '../../types';
+import { markup, formatExpressionMessage } from '../utils';
+import TEMPLATES from '../templates';
+import { renderHtmlWithoutStack, shouldRenderHtmlWithoutStack } from './utils';
 
-import TEMPLATES from './templates';
 
 function getTestCafeErrorInCustomScriptError (err, viewportWidth) {
     const originErrTemplate  = TEMPLATES[err.originError.code];
     const originErrMessage   = '\n' + err.originError.message;
     let originCallsiteMarkup = '';
 
-    if (err.errCallsite && originErrTemplate && !shouldSkipCallsite(err.originError)) {
+    if (shouldRenderHtmlWithoutStack(err)) {
         // HACK: we need to get callsite for custom TestCafe script without real file for it.
         // We use expression as a file content
-        originCallsiteMarkup = err.errCallsite._renderRecord(err.expression, {
-            renderer: renderers.html,
-            stack:    false,
-        });
+        originCallsiteMarkup = typeof err.errCallsite === 'string' ? err.errCallsite : renderHtmlWithoutStack(err);
     }
 
     const originErrorText = originErrTemplate ? originErrTemplate(err.originError, viewportWidth) : originErrMessage +
@@ -37,4 +30,3 @@ export default function renderErrorTemplate (err, viewportWidth) {
 
     return markup(err, TEMPLATES[err.code](err, viewportWidth));
 }
-

--- a/src/errors/test-run/render-error-template/utils.ts
+++ b/src/errors/test-run/render-error-template/utils.ts
@@ -1,0 +1,15 @@
+import { renderers } from 'callsite-record';
+import { UncaughtTestCafeErrorInCustomScript } from '../../test-run';
+import { shouldSkipCallsite } from '../utils';
+import TEMPLATES from '../templates';
+
+export function renderHtmlWithoutStack (err: UncaughtTestCafeErrorInCustomScript): string {
+    return err.errCallsite._renderRecord(err.expression, {
+        renderer: renderers.html,
+        stack:    false,
+    });
+}
+
+export function shouldRenderHtmlWithoutStack (err: UncaughtTestCafeErrorInCustomScript): boolean {
+    return 'errCallsite' in err && TEMPLATES[err.originError.code] && !shouldSkipCallsite(err.originError);
+}

--- a/src/reporter/command/command-formatter.ts
+++ b/src/reporter/command/command-formatter.ts
@@ -21,6 +21,8 @@ import {
 } from '../../test-run/commands/options';
 
 import CommandBase from '../../test-run/commands/base';
+import CommandType from '../../test-run/commands/type';
+import AssertionCommand from '../../test-run/commands/assertion';
 
 
 const CONFIDENTIAL_INFO_PLACEHOLDER = '********';
@@ -126,11 +128,20 @@ export class CommandFormatter {
         return command.url;
     }
 
+    private _filterNotReportedProperties (properties: string[], commandType: string): string[] {
+        if (commandType !== CommandType.assertion)
+            return properties;
+
+        return properties.filter(prop => !AssertionCommand.NOT_REPORTED_PROPERTIES.includes(prop));
+    }
+
     private _assignProperties (command: CommandBase, formattedCommand: FormattedCommand): void {
         if (!this._command._getAssignableProperties)
             return;
 
-        const sourceProperties = this._command._getAssignableProperties().map(prop => prop.name);
+        let sourceProperties = this._command._getAssignableProperties().map(prop => prop.name);
+
+        sourceProperties = this._filterNotReportedProperties(sourceProperties, this._command.type);
 
         sourceProperties.forEach((key: string) => {
             const property = this._command[key];

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -8,7 +8,6 @@ import { writable as isWritableStream } from 'is-stream';
 import ReporterPluginHost from './plugin-host';
 import ReporterPluginMethod from './plugin-methods';
 import formatCommand from './command/format-command';
-import getBrowser from '../utils/get-browser';
 import { ReporterPluginError } from '../errors/runtime';
 import Task from '../runner/task';
 import { Writable } from 'stream';
@@ -268,7 +267,7 @@ export default class Reporter {
                 id:   testRun.test.fixture.id,
             },
             command: formatCommand(command, result),
-            browser: getBrowser(testRun.browserConnection),
+            browser: testRun.browser,
         });
     }
 
@@ -358,7 +357,7 @@ export default class Reporter {
         reportItem.errs        = reportItem.errs.concat(testRun.errs);
         reportItem.warnings    = testRun.warningLog ? union(reportItem.warnings, testRun.warningLog.messages) : [];
 
-        reportItem.browsers.push(Object.assign({ testRunId: testRun.id }, getBrowser(testRun.browserConnection)));
+        reportItem.browsers.push(Object.assign({ testRunId: testRun.id }, testRun.browser));
 
         if (!reportItem.pendingRuns)
             await this._resolveReportItem(reportItem, testRun);

--- a/src/services/compiler/interfaces.ts
+++ b/src/services/compiler/interfaces.ts
@@ -29,6 +29,7 @@ export interface ExecuteActionArguments {
 export interface ExecuteCommandArguments {
     id: string;
     command: CommandBase;
+    callsite?: string;
 }
 
 export interface RemoveRequestEventListenersArguments {
@@ -93,10 +94,7 @@ export interface ExecuteMockPredicate extends RequestFilterRuleLocator {
 
 export interface InitializeTestRunDataArguments extends TestRunLocator {
     testId: string;
-}
-
-export interface GetAssertionActualValueArguments extends TestRunLocator {
-    commandId: string;
+    browser: Browser;
 }
 
 export interface RoleLocator {
@@ -115,3 +113,22 @@ export interface UpdateRolePropertyArguments extends RoleLocator {
     name: keyof Role;
     value: unknown;
 }
+
+export interface ExecuteJsExpressionOptions {
+    skipVisibilityCheck: boolean;
+}
+
+export interface ExecuteJsExpressionArguments extends TestRunLocator {
+    expression: string;
+    options: ExecuteJsExpressionOptions;
+}
+
+export interface ExecuteAsyncJsExpressionArguments extends TestRunLocator {
+    expression: string;
+    callsite?: string;
+}
+
+export interface CommandLocator extends TestRunLocator {
+    commandId: string;
+}
+

--- a/src/services/compiler/protocol.ts
+++ b/src/services/compiler/protocol.ts
@@ -9,7 +9,6 @@ import {
     ExecuteMockPredicate,
     ExecuteRequestFilterRulePredicateArguments,
     ExecuteRoleInitFnArguments,
-    GetAssertionActualValueArguments,
     InitializeTestRunDataArguments,
     RemoveHeaderOnConfigureResponseEventArguments,
     RemoveRequestEventListenersArguments,
@@ -21,6 +20,9 @@ import {
     SetOptionsArguments,
     TestRunLocator,
     UpdateRolePropertyArguments,
+    ExecuteJsExpressionArguments,
+    ExecuteAsyncJsExpressionArguments,
+    CommandLocator,
 } from './interfaces';
 
 export const BEFORE_AFTER_PROPERTIES      = ['beforeFn', 'afterFn'] as const;
@@ -50,10 +52,10 @@ export interface RunTestArguments extends TestRunLocator {
 export interface TestRunDispatcherProtocol {
     executeActionSync ({ id, apiMethodName, command, callsite }: ExecuteActionArguments): unknown;
     executeAction ({ id, apiMethodName, command, callsite }: ExecuteActionArguments): Promise<unknown>;
-    executeCommand ({ command }: ExecuteCommandArguments): Promise<unknown>;
+    executeCommand ({ command, callsite }: ExecuteCommandArguments): Promise<unknown>;
     addRequestEventListeners ( { hookId, hookClassName, rules }: AddRequestEventListenersArguments): Promise<void>;
     removeRequestEventListeners ({ rules }: RemoveRequestEventListenersArguments): Promise<void>;
-    getAssertionActualValue ({ testRunId, commandId }: GetAssertionActualValueArguments): Promise<unknown>;
+    getAssertionActualValue ({ testRunId, commandId }: CommandLocator): Promise<unknown>;
     executeRoleInitFn ({ testRunId, roleId }: ExecuteRoleInitFnArguments): Promise<unknown>;
     onRoleAppeared (role: Role): void;
 }
@@ -78,4 +80,7 @@ export interface CompilerProtocol extends TestRunDispatcherProtocol {
     setCtx ({ testRunId, value }: SetCtxArguments): Promise<void>;
     setFixtureCtx ({ testRunId, value }: SetCtxArguments): Promise<void>;
     updateRoleProperty ({ roleId, name, value }: UpdateRolePropertyArguments): Promise<void>;
+    executeJsExpression ({ expression, testRunId, options }: ExecuteJsExpressionArguments): Promise<unknown>;
+    executeAsyncJsExpression ({ expression, testRunId, callsite }: ExecuteAsyncJsExpressionArguments): Promise<unknown>;
+    executeAssertionFn ({ testRunId, commandId }: CommandLocator): Promise<unknown>;
 }

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -7,4 +7,6 @@ export interface TestRunProxyInit {
     id: string;
     test: Test;
     options: Dictionary<OptionValue>;
+    browser: Browser;
 }
+

--- a/src/services/serialization/replicator/create-replicator.ts
+++ b/src/services/serialization/replicator/create-replicator.ts
@@ -7,6 +7,10 @@ import ResponseMockTransform from './transforms/response-mock-transform';
 import RequestHookEventDataTransform from './transforms/request-hook-event-data-transform';
 import ReExecutablePromiseTransform from './transforms/re-executable-promise-transform';
 import RoleTransform from './transforms/role-transform';
+import CallsiteRecordTransform from './transforms/callsite-record-transform';
+import TestCafeErrorListTransform from './transforms/testcafe-error-list-transform';
+import FunctionMarkerTransform from './transforms/function-marker-transform';
+import PromiseMarkerTransform from './transforms/promise-marker-transform';
 
 const DEFAULT_ERROR_TRANSFORM_TYPE = '[[Error]]';
 
@@ -29,12 +33,16 @@ export default function (): Replicator {
         .addTransforms([
             customErrorTransform,
             defaultErrorTransform,
+            new TestCafeErrorListTransform(),
             new BrowserConsoleMessagesTransform(),
             new ReExecutablePromiseTransform(),
+            new FunctionMarkerTransform(),
+            new PromiseMarkerTransform(),
             new CommandBaseTransform(),
             new RequestFilterRuleTransform(),
             new ResponseMockTransform(),
             new RequestHookEventDataTransform(),
             new RoleTransform(),
+            new CallsiteRecordTransform(),
         ]);
 }

--- a/src/services/serialization/replicator/transforms/base-transform.ts
+++ b/src/services/serialization/replicator/transforms/base-transform.ts
@@ -8,4 +8,8 @@ export default abstract class BaseTransform {
     public toSerializable (value: unknown): unknown {
         return Object.assign({}, value);
     }
+
+    public fromSerializable (val: unknown): unknown {
+        return val;
+    }
 }

--- a/src/services/serialization/replicator/transforms/callsite-record-transform.ts
+++ b/src/services/serialization/replicator/transforms/callsite-record-transform.ts
@@ -1,0 +1,26 @@
+import { CallsiteRecord } from 'callsite-record';
+import prerenderCallsite, { RenderedCallsite } from '../../../../utils/prerender-callsite';
+import BaseTransform from './base-transform';
+import { ERROR_FILENAME } from '../../../../test-run/execute-js-expression/constants';
+
+interface CallsiteRecordLike {
+    filename: string;
+}
+
+const CALLSITE_RECORD_CLASS_NAME = 'CallsiteRecord';
+
+export default class CallsiteRecordTransform extends BaseTransform {
+    public constructor () {
+        super(CALLSITE_RECORD_CLASS_NAME);
+    }
+
+    public shouldTransform (_: unknown, val: CallsiteRecordLike): boolean {
+        return !!val &&
+            (!!val.constructor && val.constructor.name === CALLSITE_RECORD_CLASS_NAME) &&
+            (!!val.filename && val.filename !== ERROR_FILENAME); // Don't serialize callsites for RAW API)
+    }
+
+    public toSerializable (callsite: CallsiteRecord): RenderedCallsite {
+        return prerenderCallsite(callsite);
+    }
+}

--- a/src/services/serialization/replicator/transforms/command-base-trasform/command-constructors.ts
+++ b/src/services/serialization/replicator/transforms/command-base-trasform/command-constructors.ts
@@ -7,12 +7,25 @@ import {
 } from '../../../../../test-run/commands/observation';
 
 import {
+    ClearUploadCommand,
     ClickCommand,
+    DispatchEventCommand,
+    DoubleClickCommand,
+    DragCommand,
     DragToElementCommand,
+    ExecuteAsyncExpressionCommand,
+    ExecuteExpressionCommand,
     HoverCommand,
     NavigateToCommand,
     PressKeyCommand,
+    RightClickCommand,
+    ScrollByCommand,
+    ScrollCommand,
+    ScrollIntoViewCommand,
     SelectEditableContentCommand,
+    SelectTextAreaContentCommand,
+    SelectTextCommand,
+    SetFilesToUploadCommand,
     SetNativeDialogHandlerCommand,
     SetPageLoadTimeoutCommand,
     SetTestSpeedCommand,
@@ -24,12 +37,20 @@ import {
 import AssertionCommand from '../../../../../test-run/commands/assertion';
 import { CommandConstructor } from './types';
 
+import {
+    ResizeWindowCommand,
+    ResizeWindowToFitDeviceCommand,
+    TakeElementScreenshotCommand,
+    TakeScreenshotCommand,
+} from '../../../../../test-run/commands/browser-manipulation';
+
 
 const COMMAND_CONSTRUCTORS = new Map<string, CommandConstructor>([
     [CommandType.executeSelector, ExecuteSelectorCommand],
     [CommandType.executeClientFunction, ExecuteClientFunctionCommand],
     [CommandType.wait, WaitCommand],
     [CommandType.click, ClickCommand],
+    [CommandType.doubleClick, DoubleClickCommand],
     [CommandType.navigateTo, NavigateToCommand],
     [CommandType.typeText, TypeTextCommand],
     [CommandType.setNativeDialogHandler, SetNativeDialogHandlerCommand],
@@ -42,6 +63,22 @@ const COMMAND_CONSTRUCTORS = new Map<string, CommandConstructor>([
     [CommandType.hover, HoverCommand],
     [CommandType.assertion, AssertionCommand],
     [CommandType.useRole, UseRoleCommand],
+    [CommandType.executeExpression, ExecuteExpressionCommand],
+    [CommandType.executeAsyncExpression, ExecuteAsyncExpressionCommand],
+    [CommandType.drag, DragCommand],
+    [CommandType.rightClick, RightClickCommand],
+    [CommandType.selectText, SelectTextCommand],
+    [CommandType.selectTextAreaContent, SelectTextAreaContentCommand],
+    [CommandType.setFilesToUpload, SetFilesToUploadCommand],
+    [CommandType.clearUpload, ClearUploadCommand],
+    [CommandType.takeScreenshot, TakeScreenshotCommand],
+    [CommandType.takeElementScreenshot, TakeElementScreenshotCommand],
+    [CommandType.resizeWindow, ResizeWindowCommand],
+    [CommandType.resizeWindowToFitDevice, ResizeWindowToFitDeviceCommand],
+    [CommandType.dispatchEvent, DispatchEventCommand],
+    [CommandType.scroll, ScrollCommand],
+    [CommandType.scrollBy, ScrollByCommand],
+    [CommandType.scrollIntoView, ScrollIntoViewCommand],
 ]);
 
 export default COMMAND_CONSTRUCTORS;

--- a/src/services/serialization/replicator/transforms/custom-error-transform.ts
+++ b/src/services/serialization/replicator/transforms/custom-error-transform.ts
@@ -1,8 +1,8 @@
-export default class CustomErrorTransform {
-    public readonly type: string;
+import BaseTransform from './base-transform';
 
+export default class CustomErrorTransform extends BaseTransform {
     public constructor () {
-        this.type = 'CustomError';
+        super('CustomError');
     }
 
     private _isBuiltInError (type: string): boolean {
@@ -23,9 +23,5 @@ export default class CustomErrorTransform {
         errorData.stack   = errorData.stack || err.stack;
 
         return errorData;
-    }
-
-    public fromSerializable (val: unknown): unknown {
-        return val;
     }
 }

--- a/src/services/serialization/replicator/transforms/function-marker-transform/index.ts
+++ b/src/services/serialization/replicator/transforms/function-marker-transform/index.ts
@@ -1,0 +1,16 @@
+import BaseTransform from '../base-transform';
+import { FunctionMarker, functionMarkerSymbol } from './marker';
+
+export default class FunctionMarkerTransform extends BaseTransform {
+    public constructor () {
+        super('FunctionMarker');
+    }
+
+    public shouldTransform (_: unknown, val: unknown): boolean {
+        return val instanceof FunctionMarker;
+    }
+
+    public fromSerializable (): unknown {
+        return functionMarkerSymbol;
+    }
+}

--- a/src/services/serialization/replicator/transforms/function-marker-transform/marker.ts
+++ b/src/services/serialization/replicator/transforms/function-marker-transform/marker.ts
@@ -1,0 +1,5 @@
+export const FUNCTION_MARKER_DESCRIPTION = 'function-marker';
+
+export const functionMarkerSymbol = Symbol.for(FUNCTION_MARKER_DESCRIPTION);
+
+export class FunctionMarker {}

--- a/src/services/serialization/replicator/transforms/promise-marker-transform/index.ts
+++ b/src/services/serialization/replicator/transforms/promise-marker-transform/index.ts
@@ -1,0 +1,16 @@
+import BaseTransform from '../base-transform';
+import { PromiseMarker, promiseMarkerSymbol } from './marker';
+
+export default class PromiseMarkerTransform extends BaseTransform {
+    public constructor () {
+        super('PromiseMarker');
+    }
+
+    public shouldTransform (_: unknown, val: unknown): boolean {
+        return val instanceof PromiseMarker;
+    }
+
+    public fromSerializable (): unknown {
+        return promiseMarkerSymbol;
+    }
+}

--- a/src/services/serialization/replicator/transforms/promise-marker-transform/marker.ts
+++ b/src/services/serialization/replicator/transforms/promise-marker-transform/marker.ts
@@ -1,0 +1,5 @@
+export const PROMISE_MARKER_DESCRIPTION = 'promise-marker';
+
+export const promiseMarkerSymbol = Symbol.for(PROMISE_MARKER_DESCRIPTION);
+
+export class PromiseMarker {}

--- a/src/services/serialization/replicator/transforms/re-executable-promise-transform/index.ts
+++ b/src/services/serialization/replicator/transforms/re-executable-promise-transform/index.ts
@@ -1,6 +1,6 @@
 import BaseTransform from '../base-transform';
 import ReExecutablePromise from '../../../../../utils/re-executable-promise';
-import { reExecutablePromiseMarker } from './marker';
+import { reExecutablePromiseMarkerSymbol } from './marker';
 
 export default class ReExecutablePromiseTransform extends BaseTransform {
     public constructor () {
@@ -12,6 +12,6 @@ export default class ReExecutablePromiseTransform extends BaseTransform {
     }
 
     public fromSerializable (): unknown {
-        return reExecutablePromiseMarker;
+        return reExecutablePromiseMarkerSymbol;
     }
 }

--- a/src/services/serialization/replicator/transforms/re-executable-promise-transform/marker.ts
+++ b/src/services/serialization/replicator/transforms/re-executable-promise-transform/marker.ts
@@ -1,4 +1,4 @@
 export const RE_EXECUTABLE_PROMISE_MARKER_DESCRIPTION = 're-executable-promise-marker';
 
-export const reExecutablePromiseMarker = Symbol.for(RE_EXECUTABLE_PROMISE_MARKER_DESCRIPTION);
+export const reExecutablePromiseMarkerSymbol = Symbol.for(RE_EXECUTABLE_PROMISE_MARKER_DESCRIPTION);
 

--- a/src/services/serialization/replicator/transforms/testcafe-error-list-transform.ts
+++ b/src/services/serialization/replicator/transforms/testcafe-error-list-transform.ts
@@ -1,0 +1,24 @@
+import BaseTransform from './base-transform';
+import TestCafeErrorList from '../../../../errors/error-list';
+
+interface SerializedTestCafeErrorList {
+    items: unknown[];
+}
+
+export default class TestCafeErrorListTransform extends BaseTransform {
+    public constructor () {
+        super('TestCafeErrorList');
+    }
+
+    public shouldTransform (_: unknown, val: unknown): boolean {
+        return val instanceof TestCafeErrorList;
+    }
+
+    public fromSerializable (value: SerializedTestCafeErrorList): TestCafeErrorList {
+        const errorList = new TestCafeErrorList();
+
+        errorList.items = value.items;
+
+        return errorList;
+    }
+}

--- a/src/test-run/commands/actions.d.ts
+++ b/src/test-run/commands/actions.d.ts
@@ -81,11 +81,39 @@ export class ClickCommand extends CommandBase {
     public options: ClickOptions;
 }
 
+export class RightClickCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public selector: ExecuteClientFunctionCommand;
+    public options: ClickOptions;
+}
+
+export class DoubleClickCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public selector: ExecuteClientFunctionCommand;
+    public options: ClickOptions;
+}
+
+export class DragCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public selector: ExecuteClientFunctionCommand;
+    public dragOffsetX: number;
+    public dragOffsetY: number;
+    public options: DragToElementOptions;
+}
+
 export class DragToElementCommand extends CommandBase {
     public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
     public selector: ExecuteClientFunctionCommand;
     public destinationSelector: ExecuteClientFunctionCommand;
     public options: DragToElementOptions;
+}
+
+export class SelectTextCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public selector: ExecuteClientFunctionCommand;
+    public startPos: number;
+    public endPos: number;
+    public options: ActionOptions;
 }
 
 export class SelectEditableContentCommand extends CommandBase {
@@ -95,8 +123,71 @@ export class SelectEditableContentCommand extends CommandBase {
     public options: ActionOptions;
 }
 
+export class SelectTextAreaContentCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public selector: ExecuteClientFunctionCommand;
+    public startLine: number;
+    public startPos: number;
+    public endLine: number;
+    public endPos: number;
+    public options: ActionOptions;
+}
+
 export class HoverCommand extends CommandBase {
     public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
     public selector: ExecuteClientFunctionCommand;
     public options: MouseOptions;
+}
+
+export class ExecuteExpressionCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public expression: string;
+    public resultVariableName: string;
+}
+
+export class ExecuteAsyncExpressionCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public expression: string;
+}
+
+export class SetFilesToUploadCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public selector: ExecuteClientFunctionCommand;
+    public filePath: string | string[];
+}
+
+export class ClearUploadCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public selector: ExecuteClientFunctionCommand;
+}
+
+export class DispatchEventCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public selector: ExecuteClientFunctionCommand;
+    public eventName: string;
+    public options: ActionOptions;
+    public relatedTarget: ExecuteClientFunctionCommand;
+}
+
+export class ScrollCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public selector: ExecuteClientFunctionCommand;
+    public position: string;
+    public x: number;
+    public y: number;
+    public options: ActionOptions;
+}
+
+export class ScrollByCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public selector: ExecuteClientFunctionCommand;
+    public byX: number;
+    public byY: number;
+    public options: ActionOptions;
+}
+
+export class ScrollIntoViewCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public selector: ExecuteClientFunctionCommand;
+    public options: ActionOptions;
 }

--- a/src/test-run/commands/assertion.d.ts
+++ b/src/test-run/commands/assertion.d.ts
@@ -6,9 +6,11 @@ export default class AssertionCommand extends CommandBase {
     public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
     public id: string;
     public assertionType: string;
+    public originActual: unknown;
     public actual: unknown;
     public expected: unknown;
     public expected2: unknown;
     public message: string;
     public options: AssertionOptions;
+    public static NOT_REPORTED_PROPERTIES: string[];
 }

--- a/src/test-run/commands/assertion.js
+++ b/src/test-run/commands/assertion.js
@@ -5,11 +5,13 @@ import { APIError } from '../../errors/runtime';
 import { AssertionExecutableArgumentError } from '../../errors/test-run';
 import { executeJsExpression } from '../execute-js-expression';
 import { isJSExpression } from './utils';
+
 import {
     stringArgument,
     actionOptions,
     nonEmptyStringArgument,
 } from './validations/argument';
+
 
 // Initializers
 function initAssertionOptions (name, val) {
@@ -29,6 +31,8 @@ function initAssertionParameter (name, val, { skipVisibilityCheck, testRun }) {
     }
 }
 
+const NOT_REPORTED_PROPERTIES = ['id', 'originActual'];
+
 // Commands
 export default class AssertionCommand extends CommandBase {
     constructor (obj, testRun, validateProperties) {
@@ -39,11 +43,16 @@ export default class AssertionCommand extends CommandBase {
         return [
             { name: 'id', type: nonEmptyStringArgument, required: false },
             { name: 'assertionType', type: nonEmptyStringArgument, required: true },
+            { name: 'originActual', defaultValue: void 0 },
             { name: 'actual', init: initAssertionParameter, defaultValue: void 0 },
             { name: 'expected', init: initAssertionParameter, defaultValue: void 0 },
             { name: 'expected2', init: initAssertionParameter, defaultValue: void 0 },
             { name: 'message', type: stringArgument, defaultValue: null },
             { name: 'options', type: actionOptions, init: initAssertionOptions, required: true },
         ];
+    }
+
+    static get NOT_REPORTED_PROPERTIES () {
+        return NOT_REPORTED_PROPERTIES;
     }
 }

--- a/src/test-run/commands/browser-manipulation.js
+++ b/src/test-run/commands/browser-manipulation.js
@@ -13,18 +13,18 @@ import {
 
 import { generateScreenshotMark } from '../../screenshots/utils';
 
-function initResizeToFitDeviceOptions (name, val) {
-    return new ResizeToFitDeviceOptions(val, true);
+function initResizeToFitDeviceOptions (name, val, initOptions, validate = true) {
+    return new ResizeToFitDeviceOptions(val, validate);
 }
 
-function initElementScreenshotOptions (name, val) {
-    return new ElementScreenshotOptions(val, true);
+function initElementScreenshotOptions (name, val, initOptions, validate = true) {
+    return new ElementScreenshotOptions(val, validate);
 }
 
 // Commands
 export class TakeScreenshotBaseCommand extends CommandBase {
-    constructor (obj, testRun, type) {
-        super(obj, testRun, type);
+    constructor (obj, testRun, type, validateProperties) {
+        super(obj, testRun, type, validateProperties);
 
         this.markSeed = null;
         this.markData = '';
@@ -49,8 +49,8 @@ export class TakeScreenshotCommand extends TakeScreenshotBaseCommand {
 }
 
 export class TakeElementScreenshotCommand extends TakeScreenshotBaseCommand {
-    constructor (obj, testRun) {
-        super(obj, testRun, TYPE.takeElementScreenshot);
+    constructor (obj, testRun, validateProperties) {
+        super(obj, testRun, TYPE.takeElementScreenshot, validateProperties);
     }
 
     _getAssignableProperties () {
@@ -88,8 +88,8 @@ export class ResizeWindowCommand extends CommandBase {
 }
 
 export class ResizeWindowToFitDeviceCommand extends CommandBase {
-    constructor (obj, testRun) {
-        super(obj, testRun, TYPE.resizeWindowToFitDevice);
+    constructor (obj, testRun, validateProperties) {
+        super(obj, testRun, TYPE.resizeWindowToFitDevice, validateProperties);
     }
 
     _getAssignableProperties () {

--- a/src/test-run/commands/options.d.ts
+++ b/src/test-run/commands/options.d.ts
@@ -48,9 +48,19 @@ export class AssertionOptions {
 }
 
 export class ResizeToFitDeviceOptions {
+    public constructor (obj: object, validate: boolean);
     public portraitOrientation: boolean;
 }
 
 export class PressOptions extends ActionOptions {
     public confidential: boolean;
+}
+
+export class ElementScreenshotOptions extends ActionOptions {
+    public scrollTargetX: number;
+    public scrollTargetY: number;
+    public includeMargins: number;
+    public includeBorders: number;
+    public includePaddings: number;
+    public crop: CropOptions;
 }

--- a/src/test-run/execute-js-expression/constants.ts
+++ b/src/test-run/execute-js-expression/constants.ts
@@ -1,0 +1,9 @@
+const ERROR_LINE_COLUMN_REGEXP = /\[JS code\]:(\d+):(\d+)/;
+const ERROR_LINE_OFFSET        = -1;
+const ERROR_FILENAME           = '[JS code]';
+
+export {
+    ERROR_LINE_COLUMN_REGEXP,
+    ERROR_LINE_OFFSET,
+    ERROR_FILENAME,
+};

--- a/src/testcafe.js
+++ b/src/testcafe.js
@@ -32,7 +32,7 @@ export default class TestCafe {
         this.runners                  = [];
         this.configuration            = configuration;
 
-        this.compilerService = configuration.getOption(OPTION_NAMES.experimentalCompilerService) ? new CompilerHost() : void 0;
+        this.compilerService = configuration.getOption(OPTION_NAMES.experimentalCompilerService) ? new CompilerHost(options) : void 0;
 
         this._registerAssets(options.developmentMode);
     }

--- a/test/functional/fixtures/api/es-next/dispatch-event/test.js
+++ b/test/functional/fixtures/api/es-next/dispatch-event/test.js
@@ -23,8 +23,8 @@ describe('[API] t.dispatchEvent()', function () {
         return runTests('testcafe-fixtures/index.js', 'defaults', { skip: ['ie', 'iphone'] });
     });
 
-    it('predifined ctor', function () {
-        return runTests('testcafe-fixtures/index.js', 'predifined ctor', { skip: 'ie' });
+    it('predefined ctor', function () {
+        return runTests('testcafe-fixtures/index.js', 'predefined ctor', { skip: 'ie' });
     });
 
     it('custom event', function () {

--- a/test/functional/fixtures/api/es-next/dispatch-event/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/api/es-next/dispatch-event/testcafe-fixtures/index.js
@@ -225,7 +225,7 @@ test('defaults', async t => {
     await t.expect(log[1].buttons).eql(2);
 });
 
-test('predifined ctor', async t => {
+test('predefined ctor', async t => {
     await t.dispatchEvent(btn, 'customEvent', { eventConstructor: 'MouseEvent' });
 
     await t.expect(getMouseLog()).eql([{ isMouseEvent: true, isCustomEvent: false, detail: 0, type: 'customEvent' }]);

--- a/test/functional/fixtures/reporter/reporter.js
+++ b/test/functional/fixtures/reporter/reporter.js
@@ -61,11 +61,6 @@ function generateReporter (log, options = {}) {
 
                 const item = { name, action: 'done', command };
 
-                // NOTE: The 'id' property has a different value for each command
-                // and it's unable to use it for comparison.
-                // This is why we remove it.
-                delete item.command.id;
-
                 if (err)
                     item.err = err.code;
 

--- a/test/functional/site/server.js
+++ b/test/functional/site/server.js
@@ -2,10 +2,10 @@ const express               = require('express');
 const http                  = require('http');
 const path                  = require('path');
 const bodyParser            = require('body-parser');
-const readSync              = require('read-file-relative').readSync;
+const { readSync }          = require('read-file-relative');
 const multer                = require('multer');
 const Mustache              = require('mustache');
-const readFile              = require('../../../lib/utils/promisified-functions').readFile;
+const { readFile }          = require('../../../lib/utils/promisified-functions');
 const quarantineModeTracker = require('../quarantine-mode-tracker');
 const parseUserAgent        = require('../../../lib/utils/parse-user-agent');
 

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -3,7 +3,7 @@ const fs                  = require('fs');
 const os                  = require('os');
 const path                = require('path');
 const { promisify }       = require('util');
-const expect              = require('chai').expect;
+const { expect }          = require('chai');
 const proxyquire          = require('proxyquire');
 const sinon               = require('sinon');
 const globby              = require('globby');
@@ -17,6 +17,7 @@ const { assertError }     = require('./helpers/assert-runtime-error');
 const compile             = require('./helpers/compile');
 const Module              = require('module');
 const toPosixPath         = require('../../lib/utils/to-posix-path');
+const BaseTestRunMock     = require('./helpers/base-test-run-mock');
 
 const copy      = promisify(fs.copyFile);
 const remove    = promisify(fs.unlink);
@@ -24,21 +25,7 @@ const writeFile = promisify(fs.writeFile);
 
 require('source-map-support').install();
 
-const SessionControllerStub = { getSession: () => {
-    return { id: nanoid(7) };
-} };
-
-const TestRun = proxyquire('../../lib/test-run/index', { './session-controller': SessionControllerStub });
-
-class TestRunMock extends TestRun {
-    _addInjectables () {}
-
-    _initRequestHooks () {}
-
-    get id () {
-        return 'id';
-    }
-
+class TestRunMock extends BaseTestRunMock {
     executeCommand (command) {
         this.commands.push(command);
 
@@ -46,13 +33,7 @@ class TestRunMock extends TestRun {
     }
 
     constructor (expectedError) {
-        super({
-            test:               {},
-            browserConnection:  {},
-            screenshotCapturer: {},
-            globalWarningLog:   {},
-            opts:               {},
-        });
+        super();
 
         this.expectedError = expectedError;
         this.commands = [];

--- a/test/server/execute-async-expression-test.js
+++ b/test/server/execute-async-expression-test.js
@@ -1,38 +1,19 @@
-const proxyquire = require('proxyquire');
-const { noop }   = require('lodash');
-const nanoid     = require('nanoid');
-const expect     = require('chai').expect;
-
-const SessionControllerStub = { getSession: () => {
-    return { id: nanoid(7) };
-} };
-
-const TestRun        = proxyquire('../../lib/test-run/index', { './session-controller': SessionControllerStub });
-const TestController = require('../../lib/api/test-controller');
-const COMMAND_TYPE   = require('../../lib/test-run/commands/type');
-const markerSymbol   = require('../../lib/test-run/marker-symbol');
-
+const { noop }                   = require('lodash');
+const proxyquire                 = require('proxyquire');
+const { expect }                 = require('chai');
+const TestController             = require('../../lib/api/test-controller');
+const COMMAND_TYPE               = require('../../lib/test-run/commands/type');
+const markerSymbol               = require('../../lib/test-run/marker-symbol');
 const assertTestRunError         = require('./helpers/assert-test-run-error');
 const { createSimpleTestStream } = require('../functional/utils/stream');
+const BaseTestRunMock            = require('./helpers/base-test-run-mock');
 
 let callsite = 0;
 
-class TestRunMock extends TestRun {
-    _addInjectables () {}
-
-    _initRequestHooks () {}
-
-    get id () {
-        return 'test-run-id';
-    }
-
+class TestRunMock extends BaseTestRunMock {
     constructor () {
         super({
-            test:               { name: 'Test', testFile: { filename: __filename } },
-            browserConnection:  {},
-            screenshotCapturer: {},
-            globalWarningLog:   {},
-            opts:               {},
+            test: { name: 'Test', testFile: { filename: __filename } },
         });
 
         this.debugLog        = { command: noop };
@@ -54,8 +35,7 @@ class TestRunMock extends TestRun {
             isHeadlessBrowser: () => false,
             userAgent:         'Chrome',
             provider:          {
-                hasCustomActionForBrowser () {
-                },
+                hasCustomActionForBrowser () { },
             },
         };
     }

--- a/test/server/helpers/base-test-run-mock.js
+++ b/test/server/helpers/base-test-run-mock.js
@@ -1,0 +1,45 @@
+const proxyquire = require('proxyquire');
+
+const SessionControllerStub = {
+    getSession: () => {
+        return { id: 'sessionId' };
+    },
+};
+
+const getBrowserStub = () => {
+    return {
+        parsedUserAgent: {},
+        alias:           'browser-mock',
+        headless:        false,
+    };
+};
+
+const TestRun = proxyquire('../../../lib/test-run/index', {
+    './session-controller': SessionControllerStub,
+    '../utils/get-browser': getBrowserStub,
+});
+
+class BaseTestRunMock extends TestRun {
+    constructor (init = {}) {
+        init = Object.assign({
+            test:               {},
+            browserConnection:  {},
+            screenshotCapturer: {},
+            globalWarningLog:   {},
+            opts:               {},
+        }, init);
+
+        super(init);
+    }
+
+    _addInjectables () {}
+
+    _initRequestHooks () {}
+
+    get id () {
+        return 'id';
+    }
+}
+
+module.exports = BaseTestRunMock;
+

--- a/test/server/multiple-windows-test.js
+++ b/test/server/multiple-windows-test.js
@@ -1,23 +1,15 @@
-const expect              = require('chai').expect;
-const TestRun             = require('../../lib/test-run');
+const { expect }          = require('chai');
 const TestController      = require('../../lib/api/test-controller');
 const { TEST_RUN_ERRORS } = require('../../lib/errors/types');
+const BaseTestRunMock     = require('./helpers/base-test-run-mock');
 
-class TestRunMock extends TestRun {
+class TestRunMock extends BaseTestRunMock {
     constructor ({ activeWindowId = 'id', disableMultipleWindows = false, isLegacy = false } = {}) {
         super({
-            test:               { id: 'test-id', name: 'test-name', isLegacy: isLegacy, fixture: { path: 'dummy', id: 'fixture-id', name: 'fixture-name' } },
-            browserConnection:  { activeWindowId: activeWindowId },
-            screenshotCapturer: {},
-            globalWarningLog:   {},
-            opts:               { disableMultipleWindows: disableMultipleWindows },
+            test:              { id: 'test-id', name: 'test-name', isLegacy: isLegacy, fixture: { path: 'dummy', id: 'fixture-id', name: 'fixture-name' } },
+            browserConnection: { activeWindowId: activeWindowId },
+            opts:              { disableMultipleWindows: disableMultipleWindows },
         });
-    }
-
-    _addInjectables () {
-    }
-
-    _initRequestHooks () {
     }
 }
 
@@ -48,11 +40,5 @@ describe('Multiple windows', () => {
         catch (err) {
             expect(err.code).eql(TEST_RUN_ERRORS.multipleWindowsModeIsNotSupportedInRemoteBrowserError);
         }
-    });
-
-    it('`allowMultipleWindows` is passed to session', async () => {
-        expect(new TestRunMock().session.options.allowMultipleWindows).eql(true);
-        expect(new TestRunMock({ disableMultipleWindows: true }).session.options.allowMultipleWindows).eql(false);
-        expect(new TestRunMock({ activeWindowId: null }).session.options.allowMultipleWindows).eql(false);
     });
 });

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -9,28 +9,26 @@ const delay                           = require('../../lib/utils/delay');
 const { ReporterPluginError }         = require('../../lib/errors/runtime');
 const WarningLog                      = require('../../lib/notifications/warning-log');
 
-chai.use(require('chai-string'));
 
 describe('Reporter', () => {
     const screenshotDir = '/screenshots/1445437598847';
 
+    const browserMocks = [
+        {
+            alias:     'Chrome',
+            userAgent: 'Chrome',
+            headless:  false,
+        },
+        {
+            alias:     'Firefox',
+            userAgent: 'Firefox',
+            headless:  false,
+        },
+    ];
+
     const browserConnectionMocks = [
-        {
-            userAgent:   'Chrome',
-            browserInfo: {
-                alias:           'Chrome',
-                parsedUserAgent: { userAgent: 'Chrome' },
-            },
-            isHeadlessBrowser: () => false,
-        },
-        {
-            userAgent:   'Firefox',
-            browserInfo: {
-                alias:           'Firefox',
-                parsedUserAgent: { userAgent: 'Firefox' },
-            },
-            isHeadlessBrowser: () => false,
-        },
+        { userAgent: 'Chrome' },
+        { userAgent: 'Firefox' },
     ];
 
     const fixtureMocks = [
@@ -185,6 +183,7 @@ describe('Reporter', () => {
             quarantine:        {
                 attempts: [['1', '2'], []],
             },
+            browser: browserMocks[0],
         },
 
         //fixture1test2
@@ -194,6 +193,7 @@ describe('Reporter', () => {
             unstable:          false,
             browserConnection: browserConnectionMocks[0],
             warningLog:        { messages: [] },
+            browser:           browserMocks[0],
 
             errs: [
                 { text: 'err1' },
@@ -209,6 +209,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: [] },
+            browser:           browserMocks[0],
         },
 
         //fixture2test1
@@ -219,6 +220,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: [] },
+            browser:           browserMocks[0],
         },
 
         //fixture2test2
@@ -229,6 +231,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: [] },
+            browser:           browserMocks[0],
         },
 
         //fixture3test1
@@ -239,6 +242,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: [] },
+            browser:           browserMocks[0],
         },
 
         //fixture3test2
@@ -249,6 +253,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: [] },
+            browser:           browserMocks[0],
         },
 
         //fixture3test3
@@ -259,6 +264,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: ['warning2'] },
+            browser:           browserMocks[0],
         },
     ];
 
@@ -274,6 +280,7 @@ describe('Reporter', () => {
             quarantine:        {
                 attempts: [['1', '2'], []],
             },
+            browser: browserMocks[1],
         },
 
         // 'fixture1test2
@@ -284,6 +291,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [{ text: 'err1' }],
             warningLog:        { messages: [] },
+            browser:           browserMocks[1],
         },
 
         //fixture1test3
@@ -294,6 +302,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [],
             warningLog:        { messages: [] },
+            browser:           browserMocks[1],
         },
 
         //fixture2test1
@@ -304,6 +313,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [],
             warningLog:        { messages: [] },
+            browser:           browserMocks[1],
         },
 
         //fixture2test2
@@ -314,6 +324,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [],
             warningLog:        { messages: [] },
+            browser:           browserMocks[1],
         },
 
         //fixture3test1
@@ -324,6 +335,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [{ text: 'err1' }],
             warningLog:        { messages: ['warning1'] },
+            browser:           browserMocks[1],
         },
 
         //fixture3test2
@@ -334,6 +346,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [],
             warningLog:        { messages: [] },
+            browser:           browserMocks[1],
         },
 
         //fixture3test3
@@ -344,6 +357,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [],
             warningLog:        { messages: ['warning2', 'warning3'] },
+            browser:           browserMocks[1],
         },
     ];
 

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -22,7 +22,6 @@ const BrowserConnectionStatus = require('../../lib/browser/connection/status');
 const { noop }                = require('lodash');
 const Test                    = require('../../lib/api/structure/test');
 
-chai.use(require('chai-string'));
 
 describe('Runner', () => {
     let testCafe                  = null;

--- a/test/server/test-controller-events-test.js
+++ b/test/server/test-controller-events-test.js
@@ -2,47 +2,36 @@ const { expect }                     = require('chai');
 const { noop }                       = require('lodash');
 const AsyncEventEmitter              = require('../../lib/utils/async-event-emitter');
 const delay                          = require('../../lib/utils/delay');
-const TestRun                        = require('../../lib/test-run');
 const TestController                 = require('../../lib/api/test-controller');
 const Task                           = require('../../lib/runner/task');
 const BrowserJob                     = require('../../lib/runner/browser-job');
 const Reporter                       = require('../../lib/reporter');
 const { Role }                       = require('../../lib/api/exportable-lib');
 const TestRunErrorFormattableAdapter = require('../../lib/errors/test-run/formattable-adapter');
+const BaseTestRunMock                = require('./helpers/base-test-run-mock');
 
-class TestRunMock extends TestRun {
+class TestRunMock extends BaseTestRunMock {
     constructor () {
         super({
-            test:               { id: 'test-id', name: 'test-name', fixture: { path: 'dummy', id: 'fixture-id', name: 'fixture-name' } },
-            browserConnection:  {},
-            screenshotCapturer: {},
-            globalWarningLog:   { addPlainMessage: noop },
-            opts:               {},
+            test:              { id: 'test-id', name: 'test-name', fixture: { path: 'dummy', id: 'fixture-id', name: 'fixture-name' } },
+            globalWarningLog:  { addPlainMessage: noop },
+            browserConnection: { activeWindowId: 'activeWindowId' },
         });
 
-        this.disableMultipleWindows = false;
-
-        this.browserConnection = {
-            browserInfo: {
-                alias: 'test-browser',
-            },
-            isHeadlessBrowser: () => false,
-            activeWindowId:    'id',
+        this.browser = {
+            alias:    'test-browser',
+            headless: false,
         };
-    }
 
-    _addInjectables () {
-    }
-
-    _initRequestHooks () {
-    }
-
-    get id () {
-        return 'test-run-id';
+        this.disableMultipleWindows = false;
     }
 
     executeCommand () {
         return delay(10);
+    }
+
+    get id () {
+        return 'test-run-id';
     }
 }
 

--- a/test/server/test-controller-test.js
+++ b/test/server/test-controller-test.js
@@ -1,29 +1,13 @@
-const proxyquire        = require('proxyquire');
-const expect            = require('chai').expect;
+const { expect }        = require('chai');
 const TestController    = require('../../lib/api/test-controller');
 const AssertionExecutor = require('../../lib/assertions/executor');
-
-const SessionControllerStub = { getSession: () => {
-    return { id: 'session-id' };
-} };
-
-const TestRun = proxyquire('../../lib/test-run/index', { './session-controller': SessionControllerStub });
+const BaseTestRunMock   = require('./helpers/base-test-run-mock');
 
 const errorMessage = 'some error in click command';
 
-class TestRunMock extends TestRun {
-    _addInjectables () {}
-
-    _initRequestHooks () {}
-
+class TestRunMock extends BaseTestRunMock {
     constructor (reason) {
-        super({
-            test:               {},
-            browserConnection:  {},
-            screenshotCapturer: {},
-            globalWarningLog:   {},
-            opts:               {},
-        });
+        super();
 
         this.errors = [];
         this.reason = reason;

--- a/test/server/test-run-driver-task-queue-test.js
+++ b/test/server/test-run-driver-task-queue-test.js
@@ -1,5 +1,4 @@
 const CLIENT_MESSAGES = require('../../lib/test-run/client-messages');
-const proxyquire      = require('proxyquire');
 const { expect }      = require('chai');
 
 const {
@@ -9,40 +8,16 @@ const {
 } = require('../../lib/test-run/commands/actions');
 
 const { WaitCommand } = require('../../lib/test-run/commands/observation');
+const BaseTestRunMock = require('./helpers/base-test-run-mock');
 
-const SessionControllerStub = {
-    getSession: () => {
-        return { id: 'sessionId' };
-    },
-};
 
-const ExecuteJSExpressionStub = {
-    executeAsyncJsExpression: () => 'async expression result',
-    executeJsExpression:      () => 'expression result',
-};
-
-const TestRun = proxyquire('../../lib/test-run/index', {
-    './session-controller':    SessionControllerStub,
-    './execute-js-expression': ExecuteJSExpressionStub,
-});
-
-class TestRunMock extends TestRun {
-    constructor () {
-        super({
-            test:               {},
-            browserConnection:  {},
-            screenshotCapturer: {},
-            globalWarningLog:   {},
-            opts:               {},
-        });
+class TestRunMock extends BaseTestRunMock {
+    _executeJsExpression () {
+        return 'expression result';
     }
 
-    _addInjectables () {}
-
-    _initRequestHooks () {}
-
-    get id () {
-        return 'id';
+    _executeAsyncJsExpression () {
+        return 'async expression result';
     }
 }
 

--- a/test/server/test-run-request-handler-test.js
+++ b/test/server/test-run-request-handler-test.js
@@ -1,24 +1,11 @@
-const TestRun = require('../../lib/test-run/index');
-const delay   = require('../../lib/utils/delay');
+const delay           = require('../../lib/utils/delay');
+const BaseTestRunMock = require('./helpers/base-test-run-mock');
 
 describe('Request handling', () => {
     it("Should abort request if it's longer than 3s", function () {
         this.timeout(4000);
 
-        const testMock = {
-            fixture:       { path: '' },
-            clientScripts: [],
-            requestHooks:  [],
-        };
-
-        const testRun = new TestRun({
-            test:               testMock,
-            browserConnection:  {},
-            screenshotCapturer: {},
-            globalWarningLog:   {},
-            opts:               {},
-        });
-
+        const testRun              = new BaseTestRunMock();
         const handleRequestPromise = testRun.ready({ status: { id: 1, consoleMessages: [] } });
 
         const timeoutPromise = delay(3500).then(() => {

--- a/test/server/test-run-tracker-test.js
+++ b/test/server/test-run-tracker-test.js
@@ -1,33 +1,8 @@
-const proxyquire = require('proxyquire');
-const expect     = require('chai').expect;
-const fill       = require('lodash/fill');
-const Compiler   = require('../../lib/compiler');
+const { expect }      = require('chai');
+const fill            = require('lodash/fill');
+const Compiler        = require('../../lib/compiler');
+const BaseTestRunMock = require('./helpers/base-test-run-mock');
 
-const SessionControllerStub = { getSession: () => {
-    return { id: 'sessionId' };
-} };
-
-const TestRun = proxyquire('../../lib/test-run/index', { './session-controller': SessionControllerStub });
-
-class TestRunMock extends TestRun {
-    _addInjectables () {}
-
-    _initRequestHooks () {}
-
-    get id () {
-        return 'id';
-    }
-
-    constructor () {
-        super({
-            test:               {},
-            browserConnection:  {},
-            screenshotCapturer: {},
-            globalWarningLog:   {},
-            opts:               {},
-        });
-    }
-}
 
 describe('Test run tracker', function () {
     this.timeout(20000);
@@ -35,7 +10,7 @@ describe('Test run tracker', function () {
     function runTest (testName) {
         const src         = 'test/server/data/test-run-tracking/' + testName;
         const compiler    = new Compiler([src]);
-        const testRunMock = new TestRunMock();
+        const testRunMock = new BaseTestRunMock();
         const expected    = fill(Array(3), testRunMock.id);
 
         return compiler.getTests()


### PR DESCRIPTION
Closes https://github.com/DevExpress/testcafe/issues/6335.

Changes:
* support `raw api` and other subsystems
* specify in glob the only failed tests
* refactor `t.browser`
* refactor tests using the `TestRunMock` class
* move fix from https://github.com/DevExpress/testcafe/pull/6349 to have the debug support right now.
* fix typos and small refactoring