### PR TITLE
fix: fixed reading config files

### DIFF
--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -273,11 +273,11 @@ export default class TestCafeConfiguration extends Configuration {
         return flatten(browserInfo);
     }
 
-    protected async _isConfigurationFileExists (): Promise<boolean> {
-        const fileExists = await super._isConfigurationFileExists();
+    protected async _isConfigurationFileExists (filePath = this.filePath): Promise<boolean> {
+        const fileExists = await super._isConfigurationFileExists(filePath);
 
         if (!fileExists && this._isExplicitConfig)
-            throw new GeneralError(RUNTIME_ERRORS.cannotFindTestcafeConfigurationFile, this.filePath);
+            throw new GeneralError(RUNTIME_ERRORS.cannotFindTestcafeConfigurationFile, filePath);
 
         return fileExists;
     }

--- a/src/configuration/typescript-configuration.ts
+++ b/src/configuration/typescript-configuration.ts
@@ -55,11 +55,11 @@ export default class TypescriptConfiguration extends Configuration {
         this._notifyThatOptionsCannotBeOverridden();
     }
 
-    protected async _isConfigurationFileExists (): Promise<boolean> {
-        const fileExists = await super._isConfigurationFileExists();
+    protected async _isConfigurationFileExists (filePath = this.filePath): Promise<boolean> {
+        const fileExists = await super._isConfigurationFileExists(filePath);
 
         if (!fileExists)
-            throw new GeneralError(RUNTIME_ERRORS.cannotFindTypescriptConfigurationFile, this.filePath);
+            throw new GeneralError(RUNTIME_ERRORS.cannotFindTypescriptConfigurationFile, filePath);
 
         return true;
     }

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -321,6 +321,19 @@ describe('TestCafeConfiguration', function () {
 
                 expect(consoleWrapper.messages.log).eql(expectedMessage);
             });
+
+            it('Should read JS config file if JSON and JS default files exist', async () => {
+                createJsTestCafeConfigurationFile({
+                    'jsConfig': true,
+                });
+                createJSONTestCafeConfigurationFile({
+                    'jsConfig': false,
+                });
+
+                await testCafeConfiguration.init();
+
+                expect(testCafeConfiguration.getOption('jsConfig')).to.be.true;
+            });
         });
 
         it('File doesn\'t exists', () => {

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -312,7 +312,6 @@ describe('TestCafeConfiguration', function () {
                 consoleWrapper.wrap();
                 await testCafeConfiguration.init();
                 consoleWrapper.unwrap();
-                await del([testCafeConfiguration.defaultPaths[jsConfigIndex]]);
 
                 const expectedMessage =
                           `There are multiple configuration files found, TestCafe will only use one. The file "${pathUtil.resolve('.testcaferc.js')}" will be used.\n` +


### PR DESCRIPTION
## Purpose
Fix reading config files

## Approach
1. Add test 'Should read JS config file if JSON and JS default files exist'
2. Fix using filePath while reading configuration files

## References
https://github.com/DevExpress/testcafe/issues/6501

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail