### PR TITLE
chore: fix importing tests in debug mode

### DIFF
--- a/test/functional/fixtures/api/es-next/test-structure/test.js
+++ b/test/functional/fixtures/api/es-next/test-structure/test.js
@@ -3,8 +3,6 @@ const DEFAULT_RUN_OPTIONS        = {
     selectorTimeout: DEFAULT_SELECTOR_TIMEOUT,
 };
 
-const experimentalDebug = !!process.env.EXPERIMENTAL_DEBUG;
-
 describe('Test structure', function () {
     it('Should work import "test"', function () {
         return runTests('./testcafe-test-structure/imported-fixture-test.js', '', DEFAULT_RUN_OPTIONS);
@@ -14,10 +12,8 @@ describe('Test structure', function () {
         return runTests('./testcafe-test-structure/imported-test-test.js', '', DEFAULT_RUN_OPTIONS);
     });
 
-    if (!experimentalDebug) {
-        it('Should work attached tests', function () {
-            return runTests('./testcafe-test-structure/test-structure-test.js', 'Attached tests should work', DEFAULT_RUN_OPTIONS);
-        });
-    }
+    it('Should work attached tests', function () {
+        return runTests('./testcafe-test-structure/test-structure-test.js', 'Attached tests should work', DEFAULT_RUN_OPTIONS);
+    });
 });
 

--- a/test/functional/fixtures/api/es-next/test-structure/testcafe-test-structure/test-structure-test.js
+++ b/test/functional/fixtures/api/es-next/test-structure/testcafe-test-structure/test-structure-test.js
@@ -1,3 +1,3 @@
 // NOTE: We can just import file with tests to run them.
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import attachedTest from './attached-test';
+import * as attachedTest from './attached-test';


### PR DESCRIPTION
According to the ES modules standard, the `import attachedTest from './attached-test';` expression requires `./attached-test';` file has a default export. If it doesn't have it, we get an error message about the absence of the default export.
The module transpiler plugin of the Babel compiler is more tolerant than the ES modules standard.
So, we need just to rewrite the import statement according to the standard.



