### PR TITLE
fix: fixed processing the option 'browsers' with value 'all'

### DIFF
--- a/src/browser/provider/pool.js
+++ b/src/browser/provider/pool.js
@@ -68,10 +68,10 @@ export default {
             [];
 
         if (!allBrowserNames.length)
-            return { provider, providerName, browserName: '' };
+            return { provider, providerName, browserName: '', browserOption: '' };
 
         return allBrowserNames
-            .map(browserName => ({ provider, providerName, browserName }));
+            .map(browserName => ({ provider, providerName, browserName, browserOption: browserName }));
     },
 
     _getProviderModule (providerName, moduleName) {

--- a/test/server/browser-provider-test.js
+++ b/test/server/browser-provider-test.js
@@ -77,6 +77,23 @@ describe('Browser provider', function () {
             });
         });
 
+        it( 'Should get full info for all browsers', async () => {
+            const browserInfoProperties = [
+                'provider',
+                'providerName',
+                'browserName',
+                'browserOption',
+            ];
+
+            const browsersInfo = await browserProviderPool.getBrowserInfo( 'all' );
+
+            browsersInfo.forEach( item => {
+                browserInfoProperties.forEach(porp => {
+                    expect(item[porp]).exist;
+                });
+            } );
+        } );
+
         it('Should parse the chrome: alias with arguments', async () => {
             const builtInProviders = {
                 chrome: { isValidBrowserName: sinon.stub() },


### PR DESCRIPTION
[closes DevExpress/testcafe#6456]

## Purpose
Fix processing the option 'browsers' with value 'all'

## Approach
1. Add test
2. Add fix

## References
https://github.com/DevExpress/testcafe/issues/6456

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
