### PR TITLE
Add ability to get skipped tests when using getTestList for static analysis

### DIFF
--- a/src/compiler/test-file/formats/es-next/get-test-list.js
+++ b/src/compiler/test-file/formats/es-next/get-test-list.js
@@ -63,14 +63,15 @@ export class EsNextTestFileParser extends TestFileParserBase {
         return token.callee.property.name;
     }
 
-    formatFnData (name, value, token, meta = [{}]) {
+    formatFnData (name, value, token, meta = [{}], isSkipped) {
         return {
-            fnName: name,
-            value:  value,
-            loc:    token.loc,
-            start:  token.start,
-            end:    token.end,
-            meta:   merge({}, ...meta),
+            fnName:    name,
+            value:     value,
+            loc:       token.loc,
+            start:     token.start,
+            end:       token.end,
+            meta:      merge({}, ...meta),
+            isSkipped: isSkipped,
         };
     }
 
@@ -123,16 +124,23 @@ export class EsNextTestFileParser extends TestFileParserBase {
                     const calleeType     = parentExp.callee.type;
                     const calleeMemberFn = parentExp.callee.property && parentExp.callee.property.name;
 
-                    if (this.checkExpDefineTargetName(calleeType, calleeMemberFn))
+                    if (this.checkExpDefineTargetName(calleeType, calleeMemberFn)) {
+                        if (calleeMemberFn === 'skip')
+                            return this.formatFnData(exp.name, this.formatFnArg(parentExp.arguments[0]), token, meta, true);
                         return this.formatFnData(exp.name, this.formatFnArg(parentExp.arguments[0]), token, meta);
+                    }
                 }
 
                 if (parentExp.type === tokenType.TaggedTemplateExpression && parentExp.tag) {
                     const tagType     = parentExp.tag.type;
                     const tagMemberFn = parentExp.tag.property && parentExp.tag.property.name;
 
-                    if (this.checkExpDefineTargetName(tagType, tagMemberFn))
+                    if (this.checkExpDefineTargetName(tagType, tagMemberFn)) {
+                        if (tagMemberFn === 'skip')
+                            return this.formatFnData(exp.name, EsNextTestFileParser.getTagStrValue(parentExp.quasi), token, meta, true);
                         return this.formatFnData(exp.name, EsNextTestFileParser.getTagStrValue(parentExp.quasi), token, meta);
+                    }
+
                 }
 
                 parentExp = callStack.pop();

--- a/src/compiler/test-file/formats/es-next/get-test-list.js
+++ b/src/compiler/test-file/formats/es-next/get-test-list.js
@@ -71,7 +71,7 @@ export class EsNextTestFileParser extends TestFileParserBase {
             start:     token.start,
             end:       token.end,
             meta:      merge({}, ...meta),
-            isSkipped: token.isSkipped,
+            isSkipped: TestFileParserBase.isSkipped(token),
         };
     }
 

