### PR TITLE
refactor: pass v8 flags to the compiler process

### DIFF
--- a/bin/testcafe-with-v8-flag-filter.js
+++ b/bin/testcafe-with-v8-flag-filter.js
@@ -2,7 +2,13 @@
 
 'use strict';
 
-var path          = require('path');
-var v8FlagsFilter = require('bin-v8-flags-filter');
+const path          = require('path');
+const v8FlagsFilter = require('bin-v8-flags-filter');
 
-v8FlagsFilter(path.join(__dirname, '../lib/cli'), { useShutdownMessage: true });
+const EXPERIMENTAL_DEBUG_OPTION = '--experimental-debug';
+
+if (process.argv.slice(2).includes(EXPERIMENTAL_DEBUG_OPTION))
+    require('../lib/cli');
+
+else
+    v8FlagsFilter(path.join(__dirname, '../lib/cli'), { useShutdownMessage: true });

--- a/src/cli/node-arguments-filter.ts
+++ b/src/cli/node-arguments-filter.ts
@@ -1,0 +1,56 @@
+export const V8_DEBUG_FLAGS = [
+    '--inspect',
+    '--inspect-brk',
+];
+
+export const V8_FLAGS = [
+    ...V8_DEBUG_FLAGS,
+    'debug',
+    '--expose-gc',
+    '--gc-global',
+    '--es_staging',
+    '--no-deprecation',
+    '--prof',
+    '--log-timer-events',
+    '--throw-deprecation',
+    '--trace-deprecation',
+    '--use_strict',
+    '--allow-natives-syntax',
+    '--perf-basic-prof',
+    '--experimental-repl-await',
+];
+
+export const V8_FLAG_PREFIXES = [
+    '--harmony',
+    '--trace',
+    '--icu-data-dir',
+    '--max-old-space-size',
+    '--preserve-symlinks',
+];
+
+function isNodeFlagPrefix (arg: string): boolean {
+    return V8_FLAG_PREFIXES.some(flagPrefix => {
+        return arg.indexOf(flagPrefix) === 0;
+    });
+}
+
+interface ParsedArgs {
+    args: string[];
+    v8Flags?: string[];
+}
+
+export function extractNodeProcessArguments (cliArgs: string[]): ParsedArgs {
+    const args: string[] = [];
+    const v8Flags: string[] = [];
+
+    cliArgs.forEach(arg => {
+        const flag = arg.split('=')[0];
+
+        if (V8_FLAGS.indexOf(flag) > -1 || isNodeFlagPrefix(arg))
+            v8Flags.push(arg);
+        else
+            args.push(arg);
+    });
+
+    return { args, v8Flags: v8Flags.length ? v8Flags : void 0 };
+}

--- a/src/configuration/option-names.ts
+++ b/src/configuration/option-names.ts
@@ -48,6 +48,7 @@ enum OptionNames {
     ajaxRequestTimeout = 'ajaxRequestTimeout',
     cache = 'cache',
     userVariables = 'userVariables',
+    v8Flags = 'v8Flags',
 }
 
 export default OptionNames;

--- a/src/testcafe.js
+++ b/src/testcafe.js
@@ -32,7 +32,12 @@ export default class TestCafe {
         this.runners                  = [];
         this.configuration            = configuration;
 
-        this.compilerService = configuration.getOption(OPTION_NAMES.experimentalDebug) ? new CompilerHost(options) : void 0;
+        if (configuration.getOption(OPTION_NAMES.experimentalDebug)) {
+            const developmentMode = configuration.getOption(OPTION_NAMES.developmentMode);
+            const v8Flags         = configuration.getOption(OPTION_NAMES.v8Flags);
+
+            this.compilerService = new CompilerHost({ developmentMode, v8Flags });
+        }
 
         this._registerAssets(options.developmentMode);
     }

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -244,6 +244,15 @@ describe('CLI argument parser', function () {
         });
     });
 
+    describe('Node arguments', function () {
+        it('Should parse node flags', function () {
+            return parse('chrome test 1 --inspect-brk flag')
+                .then(function (parser) {
+                    expect(parser.opts.v8Flags).to.deep.equal(['--inspect-brk']);
+                });
+        });
+    });
+
     describe('Filtering options', function () {
         it('Should filter by test name with "-t, --test" option', function () {
             return parse('-t test.js')

--- a/test/server/test/server/node-arguments-filter-test.js
+++ b/test/server/test/server/node-arguments-filter-test.js
@@ -1,0 +1,29 @@
+const { expect } = require('chai');
+
+const {
+    extractNodeProcessArguments,
+    V8_FLAGS, V8_FLAG_PREFIXES,
+} = require('../../lib/cli/node-arguments-filter');
+
+describe('Node arguments filter', function () {
+    it('Should extract v8args and other args', function () {
+        const result = extractNodeProcessArguments(['1', 'chrome', '--inspect-brk', 'test', 'argument']);
+
+        expect(result.args).to.deep.equal(['1', 'chrome', 'test', 'argument']);
+        expect(result.v8Flags).to.deep.equal(['--inspect-brk']);
+    });
+
+    it('v8args should be \'undefined\' if empty', function () {
+        const result = extractNodeProcessArguments(['1', 'chrome', 'test', 'argument']);
+
+        expect(result.v8Flags).equal(void 0);
+    });
+
+    it('Should extract all described v8args', function () {
+        const flags = V8_FLAGS.concat(V8_FLAG_PREFIXES);
+        const result = extractNodeProcessArguments(flags);
+
+        expect(result.args).to.deep.equal([]);
+        expect(result.v8Flags).to.deep.equal(flags);
+    });
+});


### PR DESCRIPTION
Closes https://github.com/DevExpress/testcafe/issues/3811.

Changes:
* pass raw v8 flags to the `lib/cli` if the `--experimental-debug` option is specified
* merge internal and passed flag before running the service process


Based on https://github.com/DevExpress/testcafe/pull/3826/.

