### PR TITLE
release: bumped version, added missing @babel/plugin-proposal-private-methods package

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -8,7 +8,7 @@
     "gitTag": true
   },
   "confirm": false,
-  "publishTag": "latest",
+  "publishTag": "alpha",
   "prePublishScript": "gulp test-server",
   "postPublishScript": "gulp docker-publish"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "1.16.0",
+  "version": "1.16.1-alpha.1",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"
@@ -63,6 +63,7 @@
     "@babel/plugin-proposal-class-properties": "^7.12.1",
     "@babel/plugin-proposal-decorators": "^7.12.1",
     "@babel/plugin-proposal-object-rest-spread": "^7.12.1",
+    "@babel/plugin-proposal-private-methods": "^7.14.5",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-syntax-import-meta": "^7.10.4",
     "@babel/plugin-transform-async-to-generator": "^7.12.1",
@@ -133,7 +134,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.16",
-    "testcafe-hammerhead": "24.5.1",
+    "testcafe-hammerhead": "24.5.4",
     "testcafe-legacy-api": "5.1.1",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",


### PR DESCRIPTION
Closes https://github.com/DevExpress/testcafe/issues/6561.