--- a/src/compiler/test-file/formats/es-next/get-test-list.js
+++ b/src/compiler/test-file/formats/es-next/get-test-list.js
@@ -120,7 +120,6 @@ export class EsNextTestFileParser extends TestFileParserBase {
         if (parentExp.type === tokenType.CallExpression)
             return this.formatFnData(exp.name, this.formatFnArg(parentExp.arguments[0]), token, meta, currentSkip);
 
-
         if (parentExp.type === tokenType.TaggedTemplateExpression)
             return this.formatFnData(exp.name, EsNextTestFileParser.getTagStrValue(parentExp.quasi), token, meta, currentSkip);
 
@@ -131,8 +130,7 @@ export class EsNextTestFileParser extends TestFileParserBase {
                     const calleeMemberFn = parentExp.callee.property && parentExp.callee.property.name;
 
                     if (this.checkExpDefineTargetName(calleeType, calleeMemberFn)) {
-                        if (calleeMemberFn === 'skip')
-                            currentSkip = true;
+                        if (calleeMemberFn === 'skip') currentSkip = true;
 
                         return this.formatFnData(exp.name, this.formatFnArg(parentExp.arguments[0]), token, meta, currentSkip);
                     }
@@ -143,8 +141,7 @@ export class EsNextTestFileParser extends TestFileParserBase {
                     const tagMemberFn = parentExp.tag.property && parentExp.tag.property.name;
 
                     if (this.checkExpDefineTargetName(tagType, tagMemberFn)) {
-                        if (tagMemberFn === 'skip')
-                            currentSkip = true;
+                        if (tagMemberFn === 'skip') currentSkip = true;
 
                         return this.formatFnData(exp.name, EsNextTestFileParser.getTagStrValue(parentExp.quasi), token, meta, currentSkip);
                     }

--- a/src/compiler/test-file/formats/typescript/get-test-list.js
+++ b/src/compiler/test-file/formats/typescript/get-test-list.js
@@ -124,9 +124,6 @@ class TypeScriptTestFileParser extends TestFileParserBase {
 
         let currentSkip;
 
-        if (token.property && token.property.type === tokenType.Identifier && token.property.name === 'skip')
-            currentSkip = true;
-
         while (exp.kind !== this.tokenType.Identifier) {
             exp = exp.expression || exp.tag;
 
@@ -139,6 +136,10 @@ class TypeScriptTestFileParser extends TestFileParserBase {
             let parentExp = callStack.pop();
 
             while (parentExp) {
+
+                if (parentExp.parent && parentExp.parent.name && parentExp.parent.name.text === 'skip')
+                    currentSkip = true;
+
                 if (parentExp.kind === tokenType.CallExpression && parentExp.expression) {
                     const calleeType     = parentExp.expression.kind;
                     const calleeMemberFn = calleeType === tokenType.PropertyAccessExpression &&

--- a/src/compiler/test-file/formats/typescript/get-test-list.js
+++ b/src/compiler/test-file/formats/typescript/get-test-list.js
@@ -113,7 +113,7 @@ class TypeScriptTestFileParser extends TestFileParserBase {
             start:     loc.start,
             end:       loc.end,
             meta:      merge({}, ...meta),
-            isSkipped: token.isSkipped,
+            isSkipped: TestFileParserBase.isSkipped(token),
         };
     }
 

--- a/src/compiler/test-file/formats/typescript/get-test-list.js
+++ b/src/compiler/test-file/formats/typescript/get-test-list.js
@@ -122,6 +122,11 @@ class TypeScriptTestFileParser extends TestFileParserBase {
         const tokenType = this.tokenType;
         const callStack = [exp];
 
+        let currentSkip;
+
+        if (token.property && token.property.type === tokenType.Identifier && token.property.name === 'skip')
+            currentSkip = true;
+
         while (exp.kind !== this.tokenType.Identifier) {
             exp = exp.expression || exp.tag;
 
@@ -140,9 +145,9 @@ class TypeScriptTestFileParser extends TestFileParserBase {
                                            parentExp.expression.name.text;
 
                     if (this.checkExpDefineTargetName(calleeType, calleeMemberFn)) {
-                        if (calleeMemberFn === 'skip')
-                            return this.formatFnData(exp.text, this.formatFnArg(parentExp.arguments[0]), token, meta, true);
-                        return this.formatFnData(exp.text, this.formatFnArg(parentExp.arguments[0]), token, meta);
+                        if (calleeMemberFn === 'skip') currentSkip = true;
+
+                        return this.formatFnData(exp.text, this.formatFnArg(parentExp.arguments[0]), token, meta, currentSkip);
                     }
                 }
 
@@ -151,9 +156,9 @@ class TypeScriptTestFileParser extends TestFileParserBase {
                     const tagMemberFn = tagType === tokenType.PropertyAccessExpression && parentExp.tag.name.text;
 
                     if (this.checkExpDefineTargetName(tagType, tagMemberFn)) {
-                        if (tagMemberFn === 'skip')
-                            return this.formatFnData(exp.text, this.formatFnArg(parentExp), token, meta, true);
-                        return this.formatFnData(exp.text, this.formatFnArg(parentExp), token, meta);
+                        if (tagMemberFn === 'skip') currentSkip = true;
+
+                        return this.formatFnData(exp.text, this.formatFnArg(parentExp), token, meta, currentSkip);
                     }
                 }
 

--- a/src/compiler/test-file/formats/typescript/get-test-list.js
+++ b/src/compiler/test-file/formats/typescript/get-test-list.js
@@ -124,6 +124,9 @@ class TypeScriptTestFileParser extends TestFileParserBase {
 
         let currentSkip;
 
+        if (token.name && token.name.text === 'skip')
+            currentSkip = true;
+
         while (exp.kind !== this.tokenType.Identifier) {
             exp = exp.expression || exp.tag;
 

--- a/src/compiler/test-file/test-file-parser-base.js
+++ b/src/compiler/test-file/test-file-parser-base.js
@@ -169,17 +169,16 @@ export class TestFileParserBase {
         }, []);
     }
 
-    setSkipped (originalToken, token = originalToken) {
+    static isSkipped (originalToken, token = originalToken) {
         const needSkip = token?.property?.name === SKIP_PROPERTY_NAME || token?.name?.text === SKIP_PROPERTY_NAME;
 
-        if (needSkip)
-            originalToken.isSkipped = true;
-        else {
+        if (!needSkip) {
             token = token.callee || token.tag || token.object || token.expression;
 
-            if (token)
-                this.setSkipped(originalToken, token);
+            return token ? TestFileParserBase.isSkipped(originalToken, token) : false;
         }
+
+        return true;
     }
 
     checkExpDefineTargetName (type, apiFn) {
@@ -199,8 +198,6 @@ export class TestFileParserBase {
     analyzeToken (token) {
         const tokenType     = this.tokenType;
         const currTokenType = this.getTokenType(token);
-
-        this.setSkipped(token);
 
         switch (currTokenType) {
             case tokenType.ExpressionStatement:

--- a/src/compiler/test-file/test-file-parser-base.js
+++ b/src/compiler/test-file/test-file-parser-base.js
@@ -20,23 +20,25 @@ function getLoc (loc) {
 }
 
 export class Fixture {
-    constructor (name, start, end, loc, meta) {
+    constructor (name, start, end, loc, meta, isSkipped) {
         this.name  = name;
         this.loc   = getLoc(loc);
         this.start = start;
         this.end   = end;
         this.meta  = meta;
         this.tests = [];
+        this.isSkipped = isSkipped ? isSkipped : false;
     }
 }
 
 export class Test {
-    constructor (name, start, end, loc, meta) {
+    constructor (name, start, end, loc, meta, isSkipped) {
         this.name  = name;
         this.loc   = getLoc(loc);
         this.start = start;
         this.end   = end;
         this.meta  = meta;
+        this.isSkipped = isSkipped ? isSkipped : false;
     }
 }
 
@@ -235,13 +237,15 @@ export class TestFileParserBase {
             if (!call || typeof call.value !== 'string') return;
 
             if (call.fnName === 'fixture') {
-                fixtures.push(new Fixture(call.value, call.start, call.end, call.loc, call.meta));
+                fixtures.push(new Fixture(call.value, call.start, call.end, call.loc, call.meta, call.isSkipped));
                 return;
             }
 
             if (!fixtures.length) return;
 
-            const test = new Test(call.value, call.start, call.end, call.loc, call.meta);
+            // If the fixture is skipped, mark all the tests in the fixture skipped, otherwise, use the current test identifier
+            const testIsSkipped = fixtures[fixtures.length - 1].isSkipped ? fixtures[fixtures.length - 1].isSkipped : call.isSkipped;
+            const test = new Test(call.value, call.start, call.end, call.loc, call.meta, testIsSkipped);
 
             fixtures[fixtures.length - 1].tests.push(test);
         });

--- a/test/server/data/test-suites/fixture-and-test-hooks/testfile.js
+++ b/test/server/data/test-suites/fixture-and-test-hooks/testfile.js
@@ -87,3 +87,26 @@ test
     .after(async t => {})
     `${value}`
     .page('http://example.com');
+
+fixture.only(`fixture9`).skip;
+
+test.only(`fixture9test1`);
+
+fixture(`fixture10`)
+.before(async t => {})
+.beforeEach(async t => {})
+.afterEach(async t => {})
+.after(async t => {})
+.skip;
+
+test(`fixture10test1`);
+
+fixture(`fixture11`);
+
+test.only(`fixture11test1`).skip;
+
+test
+    .before(async t => {})
+    `fixture11test2`
+    .after(async t => {})
+    .skip;

--- a/test/server/data/test-suites/fixture-and-test-hooks/testfile.js
+++ b/test/server/data/test-suites/fixture-and-test-hooks/testfile.js
@@ -110,3 +110,58 @@ test
     `fixture11test2`
     .after(async t => {})
     .skip;
+
+test
+    .skip
+    .before(async t => {})
+    .after(async t => {})
+    `fixture11test3`;
+
+test
+    .before(async t => {})
+    .skip
+    .after(async t => {})
+    (`fixture11test4`, async t => {});
+
+test
+.skip
+.clientScripts()
+.requestHooks()
+.timeouts({
+    pageLoadTimeout: 2000,
+})
+.httpAuth({
+    username: 'user1',
+    password: '123'
+})
+.meta(`key1`,'value1')
+(`fixture11test5`);
+
+test.disablePageCaching
+    .before(async t => {})
+    .after(async t => {})
+    .requestHooks()
+    .clientScripts()
+    .meta(`key2`, `value2`)
+    .timeouts({
+        pageLoadTimeout: 2000,
+    })
+    `fixture11test6`.skip;
+
+fixture
+    .skip
+    .beforeEach(async t => {})
+    .before(async t => {})
+    .after(async t => {})
+    ('fixture12');
+
+fixture(`fixture13`)
+    .before(async t => {})
+    .after(async t => {})
+    .disablePageCaching
+    .clientScripts()
+    .timeouts({
+        pageLoadTimeout: 2000,
+    })
+    .skip
+    .page(`https://devexpress.github.io/testcafe/example/`);

--- a/test/server/parse-fixture-test.js
+++ b/test/server/parse-fixture-test.js
@@ -218,7 +218,19 @@ describe('Should get structure of files (esnext and typescript common cases)', f
                     [
                         new Test('fixture11test1', 1706, 1738, new Loc(106, 0, 106, 32), {}, true),
                         new Test('fixture11test2', 1741, 1829, new Loc(108, 0, 112, 9), {}, true),
+                        new Test('fixture11test3', 1832, 1920, new Loc(114, 0, 118, 20), {}, true),
+                        new Test('fixture11test4', 1923, 2028, new Loc(120, 0, 124, 37), {}, true),
+                        new Test('fixture11test5', 2031, 2216, new Loc(126, 0, 138, 18), { 'key1': 'value1' }, true),
+                        new Test('fixture11test6', 2219, 2444, new Loc(140, 0, 149, 25), { 'key2': 'value2' }, true),
                     ]
+                ),
+                new Fixture('fixture12', 2447, 2566, new Loc(151, 0, 156, 17), {},
+                    [],
+                    true
+                ),
+                new Fixture('fixture13', 2569, 2811, new Loc(158, 0, 167, 59), {},
+                    [],
+                    true
                 ),
             ],
         ];

--- a/test/server/parse-fixture-test.js
+++ b/test/server/parse-fixture-test.js
@@ -150,8 +150,9 @@ describe('Should get structure of files (esnext and typescript common cases)', f
             [
                 new Fixture('fixture1', 0, 23, new Loc(1, 0, 1, 23), {},
                     [
-                        new Test('fixture1test1', 26, 111, new Loc(3, 0, 9, 2), {}),
-                    ]
+                        new Test('fixture1test1', 26, 111, new Loc(3, 0, 9, 2), {}, true),
+                    ],
+                    true
                 ),
 
                 new Fixture('fixture2', 115, 137, new Loc(12, 0, 12, 22), {},

--- a/test/server/parse-fixture-test.js
+++ b/test/server/parse-fixture-test.js
@@ -15,9 +15,9 @@ const {
 const parserBase = require('../../lib/compiler/test-file/test-file-parser-base');
 
 const Test    = parserBase.Test;
-const Fixture = function (name, start, end, loc, meta, tests) {
+const Fixture = function (name, start, end, loc, meta, tests, isSkipped) {
     return assign(
-        new parserBase.Fixture(name, start, end, loc, meta),
+        new parserBase.Fixture(name, start, end, loc, meta, isSkipped),
         { tests: tests }
     );
 };
@@ -79,13 +79,13 @@ describe('Should get structure of files (esnext and typescript common cases)', f
                     [
                         new Test('Fixture1Test1', 52, 148, new Loc(5, 0, 9, 2), {}),
                         new Test('<computed name>(line: 13)', 187, 238, new Loc(13, 0, 15, 2), {}),
-                    ]
+                    ],
                 ),
 
                 new Fixture('<computed name>(line: 17)', 241, 353, new Loc(17, 0, 20, 26), {},
                     [
                         new Test('Fixture2Test1', 356, 413, new Loc(22, 0, 24, 2), {}),
-                    ]
+                    ],
                 ),
             ],
             [
@@ -156,11 +156,12 @@ describe('Should get structure of files (esnext and typescript common cases)', f
 
                 new Fixture('fixture2', 115, 137, new Loc(12, 0, 12, 22), {},
                     [
-                        new Test('fixture2test1', 140, 164, new Loc(14, 0, 14, 24), {}),
-                        new Test('fixture2test2', 166, 190, new Loc(15, 0, 15, 24), {}),
-                        new Test('fixture2test3', 193, 241, new Loc(17, 0, 17, 48), {}),
-                        new Test('fixture2test4', 243, 269, new Loc(18, 0, 18, 26), {}),
-                    ]
+                        new Test('fixture2test1', 140, 164, new Loc(14, 0, 14, 24), {}, true),
+                        new Test('fixture2test2', 166, 190, new Loc(15, 0, 15, 24), {}, true),
+                        new Test('fixture2test3', 193, 241, new Loc(17, 0, 17, 48), {}, true),
+                        new Test('fixture2test4', 243, 269, new Loc(18, 0, 18, 26), {}, true),
+                    ],
+                    true
                 ),
 
                 new Fixture('fixture 3', 272, 297, new Loc(20, 0, 20, 25), {},

--- a/test/server/parse-fixture-test.js
+++ b/test/server/parse-fixture-test.js
@@ -202,6 +202,24 @@ describe('Should get structure of files (esnext and typescript common cases)', f
                         new Test('<computed name>(line: 88)', 1363, 1467, new Loc(85, 0, 89, 31), {}),
                     ]
                 ),
+                new Fixture('fixture9', 1470, 1499, new Loc(91, 0, 91, 29), {},
+                    [
+                        new Test('fixture9test1', 1502, 1528, new Loc(93, 0, 93, 26), {}, true),
+                    ],
+                    true
+                ),
+                new Fixture('fixture10', 1531, 1655, new Loc(95, 0, 100, 5), {},
+                    [
+                        new Test('fixture10test1', 1658, 1680, new Loc(102, 0, 102, 22), {}, true),
+                    ],
+                    true
+                ),
+                new Fixture('fixture11', 1683, 1703, new Loc(104, 0, 104, 20), {},
+                    [
+                        new Test('fixture11test1', 1706, 1738, new Loc(106, 0, 106, 32), {}, true),
+                        new Test('fixture11test2', 1741, 1829, new Loc(108, 0, 112, 9), {}, true),
+                    ]
+                ),
             ],
         ];
 


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
_Describe the problem you want to address or the feature you want to implement._

I have opened an issue https://github.com/DevExpress/testcafe/issues/6238, and I was suggested to open a PR. The purpose is to add property of "isSkipped" when using getTypeScriptTestList / getTypeScriptTestListFromCode and getTestList / getTestListFromCode when I just want to do a static analysis without actually running the tests.

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._

1) Add property "isSkipped" in Class Fixture, Class Test and formatFnData().
2) Add check if the test / fixture is skipped by a new function getSkippedInfo().
3) Pass the isSkipped property in analyze() for fixture and test.

## References
_Provide a link to the existing issue(s), if any._

https://github.com/DevExpress/testcafe/issues/6238

## Pre-Merge TODO

I think the test "src/compiler/test-file/test-file-parser-base.js" includes the test I need, and I made the required updates.
I have run the following tests on my local,
```
gulp test-server - all pass, except for some existing "errored after" from the master branch
gulp test-functional-local - some screenshots not stable pass, and encounter `Error: Port 1337 is occupied by another process.` which exists in master branch
gulp test-client-local - there seem to be some existing failure from the master branch
```
And I found the link on Contributing Guide https://github.com/DevExpress/testcafe/blob/master/docs/articles/documentation/reference/command-line-interface.md#file-pathglob-pattern and https://github.com/DevExpress/testcafe/blob/master/docs/articles/documentation/reference/command-line-interface.md cannot be reached now.

I am opening PR for review to double-check if I am missing anything and looking for feedback on my approach. Thank you so much!

- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
marking this since the tests including my changes have passed. 

Hi @AlexSkorkin @AlexKamaev @miherlosev Would you mind helping review and approve running workflows? Thanks! I cannot add reviewers.