### PR TITLE
fix: fixed getAttribute return value (closes #5984)

### DIFF
--- a/src/client-functions/selectors/add-api.js
+++ b/src/client-functions/selectors/add-api.js
@@ -268,6 +268,14 @@ function prepareSnapshotPropertyList (customDOMProperties) {
     return properties;
 }
 
+function getAttributeValue (attributes, attrName) {
+    if (attributes && attributes.hasOwnProperty(attrName))
+        return attributes[attrName];
+
+    // NOTE: https://dom.spec.whatwg.org/#dom-element-getattribute (null result for nonexistent attributes)
+    return null;
+}
+
 function addSnapshotPropertyShorthands ({ obj, getSelector, SelectorBuilder, customDOMProperties, customMethods, observedCallsites }) {
     const properties = prepareSnapshotPropertyList(customDOMProperties);
 
@@ -296,13 +304,13 @@ function addSnapshotPropertyShorthands ({ obj, getSelector, SelectorBuilder, cus
         if (selectorApiExecutionMode.isSync) {
             const snapshot = getSnapshotSync(getSelector, callsite, SelectorBuilder);
 
-            return snapshot.attributes ? snapshot.attributes[attrName] : void 0;
+            return getAttributeValue(snapshot.attributes, attrName);
         }
 
         return ReExecutablePromise.fromFn(async () => {
             const snapshot = await getSnapshot(getSelector, callsite, SelectorBuilder);
 
-            return snapshot.attributes ? snapshot.attributes[attrName] : void 0;
+            return getAttributeValue(snapshot.attributes, attrName);
         });
     };
 

--- a/test/functional/fixtures/api/es-next/selector/test.js
+++ b/test/functional/fixtures/api/es-next/selector/test.js
@@ -143,7 +143,7 @@ describe('[API] Selector', function () {
         return runTests('./testcafe-fixtures/selector-test.js', 'Cannot use "shadowRoot" as a target', Object.assign({ shouldFail: true, skip: ['ie', 'edge'] }, DEFAULT_RUN_OPTIONS))
             .catch(function (errs) {
                 expect(errs[0]).contains('The specified selector is expected to match a DOM element, but it matches a document fragment node.');
-                expect(errs[0]).contains('> 1115 |    await t.click(shadowRoot);');
+                expect(errs[0]).contains('> 1116 |    await t.click(shadowRoot);');
             });
     });
 

--- a/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
+++ b/test/functional/fixtures/api/es-next/selector/testcafe-fixtures/selector-test.js
@@ -357,6 +357,7 @@ test('Snapshot properties shorthands on selector', async t => {
         .expect(el.getStyleProperty('display')).eql('block')
         .expect(el.getAttribute('id')).eql('htmlElement')
         .expect(el.getAttribute('class')).eql('yo hey cool')
+        .expect(el.getAttribute('nonexistent-attr')).eql(null)
         .expect(el.getBoundingClientRectProperty('width')).eql(43)
         .expect(el.getBoundingClientRectProperty('left')).eql(0)
         .expect(el.hasClass('yo')).ok()
@@ -375,7 +376,7 @@ test('Snapshot properties shorthands on selector', async t => {
     await t
         .expect(el.hasClass('some-class')).notOk()
         .expect(el.getStyleProperty('width')).eql(void 0)
-        .expect(el.getAttribute('id')).eql(void 0)
+        .expect(el.getAttribute('id')).eql(null)
         .expect(el.getBoundingClientRectProperty('left')).eql(void 0);
 
     const selector = Selector(id => document.getElementById(id));

--- a/ts-defs-src/test-api/node-snapshot.d.ts
+++ b/ts-defs-src/test-api/node-snapshot.d.ts
@@ -190,7 +190,7 @@ interface NodeSnapshot {
      *
      * @param attributeName - The name of the attribute.
      */
-    getAttribute?(attributeName: string): string;
+    getAttribute?(attributeName: string): string | null;
     /**
      * Returns the value of the property from the `boundingClientRect` object.
      *

--- a/ts-defs-src/test-api/selector.d.ts
+++ b/ts-defs-src/test-api/selector.d.ts
@@ -190,7 +190,7 @@ interface SelectorAPI {
      *
      * @param attributeName - The name of the attribute.
      */
-    getAttribute(attributeName: string): Promise<string>;
+    getAttribute(attributeName: string): Promise<string | null>;
     /**
      * Returns the value of the property from the `boundingClientRect` object.
      *


### PR DESCRIPTION
## Purpose
Our `getAttribute`'s returned value is not consistent with [`Element.getAttribute()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttribute).

## Approach
Return `null` for nonexistent attributes due to 
https://developer.mozilla.org/en-US/docs/Web/API/Element/getAttribute#non-existing_attributes,
https://dom.spec.whatwg.org/#dom-element-getattribute.

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
