### PR TITLE
feat: added the new 'reportWarnings' method for reporter

### DIFF
--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -111,9 +111,9 @@ export default class BrowserConnection extends EventEmitter {
         gateway: BrowserConnectionGateway,
         browserInfo: BrowserInfo,
         permanent: boolean,
-        messageBus?: MessageBus,
         disableMultipleWindows = false,
-        proxyless = false) {
+        proxyless = false,
+        messageBus?: MessageBus) {
         super();
 
         this.HEARTBEAT_TIMEOUT       = HEARTBEAT_TIMEOUT;

--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -25,6 +25,7 @@ import {
     LOCAL_BROWSER_INIT_TIMEOUT,
     REMOTE_BROWSER_INIT_TIMEOUT,
 } from '../../utils/browser-connection-timeouts';
+import MessageBus from '../../utils/message-bus';
 
 const getBrowserConnectionDebugScope = (id: string): string => `testcafe:browser:connection:${id}`;
 
@@ -99,6 +100,7 @@ export default class BrowserConnection extends EventEmitter {
     private readonly debugLogger: debug.Debugger;
 
     public readonly warningLog: WarningLog;
+    private _messageBus?: MessageBus;
 
     public idle: boolean;
 
@@ -109,6 +111,7 @@ export default class BrowserConnection extends EventEmitter {
         gateway: BrowserConnectionGateway,
         browserInfo: BrowserInfo,
         permanent: boolean,
+        messageBus?: MessageBus,
         disableMultipleWindows = false,
         proxyless = false) {
         super();
@@ -123,7 +126,8 @@ export default class BrowserConnection extends EventEmitter {
         this.browserConnectionGateway = gateway;
         this.disconnectionPromise     = null;
         this.testRunAborted           = false;
-        this.warningLog               = new WarningLog();
+        this._messageBus              = messageBus;
+        this.warningLog               = new WarningLog(null, WarningLog.creatAddWarningCallback(this._messageBus));
         this.debugLogger              = debug(getBrowserConnectionDebugScope(this.id));
 
         this.browserInfo                           = browserInfo;
@@ -163,6 +167,11 @@ export default class BrowserConnection extends EventEmitter {
 
         // NOTE: Give a caller time to assign event listeners
         process.nextTick(() => this._runBrowser());
+    }
+
+    public set messageBus (messageBus: MessageBus) {
+        this._messageBus = messageBus;
+        this.warningLog.callback = WarningLog.creatAddWarningCallback(this._messageBus);
     }
 
     private _setEventHandlers (): void {

--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -127,7 +127,7 @@ export default class BrowserConnection extends EventEmitter {
         this.disconnectionPromise     = null;
         this.testRunAborted           = false;
         this._messageBus              = messageBus;
-        this.warningLog               = new WarningLog(null, WarningLog.creatAddWarningCallback(this._messageBus));
+        this.warningLog               = new WarningLog(null, WarningLog.createAddWarningCallback(this._messageBus));
         this.debugLogger              = debug(getBrowserConnectionDebugScope(this.id));
 
         this.browserInfo                           = browserInfo;
@@ -171,7 +171,7 @@ export default class BrowserConnection extends EventEmitter {
 
     public set messageBus (messageBus: MessageBus) {
         this._messageBus = messageBus;
-        this.warningLog.callback = WarningLog.creatAddWarningCallback(this._messageBus);
+        this.warningLog.callback = WarningLog.createAddWarningCallback(this._messageBus);
     }
 
     private _setEventHandlers (): void {

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -121,14 +121,17 @@ export default class TestCafeConfiguration extends Configuration {
         this._prepareCompilerOptions();
     }
 
-    public notifyAboutOverriddenOptions (): void {
+    public notifyAboutOverriddenOptions (warningLog: WarningLog): void {
         if (!this._overriddenOptions.length)
             return;
 
         const optionsStr    = getConcatenatedValuesString(this._overriddenOptions);
         const optionsSuffix = getPluralSuffix(this._overriddenOptions);
+        const renderedMessage = renderTemplate(WARNING_MESSAGES.configOptionsWereOverridden, optionsStr, optionsSuffix);
 
-        Configuration._showConsoleWarning(renderTemplate(WARNING_MESSAGES.configOptionsWereOverridden, optionsStr, optionsSuffix));
+        Configuration._showConsoleWarning(renderedMessage);
+
+        warningLog.addWarning(renderedMessage);
 
         this._overriddenOptions = [];
     }

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -121,7 +121,7 @@ export default class TestCafeConfiguration extends Configuration {
         this._prepareCompilerOptions();
     }
 
-    public notifyAboutOverriddenOptions (warningLog: WarningLog): void {
+    public notifyAboutOverriddenOptions (warningLog?: WarningLog): void {
         if (!this._overriddenOptions.length)
             return;
 
@@ -131,7 +131,8 @@ export default class TestCafeConfiguration extends Configuration {
 
         Configuration._showConsoleWarning(renderedMessage);
 
-        warningLog.addWarning(renderedMessage);
+        if (warningLog)
+            warningLog.addWarning(renderedMessage);
 
         this._overriddenOptions = [];
     }

--- a/src/notifications/warning-log.ts
+++ b/src/notifications/warning-log.ts
@@ -40,12 +40,14 @@ export default class WarningLog {
         this.messages.forEach(msg => warningLog.addWarning(msg));
     }
 
-    public static creatAddWarningCallback (messageBus: MessageBus, testRun?: TestRun): (message: string) => Promise<void> {
+    public static creatAddWarningCallback (messageBus?: MessageBus, testRun?: TestRun): (message: string) => Promise<void> {
         return async (message: string) => {
-            await messageBus.emit('warning-add', {
-                message,
-                testRun,
-            });
+            if (messageBus) {
+                await messageBus.emit('warning-add', {
+                    message,
+                    testRun,
+                });
+            }
         };
     }
 }

--- a/src/notifications/warning-log.ts
+++ b/src/notifications/warning-log.ts
@@ -40,9 +40,9 @@ export default class WarningLog {
         this.messages.forEach(msg => warningLog.addWarning(msg));
     }
 
-    public static creatAddWarningCallback (messageBus?: MessageBus, testRun?: TestRun): (message: string) => Promise<void> {
+    public static creatAddWarningCallback (messageBus?: MessageBus | object, testRun?: TestRun): (message: string) => Promise<void> {
         return async (message: string) => {
-            if (messageBus) {
+            if (messageBus && messageBus instanceof MessageBus) {
                 await messageBus.emit('warning-add', {
                     message,
                     testRun,

--- a/src/notifications/warning-log.ts
+++ b/src/notifications/warning-log.ts
@@ -3,10 +3,12 @@ import renderTemplate from '../utils/render-template';
 export default class WarningLog {
     public messages: string[];
     public globalLog: WarningLog | null;
+    public callback?: (message: string) => void;
 
-    public constructor (globalLog: WarningLog | null = null) {
+    public constructor (globalLog: WarningLog | null = null, callback?: (message: string) => void) {
         this.globalLog = globalLog;
         this.messages  = [];
+        this.callback  = callback;
     }
 
     public addPlainMessage (msg: string): void {
@@ -23,6 +25,9 @@ export default class WarningLog {
 
         if (this.globalLog)
             this.globalLog.addPlainMessage(msg);
+
+        if (this.callback)
+            this.callback(msg);
     }
 
     public clear (): void {

--- a/src/notifications/warning-log.ts
+++ b/src/notifications/warning-log.ts
@@ -40,7 +40,7 @@ export default class WarningLog {
         this.messages.forEach(msg => warningLog.addWarning(msg));
     }
 
-    public static creatAddWarningCallback (messageBus?: MessageBus | object, testRun?: TestRun): (message: string) => Promise<void> {
+    public static createAddWarningCallback (messageBus?: MessageBus | object, testRun?: TestRun): (message: string) => Promise<void> {
         return async (message: string) => {
             if (messageBus && messageBus instanceof MessageBus) {
                 await messageBus.emit('warning-add', {

--- a/src/notifications/warning-log.ts
+++ b/src/notifications/warning-log.ts
@@ -1,11 +1,13 @@
 import renderTemplate from '../utils/render-template';
+import TestRun from '../test-run';
+import MessageBus from '../utils/message-bus';
 
 export default class WarningLog {
     public messages: string[];
     public globalLog: WarningLog | null;
-    public callback?: (message: string) => void;
+    public callback?: (message: string) => Promise<void>;
 
-    public constructor (globalLog: WarningLog | null = null, callback?: (message: string) => void) {
+    public constructor (globalLog: WarningLog | null = null, callback?: (message: string) => Promise<void>) {
         this.globalLog = globalLog;
         this.messages  = [];
         this.callback  = callback;
@@ -36,5 +38,14 @@ export default class WarningLog {
 
     public copyTo (warningLog: WarningLog): void {
         this.messages.forEach(msg => warningLog.addWarning(msg));
+    }
+
+    public static creatAddWarningCallback (messageBus: MessageBus, testRun?: TestRun): (message: string) => Promise<void> {
+        return async (message: string) => {
+            await messageBus.emit('warning-add', {
+                message,
+                testRun,
+            });
+        };
     }
 }

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -436,15 +436,17 @@ export default class Reporter {
             ],
         });
 
-        await this.dispatchToPlugin({
-            method:        ReporterPluginMethod.reportFixtureStart,
-            initialObject: task,
-            args:          [
-                first.fixture.name,
-                first.fixture.path,
-                first.fixture.meta,
-            ],
-        });
+        if (first) {
+            await this.dispatchToPlugin({
+                method:        ReporterPluginMethod.reportFixtureStart,
+                initialObject: task,
+                args:          [
+                    first.fixture.name,
+                    first.fixture.path,
+                    first.fixture.meta,
+                ],
+            });
+        }
     }
 
     private async _onTaskTestRunStartHandler (testRun: TestRun): Promise<unknown> {

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -228,19 +228,16 @@ export default class Reporter {
     }
 
     private async _onWarningAddHandler ({ message, testRun }: ReportWarningEventArguments): Promise<void> {
-        // @ts-ignore
-        if (this.plugin.reportWarnings) {
-            await this.dispatchToPlugin({
-                method:        ReporterPluginMethod.reportWarnings as string,
-                initialObject: this.messageBus,
-                args:          [
-                    {
-                        message,
-                        testRunId: testRun?.id,
-                    },
-                ],
-            });
-        }
+        await this.dispatchToPlugin({
+            method:        ReporterPluginMethod.reportWarnings as string,
+            initialObject: this.messageBus,
+            args:          [
+                {
+                    message,
+                    testRunId: testRun?.id,
+                },
+            ],
+        });
     }
 
     //Task

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -210,7 +210,7 @@ export default class Reporter {
         });
     }
 
-    public static async getReporterPlugins (reporters: ReporterSource[]): Promise<ReporterPluginSource[]> {
+    public static async getReporterPlugins (reporters: ReporterSource[] = []): Promise<ReporterPluginSource[]> {
         if (!reporters.length)
             Reporter._addDefaultReporter(reporters);
 

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -412,7 +412,7 @@ export default class Reporter {
             skipped:                0,
             testCount:              task.tests.filter(test => !test.skip).length,
             testQueue:              Reporter._createTestQueue(task),
-            stopOnFirstFail:        false,
+            stopOnFirstFail:        task.opts.stopOnFirstFail as boolean,
             pendingTaskDonePromise: Reporter._createPendingPromise(),
         };
 

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -109,7 +109,7 @@ export default class Reporter {
     public taskInfo: TaskInfo | null;
     public readonly outStream: Writable;
 
-    public constructor (messageBus: MessageBus, plugin: ReporterPlugin, outStream: Writable, name: string) {
+    public constructor (plugin: ReporterPlugin, messageBus: MessageBus, outStream: Writable, name: string) {
         this.plugin     = new ReporterPluginHost(plugin, outStream, name);
         this.messageBus = messageBus;
 

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -79,7 +79,7 @@ interface TestRunInfo {
 }
 
 interface PluginMethodArguments {
-    initialObject: Task | null;
+    initialObject: Task | MessageBus | null;
     method: string;
     args: unknown[];
 }
@@ -232,7 +232,7 @@ export default class Reporter {
         if (this.plugin.reportWarnings) {
             await this.dispatchToPlugin({
                 method:        ReporterPluginMethod.reportWarnings as string,
-                initialObject: null,
+                initialObject: this.messageBus,
                 args:          [
                     {
                         message,

--- a/src/reporter/interfaces.ts
+++ b/src/reporter/interfaces.ts
@@ -8,6 +8,7 @@ export interface ReporterPlugin {
     reportTestActionDone?(): void;
     reportTestDone(): void;
     reportTaskDone(): void;
+    reportWarnings?(): void;
 }
 
 export interface ReporterSource {

--- a/src/reporter/interfaces.ts
+++ b/src/reporter/interfaces.ts
@@ -17,6 +17,7 @@ export interface ReporterSource {
 
 export interface ReporterPluginSource {
     plugin: ReporterPlugin;
+    name: string;
     outStream?: WritableStream;
 }
 

--- a/src/reporter/plugin-host.ts
+++ b/src/reporter/plugin-host.ts
@@ -192,4 +192,9 @@ export default class ReporterPluginHost {
     public async reportTaskDone (/* endTime, passed, warnings */): Promise<never> {
         throw new Error('Not implemented');
     }
+
+    // NOTE: It's an optional method
+    // public async reportWarnings (/* warnings */): Promise<never> {
+    //     throw new Error('Not implemented');
+    // }
 }

--- a/src/reporter/plugin-host.ts
+++ b/src/reporter/plugin-host.ts
@@ -194,7 +194,7 @@ export default class ReporterPluginHost {
     }
 
     // NOTE: It's an optional method
-    // public async reportWarnings (/* warnings */): Promise<never> {
-    //     throw new Error('Not implemented');
-    // }
+    public async reportWarnings (/* warnings */): Promise<void> {
+        return Promise.resolve();
+    }
 }

--- a/src/reporter/plugin-methods.ts
+++ b/src/reporter/plugin-methods.ts
@@ -9,6 +9,7 @@ const ReporterPluginMethod: EnumFromPropertiesOf<ReporterPlugin> = {
     reportTestActionDone:  'reportTestActionDone',
     reportTestDone:        'reportTestDone',
     reportTaskDone:        'reportTaskDone',
+    reportWarnings:        'reportWarnings',
 };
 
 export default ReporterPluginMethod;

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -89,7 +89,7 @@ export default class Bootstrapper {
     private readonly compilerService?: CompilerService;
     private readonly debugLogger: debug.Debugger;
     private readonly warningLog: WarningLog;
-    private readonly messageBus?: MessageBus;
+    private readonly messageBus: MessageBus;
 
     private readonly TESTS_COMPILATION_UPPERBOUND: number;
 
@@ -162,8 +162,7 @@ export default class Bootstrapper {
         let browserConnections = this._createAutomatedConnections(automated);
 
         remotes.forEach(remoteConnection => {
-            if (this.messageBus)
-                remoteConnection.messageBus = this.messageBus;
+            remoteConnection.messageBus = this.messageBus;
         });
 
         browserConnections = browserConnections.concat(chunk(remotes, this.concurrency));

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -1,11 +1,8 @@
-import path from 'path';
-import fs from 'fs';
 import {
     chunk,
     times,
 } from 'lodash';
 
-import makeDir from 'make-dir';
 import debug from 'debug';
 import prettyTime from 'pretty-hrtime';
 import Compiler from '../compiler';
@@ -15,18 +12,15 @@ import { GeneralError } from '../errors/runtime';
 import { RUNTIME_ERRORS } from '../errors/types';
 import TestedApp from './tested-app';
 import parseFileList from '../utils/parse-file-list';
-import resolvePathRelativelyCwd from '../utils/resolve-path-relatively-cwd';
 import loadClientScripts from '../custom-client-scripts/load';
 import { getConcatenatedValuesString } from '../utils/string';
-import { Writable as WritableStream } from 'stream';
-import { ReporterSource, ReporterPluginSource } from '../reporter/interfaces';
+import { ReporterSource } from '../reporter/interfaces';
 import ClientScript from '../custom-client-scripts/client-script';
 import ClientScriptInit from '../custom-client-scripts/client-script-init';
 import BrowserConnectionGateway from '../browser/connection/gateway';
 import { CompilerArguments } from '../compiler/interfaces';
 import CompilerService from '../services/compiler/host';
 import Test from '../api/structure/test';
-import { getPluginFactory, processReporterName } from '../utils/reporter';
 import { BootstrapperInit, BrowserSetOptions } from './interfaces';
 import WarningLog from '../notifications/warning-log';
 import WARNING_MESSAGES from '../notifications/warning-message';
@@ -55,7 +49,6 @@ interface BasicRuntimeResources {
 }
 
 interface RuntimeResources extends BasicRuntimeResources {
-    reporterPlugins: ReporterPluginSource[];
     commonClientScripts: ClientScript[];
 }
 
@@ -231,41 +224,6 @@ export default class Bootstrapper {
         return tests;
     }
 
-    private async _ensureOutStream (outStream: string | WritableStream): Promise<WritableStream> {
-        if (typeof outStream !== 'string')
-            return outStream;
-
-        const fullReporterOutputPath = resolvePathRelativelyCwd(outStream);
-
-        await makeDir(path.dirname(fullReporterOutputPath));
-
-        return fs.createWriteStream(fullReporterOutputPath);
-    }
-
-    private static _addDefaultReporter (reporters: ReporterSource[]): void {
-        reporters.push({
-            name:   'spec',
-            output: process.stdout,
-        });
-    }
-
-    private async _getReporterPlugins (): Promise<ReporterPluginSource[]> {
-        if (!this.reporters.length)
-            Bootstrapper._addDefaultReporter(this.reporters);
-
-        return Promise.all(this.reporters.map(async ({ name, output }) => {
-            const pluginFactory = getPluginFactory(name);
-            const processedName = processReporterName(name);
-            const outStream     = output ? await this._ensureOutStream(output) : void 0;
-
-            return {
-                plugin: pluginFactory(),
-                name:   processedName,
-                outStream,
-            };
-        }));
-    }
-
     private async _startTestedApp (): Promise<TestedApp|undefined> {
         if (!this.appCommand)
             return void 0;
@@ -355,12 +313,11 @@ export default class Bootstrapper {
 
     // API
     public async createRunnableConfiguration (): Promise<RuntimeResources> {
-        const reporterPlugins     = await this._getReporterPlugins();
         const commonClientScripts = await loadClientScripts(this.clientScripts);
 
         if (await this._canUseParallelBootstrapping(this.browsers))
-            return { reporterPlugins, ...await this._bootstrapParallel(this.browsers), commonClientScripts };
+            return { ...await this._bootstrapParallel(this.browsers), commonClientScripts };
 
-        return { reporterPlugins, ...await this._bootstrapSequence(this.browsers), commonClientScripts };
+        return { ...await this._bootstrapSequence(this.browsers), commonClientScripts };
     }
 }

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -106,9 +106,7 @@ export default class Bootstrapper {
         this.proxyless                = false;
         this.compilerOptions          = void 0;
         this.debugLogger              = debug(DEBUG_SCOPE);
-        this.warningLog               = new WarningLog(null, async message => {
-            await messageBus.emit('warning-add', { message });
-        });
+        this.warningLog               = new WarningLog(null, WarningLog.creatAddWarningCallback(messageBus));
         this.compilerService          = compilerService;
 
         this.TESTS_COMPILATION_UPPERBOUND = 60;

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -108,7 +108,7 @@ export default class Bootstrapper {
         this.proxyless                = false;
         this.compilerOptions          = void 0;
         this.debugLogger              = debug(DEBUG_SCOPE);
-        this.warningLog               = new WarningLog(null, WarningLog.creatAddWarningCallback(messageBus));
+        this.warningLog               = new WarningLog(null, WarningLog.createAddWarningCallback(messageBus));
         this.compilerService          = compilerService;
         this.messageBus               = messageBus;
 

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -91,7 +91,7 @@ export default class Bootstrapper {
 
     private readonly TESTS_COMPILATION_UPPERBOUND: number;
 
-    public constructor ({ browserConnectionGateway, compilerService }: BootstrapperInit) {
+    public constructor ({ browserConnectionGateway, compilerService, messageBus }: BootstrapperInit) {
         this.browserConnectionGateway = browserConnectionGateway;
         this.concurrency              = 1;
         this.sources                  = [];
@@ -106,7 +106,9 @@ export default class Bootstrapper {
         this.proxyless                = false;
         this.compilerOptions          = void 0;
         this.debugLogger              = debug(DEBUG_SCOPE);
-        this.warningLog               = new WarningLog();
+        this.warningLog               = new WarningLog(null, async message => {
+            await messageBus.emit('warning-add', { message });
+        });
         this.compilerService          = compilerService;
 
         this.TESTS_COMPILATION_UPPERBOUND = 60;

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -142,7 +142,7 @@ export default class Bootstrapper {
 
         return browserInfo
             .map(browser => times(this.concurrency, () => new BrowserConnection(
-                this.browserConnectionGateway, browser, false, this.messageBus, this.disableMultipleWindows, this.proxyless)));
+                this.browserConnectionGateway, browser, false, this.disableMultipleWindows, this.proxyless, this.messageBus)));
     }
 
     private _getBrowserSetOptions (): BrowserSetOptions {

--- a/src/runner/browser-job.ts
+++ b/src/runner/browser-job.ts
@@ -12,6 +12,7 @@ import { Dictionary } from '../configuration/interfaces';
 import BrowserJobResult from './browser-job-result';
 import CompilerService from '../services/compiler/host';
 import { BrowserJobInit } from './interfaces';
+import MessageBus from '../utils/message-bus';
 
 interface BrowserJobResultInfo {
     status: BrowserJobResult;
@@ -34,6 +35,7 @@ export default class BrowserJob extends AsyncEventEmitter {
     private readonly _connectionErrorListener: (error: Error) => void;
     private readonly _completionQueue: TestRunController[];
     private _resolveWaitingLastTestInFixture: Function | null;
+    private readonly _messageBus: MessageBus;
 
     public constructor ({
         tests,
@@ -44,6 +46,7 @@ export default class BrowserJob extends AsyncEventEmitter {
         fixtureHookController,
         opts,
         compilerService,
+        messageBus,
     }: BrowserJobInit) {
         super();
 
@@ -58,6 +61,7 @@ export default class BrowserJob extends AsyncEventEmitter {
         this.warningLog            = warningLog;
         this.fixtureHookController = fixtureHookController;
         this._result               = null;
+        this._messageBus           = messageBus;
 
         this._testRunControllerQueue = tests.map((test, index) => this._createTestRunController(test, index, compilerService));
 
@@ -80,6 +84,7 @@ export default class BrowserJob extends AsyncEventEmitter {
             warningLog:            this.warningLog,
             fixtureHookController: this.fixtureHookController,
             opts:                  this._opts,
+            messageBus:            this._messageBus,
             compilerService,
         });
 

--- a/src/runner/browser-job.ts
+++ b/src/runner/browser-job.ts
@@ -91,9 +91,6 @@ export default class BrowserJob extends AsyncEventEmitter {
         testRunController.on('test-run-create', async testRunInfo => {
             await this.emit('test-run-create', testRunInfo);
         });
-        testRunController.on('test-run-start', async () => {
-            await this.emit('test-run-start', testRunController.testRun);
-        });
         testRunController.on('test-run-ready', async () => {
             await this.emit('test-run-ready', testRunController);
         });

--- a/src/runner/browser-job.ts
+++ b/src/runner/browser-job.ts
@@ -100,10 +100,6 @@ export default class BrowserJob extends AsyncEventEmitter {
         });
         testRunController.on('test-run-done', async () => this._onTestRunDone(testRunController));
 
-        testRunController.on('test-action-start', async args => {
-            await this.emit('test-action-start', args);
-        });
-
         testRunController.on('test-action-done', async args => {
             await this.emit('test-action-done', args);
         });

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -147,9 +147,9 @@ export default class Runner extends EventEmitter {
 
         const browserSetErrorPromise = promisifyEvent(browserSet, 'error');
         const taskErrorPromise       = promisifyEvent(task, 'error');
-        const streamController       = new ReporterStreamController(task, reporters);
+        const streamController       = new ReporterStreamController(this._messageBus, reporters);
 
-        const taskDonePromise = task.once('done')
+        const taskDonePromise = this._messageBus.once('done')
             .then(() => browserSetErrorPromise.cancel())
             .then(() => {
                 return Promise.all(reporters.map(reporter => reporter.taskInfo.pendingTaskDonePromise));
@@ -205,7 +205,7 @@ export default class Runner extends EventEmitter {
             this._messageBus.on('test-run-done', removeRunningTest);
         }
 
-        task.on('done', stopHandlingTestErrors);
+        this._messageBus.on('done', stopHandlingTestErrors);
 
         task.on('error', stopHandlingTestErrors);
 

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -90,6 +90,7 @@ export default class Runner extends EventEmitter {
         task.abort();
         task.unRegisterClientScriptRouting();
         task.clearListeners();
+        this._messageBus.abort();
 
         await this._disposeAssets(browserSet, reporters, testedApp);
     }

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -58,7 +58,7 @@ export default class Runner extends EventEmitter {
         this.pendingTaskPromises = [];
         this.configuration       = configuration;
         this.isCli               = false;
-        this.warningLog          = new WarningLog();
+        this.warningLog          = new WarningLog(null, WarningLog.creatAddWarningCallback(this._messageBus));
         this.compilerService     = compilerService;
         this._options            = {};
 
@@ -653,10 +653,10 @@ export default class Runner extends EventEmitter {
     }
 
     run (options = {}) {
-        this.apiMethodWasCalled.reset();
-        this.configuration.mergeOptions(options);
-
         let reporters;
+
+        this.apiMethodWasCalled.reset();
+        this._options = Object.assign(this._options, options);
 
         const runTaskPromise = Promise.resolve()
             .then(() => Reporter.getReporterPlugins(this._options.reporter))

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -198,7 +198,7 @@ export default class Runner extends EventEmitter {
         const completionPromise = this._getTaskResult(task, browserSet, reporters, testedApp);
         let completed           = false;
 
-        task.on('start', startHandlingTestErrors);
+        this._messageBus.on('start', startHandlingTestErrors);
 
         if (!this.configuration.getOption(OPTION_NAMES.skipUncaughtErrors)) {
             this._messageBus.on('test-run-start', addRunningTest);

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -147,6 +147,7 @@ export default class Runner extends EventEmitter {
 
         const browserSetErrorPromise = promisifyEvent(browserSet, 'error');
         const taskErrorPromise       = promisifyEvent(task, 'error');
+        const messageBusErrorPromise = promisifyEvent(this._messageBus, 'error');
         const streamController       = new ReporterStreamController(this._messageBus, reporters);
 
         const taskDonePromise = this._messageBus.once('done')
@@ -159,6 +160,7 @@ export default class Runner extends EventEmitter {
             taskDonePromise,
             browserSetErrorPromise,
             taskErrorPromise,
+            messageBusErrorPromise,
         ];
 
         if (testedApp)

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -44,6 +44,7 @@ import OS from 'os-family';
 import detectDisplay from '../utils/detect-display';
 import { validateQuarantineOptions } from '../utils/get-options/quarantine';
 import logEntry from '../utils/log-entry';
+import MessageBus from '../utils/message-bus';
 
 const DEBUG_LOGGER = debug('testcafe:runner');
 
@@ -59,6 +60,7 @@ export default class Runner extends EventEmitter {
         this.warningLog          = new WarningLog();
         this.compilerService     = compilerService;
         this._options            = {};
+        this._messageBus         = new MessageBus();
 
         this.apiMethodWasCalled = new FlagList([
             OPTION_NAMES.src,
@@ -187,6 +189,7 @@ export default class Runner extends EventEmitter {
             opts,
             runnerWarningLog: warningLog,
             compilerService:  this.compilerService,
+            messageBus:       this._messageBus,
         });
     }
 

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -656,6 +656,8 @@ export default class Runner extends EventEmitter {
         let reporters;
 
         this.apiMethodWasCalled.reset();
+        this._messageBus.clearListeners();
+
         this._options = Object.assign(this._options, options);
 
         const runTaskPromise = Promise.resolve()

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -52,15 +52,15 @@ export default class Runner extends EventEmitter {
     constructor ({ proxy, browserConnectionGateway, configuration, compilerService }) {
         super();
 
+        this._messageBus         = new MessageBus();
         this.proxy               = proxy;
-        this.bootstrapper        = this._createBootstrapper(browserConnectionGateway, compilerService);
+        this.bootstrapper        = this._createBootstrapper(browserConnectionGateway, compilerService, this._messageBus);
         this.pendingTaskPromises = [];
         this.configuration       = configuration;
         this.isCli               = false;
         this.warningLog          = new WarningLog();
         this.compilerService     = compilerService;
         this._options            = {};
-        this._messageBus         = new MessageBus();
 
         this.apiMethodWasCalled = new FlagList([
             OPTION_NAMES.src,
@@ -70,8 +70,8 @@ export default class Runner extends EventEmitter {
         ]);
     }
 
-    _createBootstrapper (browserConnectionGateway, compilerService) {
-        return new Bootstrapper({ browserConnectionGateway, compilerService });
+    _createBootstrapper (browserConnectionGateway, compilerService, messageBus) {
+        return new Bootstrapper({ browserConnectionGateway, compilerService, messageBus });
     }
 
     _disposeBrowserSet (browserSet) {

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -58,7 +58,7 @@ export default class Runner extends EventEmitter {
         this.pendingTaskPromises = [];
         this.configuration       = configuration;
         this.isCli               = false;
-        this.warningLog          = new WarningLog(null, WarningLog.creatAddWarningCallback(this._messageBus));
+        this.warningLog          = new WarningLog(null, WarningLog.createAddWarningCallback(this._messageBus));
         this.compilerService     = compilerService;
         this._options            = {};
 

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -201,7 +201,7 @@ export default class Runner extends EventEmitter {
         task.on('start', startHandlingTestErrors);
 
         if (!this.configuration.getOption(OPTION_NAMES.skipUncaughtErrors)) {
-            task.on('test-run-start', addRunningTest);
+            this._messageBus.on('test-run-start', addRunningTest);
             task.on('test-run-done', removeRunningTest);
         }
 

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -457,7 +457,7 @@ export default class Runner extends EventEmitter {
 
     _setBootstrapperOptions () {
         this.configuration.prepare();
-        this.configuration.notifyAboutOverriddenOptions();
+        this.configuration.notifyAboutOverriddenOptions(this.warningLog);
         this.configuration.notifyAboutDeprecatedOptions(this.warningLog);
 
         this.bootstrapper.sources                = this.configuration.getOption(OPTION_NAMES.src) || this.bootstrapper.sources;

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -130,7 +130,7 @@ export default class Runner extends EventEmitter {
 
     // Run task
     _getFailedTestCount (task, reporter) {
-        let failedTestCount = reporter.testCount - reporter.passed;
+        let failedTestCount = reporter.taskInfo.testCount - reporter.taskInfo.passed;
 
         if (task.opts.stopOnFirstFail && !!failedTestCount)
             failedTestCount = 1;
@@ -152,7 +152,7 @@ export default class Runner extends EventEmitter {
         const taskDonePromise = task.once('done')
             .then(() => browserSetErrorPromise.cancel())
             .then(() => {
-                return Promise.all(reporters.map(reporter => reporter.pendingTaskDonePromise));
+                return Promise.all(reporters.map(reporter => reporter.taskInfo.pendingTaskDonePromise));
             });
 
         const promises = [

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -202,7 +202,7 @@ export default class Runner extends EventEmitter {
 
         if (!this.configuration.getOption(OPTION_NAMES.skipUncaughtErrors)) {
             this._messageBus.on('test-run-start', addRunningTest);
-            task.on('test-run-done', removeRunningTest);
+            this._messageBus.on('test-run-done', removeRunningTest);
         }
 
         task.on('done', stopHandlingTestErrors);

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -661,7 +661,7 @@ export default class Runner extends EventEmitter {
         const runTaskPromise = Promise.resolve()
             .then(() => Reporter.getReporterPlugins(this._options.reporter))
             .then(reporterPlugins => {
-                reporters = reporterPlugins.map(reporter => new Reporter(this._messageBus, reporter.plugin, reporter.outStream, reporter.name));
+                reporters = reporterPlugins.map(reporter => new Reporter(reporter.plugin, this._messageBus, reporter.outStream, reporter.name));
             })
             .then(() => this._applyOptions())
             .then(() => {

--- a/src/runner/interfaces.ts
+++ b/src/runner/interfaces.ts
@@ -51,6 +51,7 @@ export type BrowserInit = string | object | BrowserConnection;
 export interface BootstrapperInit {
     browserConnectionGateway: BrowserConnectionGateway;
     compilerService?: CompilerService;
+    messageBus: MessageBus;
 }
 
 export interface BrowserJobInit {

--- a/src/runner/interfaces.ts
+++ b/src/runner/interfaces.ts
@@ -51,7 +51,7 @@ export type BrowserInit = string | object | BrowserConnection;
 export interface BootstrapperInit {
     browserConnectionGateway: BrowserConnectionGateway;
     compilerService?: CompilerService;
-    messageBus: MessageBus;
+    messageBus?: MessageBus;
 }
 
 export interface BrowserJobInit {

--- a/src/runner/interfaces.ts
+++ b/src/runner/interfaces.ts
@@ -11,6 +11,7 @@ import { Dictionary } from '../configuration/interfaces';
 import FixtureHookController from './fixture-hook-controller';
 import Screenshots from '../screenshots';
 import Capturer from '../screenshots/capturer';
+import MessageBus from '../utils/message-bus';
 
 export interface ActionEventArg {
     apiActionName: string;
@@ -61,6 +62,7 @@ export interface BrowserJobInit {
     fixtureHookController: FixtureHookController;
     opts: Dictionary<OptionValue>;
     compilerService?: CompilerService;
+    messageBus: MessageBus;
 }
 
 export interface TaskInit {
@@ -70,6 +72,7 @@ export interface TaskInit {
     opts: Dictionary<OptionValue>;
     runnerWarningLog: WarningLog;
     compilerService?: CompilerService;
+    messageBus: MessageBus;
 }
 
 export interface TestRunControllerInit {
@@ -81,6 +84,7 @@ export interface TestRunControllerInit {
     fixtureHookController: FixtureHookController;
     opts: Dictionary<OptionValue>;
     compilerService?: CompilerService;
+    messageBus: MessageBus;
 }
 
 export interface TestRunInit {

--- a/src/runner/interfaces.ts
+++ b/src/runner/interfaces.ts
@@ -51,7 +51,7 @@ export type BrowserInit = string | object | BrowserConnection;
 export interface BootstrapperInit {
     browserConnectionGateway: BrowserConnectionGateway;
     compilerService?: CompilerService;
-    messageBus?: MessageBus;
+    messageBus: MessageBus;
 }
 
 export interface BrowserJobInit {

--- a/src/runner/reporter-stream-controller.ts
+++ b/src/runner/reporter-stream-controller.ts
@@ -13,11 +13,11 @@ interface PluginInfo {
 class ReporterStreamController {
     public multipleStreamError: GeneralError | null;
     private _pluginInfos: PluginInfo[];
-    private _task: EventEmitter;
+    private _messageBus: EventEmitter;
 
-    public constructor (task: EventEmitter, reporters: Reporter[]) {
+    public constructor (messageBus: EventEmitter, reporters: Reporter[]) {
         this._pluginInfos = [];
-        this._task = task;
+        this._messageBus = messageBus;
         this.multipleStreamError = null;
 
         reporters.forEach(({ plugin }) => {
@@ -35,7 +35,7 @@ class ReporterStreamController {
 
             this.multipleStreamError = new GeneralError(RUNTIME_ERRORS.multipleSameStreamReporters, message);
 
-            this._task.emit('done');
+            this._messageBus.emit('done');
 
             return false;
         }

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -87,10 +87,6 @@ export default class Task extends AsyncEventEmitter {
     }
 
     private _assignBrowserJobEventHandlers (job: BrowserJob): void {
-        job.on('test-run-start', async (testRun: TestRun) => {
-            await this.emit('test-run-start', testRun);
-        });
-
         job.on('test-run-done', async (testRun: TestRun) => {
             await this.emit('test-run-done', testRun);
 

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -58,7 +58,7 @@ export default class Task extends AsyncEventEmitter {
         this.tests                   = tests;
         this.opts                    = opts;
         this._proxy                  = proxy;
-        this.warningLog              = new WarningLog(null, WarningLog.creatAddWarningCallback(messageBus));
+        this.warningLog              = new WarningLog(null, WarningLog.createAddWarningCallback(messageBus));
         this._compilerService        = compilerService;
         this._messageBus             = messageBus;
 

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -93,7 +93,7 @@ export default class Task extends AsyncEventEmitter {
             if (this.opts.stopOnFirstFail && testRun.errs.length) {
                 this.abort();
 
-                await this.emit('done');
+                await this._messageBus.emit('done');
             }
         });
 
@@ -113,7 +113,7 @@ export default class Task extends AsyncEventEmitter {
             if (!this._pendingBrowserJobs.length) {
                 this._phase = TaskPhase.done;
 
-                await this.emit('done');
+                await this._messageBus.emit('done');
             }
         });
 

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -88,7 +88,7 @@ export default class Task extends AsyncEventEmitter {
 
     private _assignBrowserJobEventHandlers (job: BrowserJob): void {
         job.on('test-run-done', async (testRun: TestRun) => {
-            await this.emit('test-run-done', testRun);
+            await this._messageBus.emit('test-run-done', testRun);
 
             if (this.opts.stopOnFirstFail && testRun.errs.length) {
                 this.abort();

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -22,6 +22,7 @@ import { VideoOptions } from '../../video-recorder/interfaces';
 import TaskPhase from './phase';
 import CompilerService from '../../services/compiler/host';
 import Fixture from '../../api/structure/fixture';
+import MessageBus from '../../utils/message-bus';
 
 export default class Task extends AsyncEventEmitter {
     private readonly _timeStamp: moment.Moment;
@@ -38,6 +39,7 @@ export default class Task extends AsyncEventEmitter {
     public readonly testStructure: ReportedTestStructureItem[];
     public readonly videos?: Videos;
     private readonly _compilerService?: CompilerService;
+    private readonly _messageBus: MessageBus;
 
     public constructor ({
         tests,
@@ -46,6 +48,7 @@ export default class Task extends AsyncEventEmitter {
         opts,
         runnerWarningLog,
         compilerService,
+        messageBus,
     }: TaskInit) {
         super({ captureRejections: true });
 
@@ -57,6 +60,7 @@ export default class Task extends AsyncEventEmitter {
         this._proxy                  = proxy;
         this.warningLog              = new WarningLog();
         this._compilerService        = compilerService;
+        this._messageBus             = messageBus;
 
         runnerWarningLog.copyTo(this.warningLog);
 
@@ -162,6 +166,7 @@ export default class Task extends AsyncEventEmitter {
                 warningLog:            this.warningLog,
                 fixtureHookController: this.fixtureHookController,
                 compilerService:       this._compilerService,
+                messageBus:            this._messageBus,
                 proxy,
                 opts,
             });

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -117,10 +117,6 @@ export default class Task extends AsyncEventEmitter {
             }
         });
 
-        job.on('test-action-start', async (args: ActionEventArg) => {
-            await this.emit('test-action-start', args);
-        });
-
         job.on('test-action-done', async (args: ActionEventArg) => {
             if (this._phase === TaskPhase.done)
                 return;

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -101,7 +101,7 @@ export default class Task extends AsyncEventEmitter {
             if (this._phase !== TaskPhase.started) {
                 this._phase = TaskPhase.started;
 
-                await this.emit('start');
+                await this._messageBus.emit('start', this);
             }
         });
 

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -58,7 +58,9 @@ export default class Task extends AsyncEventEmitter {
         this.tests                   = tests;
         this.opts                    = opts;
         this._proxy                  = proxy;
-        this.warningLog              = new WarningLog();
+        this.warningLog              = new WarningLog(null, async message => {
+            await messageBus.emit('warning-add', { message });
+        });
         this._compilerService        = compilerService;
         this._messageBus             = messageBus;
 

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -58,9 +58,7 @@ export default class Task extends AsyncEventEmitter {
         this.tests                   = tests;
         this.opts                    = opts;
         this._proxy                  = proxy;
-        this.warningLog              = new WarningLog(null, async message => {
-            await messageBus.emit('warning-add', { message });
-        });
+        this.warningLog              = new WarningLog(null, WarningLog.creatAddWarningCallback(messageBus));
         this._compilerService        = compilerService;
         this._messageBus             = messageBus;
 

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -121,7 +121,7 @@ export default class Task extends AsyncEventEmitter {
             if (this._phase === TaskPhase.done)
                 return;
 
-            await this.emit('test-action-done', args);
+            await this._messageBus.emit('test-action-done', args);
         });
 
     }

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -83,6 +83,7 @@ export default class TestRunController extends AsyncEventEmitter {
             globalWarningLog:  this._warningLog,
             opts:              this._opts,
             compilerService:   this.compilerService,
+            messageBus:        this._messageBus,
             screenshotCapturer,
         });
 

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -175,7 +175,7 @@ export default class TestRunController extends AsyncEventEmitter {
     }
 
     private async _emitTestRunStart (): Promise<void> {
-        await this.emit('test-run-start');
+        await this._messageBus.emit('test-run-start', this.testRun);
     }
 
     private async _testRunBeforeDone (): Promise<void> {
@@ -228,7 +228,7 @@ export default class TestRunController extends AsyncEventEmitter {
         const hookOk = await this._fixtureHookController.runFixtureBeforeHookIfNecessary(testRun);
 
         if (this.test.skip || !hookOk) {
-            await this.emit('test-run-start');
+            await this._emitTestRunStart();
             await this.emit('test-run-before-done');
             await this._emitTestRunDone();
 

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -13,6 +13,7 @@ import { Dictionary } from '../configuration/interfaces';
 import { ActionEventArg, TestRunControllerInit } from './interfaces';
 import CompilerService from '../services/compiler/host';
 import { Quarantine } from '../utils/get-options/quarantine';
+import MessageBus from '../utils/message-bus';
 
 const DISCONNECT_THRESHOLD = 3;
 
@@ -31,6 +32,7 @@ export default class TestRunController extends AsyncEventEmitter {
     public testRun: null | LegacyTestRun | TestRun;
     public done: boolean;
     private readonly compilerService?: CompilerService;
+    private readonly _messageBus: MessageBus;
 
     public constructor ({
         test,
@@ -41,6 +43,7 @@ export default class TestRunController extends AsyncEventEmitter {
         fixtureHookController,
         opts,
         compilerService,
+        messageBus,
     }: TestRunControllerInit) {
         super();
 
@@ -60,6 +63,7 @@ export default class TestRunController extends AsyncEventEmitter {
         this._quarantine         = this._opts.quarantineMode ? new Quarantine() : null;
         this._disconnectionCount = 0;
         this.compilerService     = compilerService;
+        this._messageBus         = messageBus;
     }
 
     private static _getTestRunCtor (test: Test, opts: Dictionary<OptionValue>): LegacyTestRun | TestRun {
@@ -153,7 +157,7 @@ export default class TestRunController extends AsyncEventEmitter {
     }
 
     private async _emitActionStart (args: ActionEventArg): Promise<void> {
-        await this.emit('test-action-start', args);
+        await this._messageBus.emit('test-action-start', args);
     }
 
     private async _emitActionDone (args: ActionEventArg): Promise<void> {

--- a/src/services/compiler/host.ts
+++ b/src/services/compiler/host.ts
@@ -456,10 +456,10 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
         await this.emit('removeRequestEventListeners', { rules });
     }
 
-    public async initializeTestRunData ({ testRunId, testId, browser, activeWindowId }: InitializeTestRunDataArguments): Promise<void> {
+    public async initializeTestRunData ({ testRunId, testId, browser, activeWindowId, messageBus }: InitializeTestRunDataArguments): Promise<void> {
         const { proxy } = await this._getRuntime();
 
-        return proxy.call(this.initializeTestRunData, { testRunId, testId, browser, activeWindowId });
+        return proxy.call(this.initializeTestRunData, { testRunId, testId, browser, activeWindowId, messageBus });
     }
 
     public async getAssertionActualValue ({ testRunId, commandId }: CommandLocator): Promise<unknown> {

--- a/src/services/compiler/interfaces.ts
+++ b/src/services/compiler/interfaces.ts
@@ -15,6 +15,7 @@ import { Dictionary } from '../../configuration/interfaces';
 import RequestHookMethodNames from '../../api/request-hooks/hook-method-names';
 import Role from '../../role/role';
 import { CallsiteRecord } from 'callsite-record';
+import MessageBus from '../../utils/message-bus';
 
 export interface TestRunLocator {
     testRunId: string;
@@ -90,6 +91,7 @@ export interface InitializeTestRunDataArguments extends TestRunLocator {
     testId: string;
     browser: Browser;
     activeWindowId: string | null;
+    messageBus?: MessageBus;
 }
 
 export interface RoleLocator {

--- a/src/services/compiler/service.ts
+++ b/src/services/compiler/service.ts
@@ -88,6 +88,7 @@ import { renderHtmlWithoutStack, shouldRenderHtmlWithoutStack } from '../../erro
 import setupSourceMapSupport from '../../utils/setup-sourcemap-support';
 import { formatError } from '../../utils/handle-errors';
 import { SwitchToWindowPredicateError } from '../../shared/errors';
+import MessageBus from '../../utils/message-bus';
 
 setupSourceMapSupport();
 
@@ -112,6 +113,7 @@ interface InitTestRunProxyData {
     test: Test;
     browser: Browser;
     activeWindowId: string | null;
+    messageBus?: MessageBus;
 }
 
 class CompilerService implements CompilerProtocol {
@@ -256,7 +258,7 @@ class CompilerService implements CompilerProtocol {
         };
     }
 
-    private _initializeTestRunProxy ({ testRunId, test, browser, activeWindowId }: InitTestRunProxyData): void {
+    private _initializeTestRunProxy ({ testRunId, test, browser, activeWindowId, messageBus }: InitTestRunProxyData): void {
         const testRunProxy = new TestRunProxy({
             dispatcher: this,
             id:         testRunId,
@@ -264,6 +266,7 @@ class CompilerService implements CompilerProtocol {
             test,
             browser,
             activeWindowId,
+            messageBus,
         });
 
         this.state.testRuns[testRunId] = testRunProxy;
@@ -403,10 +406,10 @@ class CompilerService implements CompilerProtocol {
         return await this.proxy.call(this.removeRequestEventListeners, { rules });
     }
 
-    public async initializeTestRunData ({ testRunId, testId, browser, activeWindowId }: InitializeTestRunDataArguments): Promise<void> {
+    public async initializeTestRunData ({ testRunId, testId, browser, activeWindowId, messageBus }: InitializeTestRunDataArguments): Promise<void> {
         const test = this.state.units[testId] as Test;
 
-        this._initializeTestRunProxy({ testRunId, test, browser, activeWindowId });
+        this._initializeTestRunProxy({ testRunId, test, browser, activeWindowId, messageBus });
         this._initializeFixtureCtx(test);
     }
 

--- a/src/services/compiler/test-run-proxy.ts
+++ b/src/services/compiler/test-run-proxy.ts
@@ -49,7 +49,7 @@ class TestRunProxy extends AsyncEventEmitter {
     public readonly disableMultipleWindows: boolean;
     public activeWindowId: null | string;
 
-    public constructor ({ dispatcher, id, test, options, browser, activeWindowId }: TestRunProxyInit) {
+    public constructor ({ dispatcher, id, test, options, browser, activeWindowId, messageBus }: TestRunProxyInit) {
         super();
 
         this[testRunMarker]                    = true;
@@ -65,7 +65,7 @@ class TestRunProxy extends AsyncEventEmitter {
         this.asyncJsExpressionCallsites        = new Map<string, CallsiteRecord>();
         this.controller                        = new TestController(this);
         this.observedCallsites                 = new ObservedCallsitesStorage();
-        this.warningLog                        = new WarningLog();
+        this.warningLog                        = new WarningLog(null, WarningLog.creatAddWarningCallback(messageBus));
         this.disableMultipleWindows            = options.disableMultipleWindows as boolean;
         this.activeWindowId                    = activeWindowId;
 

--- a/src/services/compiler/test-run-proxy.ts
+++ b/src/services/compiler/test-run-proxy.ts
@@ -65,7 +65,7 @@ class TestRunProxy extends AsyncEventEmitter {
         this.asyncJsExpressionCallsites        = new Map<string, CallsiteRecord>();
         this.controller                        = new TestController(this);
         this.observedCallsites                 = new ObservedCallsitesStorage();
-        this.warningLog                        = new WarningLog(null, WarningLog.creatAddWarningCallback(messageBus));
+        this.warningLog                        = new WarningLog(null, WarningLog.createAddWarningCallback(messageBus));
         this.disableMultipleWindows            = options.disableMultipleWindows as boolean;
         this.activeWindowId                    = activeWindowId;
 

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -1,6 +1,7 @@
 import { TestRunDispatcherProtocol } from './compiler/protocol';
 import { Dictionary } from '../configuration/interfaces';
 import Test from '../api/structure/test';
+import MessageBus from '../utils/message-bus';
 
 export interface TestRunProxyInit {
     dispatcher: TestRunDispatcherProtocol;
@@ -9,5 +10,6 @@ export interface TestRunProxyInit {
     options: Dictionary<OptionValue>;
     browser: Browser;
     activeWindowId: null | string;
+    messageBus?: MessageBus;
 }
 

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -232,12 +232,7 @@ export default class TestRun extends AsyncEventEmitter {
         super();
 
         this[testRunMarker]    = true;
-        this.warningLog        = new WarningLog(globalWarningLog, async (message: string) => {
-            await messageBus.emit('warning-add', {
-                message,
-                testRun: this,
-            });
-        });
+        this.warningLog        = new WarningLog(globalWarningLog, WarningLog.creatAddWarningCallback(messageBus, this));
         this.opts              = opts;
         this.test              = test;
         this.browserConnection = browserConnection;

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -143,7 +143,7 @@ interface TestRunInit {
     globalWarningLog: WarningLog;
     opts: Dictionary<OptionValue>;
     compilerService?: CompilerService;
-    messageBus: MessageBus;
+    messageBus?: MessageBus;
 }
 
 interface DriverTask {
@@ -227,11 +227,13 @@ export default class TestRun extends AsyncEventEmitter {
     private errScreenshotPath: string | null;
     private asyncJsExpressionCallsites: Map<string, CallsiteRecord>;
     public readonly browser: Browser;
+    private readonly _messageBus?: MessageBus;
 
     public constructor ({ test, browserConnection, screenshotCapturer, globalWarningLog, opts, compilerService, messageBus }: TestRunInit) {
         super();
 
         this[testRunMarker]    = true;
+        this._messageBus       = messageBus;
         this.warningLog        = new WarningLog(globalWarningLog, WarningLog.creatAddWarningCallback(messageBus, this));
         this.opts              = opts;
         this.test              = test;

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -1345,6 +1345,7 @@ export default class TestRun extends AsyncEventEmitter {
             testId:         this.test.id,
             browser:        this.browser,
             activeWindowId: this.activeWindowId,
+            messageBus:     this._messageBus,
         });
     }
 

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -108,6 +108,7 @@ import AssertionExecutor from '../assertions/executor';
 import asyncFilter from '../utils/async-filter';
 import PROXYLESS_COMMANDS from './proxyless-commands-support';
 import Fixture from '../api/structure/fixture';
+import MessageBus from '../utils/message-bus';
 
 const lazyRequire                 = require('import-lazy')(require);
 const ClientFunctionBuilder       = lazyRequire('../client-functions/client-function-builder');
@@ -142,6 +143,7 @@ interface TestRunInit {
     globalWarningLog: WarningLog;
     opts: Dictionary<OptionValue>;
     compilerService?: CompilerService;
+    messageBus: MessageBus;
 }
 
 interface DriverTask {
@@ -226,11 +228,16 @@ export default class TestRun extends AsyncEventEmitter {
     private asyncJsExpressionCallsites: Map<string, CallsiteRecord>;
     public readonly browser: Browser;
 
-    public constructor ({ test, browserConnection, screenshotCapturer, globalWarningLog, opts, compilerService }: TestRunInit) {
+    public constructor ({ test, browserConnection, screenshotCapturer, globalWarningLog, opts, compilerService, messageBus }: TestRunInit) {
         super();
 
         this[testRunMarker]    = true;
-        this.warningLog        = new WarningLog(globalWarningLog);
+        this.warningLog        = new WarningLog(globalWarningLog, async (message: string) => {
+            await messageBus.emit('warning-add', {
+                message,
+                testRun: this,
+            });
+        });
         this.opts              = opts;
         this.test              = test;
         this.browserConnection = browserConnection;

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -234,7 +234,7 @@ export default class TestRun extends AsyncEventEmitter {
 
         this[testRunMarker]    = true;
         this._messageBus       = messageBus;
-        this.warningLog        = new WarningLog(globalWarningLog, WarningLog.creatAddWarningCallback(messageBus, this));
+        this.warningLog        = new WarningLog(globalWarningLog, WarningLog.createAddWarningCallback(messageBus, this));
         this.opts              = opts;
         this.test              = test;
         this.browserConnection = browserConnection;

--- a/src/utils/message-bus.ts
+++ b/src/utils/message-bus.ts
@@ -1,5 +1,7 @@
 import AsyncEventEmitter from './async-event-emitter';
 
 export default class MessageBus extends AsyncEventEmitter {
-
+    public abort (): void {
+        this.clearListeners();
+    }
 }

--- a/src/utils/message-bus.ts
+++ b/src/utils/message-bus.ts
@@ -1,0 +1,5 @@
+import AsyncEventEmitter from './async-event-emitter';
+
+export default class MessageBus extends AsyncEventEmitter {
+
+}

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -229,6 +229,10 @@ module.exports = {
         return this.currentEnvironment.retryTestPages;
     },
 
+    get experimentalDebug () {
+        return !!process.env.EXPERIMENTAL_DEBUG;
+    },
+
     testingEnvironmentNames,
     testingEnvironments,
     browserProviderNames,

--- a/test/functional/fixtures/regression/gh-3456/test.js
+++ b/test/functional/fixtures/regression/gh-3456/test.js
@@ -38,7 +38,7 @@ if (config.useLocalBrowsers) {
 
                     return assertionHelper.removeScreenshotDir();
                 })
-                .then(() => {
+                .finally(() => {
                     return testCafe.close();
                 });
         });

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -1039,10 +1039,6 @@ describe('Reporter', () => {
     });
 
     it('Should raise an error when uncaught exception occurred in any reporter method', async () => {
-        const exceptions = [
-            'reportWarnings',
-        ];
-
         function createReporterWithBrokenMethod (method) {
             const base = {
                 async reportTaskStart () {},
@@ -1059,16 +1055,14 @@ describe('Reporter', () => {
         }
 
         for (const method of Object.values(ReporterPluginMethod)) {
-            if (exceptions.includes(method))
-                continue;
-
             try {
                 await runTests(
                     'testcafe-fixtures/index-test.js',
                     'Simple test',
                     {
-                        reporter:   createReporterWithBrokenMethod(method),
-                        shouldFail: true,
+                        reporter:     createReporterWithBrokenMethod(method),
+                        shouldFail:   true,
+                        tsConfigPath: 'path-to-ts-config',
                     }
                 );
 

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -5,6 +5,7 @@ const { createReporter }   = require('../../utils/reporter');
 const ReporterPluginMethod = require('../../../../lib/reporter/plugin-methods');
 const assertionHelper      = require('../../assertion-helper.js');
 const path                 = require('path');
+const config               = require('../../config');
 
 const {
     createSimpleTestStream,
@@ -841,21 +842,23 @@ describe('Reporter', () => {
             resultWarning = {};
         });
 
-        it('Should get warning for TestRun', async () => {
-            try {
-                await runTests('testcafe-fixtures/index-test.js', 'Asynchronous method', {
-                    reporter,
-                    shouldFail: true,
-                });
+        if (!config.experimentalDebug) {
+            it('Should get warning for TestRun', async () => {
+                try {
+                    await runTests('testcafe-fixtures/index-test.js', 'Asynchronous method', {
+                        reporter,
+                        shouldFail: true,
+                    });
 
-                throw new Error('Promise rejection expected');
-            }
-            catch (err) {
-                expect(resultWarning.message).to.include("An asynchronous method that you do not await includes an assertion. Inspect that method's execution chain and add the 'await' keyword where necessary.");
-                expect(resultWarning.testRunId).to.be.a('string');
-                expect(resultWarning.testRunId).to.not.empty;
-            }
-        });
+                    throw new Error('Promise rejection expected');
+                }
+                catch (err) {
+                    expect(resultWarning.message).to.include("An asynchronous method that you do not await includes an assertion. Inspect that method's execution chain and add the 'await' keyword where necessary.");
+                    expect(resultWarning.testRunId).to.be.a('string');
+                    expect(resultWarning.testRunId).to.not.empty;
+                }
+            });
+        }
 
         it('Should get warning for Task', async () => {
             await runTests('./testcafe-fixtures/index-test.js', 'Take screenshots with same path', {

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -1,6 +1,7 @@
 const expect               = require('chai').expect;
 const fs                   = require('fs');
 const generateReporter     = require('./reporter');
+const { createReporter }   = require('../../utils/reporter');
 const ReporterPluginMethod = require('../../../../lib/reporter/plugin-methods');
 const { createReporter }   = require('../../utils/reporter');
 
@@ -825,6 +826,35 @@ describe('Reporter', () => {
                 ]);
             });
         });
+    });
+
+    describe('Warnings', () => {
+        it('Should show warning with test ID', async () => {
+            const resultWarning = {};
+            const reporter      = createReporter({
+                reportWarnings: (warning) => {
+                    Object.assign(resultWarning, warning);
+                },
+            });
+
+            try {
+                await runTests(
+                    'testcafe-fixtures/index-test.js',
+                    'Test warning',
+                    {
+                        reporter:   reporter,
+                        shouldFail: true,
+                    }
+                );
+
+                throw new Error('Promise rejection expected');
+            }
+            catch (err) {
+                expect(resultWarning.text).to.be.eql("An asynchronous method that you do not await includes an assertion. Inspect that method's execution chain and add the 'await' keyword where necessary.");
+                expect(resultWarning.testRunId).to.be.eql('1');
+            }
+        });
+
     });
 
     describe('Action snapshots', () => {

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -1024,6 +1024,10 @@ describe('Reporter', () => {
     });
 
     it('Should raise an error when uncaught exception occurred in any reporter method', async () => {
+        const exceptions = [
+            'reportWarnings',
+        ];
+
         function createReporterWithBrokenMethod (method) {
             const base = {
                 async reportTaskStart () {},
@@ -1040,6 +1044,9 @@ describe('Reporter', () => {
         }
 
         for (const method of Object.values(ReporterPluginMethod)) {
+            if (exceptions.includes(method))
+                continue;
+
             try {
                 await runTests(
                     'testcafe-fixtures/index-test.js',

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -861,20 +861,26 @@ describe('Reporter', () => {
         }
 
         it('Should get warning for Task', async () => {
-            await runTests('./testcafe-fixtures/index-test.js', 'Take screenshots with same path', {
-                setScreenshotPath: true,
-                reporter,
-            });
+            try {
+                await runTests('./testcafe-fixtures/index-test.js', 'Take screenshots with same path', {
+                    setScreenshotPath: true,
+                    shouldFail:        true,
+                    reporter,
+                });
 
-            const SCREENSHOTS_PATH   = path.resolve(assertionHelper.SCREENSHOTS_PATH);
-            const screenshotFileName = path.join(SCREENSHOTS_PATH, '1.png');
+                throw new Error('Promise rejection expected');
+            }
+            catch (err) {
+                const SCREENSHOTS_PATH   = path.resolve(assertionHelper.SCREENSHOTS_PATH);
+                const screenshotFileName = path.join(SCREENSHOTS_PATH, '1.png');
 
-            expect(resultWarning.message).to.include(
-                `The file at "${screenshotFileName}" already exists. It has just been rewritten ` +
-                'with a recent screenshot. This situation can possibly cause issues. To avoid them, make sure ' +
-                'that each screenshot has a unique path. If a test runs in multiple browsers, consider ' +
-                'including the user agent in the screenshot path or generate a unique identifier in another way.',
-            );
+                expect(resultWarning.message).to.include(
+                    `The file at "${screenshotFileName}" already exists. It has just been rewritten ` +
+                    'with a recent screenshot. This situation can possibly cause issues. To avoid them, make sure ' +
+                    'that each screenshot has a unique path. If a test runs in multiple browsers, consider ' +
+                    'including the user agent in the screenshot path or generate a unique identifier in another way.',
+                );
+            }
 
             await assertionHelper.removeScreenshotDir();
         });

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -838,20 +838,17 @@ describe('Reporter', () => {
             });
 
             try {
-                await runTests(
-                    'testcafe-fixtures/index-test.js',
-                    'Test warning',
-                    {
-                        reporter:   reporter,
-                        shouldFail: true,
-                    }
-                );
+                await runTests('testcafe-fixtures/index-test.js', 'Asynchronous method', {
+                    reporter,
+                    shouldFail: true,
+                } );
 
                 throw new Error('Promise rejection expected');
             }
             catch (err) {
-                expect(resultWarning.text).to.be.eql("An asynchronous method that you do not await includes an assertion. Inspect that method's execution chain and add the 'await' keyword where necessary.");
-                expect(resultWarning.testRunId).to.be.eql('1');
+                expect(resultWarning.message).to.include("An asynchronous method that you do not await includes an assertion. Inspect that method's execution chain and add the 'await' keyword where necessary.");
+                expect(resultWarning.testRunId).to.be.a('string');
+                expect(resultWarning.testRunId).to.not.empty;
             }
         });
 

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -843,6 +843,8 @@ describe('Reporter', () => {
         });
 
         if (!config.experimentalDebug) {
+            //TODO: Debug mode loses synchronization with unwaiting async function. This bug need to fix.
+
             it('Should get warning for TestRun', async () => {
                 try {
                     await runTests('testcafe-fixtures/index-test.js', 'Asynchronous method', {

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -862,30 +862,32 @@ describe('Reporter', () => {
             });
         }
 
-        it('Should get warning for Task', async () => {
-            try {
-                await runTests('./testcafe-fixtures/index-test.js', 'Take screenshots with same path', {
-                    setScreenshotPath: true,
-                    shouldFail:        true,
-                    reporter,
-                });
+        if (config.useLocalBrowsers) {
+            it('Should get warning for Task', async () => {
+                try {
+                    await runTests('./testcafe-fixtures/index-test.js', 'Take screenshots with same path', {
+                        setScreenshotPath: true,
+                        shouldFail:        true,
+                        reporter,
+                    });
 
-                throw new Error('Promise rejection expected');
-            }
-            catch (err) {
-                const SCREENSHOTS_PATH   = path.resolve(assertionHelper.SCREENSHOTS_PATH);
-                const screenshotFileName = path.join(SCREENSHOTS_PATH, '1.png');
+                    throw new Error('Promise rejection expected');
+                }
+                catch (err) {
+                    const SCREENSHOTS_PATH   = path.resolve(assertionHelper.SCREENSHOTS_PATH);
+                    const screenshotFileName = path.join(SCREENSHOTS_PATH, '1.png');
 
-                expect(resultWarning.message).to.include(
-                    `The file at "${screenshotFileName}" already exists. It has just been rewritten ` +
-                    'with a recent screenshot. This situation can possibly cause issues. To avoid them, make sure ' +
-                    'that each screenshot has a unique path. If a test runs in multiple browsers, consider ' +
-                    'including the user agent in the screenshot path or generate a unique identifier in another way.',
-                );
-            }
+                    expect(resultWarning.message).to.include(
+                        `The file at "${screenshotFileName}" already exists. It has just been rewritten ` +
+                        'with a recent screenshot. This situation can possibly cause issues. To avoid them, make sure ' +
+                        'that each screenshot has a unique path. If a test runs in multiple browsers, consider ' +
+                        'including the user agent in the screenshot path or generate a unique identifier in another way.',
+                    );
+                }
 
-            await assertionHelper.removeScreenshotDir();
-        });
+                await assertionHelper.removeScreenshotDir();
+            });
+        }
 
         it('Should get warning for request hook', async () => {
             await runTests('./testcafe-fixtures/failed-cors-validation.js', 'Failed CORS validation', {

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -885,7 +885,7 @@ describe('Reporter', () => {
 
         it('Should get warning for request hook', async () => {
             await runTests('./testcafe-fixtures/index-test.js', 'Simple test', {
-                only: 'chrome',
+                only:         'chrome',
                 reporter,
                 tsConfigPath: 'path-to-ts-config',
             });

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -873,6 +873,15 @@ describe('Reporter', () => {
                 'including the user agent in the screenshot path or generate a unique identifier in another way.',
             );
         });
+
+        it('Should get warning for request hook', async () => {
+            await runTests('./testcafe-fixtures/failed-cors-validation.js', 'Failed CORS validation', {
+                only: 'chrome',
+                reporter,
+            });
+
+            expect(resultWarning.message).to.include('RequestMock: CORS validation failed for a request specified as { url: "http://dummy-url.com/get" }');
+        });
     });
 
     describe('Action snapshots', () => {

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -872,6 +872,8 @@ describe('Reporter', () => {
                 'that each screenshot has a unique path. If a test runs in multiple browsers, consider ' +
                 'including the user agent in the screenshot path or generate a unique identifier in another way.',
             );
+
+            await assertionHelper.removeScreenshotDir();
         });
 
         it('Should get warning for request hook', async () => {

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -846,7 +846,7 @@ describe('Reporter', () => {
                 await runTests('testcafe-fixtures/index-test.js', 'Asynchronous method', {
                     reporter,
                     shouldFail: true,
-                } );
+                });
 
                 throw new Error('Promise rejection expected');
             }

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -882,6 +882,16 @@ describe('Reporter', () => {
 
             expect(resultWarning.message).to.include('RequestMock: CORS validation failed for a request specified as { url: "http://dummy-url.com/get" }');
         });
+
+        it('Should get warning for request hook', async () => {
+            await runTests('./testcafe-fixtures/index-test.js', 'Simple test', {
+                only: 'chrome',
+                reporter,
+                tsConfigPath: 'path-to-ts-config',
+            });
+
+            expect(resultWarning.message).to.eql("The 'tsConfigPath' option is deprecated and will be removed in the next major release. Use the 'compilerOptions.typescript.configPath' option instead.");
+        });
     });
 
     describe('Action snapshots', () => {

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -3,7 +3,8 @@ const fs                   = require('fs');
 const generateReporter     = require('./reporter');
 const { createReporter }   = require('../../utils/reporter');
 const ReporterPluginMethod = require('../../../../lib/reporter/plugin-methods');
-const { createReporter }   = require('../../utils/reporter');
+const assertionHelper      = require('../../assertion-helper.js');
+const path                 = require('path');
 
 const {
     createSimpleTestStream,
@@ -829,14 +830,18 @@ describe('Reporter', () => {
     });
 
     describe('Warnings', () => {
-        it('Should show warning with test ID', async () => {
-            const resultWarning = {};
-            const reporter      = createReporter({
-                reportWarnings: (warning) => {
-                    Object.assign(resultWarning, warning);
-                },
-            });
+        let resultWarning = {};
+        const reporter    = createReporter({
+            reportWarnings: (warning) => {
+                resultWarning = warning;
+            },
+        });
 
+        afterEach(() => {
+            resultWarning = {};
+        });
+
+        it('Should get warning for TestRun', async () => {
             try {
                 await runTests('testcafe-fixtures/index-test.js', 'Asynchronous method', {
                     reporter,
@@ -852,6 +857,22 @@ describe('Reporter', () => {
             }
         });
 
+        it('Should get warning for Task', async () => {
+            await runTests('./testcafe-fixtures/index-test.js', 'Take screenshots with same path', {
+                setScreenshotPath: true,
+                reporter,
+            });
+
+            const SCREENSHOTS_PATH   = path.resolve(assertionHelper.SCREENSHOTS_PATH);
+            const screenshotFileName = path.join(SCREENSHOTS_PATH, '1.png');
+
+            expect(resultWarning.message).to.include(
+                `The file at "${screenshotFileName}" already exists. It has just been rewritten ` +
+                'with a recent screenshot. This situation can possibly cause issues. To avoid them, make sure ' +
+                'that each screenshot has a unique path. If a test runs in multiple browsers, consider ' +
+                'including the user agent in the screenshot path or generate a unique identifier in another way.',
+            );
+        });
     });
 
     describe('Action snapshots', () => {

--- a/test/functional/fixtures/reporter/testcafe-fixtures/failed-cors-validation.js
+++ b/test/functional/fixtures/reporter/testcafe-fixtures/failed-cors-validation.js
@@ -1,0 +1,15 @@
+import { Selector, RequestMock } from 'testcafe';
+
+const mock = RequestMock()
+    .onRequestTo('http://dummy-url.com/get')
+    .respond({ prop: 'value' }, 200, { 'not-specify-cors-headers': true });
+
+fixture `Failed CORS validation`
+    .page('http://localhost:3000/fixtures/api/es-next/request-hooks/pages/request-mock/failed-cors-validation.html')
+    .requestHooks(mock);
+
+test('Failed CORS validation', async t => {
+    await t
+        .click('#btnSendFetch')
+        .expect(Selector('#requestStatusText').textContent).eql('CORS failed');
+});

--- a/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
@@ -118,3 +118,9 @@ test('Asynchronous method', async t => {
 test('Asynchronous method', async t => {
     await errorCheck(t);
 });
+
+test('Take screenshots with same path', async t => {
+    await t
+        .takeScreenshot('1.png')
+        .takeScreenshot('1.png');
+});

--- a/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
@@ -111,10 +111,10 @@ test('The "pressKey" action with the input[type=password] and the "confidential"
         .pressKey('p a $ $ w 0 r d enter', { confidential: false });
 });
 
-test('Test warning', async t => {
+test('Asynchronous method', async t => {
     errorCheck(t);
 });
 
-test('Test warning', async t => {
+test('Asynchronous method', async t => {
     await errorCheck(t);
 });

--- a/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
@@ -18,6 +18,11 @@ const errorRole = Role(page, async t => {
 
 const foo = ClientFunction(bool => () => bool);
 
+async function errorCheck (t) {
+    await new Promise(r => setTimeout(r, 100));
+    await t.expect(false).ok();
+}
+
 test('Simple test', async t => {
     await t.wait(1);
 });
@@ -104,4 +109,12 @@ test('The "pressKey" action with the input[type=password] and the "confidential"
     await t
         .click('#password-input')
         .pressKey('p a $ $ w 0 r d enter', { confidential: false });
+});
+
+test('Test warning', async t => {
+    errorCheck(t);
+});
+
+test('Test warning', async t => {
+    await errorCheck(t);
 });

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -233,6 +233,7 @@ before(function () {
                     pageRequestTimeout,
                     ajaxRequestTimeout,
                     userVariables,
+                    tsConfigPath,
                 } = opts;
 
                 const actualBrowsers = browsersInfo.filter(browserInfo => {
@@ -298,6 +299,7 @@ before(function () {
                         pageRequestTimeout,
                         ajaxRequestTimeout,
                         userVariables,
+                        tsConfigPath,
                     })
                     .then(failedCount => {
                         if (customReporters)

--- a/test/server/browser-job-test.js
+++ b/test/server/browser-job-test.js
@@ -18,14 +18,12 @@ describe('Browser Job', function () {
 
         const testRunController = job._testRunControllerQueue[0];
 
-        expect(testRunController.listenerCount()).eql(8);
+        expect(testRunController.listenerCount()).eql(6);
         expect(testRunController.listenerCount('test-run-create')).eql(1);
-        expect(testRunController.listenerCount('test-run-start')).eql(1);
         expect(testRunController.listenerCount('test-run-ready')).eql(1);
         expect(testRunController.listenerCount('test-run-restart')).eql(1);
         expect(testRunController.listenerCount('test-run-before-done')).eql(1);
         expect(testRunController.listenerCount('test-run-done')).eql(1);
-        expect(testRunController.listenerCount('test-action-start')).eql(1);
         expect(testRunController.listenerCount('test-action-done')).eql(1);
     });
 });

--- a/test/server/error-handle-test.js
+++ b/test/server/error-handle-test.js
@@ -169,20 +169,20 @@ describe('Global error handlers', () => {
         const runner = new RunnerMock();
 
         const { completionPromise } = runner._runTask({
-            reporterPlugins: [],
-            browserSet:      new BrowserSetMock(),
-            testedApp:       null,
+            reporters:  [],
+            browserSet: new BrowserSetMock(),
+            testedApp:  null,
         });
 
         const testRunMock1 = new TestRunMock(1);
         const testRunMock2 = new TestRunMock(2);
         const testRunMock3 = new TestRunMock(3);
 
-        await runner.task.emit('start');
+        await runner._messageBus.emit('start');
 
-        await runner.task.emit('test-run-start', testRunMock1);
-        await runner.task.emit('test-run-start', testRunMock2);
-        await runner.task.emit('test-run-start', testRunMock3);
+        await runner._messageBus.emit('test-run-start', testRunMock1);
+        await runner._messageBus.emit('test-run-start', testRunMock2);
+        await runner._messageBus.emit('test-run-start', testRunMock3);
 
         /* eslint-disable no-new */
         new Promise((resolve, reject) => {
@@ -191,7 +191,7 @@ describe('Global error handlers', () => {
         /* eslint-enable no-new */
 
         await delay(1);
-        await runner.task.emit('done');
+        await runner._messageBus.emit('done');
         await completionPromise;
 
         expect(testRunMock1.errors.length).eql(1);

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -472,6 +472,25 @@ describe('Reporter', () => {
         log = [];
     });
 
+    it('MessageBus events', () => {
+        function createReporter (messageBus) {
+            return new Reporter({}, messageBus);
+        }
+
+        const messageBus = new MessageBus();
+
+        createReporter(messageBus);
+
+        expect(messageBus.listenerCount()).eql(7);
+        expect(messageBus.listenerCount('warning-add')).eql(1);
+        expect(messageBus.listenerCount('start')).eql(1);
+        expect(messageBus.listenerCount('test-run-start')).eql(1);
+        expect(messageBus.listenerCount('test-run-done')).eql(1);
+        expect(messageBus.listenerCount('test-action-start')).eql(1);
+        expect(messageBus.listenerCount('test-action-done')).eql(1);
+        expect(messageBus.listenerCount('done')).eql(1);
+    });
+
     it('Should analyze task progress and call appropriate plugin methods', function () {
         this.timeout(30000);
 

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -165,8 +165,8 @@ describe('Runner', () => {
         it('Should fallback to the default reporter if reporter was not set', () => {
             const storedRunTaskFn = runner._runTask;
 
-            runner._runTask = ({ reporterPlugins }) => {
-                const reporterPlugin = reporterPlugins[0].plugin;
+            runner._runTask = ({ reporters }) => {
+                const reporterPlugin = reporters[0].plugin;
 
                 expect(reporterPlugin.reportFixtureStart).to.be.a('function');
                 expect(reporterPlugin.reportTestDone).to.be.a('function');
@@ -933,6 +933,7 @@ describe('Runner', () => {
                         expect(err.message).eql(expectedErrorMessage);
 
                         delete runner.configuration._options[optionName];
+                        delete runner._options[optionName];
                     });
             };
 
@@ -1262,7 +1263,7 @@ describe('Runner', () => {
                 this.emit('browser-job-done', job);
             });
 
-            this.emit('done');
+            this._messageBus.emit('done');
         }
 
         beforeEach(() => {
@@ -1279,6 +1280,8 @@ describe('Runner', () => {
             browserProviderPool.addProvider('mock', MockBrowserProvider);
 
             Task.prototype._createBrowserJobs = function () {
+                this._messageBus.emit('start', this);
+
                 setTimeout(taskActionCallback.bind(this), TASK_ACTION_DELAY);
 
                 return this.browserConnectionGroups.map(bcGroup => {


### PR DESCRIPTION
[closes DevExpress/testcafe#6476]

## Purpose
Add the new 'reportWarnings' method for reporters to get warnings on demand.

```ts
interface Warning {
    message: string;
    testRunId?: string;
}

reportWarnings(warnings: Warning[]);
```

## Approach
1. Add method 'reportWarnings' to the Reporter
2. Add common emitter `messageBus`
3. Replace calling all reporters via `messageBus` instead of `task`
4. Add calling a new method in each place with creating a warning
5. Add test for new feature

## References
https://github.com/DevExpress/testcafe/issues/6476

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
