### PR TITLE
feat: async runner.filter predicate (#6370)

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -273,7 +273,7 @@ gulp.step('test-server-run', () => {
         return gulp
             .src('test/server/*-test.js', { read: false })
             .pipe(mocha({
-                timeout: getTimeout(2000),
+                timeout: getTimeout(4_000)
             }));
     }
     finally {

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -273,7 +273,7 @@ gulp.step('test-server-run', () => {
         return gulp
             .src('test/server/*-test.js', { read: false })
             .pipe(mocha({
-                timeout: getTimeout(4_000)
+                timeout: getTimeout(4_000),
             }));
     }
     finally {

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -176,7 +176,7 @@ export default class Bootstrapper {
         return arr.filter((_v, index) => results[index]);
     }
 
-    private _filterTests (tests: Test[], predicate: Filter): Promise<Test[]> {
+    private async _filterTests (tests: Test[], predicate: Filter): Promise<Test[]> {
         return Bootstrapper.asyncFilter(
             tests, async (test: Test): Promise<boolean> => predicate(
                 test.name as string, test.fixture.name as string, test.fixture.path, test.meta, test.fixture.meta

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -173,7 +173,7 @@ export default class Bootstrapper {
     private static async asyncFilter<T> (arr: T[], predicate: (item: T) => Promise<boolean>): Promise<T[]> {
         const results = await Promise.all(arr.map(predicate));
 
-        return arr.filter((_v, index) => results[index]);
+        return arr.filter((_, index) => results[index]);
     }
 
     private async _filterTests (tests: Test[], predicate: Filter): Promise<Test[]> {

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -25,7 +25,6 @@ import ClientScriptInit from '../custom-client-scripts/client-script-init';
 import BrowserConnectionGateway from '../browser/connection/gateway';
 import { CompilerArguments } from '../compiler/interfaces';
 import CompilerService from '../services/compiler/host';
-import { Metadata } from '../api/structure/interfaces';
 import Test from '../api/structure/test';
 import { getPluginFactory, processReporterName } from '../utils/reporter';
 import { BootstrapperInit, BrowserSetOptions } from './interfaces';
@@ -37,10 +36,6 @@ import asyncFilter from '../utils/async-filter';
 const DEBUG_SCOPE = 'testcafe:bootstrapper';
 
 type TestSource = unknown;
-
-interface Filter {
-    (testName: string, fixtureName: string, fixturePath: string, testMeta: Metadata, fixtureMeta: Metadata): Promise<boolean>;
-}
 
 type BrowserInfoSource = BrowserInfo | BrowserConnection;
 
@@ -86,7 +81,7 @@ export default class Bootstrapper {
     public sources: TestSource[];
     public browsers: BrowserInfoSource[];
     public reporters: ReporterSource[];
-    public filter?: Filter;
+    public filter?: FilterFunction;
     public appCommand?: string;
     public appInitDelay?: number;
     public tsConfigPath?: string;
@@ -171,7 +166,7 @@ export default class Bootstrapper {
         return BrowserSet.from(browserConnections, this._getBrowserSetOptions());
     }
 
-    private async _filterTests (tests: Test[], predicate: Filter): Promise<Test[]> {
+    private async _filterTests (tests: Test[], predicate: FilterFunction): Promise<Test[]> {
         return asyncFilter(tests, test => {
             return predicate(
                 test.name as string,

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -32,6 +32,7 @@ import { BootstrapperInit, BrowserSetOptions } from './interfaces';
 import WarningLog from '../notifications/warning-log';
 import WARNING_MESSAGES from '../notifications/warning-message';
 import guardTimeExecution from '../utils/guard-time-execution';
+import asyncFilter from '../utils/async-filter';
 
 const DEBUG_SCOPE = 'testcafe:bootstrapper';
 
@@ -170,18 +171,15 @@ export default class Bootstrapper {
         return BrowserSet.from(browserConnections, this._getBrowserSetOptions());
     }
 
-    private static async asyncFilter<T> (arr: T[], predicate: (item: T) => Promise<boolean>): Promise<T[]> {
-        const results = await Promise.all(arr.map(predicate));
-
-        return arr.filter((_, index) => results[index]);
-    }
-
     private async _filterTests (tests: Test[], predicate: Filter): Promise<Test[]> {
-        return Bootstrapper.asyncFilter(
-            tests, async (test: Test): Promise<boolean> => predicate(
-                test.name as string, test.fixture.name as string, test.fixture.path, test.meta, test.fixture.meta
-            )
-        );
+        return asyncFilter(tests, test => {
+            return predicate(
+                test.name as string,
+                test.fixture.name as string,
+                test.fixture.path,
+                test.meta,
+                test.fixture.meta);
+        });
     }
 
     private async _compileTests ({ sourceList, compilerOptions }: CompilerArguments): Promise<Test[]> {

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -618,7 +618,11 @@ describe('Runner', () => {
         });
 
         it('Should filter by async predicate', () => {
-            const filter = async testName => testName.includes('Fixture5');
+            const filter = async testName => {
+                await new Promise(r => setTimeout(r, 2000));
+
+                return testName.includes('Fixture5');
+            };
 
             const expectedTestNames = [
                 'Fixture5Test1',

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -582,6 +582,17 @@ describe('Runner', () => {
             return testFilter(filter, expectedTestNames);
         });
 
+        it('Should filter by async predicate', () => {
+            const filter = testName => async () => testName.includes('Fixture5');
+
+            const expectedTestNames = [
+                'Fixture5Test1',
+                'Fixture5Test2'
+            ];
+
+            return testFilter(filter, expectedTestNames);
+        });
+
         it('Should filter by fixture name', () => {
             const filter = (testName, fixtureName) => fixtureName === 'Fixture1';
 

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -582,17 +582,6 @@ describe('Runner', () => {
             return testFilter(filter, expectedTestNames);
         });
 
-        it('Should filter by async predicate', () => {
-            const filter = testName => async () => testName.includes('Fixture5');
-
-            const expectedTestNames = [
-                'Fixture5Test1',
-                'Fixture5Test2'
-            ];
-
-            return testFilter(filter, expectedTestNames);
-        });
-
         it('Should filter by fixture name', () => {
             const filter = (testName, fixtureName) => fixtureName === 'Fixture1';
 
@@ -624,6 +613,17 @@ describe('Runner', () => {
             const filter = (testName, fixtureName, fixturePath, testMeta, fixtureMeta) => fixtureMeta.meta === 'test';
 
             const expectedTestNames = ['Fixture4Test1'];
+
+            return testFilter(filter, expectedTestNames);
+        });
+
+        it('Should filter by async predicate', () => {
+            const filter = async testName => testName.includes('Fixture5');
+
+            const expectedTestNames = [
+                'Fixture5Test1',
+                'Fixture5Test2'
+            ];
 
             return testFilter(filter, expectedTestNames);
         });

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -622,7 +622,7 @@ describe('Runner', () => {
 
             const expectedTestNames = [
                 'Fixture5Test1',
-                'Fixture5Test2'
+                'Fixture5Test2',
             ];
 
             return testFilter(filter, expectedTestNames);

--- a/ts-defs-src/runner-api/options.d.ts
+++ b/ts-defs-src/runner-api/options.d.ts
@@ -59,7 +59,7 @@ type FilterFunction = (
     fixturePath: string,
     testMeta: Metadata,
     fixtureMeta: Metadata
-) => boolean;
+) => Promise<boolean>;
 
 interface FilterDescriptor {
     test?: string;


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
I need to have freedom in using both, sync and async functions when filtering tests using the Runner object

## Approach
use an asynchronous filter

## References
https://github.com/DevExpress/testcafe/issues/6370

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
