### PR TITLE
fix: added allowing unknown options

### DIFF
--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -114,6 +114,7 @@ export default class CLIArgumentParser {
             .usage('[options] <comma-separated-browser-list> <file-or-glob ...>')
             .description(CLIArgumentParser._getDescription())
 
+            .allowUnknownOption()
             .option('-b, --list-browsers [provider]', 'output the aliases for local browsers or browsers available through the specified browser provider')
             .option('-r, --reporter <name[:outputFile][,...]>', 'specify the reporters and optionally files where reports are saved')
             .option('-s, --screenshots <option=value[,...]>', 'specify screenshot options')

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -744,6 +744,15 @@ describe('CLI argument parser', function () {
             });
     });
 
+    it('Should parse unknown command line arguments', function () {
+        const unknownArgument = '--unknown-argument=unknown-value';
+
+        return parse(unknownArgument)
+            .then(parser => {
+                expect(parser.args).eql([unknownArgument]);
+            });
+    });
+
     it('Should have static CLI', () => {
         const CHANGE_CLI_WARNING         = 'IMPORTANT: Please be sure what you want to change CLI if this test is failing!';
         const ADD_TO_RUN_OPTIONS_WARNING = 'Check that the added option is correctly passed from the command-line interface to the run options.' +


### PR DESCRIPTION
[closes DevExpress/testcafe#6426]

## Purpose
Add allowing unknown options in the CLI

## Approach
1. Add a test with the setting an unknown option in CLI
2. Call method allowUnknownOption

## References
https://github.com/DevExpress/testcafe/issues/6426

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
