### PR TITLE
refactor: fix multiple windows test in the compiler service mode

### DIFF
--- a/.github/workflows/deploy-to-artifacts.yml
+++ b/.github/workflows/deploy-to-artifacts.yml
@@ -165,7 +165,7 @@ jobs:
 
             tasks.push('test-functional-docker.yml');
             tasks.push('test-functional-local-chrome.yml');
-            tasks.push('test-functional-local-compiler-service.yml');
+            tasks.push('test-functional-local-debug.yml');
             tasks.push('test-functional-local-firefox.yml');
             tasks.push('test-functional-local-ie.yml');
             tasks.push('test-functional-local-multiple-windows.yml');

--- a/.github/workflows/test-functional-local-debug.yml
+++ b/.github/workflows/test-functional-local-debug.yml
@@ -1,4 +1,4 @@
-name: Test Functional (Compiler Service)
+name: Test Functional (Debug)
 
 on:
   workflow_dispatch:
@@ -86,7 +86,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       - run: npm ci
-      - run: npx gulp test-functional-local-compiler-service-run --steps-as-tasks
+      - run: npx gulp test-functional-local-debug-run --steps-as-tasks
         timeout-minutes: 60
       - uses: actions/github-script@v3
         with:

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -34,7 +34,7 @@ const {
     TESTS_GLOB,
     LEGACY_TESTS_GLOB,
     MULTIPLE_WINDOWS_TESTS_GLOB,
-    MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB,
+    DEBUG_GLOB,
 } = require('./gulp/constants/functional-test-globs');
 
 const {
@@ -409,11 +409,11 @@ gulp.step('test-functional-local-multiple-windows-run', () => {
 
 gulp.task('test-functional-local-multiple-windows', gulp.series('prepare-tests', 'test-functional-local-multiple-windows-run'));
 
-gulp.step('test-functional-local-compiler-service-run', () => {
-    return testFunctional(MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB, functionalTestConfig.testingEnvironmentNames.localHeadlessChrome, { experimentalCompilerService: true });
+gulp.step('test-functional-local-debug-run', () => {
+    return testFunctional(DEBUG_GLOB, functionalTestConfig.testingEnvironmentNames.localHeadlessChrome, { experimentalDebug: true });
 });
 
-gulp.task('test-functional-local-compiler-service', gulp.series('prepare-tests', 'test-functional-local-compiler-service-run'));
+gulp.task('test-functional-local-debug', gulp.series('prepare-tests', 'test-functional-local-debug-run'));
 
 gulp.step('test-functional-local-proxyless-run', () => {
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localHeadlessChrome, { isProxyless: true });

--- a/gulp/constants/functional-test-globs.js
+++ b/gulp/constants/functional-test-globs.js
@@ -9,17 +9,16 @@ const TESTS_GLOB = [
     `!${COMPILER_SERVICE_TESTS_GLOB}`,
 ];
 
-const MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB = [
+const DEBUG_GLOB = [
     BASIC_TESTS_GLOB,
     COMPILER_SERVICE_TESTS_GLOB,
-    '!test/functional/fixtures/multiple-windows/test.js',
-    '!test/functional/fixtures/regression/gh-2846/test.js',
 ];
 
 module.exports = {
     TESTS_GLOB,
     LEGACY_TESTS_GLOB,
     MULTIPLE_WINDOWS_TESTS_GLOB,
-    MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB,
+    BASIC_TESTS_GLOB,
     COMPILER_SERVICE_TESTS_GLOB,
+    DEBUG_GLOB,
 };

--- a/gulp/helpers/test-functional.js
+++ b/gulp/helpers/test-functional.js
@@ -23,12 +23,12 @@ function shouldAddTakeScreenshotTestGlob (glob) {
     return [TESTS_GLOB, MIGRATE_ALL_TESTS_TO_COMPILER_SERVICE_GLOB].includes(glob);
 }
 
-module.exports = function testFunctional (src, testingEnvironmentName, { experimentalCompilerService, isProxyless } = {}) {
+module.exports = function testFunctional (src, testingEnvironmentName, { experimentalDebug, isProxyless } = {}) {
     process.env.TESTING_ENVIRONMENT       = testingEnvironmentName;
     process.env.BROWSERSTACK_USE_AUTOMATE = 1;
 
-    if (experimentalCompilerService)
-        process.env.EXPERIMENTAL_COMPILER_SERVICE = 'true';
+    if (experimentalDebug)
+        process.env.EXPERIMENTAL_DEBUG = 'true';
 
     if (isProxyless)
         process.env.PROXYLESS = 'true';

--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -169,7 +169,7 @@ export default class CLIArgumentParser {
             .option('--no-color', 'disable colors in command line')
 
             // NOTE: temporary hide experimental options from --help command
-            .addOption(new Option('--experimental-compiler-service', 'run compiler in a separate process').hideHelp())
+            .addOption(new Option('--experimental-debug', 'enable experimental debug mode').hideHelp())
             .addOption(new Option('--cache', 'cache web assets between test runs').hideHelp());
     }
 

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -75,7 +75,7 @@ async function runTests (argParser) {
 
     log.showSpinner();
 
-    const { hostname, ssl, dev, experimentalCompilerService, retryTestPages, cache } = opts;
+    const { hostname, ssl, dev, experimentalDebug, retryTestPages, cache } = opts;
 
     const testCafe = await createTestCafe({
         developmentMode: dev,
@@ -84,7 +84,7 @@ async function runTests (argParser) {
         port1,
         port2,
         ssl,
-        experimentalCompilerService,
+        experimentalDebug,
         retryTestPages,
         cache,
         configFile,

--- a/src/configuration/option-names.ts
+++ b/src/configuration/option-names.ts
@@ -41,7 +41,7 @@ enum OptionNames {
     disableScreenshots = 'disableScreenshots',
     debugLogger = 'debugLogger',
     disableMultipleWindows = 'disableMultipleWindows',
-    experimentalCompilerService = 'experimentalCompilerService',
+    experimentalDebug = 'experimentalDebug',
     compilerOptions = 'compilerOptions',
     pageRequestTimeout = 'pageRequestTimeout',
     ajaxRequestTimeout = 'ajaxRequestTimeout',

--- a/src/testcafe.js
+++ b/src/testcafe.js
@@ -32,7 +32,7 @@ export default class TestCafe {
         this.runners                  = [];
         this.configuration            = configuration;
 
-        this.compilerService = configuration.getOption(OPTION_NAMES.experimentalCompilerService) ? new CompilerHost(options) : void 0;
+        this.compilerService = configuration.getOption(OPTION_NAMES.experimentalDebug) ? new CompilerHost(options) : void 0;
 
         this._registerAssets(options.developmentMode);
     }

--- a/test/functional/fixtures/multiple-windows/test.js
+++ b/test/functional/fixtures/multiple-windows/test.js
@@ -8,6 +8,8 @@ const config                     = require('../../config');
 
 const SCREENSHOTS_PATH = config.testScreenshotsDir;
 
+const experimentalDebug = !!process.env.EXPERIMENTAL_DEBUG;
+
 async function assertScreenshotColor (fileName, pixel) {
     for (const browser of config.currentEnvironment.browsers) {
         const filePath = path.join(SCREENSHOTS_PATH, 'custom', browser.alias + fileName);
@@ -99,9 +101,15 @@ describe('Multiple windows', () => {
         return runTests('testcafe-fixtures/cookie-synchronization/same-domain.js', null, { only: 'chrome' });
     });
 
-    it('Should continue debugging when a child window closes', () => {
-        return runTests('testcafe-fixtures/debug-synchronization.js', null, { only: 'chrome' });
-    });
+    if (!experimentalDebug) {
+        it('Should continue debugging when a child window closes', () => {
+            // NOTE: This test imitates the user clicks for TestCafe's debug UI.
+            // This scenario is not suitable for a run in compiler service due to
+            // the compiler service tests execute in the headless chrome
+            // and TestCafe's debug UI is not visible for end-user.
+            return runTests('testcafe-fixtures/debug-synchronization.js', null, { only: 'chrome' });
+        });
+    }
 
     it('Should make screenshots of different windows', () => {
         return runTests('testcafe-fixtures/features/screenshots.js', null, { setScreenshotPath: true })

--- a/test/functional/fixtures/multiple-windows/testcafe-fixtures/features/screenshots.js
+++ b/test/functional/fixtures/multiple-windows/testcafe-fixtures/features/screenshots.js
@@ -5,13 +5,15 @@ fixture `Screenshots`
     .page(RED_PAGE);
 
 test('should make screenshots of multiple windows', async t => {
-    await t.takeScreenshot(`custom/${t.browser.alias}0.png`);
+    const browserName = t.browser.name.toLowerCase();
+
+    await t.takeScreenshot(`custom/${browserName}0.png`);
 
     const child = await t.openWindow(GREEN_PAGE);
 
-    await t.takeScreenshot(`custom/${t.browser.alias}1.png`);
+    await t.takeScreenshot(`custom/${browserName}1.png`);
     await t.openWindow(RED_PAGE);
-    await t.takeScreenshot(`custom/${t.browser.alias}2.png`);
+    await t.takeScreenshot(`custom/${browserName}2.png`);
     await t.switchToWindow(child);
-    await t.takeScreenshot(`custom/${t.browser.alias}3.png`);
+    await t.takeScreenshot(`custom/${browserName}3.png`);
 });

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -153,8 +153,8 @@ before(function () {
 
         retryTestPages,
 
-        experimentalCompilerService: !!process.env.EXPERIMENTAL_COMPILER_SERVICE,
-        isProxyless:                 config.isProxyless,
+        experimentalDebug: !!process.env.EXPERIMENTAL_DEBUG,
+        isProxyless:       config.isProxyless,
     };
 
     return createTestCafe(testCafeOptions)

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -807,7 +807,7 @@ describe('CLI argument parser', function () {
             { long: '--disable-screenshots' },
             { long: '--screenshots-full-page' },
             { long: '--disable-multiple-windows' },
-            { long: '--experimental-compiler-service' },
+            { long: '--experimental-debug' },
             { long: '--compiler-options' },
             { long: '--page-request-timeout' },
             { long: '--ajax-request-timeout' },


### PR DESCRIPTION
Closes https://github.com/DevExpress/testcafe/issues/6390

Changes:
* fix tests
* rename `--experimental-compiler-service` to `--experimental-debug`
