### PR TITLE
fix: restored watching files in the live mode 

### DIFF
--- a/src/live/test-runner.js
+++ b/src/live/test-runner.js
@@ -101,13 +101,11 @@ class LiveModeRunner extends Runner {
 
         this.opts = Object.assign({}, this.opts, options);
 
-        const fileListPromise = parseFileList(this.bootstrapper.sources, process.cwd());
-
-        fileListPromise
+        this._applyOptions()
+            .then(() => parseFileList(this.bootstrapper.sources, process.cwd()))
             .then(files => {
                 return this.controller.init(files);
             })
-            .then(() => this._applyOptions())
             .then(() => this._createRunnableConfiguration())
             .then(() => this.runTests(true));
 

--- a/test/functional/fixtures/live/pages/index.html
+++ b/test/functional/fixtures/live/pages/index.html
@@ -4,5 +4,7 @@
     </head>
     <body>
         <h1>Live test</h1>
+        <button id="button1">button1</button>
+        <button id="button2">button2</button>
     </body>
 </html>

--- a/test/server/live-test.js
+++ b/test/server/live-test.js
@@ -339,6 +339,12 @@ describe('TestCafe Live', function () {
             });
     });
 
+    it('Should fill bootstraper source', async () => {
+        await runTests([testFileWithSingleTestPath, testFileWithMultipleTestsPath]);
+
+        expect(runner.bootstrapper.sources).eql([testFileWithSingleTestPath, testFileWithMultipleTestsPath]);
+    });
+
     it('done-bootstrap event', function () {
         let handled = false;
 


### PR DESCRIPTION
[closes DevExpress/testcafe#6481]

## Purpose
Restore watching files in the live mode 

## Approach
1. Add test
2. Fix functional

## References
https://github.com/DevExpress/testcafe/issues/6481

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
