### PR TITLE
refactor: hack for supporting 'import { t } from testcafe' in the experimental debug mode.

### DIFF
--- a/src/services/compiler/service.ts
+++ b/src/services/compiler/service.ts
@@ -91,6 +91,10 @@ import { SwitchToWindowPredicateError } from '../../shared/errors';
 
 setupSourceMapSupport();
 
+// This is hack for supporting the 'import { t } from "testcafe"' expression in tests.
+// It caused by using the 'esm' module.
+require('../../api/test-controller/proxy');
+
 interface ServiceState {
     testRuns: { [id: string]: TestRunProxy };
     fixtureCtxs: { [id: string]: object };

--- a/test/functional/fixtures/api/coffeescript/smoke/test.js
+++ b/test/functional/fixtures/api/coffeescript/smoke/test.js
@@ -1,14 +1,10 @@
 const { expect } = require('chai');
 
-const experimentalDebug = !!process.env.EXPERIMENTAL_DEBUG;
-
 describe('[CoffeeScript] Smoke tests', function () {
-    if (!experimentalDebug) {
-        // TODO: IMPORTANT: Azure test tasks hang when a role is used in a test, fix it immediately
-        it('Should run non-trivial tests', function () {
-            return runTests('./testcafe-fixtures/non-trivial-test.coffee', null, { skip: ['safari', 'chrome-osx', 'firefox-osx', 'ipad', 'iphone'], selectorTimeout: 5000 });
-        });
-    }
+    // TODO: IMPORTANT: Azure test tasks hang when a role is used in a test, fix it immediately
+    it('Should run non-trivial tests', function () {
+        return runTests('./testcafe-fixtures/non-trivial-test.coffee', null, { skip: ['safari', 'chrome-osx', 'firefox-osx', 'ipad', 'iphone'], selectorTimeout: 5000 });
+    });
 
     it('Should produce correct callsites on error', function () {
         return runTests('./testcafe-fixtures/callsite-test.coffee', null, { shouldFail: true })

--- a/test/functional/fixtures/api/es-next/roles/test.js
+++ b/test/functional/fixtures/api/es-next/roles/test.js
@@ -12,12 +12,9 @@ const TEST_WITH_IFRAME_FAILED_RUN_OPTIONS = {
     selectorTimeout: IFRAME_SELECTOR_TIMEOUT,
 };
 
-const experimentalDebug = !!process.env.EXPERIMENTAL_DEBUG;
-
 // TODO: IMPORTANT: Azure test tasks hang when a role is used in a test, fix it immediately
 if (config.currentEnvironmentName !== config.testingEnvironmentNames.osXDesktopAndMSEdgeBrowsers &&
-    config.currentEnvironmentName !== config.testingEnvironmentNames.mobileBrowsers &&
-    !experimentalDebug) {
+    config.currentEnvironmentName !== config.testingEnvironmentNames.mobileBrowsers) {
     describe('[API] t.useRole()', function () {
         it('Should initialize and switch roles', function () {
             return runTests('./testcafe-fixtures/use-role-test.js', null, { only: 'chrome,ie,firefox' });

--- a/test/functional/fixtures/api/es-next/test-controller/test.js
+++ b/test/functional/fixtures/api/es-next/test-controller/test.js
@@ -1,7 +1,5 @@
 const { expect } = require('chai');
 
-const experimentalDebug = !!process.env.EXPERIMENTAL_DEBUG;
-
 // NOTE: we run tests in chrome only, because we mainly test server API functionality.
 // Actions functionality is tested in lower-level raw API.
 describe('[API] TestController', () => {
@@ -32,11 +30,9 @@ describe('[API] TestController', () => {
     });
 
     describe('Proxy object', () => {
-        if (!experimentalDebug) {
-            it('Should provide importable proxy object', () => {
-                return runTests('./testcafe-fixtures/proxy-test.js', 'Proxy object');
-            });
-        }
+        it.only('Should provide importable proxy object', () => {
+            return runTests('./testcafe-fixtures/proxy-test.js', 'Proxy object');
+        });
     });
 
     describe('Missing `await` tracking', () => {

--- a/test/functional/fixtures/api/es-next/test-controller/test.js
+++ b/test/functional/fixtures/api/es-next/test-controller/test.js
@@ -30,7 +30,7 @@ describe('[API] TestController', () => {
     });
 
     describe('Proxy object', () => {
-        it.only('Should provide importable proxy object', () => {
+        it('Should provide importable proxy object', () => {
             return runTests('./testcafe-fixtures/proxy-test.js', 'Proxy object');
         });
     });

--- a/test/functional/fixtures/api/typescript/smoke/test.js
+++ b/test/functional/fixtures/api/typescript/smoke/test.js
@@ -1,14 +1,10 @@
 const { expect } = require('chai');
 
-const experimentalDebug = !!process.env.EXPERIMENTAL_DEBUG;
-
 describe('[TypeScript] Smoke tests', function () {
-    if (!experimentalDebug) {
-        // TODO: IMPORTANT: Azure test tasks hang when a role is used in a test, fix it immediately
-        it('Should run non-trivial tests', function () {
-            return runTests('./testcafe-fixtures/non-trivial-test.ts', null, { skip: ['safari', 'chrome-osx', 'firefox-osx', 'ipad', 'iphone'], selectorTimeout: 5000 });
-        });
-    }
+    // TODO: IMPORTANT: Azure test tasks hang when a role is used in a test, fix it immediately
+    it('Should run non-trivial tests', function () {
+        return runTests('./testcafe-fixtures/non-trivial-test.ts', null, { skip: ['safari', 'chrome-osx', 'firefox-osx', 'ipad', 'iphone'], selectorTimeout: 5000 });
+    });
 
     it('Should produce correct callsites on error', function () {
         return runTests('./testcafe-fixtures/callsite-test.ts', null, { shouldFail: true })

--- a/test/functional/fixtures/regression/gh-1311/test.js
+++ b/test/functional/fixtures/regression/gh-1311/test.js
@@ -1,13 +1,9 @@
-const experimentalDebug = !!process.env.EXPERIMENTAL_DEBUG;
-
-if (!experimentalDebug) {
-    describe('[Regression](GH-1311)', function () {
-        it('Should raise "input" event while changing value in select input', function () {
-            return runTests('testcafe-fixtures/index.test.js', 'Click on select option (Non IE)', { skip: ['ie', 'edge-legacy'] });
-        });
-
-        it('Should not raise "input" event in IE while changing value in select input', function () {
-            return runTests('testcafe-fixtures/index.test.js', 'Click on select option (IE)', { only: ['ie', 'edge-legacy'] });
-        });
+describe('[Regression](GH-1311)', function () {
+    it('Should raise "input" event while changing value in select input', function () {
+        return runTests('testcafe-fixtures/index.test.js', 'Click on select option (Non IE)', { skip: ['ie', 'edge-legacy'] });
     });
-}
+
+    it('Should not raise "input" event in IE while changing value in select input', function () {
+        return runTests('testcafe-fixtures/index.test.js', 'Click on select option (IE)', { only: ['ie', 'edge-legacy'] });
+    });
+});

--- a/test/functional/fixtures/run-options/disable-page-caching/test.js
+++ b/test/functional/fixtures/run-options/disable-page-caching/test.js
@@ -1,18 +1,14 @@
-const experimentalDebug = !!process.env.EXPERIMENTAL_DEBUG;
-
-if (!experimentalDebug) {
-    describe('Disable page caching', () => {
-        it('Test run', () => {
-            return runTests('testcafe-fixtures/test-run.js', null, { disablePageCaching: true, disableMultipleWindows: true });
-        });
-
-        it('Fixture', () => {
-            return runTests('testcafe-fixtures/fixture.js', null, { disableMultipleWindows: true });
-        });
-
-        it('Single test', () => {
-            return runTests('testcafe-fixtures/single-test.js', null, { disableMultipleWindows: true });
-        });
+describe('Disable page caching', () => {
+    it('Test run', () => {
+        return runTests('testcafe-fixtures/test-run.js', null, { disablePageCaching: true, disableMultipleWindows: true });
     });
-}
+
+    it('Fixture', () => {
+        return runTests('testcafe-fixtures/fixture.js', null, { disableMultipleWindows: true });
+    });
+
+    it('Single test', () => {
+        return runTests('testcafe-fixtures/single-test.js', null, { disableMultipleWindows: true });
+    });
+});
 


### PR DESCRIPTION
The main change is https://github.com/DevExpress/testcafe/pull/6542/files#diff-1f8383a36bf02f58356a4c61f8897a4d5d3349c273e565e7e2c0761435c45634R96