### PR TITLE
fix: fixed overwriting the quarantine mode if the config file is used

### DIFF
--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -79,8 +79,6 @@ export default class TestCafeConfiguration extends Configuration {
     }
 
     public async init (options?: object): Promise<void> {
-        options = options || {};
-
         await super.init();
 
         const opts = await this._load();
@@ -91,7 +89,13 @@ export default class TestCafeConfiguration extends Configuration {
             await this._normalizeOptionsAfterLoad();
         }
 
-        this.mergeOptions(options);
+        await this.asyncMergeOptions(options);
+    }
+
+    public async asyncMergeOptions (options?: object): Promise<void> {
+        options = options || {};
+
+        super.mergeOptions(options);
 
         if (this._options.browsers)
             this._options.browsers.value = await this._getBrowserInfo();

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -535,7 +535,7 @@ export default class Runner extends EventEmitter {
     }
 
     async _applyOptions () {
-        await this.configuration.init(this._options);
+        await this.configuration.asyncMergeOptions(this._options);
 
         return this._setBootstrapperOptions();
     }

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -552,7 +552,7 @@ describe('TypeScriptConfiguration', function () {
                 });
         });
 
-        it('TestCafe config + TypeScript config', function () {
+        it('TestCafe config + TypeScript config', async function () {
             createTestCafeConfigurationFile({
                 tsConfigPath: customTSConfigFilePath,
             });
@@ -566,19 +566,15 @@ describe('TypeScriptConfiguration', function () {
             const configuration = new TestCafeConfiguration();
             const runner        = new RunnerCtor({ configuration });
 
-            return runner
-                .src('test/server/data/test-suites/typescript-basic/testfile1.ts')
-                ._applyOptions()
-                .then(() => {
-                    return runner.bootstrapper._getTests();
-                })
-                .then(() => {
-                    fs.unlinkSync(TestCafeConfiguration.FILENAME);
-                    typeScriptConfiguration._filePath = customTSConfigFilePath;
+            await configuration.init();
+            await runner.src('test/server/data/test-suites/typescript-basic/testfile1.ts')._applyOptions();
+            await runner.bootstrapper._getTests();
 
-                    expect(runner.bootstrapper.tsConfigPath).eql(customTSConfigFilePath);
-                    expect(consoleWrapper.messages.log).contains('You cannot override the "target" compiler option in the TypeScript configuration file.');
-                });
+            fs.unlinkSync(TestCafeConfiguration.FILENAME);
+            typeScriptConfiguration._filePath = customTSConfigFilePath;
+
+            expect(runner.bootstrapper.tsConfigPath).eql(customTSConfigFilePath);
+            expect(consoleWrapper.messages.log).contains('You cannot override the "target" compiler option in the TypeScript configuration file.');
         });
 
         describe('Should warn message on rewrite a non-overridable property', () => {


### PR DESCRIPTION
[closes DevExpress/testcafe#6420]

## Purpose
Fixed overwriting the quarantine mode if the config file is used

## Approach
1. Add a test with setting the quarantine mode and creating the config file
2. Remove a repeat config initialization

## References
https://github.com/DevExpress/testcafe/issues/6420

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
