### PR TITLE
fix: added condition if filter equals a function it should return the same function

### DIFF
--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -273,11 +273,11 @@ export default class TestCafeConfiguration extends Configuration {
         return flatten(browserInfo);
     }
 
-    protected async _isConfigurationFileExists (): Promise<boolean> {
-        const fileExists = await super._isConfigurationFileExists();
+    protected async _isConfigurationFileExists (filePath = this.filePath): Promise<boolean> {
+        const fileExists = await super._isConfigurationFileExists(filePath);
 
         if (!fileExists && this._isExplicitConfig)
-            throw new GeneralError(RUNTIME_ERRORS.cannotFindTestcafeConfigurationFile, this.filePath);
+            throw new GeneralError(RUNTIME_ERRORS.cannotFindTestcafeConfigurationFile, filePath);
 
         return fileExists;
     }

--- a/src/configuration/typescript-configuration.ts
+++ b/src/configuration/typescript-configuration.ts
@@ -55,11 +55,11 @@ export default class TypescriptConfiguration extends Configuration {
         this._notifyThatOptionsCannotBeOverridden();
     }
 
-    protected async _isConfigurationFileExists (): Promise<boolean> {
-        const fileExists = await super._isConfigurationFileExists();
+    protected async _isConfigurationFileExists (filePath = this.filePath): Promise<boolean> {
+        const fileExists = await super._isConfigurationFileExists(filePath);
 
         if (!fileExists)
-            throw new GeneralError(RUNTIME_ERRORS.cannotFindTypescriptConfigurationFile, this.filePath);
+            throw new GeneralError(RUNTIME_ERRORS.cannotFindTypescriptConfigurationFile, filePath);
 
         return true;
     }

--- a/src/utils/get-filter-fn.js
+++ b/src/utils/get-filter-fn.js
@@ -40,6 +40,9 @@ function createFilterFn (opts) {
 }
 
 export default function (opts) {
+    if (typeof opts === 'function')
+        return opts;
+
     const filteringOpts = pick(opts, Object.keys(FILTERING_OPTIONS));
 
     if (isAllFilteringOptionsAreUndefined(filteringOpts))

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -300,6 +300,14 @@ describe('TestCafeConfiguration', function () {
                 });
             });
 
+            it('Filter option with function', async () => {
+                fs.writeFileSync(TestCafeConfiguration.FILENAMES[jsConfigIndex], `module.exports = {filter: (testName, fixtureName, fixturePath, testMeta, fixtureMeta) => {}}`)
+
+                await testCafeConfiguration.init();
+
+                expect(testCafeConfiguration.getOption('filter')).to.be.a('function');
+            });
+
             it('Should warn message on multiple configuration files', async () => {
                 createJsTestCafeConfigurationFile({
                     'hostname': '123.456.789',

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -300,12 +300,13 @@ describe('TestCafeConfiguration', function () {
                 });
             });
 
-            it('Filter option with function', async () => {
-                fs.writeFileSync(TestCafeConfiguration.FILENAMES[jsConfigIndex], `module.exports = {filter: (testName, fixtureName, fixturePath, testMeta, fixtureMeta) => {}}`)
+            it("Shouldn't change filter option with function", async () => {
+                fs.writeFileSync(TestCafeConfiguration.FILENAMES[jsConfigIndex], `module.exports = {filter: (testName, fixtureName, fixturePath, testMeta, fixtureMeta) => true}`);
 
                 await testCafeConfiguration.init();
 
                 expect(testCafeConfiguration.getOption('filter')).to.be.a('function');
+                expect(testCafeConfiguration.getOption('filter')()).to.be.true;
             });
 
             it('Should warn message on multiple configuration files', async () => {


### PR DESCRIPTION
## Purpose
To leave filter function from the js config without changes

## Approach
1. Add test 'Shouldn't change filter option with a function'
2. Add skip changes condition for filter with any function

## References
https://github.com/DevExpress/testcafe/issues/6501
https://teams.microsoft.com/l/message/19:ece0830172fd4073b11b897657443889@thread.skype/1630066293120?tenantId=e4d60396-9352-4ae8-b84c-e69244584fa4&groupId=c3abb0f3-231c-4d87-b5a3-44925dc1d075&parentMessageId=1630066293120&teamName=TestCafe&channelName=Support%20(Daily)&createdTime=1630066293120

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
