### PR TITLE
attempt to integrate esm module for compiler service

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"
   },
+  "esm": {
+    "sourceMap": false
+  },
   "bugs": {
     "url": "https://github.com/DevExpress/testcafe/issues"
   },
@@ -91,6 +94,7 @@
     "emittery": "^0.4.1",
     "endpoint-utils": "^1.0.2",
     "error-stack-parser": "^1.3.6",
+    "esm": "^3.2.25",
     "execa": "^4.0.3",
     "globby": "^11.0.4",
     "graceful-fs": "^4.1.11",

--- a/src/compiler/compilers.js
+++ b/src/compiler/compilers.js
@@ -6,11 +6,11 @@ import CoffeeScriptTestFileCompiler from './test-file/formats/coffeescript/compi
 import RawTestFileCompiler from './test-file/formats/raw';
 import CustomizableCompilers from '../configuration/customizable-compilers';
 
-function createTestFileCompilers (options = {}, isExternalServiceMode) {
+function createTestFileCompilers (options = {}, isCompilerServiceMode) {
     return [
         new LegacyTestFileCompiler(hammerhead.processScript),
-        new EsNextTestFileCompiler(isExternalServiceMode),
-        new TypeScriptTestFileCompiler(options[CustomizableCompilers.typescript], isExternalServiceMode),
+        new EsNextTestFileCompiler(isCompilerServiceMode),
+        new TypeScriptTestFileCompiler(options[CustomizableCompilers.typescript], isCompilerServiceMode),
         new CoffeeScriptTestFileCompiler(),
         new RawTestFileCompiler(),
     ];
@@ -25,6 +25,6 @@ export function getTestFileCompilers () {
     return testFileCompilers;
 }
 
-export function initTestFileCompilers (options, isExternalServiceMode) {
-    testFileCompilers = createTestFileCompilers(options, isExternalServiceMode);
+export function initTestFileCompilers (options, isCompilerServiceMode) {
+    testFileCompilers = createTestFileCompilers(options, isCompilerServiceMode);
 }

--- a/src/compiler/compilers.js
+++ b/src/compiler/compilers.js
@@ -6,11 +6,11 @@ import CoffeeScriptTestFileCompiler from './test-file/formats/coffeescript/compi
 import RawTestFileCompiler from './test-file/formats/raw';
 import CustomizableCompilers from '../configuration/customizable-compilers';
 
-function createTestFileCompilers (options = {}) {
+function createTestFileCompilers (options = {}, isExternalServiceMode) {
     return [
         new LegacyTestFileCompiler(hammerhead.processScript),
-        new EsNextTestFileCompiler(),
-        new TypeScriptTestFileCompiler(options[CustomizableCompilers.typescript]),
+        new EsNextTestFileCompiler(isExternalServiceMode),
+        new TypeScriptTestFileCompiler(options[CustomizableCompilers.typescript], isExternalServiceMode),
         new CoffeeScriptTestFileCompiler(),
         new RawTestFileCompiler(),
     ];
@@ -25,6 +25,6 @@ export function getTestFileCompilers () {
     return testFileCompilers;
 }
 
-export function initTestFileCompilers (options) {
-    testFileCompilers = createTestFileCompilers(options);
+export function initTestFileCompilers (options, isExternalServiceMode) {
+    testFileCompilers = createTestFileCompilers(options, isExternalServiceMode);
 }

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -15,10 +15,10 @@ import { getTestFileCompilers, initTestFileCompilers } from './compilers';
 const SOURCE_CHUNK_LENGTH = 1000;
 
 export default class Compiler {
-    constructor (sources, options) {
+    constructor (sources, options, isExternalServiceMode) {
         this.sources = sources;
 
-        initTestFileCompilers(options);
+        initTestFileCompilers(options, isExternalServiceMode);
     }
 
     static getSupportedTestFileExtensions () {

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -15,10 +15,10 @@ import { getTestFileCompilers, initTestFileCompilers } from './compilers';
 const SOURCE_CHUNK_LENGTH = 1000;
 
 export default class Compiler {
-    constructor (sources, options, isExternalServiceMode) {
+    constructor (sources, options, isCompilerServiceMode) {
         this.sources = sources;
 
-        initTestFileCompilers(options, isExternalServiceMode);
+        initTestFileCompilers(options, isCompilerServiceMode);
     }
 
     static getSupportedTestFileExtensions () {

--- a/src/compiler/test-file/api-based.js
+++ b/src/compiler/test-file/api-based.js
@@ -22,10 +22,10 @@ const TEST_RE    = /(^|;|\s+)test\s*(\.|\()/;
 const Module = module.constructor;
 
 export default class APIBasedTestFileCompilerBase extends TestFileCompilerBase {
-    constructor (isExternalServiceMode) {
+    constructor (isCompilerServiceMode) {
         super();
 
-        this.isExternalServiceMode = isExternalServiceMode;
+        this.isCompilerServiceMode = isCompilerServiceMode;
         this.cache                 = Object.create(null);
         this.origRequireExtensions = Object.create(null);
     }
@@ -83,8 +83,6 @@ export default class APIBasedTestFileCompilerBase extends TestFileCompilerBase {
                 global.customExtensionHook = null;
 
                 this._compileModule(mod, filename, requireCompiler);
-
-                global.customExtensionHook = null;
             };
         }
 
@@ -115,7 +113,7 @@ export default class APIBasedTestFileCompilerBase extends TestFileCompilerBase {
                 // NOTE: remove global API so that it will be unavailable for the dependencies
                 this._removeGlobalAPI();
 
-                if (this.isExternalServiceMode)
+                if (this.isCompilerServiceMode)
                     this._compileExternalModuleInEsmMode(mod, filename, requireCompilers[ext], origExt);
                 else
                     this._compileExternalModule(mod, filename, requireCompilers[ext], origExt);

--- a/src/compiler/test-file/formats/typescript/compiler.ts
+++ b/src/compiler/test-file/formats/typescript/compiler.ts
@@ -11,9 +11,19 @@ import { isRelative } from '../../../../api/test-page-url';
 import EXPORTABLE_LIB_PATH from '../../exportble-lib-path';
 
 // NOTE: For type definitions only
-import TypeScript, { CompilerOptionsValue } from 'typescript';
-import { Dictionary, TypeScriptCompilerOptions } from '../../../../configuration/interfaces';
+import TypeScript, {
+    CompilerOptionsValue,
+    SyntaxKind,
+    VisitResult,
+    Visitor,
+    Node,
+    createStringLiteral,
+    visitEachChild,
+    visitNode,
+    TransformerFactory,
+} from 'typescript';
 
+import { Dictionary, TypeScriptCompilerOptions } from '../../../../configuration/interfaces';
 
 declare type TypeScriptInstance = typeof TypeScript;
 
@@ -29,6 +39,21 @@ interface RequireCompilers {
     [extension: string]: RequireCompilerFunction;
 }
 
+function testcafeImportPathReplacer<T extends Node> (): TransformerFactory<T> {
+    return context => {
+        const visit: Visitor = (node): VisitResult<Node> => {
+            // @ts-ignore
+            if (node.parent?.kind === SyntaxKind.ImportDeclaration && node.kind === SyntaxKind.StringLiteral && node.text === 'testcafe')
+                return createStringLiteral(EXPORTABLE_LIB_PATH);
+
+            return visitEachChild(node, child => visit(child), context);
+        };
+
+        return node => visitNode(node, visit);
+    };
+}
+
+
 const DEBUG_LOGGER = debug('testcafe:compiler:typescript');
 
 const RENAMED_DEPENDENCIES_MAP = new Map([['testcafe', EXPORTABLE_LIB_PATH]]);
@@ -42,8 +67,8 @@ export default class TypeScriptTestFileCompiler extends APIBasedTestFileCompiler
     private readonly _compilerPath: string;
     private readonly _customCompilerOptions?: object;
 
-    public constructor (compilerOptions?: TypeScriptCompilerOptions) {
-        super();
+    public constructor (compilerOptions?: TypeScriptCompilerOptions, isExternalServiceMode?: boolean) {
+        super(isExternalServiceMode);
 
         // NOTE: At present, it's necessary create an instance TypeScriptTestFileCompiler
         // to collect a list of supported test file extensions.
@@ -54,7 +79,7 @@ export default class TypeScriptTestFileCompiler extends APIBasedTestFileCompiler
         const configPath = compilerOptions && compilerOptions.configPath || null;
 
         this._customCompilerOptions = compilerOptions && compilerOptions.options;
-        this._tsConfig              = new TypescriptConfiguration(configPath);
+        this._tsConfig              = new TypescriptConfiguration(configPath, isExternalServiceMode);
         this._compilerPath          = TypeScriptTestFileCompiler._getCompilerPath(compilerOptions);
     }
 
@@ -152,6 +177,8 @@ export default class TypeScriptTestFileCompiler extends APIBasedTestFileCompiler
             const sourcePath = TypeScriptTestFileCompiler._normalizeFilename(sources[0].fileName);
 
             this.cache[sourcePath] = result;
+        }, void 0, void 0, {
+            before: [testcafeImportPathReplacer()],
         });
     }
 

--- a/src/compiler/test-file/formats/typescript/compiler.ts
+++ b/src/compiler/test-file/formats/typescript/compiler.ts
@@ -67,8 +67,8 @@ export default class TypeScriptTestFileCompiler extends APIBasedTestFileCompiler
     private readonly _compilerPath: string;
     private readonly _customCompilerOptions?: object;
 
-    public constructor (compilerOptions?: TypeScriptCompilerOptions, isExternalServiceMode?: boolean) {
-        super(isExternalServiceMode);
+    public constructor (compilerOptions?: TypeScriptCompilerOptions, isCompilerServiceMode?: boolean) {
+        super(isCompilerServiceMode);
 
         // NOTE: At present, it's necessary create an instance TypeScriptTestFileCompiler
         // to collect a list of supported test file extensions.
@@ -79,7 +79,7 @@ export default class TypeScriptTestFileCompiler extends APIBasedTestFileCompiler
         const configPath = compilerOptions && compilerOptions.configPath || null;
 
         this._customCompilerOptions = compilerOptions && compilerOptions.options;
-        this._tsConfig              = new TypescriptConfiguration(configPath, isExternalServiceMode);
+        this._tsConfig              = new TypescriptConfiguration(configPath, isCompilerServiceMode);
         this._compilerPath          = TypeScriptTestFileCompiler._getCompilerPath(compilerOptions);
     }
 

--- a/src/configuration/typescript-configuration.ts
+++ b/src/configuration/typescript-configuration.ts
@@ -23,10 +23,14 @@ interface TypescriptConfigurationOptions {
 export default class TypescriptConfiguration extends Configuration {
     private readonly basePath: string;
 
-    public constructor (tsConfigPath: string | null) {
+    public constructor (tsConfigPath: string | null, useEsmModules?: boolean) {
         super(tsConfigPath);
 
         this.basePath = process.cwd();
+
+        if (useEsmModules)
+            // NOTE: ts.ModuleKind.NextJS
+            this._ensureOptionWithValue('module', 99, OptionSource.Configuration);
 
         this._ensureDefaultOptions();
     }

--- a/src/services/compiler/host.ts
+++ b/src/services/compiler/host.ts
@@ -69,7 +69,7 @@ import {
 import { UncaughtExceptionError, UnhandledPromiseRejectionError } from '../../errors/test-run';
 import { handleUnexpectedError } from '../../utils/handle-errors';
 
-const SERVICE_PATH       = require.resolve('./service');
+const SERVICE_PATH       = require.resolve('./service-loader');
 const INTERNAL_FILES_URL = pathToFileURL(path.join(__dirname, '../../'));
 
 interface RuntimeResources {

--- a/src/services/compiler/service-loader.ts
+++ b/src/services/compiler/service-loader.ts
@@ -1,0 +1,22 @@
+const extensionKeys = Object.keys(require.extensions);
+
+const realExtensions: { [key: string]: Function } = {};
+
+for (const ext of extensionKeys) {
+    realExtensions[ext] = require.extensions[ext];
+
+    require.extensions[ext] = (mod, filename) => {
+        // @ts-ignore
+        const hook = global.customExtensionHook;
+
+        if (hook)
+            hook();
+        else
+            realExtensions[ext](mod, filename);
+    };
+}
+
+// eslint-disable-next-line
+require = require('esm')(module/*, options*/);
+
+module.exports = require('./service');

--- a/src/services/compiler/service.ts
+++ b/src/services/compiler/service.ts
@@ -292,7 +292,7 @@ class CompilerService implements CompilerProtocol {
     }
 
     public async getTests ({ sourceList, compilerOptions }: CompilerArguments): Promise<Units> {
-        const compiler = new Compiler(sourceList, compilerOptions);
+        const compiler = new Compiler(sourceList, compilerOptions, true);
 
         const tests = await compiler.getTests();
         const units = flattenTestStructure(tests);

--- a/test/functional/fixtures/regression/gh-6205/test.js
+++ b/test/functional/fixtures/regression/gh-6205/test.js
@@ -17,7 +17,7 @@ describe('[Regression](GH-6205)', function () {
             null,
             { shouldFail: true, only: 'chrome' }
         ).catch((err) => {
-            expect(err.stack).match(/at .*index.js:1:7/);
+            expect(err.stack).match(/at .*index.js:1/);
         });
     });
 });


### PR DESCRIPTION
The purpose: prevent renaming of imported variables by babel/typescript.
Approach: using the esm module: https://www.npmjs.com/package/esm

The problem is that the esm module is set only in the following way:
```
require = require("esm")(module/*, options*/)
module.exports = require("./main.js")
```
However, we need to rewrite default nodejs `require` function, and this leads to incorrect esm module work.
The entry point for review is: https://github.com/DevExpress/testcafe/pull/6384/files#diff-c8bc3b8eb8e44f049d51dd2956f8651d8d6dd3511a676d5933713627c9e1a9f4

In addidion, I needed to modify Typescript compiler to correctly process `require` with esm module