### PR TITLE
refactor: partial support of multiple windows tests in compiler service

### DIFF
--- a/gulp/constants/functional-test-globs.js
+++ b/gulp/constants/functional-test-globs.js
@@ -13,7 +13,6 @@ const MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB = [
     BASIC_TESTS_GLOB,
     COMPILER_SERVICE_TESTS_GLOB,
     '!test/functional/fixtures/multiple-windows/test.js',
-    '!test/functional/fixtures/api/es-next/assertions/test.js',
     '!test/functional/fixtures/regression/gh-2846/test.js',
 ];
 

--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -153,12 +153,12 @@ export default class TestController {
     }
 
     _validateMultipleWindowCommand (apiMethodName) {
-        const { disableMultipleWindows, browserConnection } = this.testRun;
+        const { disableMultipleWindows, activeWindowId } = this.testRun;
 
         if (disableMultipleWindows)
             throw new MultipleWindowsModeIsDisabledError(apiMethodName);
 
-        if (!browserConnection.activeWindowId)
+        if (!activeWindowId)
             throw new MultipleWindowsModeIsNotAvailableInRemoteBrowserError(apiMethodName);
     }
 
@@ -397,7 +397,7 @@ export default class TestController {
         if (typeof windowSelector === 'function') {
             command = SwitchToWindowByPredicateCommand;
 
-            args = { findWindow: windowSelector };
+            args = { checkWindow: windowSelector };
         }
         else {
             command = SwitchToWindowCommand;

--- a/src/api/test-run-tracker.ts
+++ b/src/api/test-run-tracker.ts
@@ -112,6 +112,10 @@ class TestRunTracker extends EventEmitter {
 
         testRun.onAny((eventName: string, eventData: unknown) => this.emit(eventName, { testRun, data: eventData }));
     }
+
+    public removeActiveTestRun (id: string): void {
+        delete this.activeTestRuns[id];
+    }
 }
 
 // Tracker

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -1247,7 +1247,7 @@ export default class Driver extends serviceUtils.EventEmitter {
 
     async _onSwitchToWindow (command, err) {
         const wnd      = this._getTopOpenedWindow();
-        const response = await this._validateChildWindowSwitchToWindowCommandExists({ windowId: command.windowId, fn: command.findWindow }, wnd);
+        const response = await this._validateChildWindowSwitchToWindowCommandExists({ windowId: command.windowId, fn: command.checkWindow }, wnd);
         const result   = response.result;
 
         if (!result.success) {
@@ -1259,7 +1259,7 @@ export default class Driver extends serviceUtils.EventEmitter {
         else {
             this._stopInternal();
 
-            sendMessageToDriver(new SwitchToWindowCommandMessage({ windowId: command.windowId, fn: command.findWindow }), wnd, WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT, CannotSwitchToWindowError);
+            sendMessageToDriver(new SwitchToWindowCommandMessage({ windowId: command.windowId, fn: command.checkWindow }), wnd, WAIT_FOR_WINDOW_DRIVER_RESPONSE_TIMEOUT, CannotSwitchToWindowError);
         }
     }
 

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -18,7 +18,6 @@ import parseFileList from '../utils/parse-file-list';
 import resolvePathRelativelyCwd from '../utils/resolve-path-relatively-cwd';
 import loadClientScripts from '../custom-client-scripts/load';
 import { getConcatenatedValuesString } from '../utils/string';
-
 import { Writable as WritableStream } from 'stream';
 import { ReporterSource, ReporterPluginSource } from '../reporter/interfaces';
 import ClientScript from '../custom-client-scripts/client-script';

--- a/src/services/compiler/interfaces.ts
+++ b/src/services/compiler/interfaces.ts
@@ -95,6 +95,7 @@ export interface ExecuteMockPredicate extends RequestFilterRuleLocator {
 export interface InitializeTestRunDataArguments extends TestRunLocator {
     testId: string;
     browser: Browser;
+    activeWindowId: string | null;
 }
 
 export interface RoleLocator {
@@ -135,5 +136,11 @@ export interface CommandLocator extends TestRunLocator {
 export interface AddUnexpectedErrorArguments {
     type: string;
     message: string;
+}
+
+export interface CheckWindowArgument extends TestRunLocator {
+    commandId: string;
+    url: URL;
+    title: string;
 }
 

--- a/src/services/compiler/protocol.ts
+++ b/src/services/compiler/protocol.ts
@@ -24,6 +24,7 @@ import {
     ExecuteAsyncJsExpressionArguments,
     CommandLocator,
     AddUnexpectedErrorArguments,
+    CheckWindowArgument,
 } from './interfaces';
 
 export const BEFORE_AFTER_PROPERTIES      = ['beforeFn', 'afterFn'] as const;
@@ -85,4 +86,5 @@ export interface CompilerProtocol extends TestRunDispatcherProtocol {
     executeAsyncJsExpression ({ expression, testRunId, callsite }: ExecuteAsyncJsExpressionArguments): Promise<unknown>;
     executeAssertionFn ({ testRunId, commandId }: CommandLocator): Promise<unknown>;
     addUnexpectedError ({ type, message }: AddUnexpectedErrorArguments): Promise<void>;
+    checkWindow ({ url, title }: CheckWindowArgument): Promise<boolean>;
 }

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -8,5 +8,6 @@ export interface TestRunProxyInit {
     test: Test;
     options: Dictionary<OptionValue>;
     browser: Browser;
+    activeWindowId: null | string;
 }
 

--- a/src/services/serialization/prepare-options.ts
+++ b/src/services/serialization/prepare-options.ts
@@ -5,6 +5,7 @@ const NECESSARY_OPTIONS = [
     OptionNames.assertionTimeout,
     OptionNames.speed,
     OptionNames.pageLoadTimeout,
+    OptionNames.disableMultipleWindows,
 ];
 
 export default function (value: Dictionary<OptionValue>): Dictionary<OptionValue> {

--- a/src/services/serialization/replicator/create-replicator.ts
+++ b/src/services/serialization/replicator/create-replicator.ts
@@ -12,6 +12,7 @@ import TestCafeErrorListTransform from './transforms/testcafe-error-list-transfo
 import FunctionMarkerTransform from './transforms/function-marker-transform';
 import PromiseMarkerTransform from './transforms/promise-marker-transform';
 import ConfigureResponseEventOptionTransform from './transforms/configure-response-event-option-transform';
+import URLTransform from './transforms/url-transform';
 
 const DEFAULT_ERROR_TRANSFORM_TYPE = '[[Error]]';
 
@@ -34,6 +35,7 @@ export default function (): Replicator {
         .addTransforms([
             customErrorTransform,
             defaultErrorTransform,
+            new URLTransform(),
             new TestCafeErrorListTransform(),
             new BrowserConsoleMessagesTransform(),
             new ReExecutablePromiseTransform(),

--- a/src/services/serialization/replicator/transforms/command-base-trasform/command-constructors.ts
+++ b/src/services/serialization/replicator/transforms/command-base-trasform/command-constructors.ts
@@ -9,14 +9,17 @@ import {
 import {
     ClearUploadCommand,
     ClickCommand,
+    CloseWindowCommand,
     DispatchEventCommand,
     DoubleClickCommand,
     DragCommand,
     DragToElementCommand,
     ExecuteAsyncExpressionCommand,
     ExecuteExpressionCommand,
+    GetCurrentWindowCommand,
     HoverCommand,
     NavigateToCommand,
+    OpenWindowCommand,
     PressKeyCommand,
     RightClickCommand,
     ScrollByCommand,
@@ -30,6 +33,10 @@ import {
     SetPageLoadTimeoutCommand,
     SetTestSpeedCommand,
     SwitchToIframeCommand,
+    SwitchToParentWindowCommand,
+    SwitchToPreviousWindowCommand,
+    SwitchToWindowByPredicateCommand,
+    SwitchToWindowCommand,
     TypeTextCommand,
     UseRoleCommand,
 } from '../../../../../test-run/commands/actions';
@@ -79,6 +86,13 @@ const COMMAND_CONSTRUCTORS = new Map<string, CommandConstructor>([
     [CommandType.scroll, ScrollCommand],
     [CommandType.scrollBy, ScrollByCommand],
     [CommandType.scrollIntoView, ScrollIntoViewCommand],
+    [CommandType.openWindow, OpenWindowCommand],
+    [CommandType.closeWindow, CloseWindowCommand],
+    [CommandType.getCurrentWindow, GetCurrentWindowCommand],
+    [CommandType.switchToWindow, SwitchToWindowCommand],
+    [CommandType.switchToWindowByPredicate, SwitchToWindowByPredicateCommand],
+    [CommandType.switchToParentWindow, SwitchToParentWindowCommand],
+    [CommandType.switchToPreviousWindow, SwitchToPreviousWindowCommand],
 ]);
 
 export default COMMAND_CONSTRUCTORS;

--- a/src/services/serialization/replicator/transforms/url-transform.ts
+++ b/src/services/serialization/replicator/transforms/url-transform.ts
@@ -1,0 +1,19 @@
+import BaseTransform from './base-transform';
+
+export default class URLTransform extends BaseTransform {
+    public constructor () {
+        super('URL');
+    }
+
+    public shouldTransform (_: unknown, val: unknown): boolean {
+        return val instanceof URL;
+    }
+
+    public toSerializable (value: URL): string {
+        return value.toString();
+    }
+
+    public fromSerializable (value: string): URL {
+        return new URL(value);
+    }
+}

--- a/src/test-run/commands/actions.d.ts
+++ b/src/test-run/commands/actions.d.ts
@@ -13,6 +13,7 @@ import {
 import Role from '../../role/role';
 import TestRun from '../index';
 
+
 export class SetNativeDialogHandlerCommand extends CommandBase {
     public constructor(obj: object, testRun?: TestRun, validateProperties?: boolean);
     public dialogHandler: ExecuteClientFunctionCommand;
@@ -44,6 +45,20 @@ export class UseRoleCommand extends CommandBase {
     public role: Role;
 }
 
+export class OpenWindowCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public url: string;
+}
+
+export class CloseWindowCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public windowId: string;
+}
+
+export class GetCurrentWindowCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+}
+
 export class GetCurrentWindowsCommand extends CommandBase {
     public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
 }
@@ -53,9 +68,23 @@ export class SwitchToWindowCommand extends CommandBase {
     public windowId: string;
 }
 
+export interface CheckWindowPredicateData {
+    url: URL;
+    title: string;
+}
+
 export class SwitchToWindowByPredicateCommand extends CommandBase {
     public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
-    public findWindow: Function;
+    public id: string;
+    public checkWindow(w: CheckWindowPredicateData): boolean;
+}
+
+export class SwitchToParentWindowCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+}
+
+export class SwitchToPreviousWindowCommand extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
 }
 
 export class SetTestSpeedCommand extends CommandBase {

--- a/src/test-run/commands/actions.js
+++ b/src/test-run/commands/actions.js
@@ -459,7 +459,8 @@ export class SwitchToWindowByPredicateCommand extends CommandBase {
 
     _getAssignableProperties () {
         return [
-            { name: 'findWindow', type: functionArgument, required: true },
+            { name: 'id', type: nonEmptyStringArgument, required: false },
+            { name: 'checkWindow', type: functionArgument, required: true },
         ];
     }
 }

--- a/src/utils/async-filter.ts
+++ b/src/utils/async-filter.ts
@@ -1,0 +1,5 @@
+export default async function <T> (arr: T[], predicate: (value: T, index: number, array: T[]) => unknown): Promise<T[]> {
+    const results = await Promise.all(arr.map(predicate));
+
+    return arr.filter((_, index) => results[index]);
+}

--- a/src/utils/async-filter.ts
+++ b/src/utils/async-filter.ts
@@ -1,4 +1,4 @@
-export default async function <T> (arr: T[], predicate: (value: T, index: number, array: T[]) => unknown): Promise<T[]> {
+export default async function <T> (arr: T[], predicate: (value: Readonly<T>, index: number, array: T[]) => unknown): Promise<T[]> {
     const results = await Promise.all(arr.map(predicate));
 
     return arr.filter((_, index) => results[index]);

--- a/src/utils/parse-file-list.js
+++ b/src/utils/parse-file-list.js
@@ -5,6 +5,7 @@ import Compiler from '../compiler';
 import OS from 'os-family';
 import { isEmpty, flatten } from 'lodash';
 import { stat } from '../utils/promisified-functions';
+import asyncFilter from '../utils/async-filter';
 
 const DEFAULT_TEST_LOOKUP_DIRS = ['test', 'tests'];
 const TEST_FILE_GLOB_PATTERN   = `./**/*@(${Compiler.getSupportedTestFileExtensions().join('|')})`;
@@ -39,7 +40,7 @@ function ensurePosix (fileString) {
 }
 
 async function convertDirsToGlobs (fileList, baseDir) {
-    fileList = await Promise.all(fileList.map(async file => {
+    fileList = await asyncFilter(fileList, async file => {
         if (!isGlob(file)) {
             const absPath = path.resolve(baseDir, file);
             let fileStat  = null;
@@ -69,7 +70,7 @@ async function convertDirsToGlobs (fileList, baseDir) {
         }
 
         return ensurePosix(file);
-    }));
+    });
 
     return fileList.filter(file => !!file);
 }

--- a/src/utils/parse-file-list.js
+++ b/src/utils/parse-file-list.js
@@ -5,7 +5,7 @@ import Compiler from '../compiler';
 import OS from 'os-family';
 import { isEmpty, flatten } from 'lodash';
 import { stat } from '../utils/promisified-functions';
-import asyncFilter from '../utils/async-filter';
+
 
 const DEFAULT_TEST_LOOKUP_DIRS = ['test', 'tests'];
 const TEST_FILE_GLOB_PATTERN   = `./**/*@(${Compiler.getSupportedTestFileExtensions().join('|')})`;
@@ -40,7 +40,7 @@ function ensurePosix (fileString) {
 }
 
 async function convertDirsToGlobs (fileList, baseDir) {
-    fileList = await asyncFilter(fileList, async file => {
+    fileList = await Promise.all(fileList.map(async file => {
         if (!isGlob(file)) {
             const absPath = path.resolve(baseDir, file);
             let fileStat  = null;
@@ -70,7 +70,7 @@ async function convertDirsToGlobs (fileList, baseDir) {
         }
 
         return ensurePosix(file);
-    });
+    }));
 
     return fileList.filter(file => !!file);
 }

--- a/test/functional/fixtures/regression/gh-2846/pages/index.html
+++ b/test/functional/fixtures/regression/gh-2846/pages/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <title>gh-2846</title>
-</head>
-<body>
-</body>
-</html>

--- a/test/functional/fixtures/regression/gh-2846/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-2846/testcafe-fixtures/index.js
@@ -1,5 +1,4 @@
-fixture `GH-2846`
-    .page `http://localhost:3000/fixtures/regression/gh-2846/pages/index.html`;
+fixture `GH-2846`;
 
 test(`Debug`, async t => {
     await t.debug();


### PR DESCRIPTION
Changes:
* improve serialization of `URL` class
* rename `SwitchToWindowByPredicateCommand.findWindow` -> `SwitchToWindowByPredicateCommand.checkWindow`
* add `asyncFilter` function
* other refactorings