### PR TITLE
feat: added verification of the existence of the configuration file

### DIFF
--- a/src/errors/runtime/templates.js
+++ b/src/errors/runtime/templates.js
@@ -126,6 +126,7 @@ export default {
     [RUNTIME_ERRORS.browserConnectionError]:               '{originErrorMessage}\n{numOfNotOpenedConnection} of {numOfAllConnections} browser connections have not been established:\n{listOfNotOpenedConnections}\n\nHints:\n{listOfHints}',
     [BrowserConnectionErrorHint.TooHighConcurrencyFactor]: 'The host machine may not be powerful enough to handle the specified concurrency factor ({concurrencyFactor}). ' +
                                                            'Try to decrease the concurrency factor or allocate more computing resources to the host machine.',
-    [BrowserConnectionErrorHint.UseBrowserInitOption]: 'Increase the value of the "browserInitTimeout" option if it is too low (currently: {browserInitTimeoutMsg}). This option determines how long TestCafe waits for browsers to be ready.',
-    [BrowserConnectionErrorHint.RestErrorCauses]:      'The error can also be caused by network issues or remote device failure. Make sure that your network connection is stable and you can reach the remote device.',
+    [BrowserConnectionErrorHint.UseBrowserInitOption]:    'Increase the value of the "browserInitTimeout" option if it is too low (currently: {browserInitTimeoutMsg}). This option determines how long TestCafe waits for browsers to be ready.',
+    [BrowserConnectionErrorHint.RestErrorCauses]:         'The error can also be caused by network issues or remote device failure. Make sure that your network connection is stable and you can reach the remote device.',
+    [RUNTIME_ERRORS.cannotFindTestcafeConfigurationFile]: '"{filePath}" is not a valid TestCafe configuration file.',
 };

--- a/src/errors/runtime/templates.js
+++ b/src/errors/runtime/templates.js
@@ -128,5 +128,5 @@ export default {
                                                            'Try to decrease the concurrency factor or allocate more computing resources to the host machine.',
     [BrowserConnectionErrorHint.UseBrowserInitOption]:    'Increase the value of the "browserInitTimeout" option if it is too low (currently: {browserInitTimeoutMsg}). This option determines how long TestCafe waits for browsers to be ready.',
     [BrowserConnectionErrorHint.RestErrorCauses]:         'The error can also be caused by network issues or remote device failure. Make sure that your network connection is stable and you can reach the remote device.',
-    [RUNTIME_ERRORS.cannotFindTestcafeConfigurationFile]: '"{filePath}" is not a valid TestCafe configuration file.',
+    [RUNTIME_ERRORS.cannotFindTestcafeConfigurationFile]: '"{filePath}" is not a valid path to the TestCafe configuration file. Make sure the configuration file exists and you spell the path name correctly.',
 };

--- a/src/errors/types.js
+++ b/src/errors/types.js
@@ -155,4 +155,5 @@ export const RUNTIME_ERRORS = {
     invalidAttemptLimitValue:                           'E1067',
     invalidSuccessThresholdValue:                       'E1068',
     cannotSetConcurrencyWithCDPPort:                    'E1069',
+    cannotFindTestcafeConfigurationFile:                'E1070',
 };

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -286,6 +286,21 @@ describe('TestCafeConfiguration', function () {
                     expect(testCafeConfiguration._options).to.deep.equal(defaultOptions);
                 });
         });
+
+        it('Explicitly specified configuration file doesn\'t exist', async () => {
+            let message = null;
+
+            const nonExistingConfiguration = new TestCafeConfiguration('non-existing-path');
+
+            try {
+                await nonExistingConfiguration.init();
+            }
+            catch (err) {
+                message = err.message;
+            }
+
+            expect(message).eql(`"${nonExistingConfiguration.filePath}" is not a valid TestCafe configuration file.`);
+        });
     });
 
     describe('Merge options', () => {

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -299,7 +299,7 @@ describe('TestCafeConfiguration', function () {
                 message = err.message;
             }
 
-            expect(message).eql(`"${nonExistingConfiguration.filePath}" is not a valid TestCafe configuration file.`);
+            expect(message).eql(`"${nonExistingConfiguration.filePath}" is not a valid path to the TestCafe configuration file. Make sure the configuration file exists and you spell the path name correctly.`);
         });
     });
 

--- a/test/server/create-testcafe-test.js
+++ b/test/server/create-testcafe-test.js
@@ -109,15 +109,6 @@ describe('TestCafe factory function', function () {
     });
 
     describe('Custom Testcafe Config Path', () => {
-        it('Custom config path is used', () => {
-            const configFile = 'custom.testcaferc.json';
-
-            return getTestCafe('localhost', 1338, 1339, null, null, null, null, configFile)
-                .then(() => {
-                    expect(path.basename(testCafe.configuration.filePath)).eql(configFile);
-                });
-        });
-
         it('Reverts back to default when not specified', () => {
             const defaultConfigFile = '.testcaferc.json';
 


### PR DESCRIPTION
[closes DevExpress/testcafe#6337]

## Purpose
Show an error if the explicitly configuration file doesn't exist

## Approach
1. Add a test with getting an error
2. Add a new error type
3. Add a condition for the existence of the configuration file

## References
https://github.com/DevExpress/testcafe/issues/6337

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
