### PR TITLE
refactor: decrease memory usage for the debug mode

### DIFF
--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -81,24 +81,12 @@ export default class Task extends AsyncEventEmitter {
         }
     }
 
-    private async _copyWarningsFromCompilerService (testRun: TestRun): Promise<void> {
-        if (!this._compilerService)
-            return;
-
-        const warnings = await this._compilerService.getWarningMessages({ testRunId: testRun.id });
-
-        warnings.forEach(warning => {
-            testRun.warningLog.addWarning(warning);
-        });
-    }
-
     private _assignBrowserJobEventHandlers (job: BrowserJob): void {
         job.on('test-run-start', async (testRun: TestRun) => {
             await this.emit('test-run-start', testRun);
         });
 
         job.on('test-run-done', async (testRun: TestRun) => {
-            await this._copyWarningsFromCompilerService(testRun);
             await this.emit('test-run-done', testRun);
 
             if (this.opts.stopOnFirstFail && testRun.errs.length) {

--- a/src/services/compiler/host.ts
+++ b/src/services/compiler/host.ts
@@ -147,6 +147,7 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
             this.executeAssertionFn,
             this.addUnexpectedError,
             this.checkWindow,
+            this.removeTestRun,
         ], this);
     }
 
@@ -527,5 +528,11 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
         const { proxy } = await this._getRuntime();
 
         return proxy.call(this.checkWindow, { testRunId, commandId, url, title });
+    }
+
+    public async removeTestRun ({ testRunId }: TestRunLocator): Promise<void> {
+        const { proxy } = await this._getRuntime();
+
+        return proxy.call(this.removeTestRun, { testRunId });
     }
 }

--- a/src/services/compiler/host.ts
+++ b/src/services/compiler/host.ts
@@ -64,6 +64,7 @@ import {
     CommandLocator,
     AddUnexpectedErrorArguments,
     CheckWindowArgument,
+    RemoveFixtureCtxArguments,
 } from './interfaces';
 
 import { UncaughtExceptionError, UnhandledPromiseRejectionError } from '../../errors/test-run';
@@ -148,6 +149,7 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
             this.addUnexpectedError,
             this.checkWindow,
             this.removeTestRun,
+            this.removeFixtureCtx,
         ], this);
     }
 
@@ -534,5 +536,11 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
         const { proxy } = await this._getRuntime();
 
         return proxy.call(this.removeTestRun, { testRunId });
+    }
+
+    public async removeFixtureCtx ({ fixtureId }: RemoveFixtureCtxArguments): Promise<void> {
+        const { proxy } = await this._getRuntime();
+
+        return proxy.call(this.removeFixtureCtx, { fixtureId });
     }
 }

--- a/src/services/compiler/interfaces.ts
+++ b/src/services/compiler/interfaces.ts
@@ -144,3 +144,7 @@ export interface CheckWindowArgument extends TestRunLocator {
     title: string;
 }
 
+export interface RemoveFixtureCtxArguments {
+    fixtureId: string;
+}
+

--- a/src/services/compiler/protocol.ts
+++ b/src/services/compiler/protocol.ts
@@ -25,6 +25,7 @@ import {
     CommandLocator,
     AddUnexpectedErrorArguments,
     CheckWindowArgument,
+    RemoveFixtureCtxArguments,
 } from './interfaces';
 
 export const BEFORE_AFTER_PROPERTIES      = ['beforeFn', 'afterFn'] as const;
@@ -88,4 +89,5 @@ export interface CompilerProtocol extends TestRunDispatcherProtocol {
     addUnexpectedError ({ type, message }: AddUnexpectedErrorArguments): Promise<void>;
     checkWindow ({ url, title }: CheckWindowArgument): Promise<boolean>;
     removeTestRun({ testRunId }: TestRunLocator): Promise<void>;
+    removeFixtureCtx ({ fixtureId }: RemoveFixtureCtxArguments): Promise<void>;
 }

--- a/src/services/compiler/protocol.ts
+++ b/src/services/compiler/protocol.ts
@@ -87,4 +87,5 @@ export interface CompilerProtocol extends TestRunDispatcherProtocol {
     executeAssertionFn ({ testRunId, commandId }: CommandLocator): Promise<unknown>;
     addUnexpectedError ({ type, message }: AddUnexpectedErrorArguments): Promise<void>;
     checkWindow ({ url, title }: CheckWindowArgument): Promise<boolean>;
+    removeTestRun({ testRunId }: TestRunLocator): Promise<void>;
 }

--- a/src/services/compiler/service.ts
+++ b/src/services/compiler/service.ts
@@ -201,6 +201,7 @@ class CompilerService implements CompilerProtocol {
             this.executeAsyncJsExpression,
             this.addUnexpectedError,
             this.checkWindow,
+            this.removeTestRun,
         ], this);
     }
 
@@ -501,6 +502,10 @@ class CompilerService implements CompilerProtocol {
         catch (err) {
             throw new SwitchToWindowPredicateError(err.message);
         }
+    }
+
+    public async removeTestRun ({ testRunId }: TestRunLocator): Promise<void> {
+        delete this.state.testRuns[testRunId];
     }
 }
 

--- a/src/services/compiler/service.ts
+++ b/src/services/compiler/service.ts
@@ -53,6 +53,7 @@ import {
     CommandLocator,
     AddUnexpectedErrorArguments,
     CheckWindowArgument,
+    RemoveFixtureCtxArguments,
 } from './interfaces';
 
 import { CompilerArguments } from '../../compiler/interfaces';
@@ -202,6 +203,7 @@ class CompilerService implements CompilerProtocol {
             this.addUnexpectedError,
             this.checkWindow,
             this.removeTestRun,
+            this.removeFixtureCtx,
         ], this);
     }
 
@@ -506,6 +508,10 @@ class CompilerService implements CompilerProtocol {
 
     public async removeTestRun ({ testRunId }: TestRunLocator): Promise<void> {
         delete this.state.testRuns[testRunId];
+    }
+
+    public async removeFixtureCtx ({ fixtureId }: RemoveFixtureCtxArguments): Promise<void> {
+        delete this.state.fixtureCtxs[fixtureId];
     }
 }
 


### PR DESCRIPTION
Changes:
* remove `testRun` from service state of compiler service at the end of the `testRun` execution in the main process.
* remove `fixtureCtx` from service state after the `fixture.after` method execution.