### PR TITLE
Improve performance of the debug mode (part 1)

### DIFF
--- a/src/compiler/interfaces.ts
+++ b/src/compiler/interfaces.ts
@@ -1,4 +1,5 @@
 export interface CompilerArguments {
     sourceList: string[];
     compilerOptions?: CompilerOptions;
+    runnableConfigurationId: string;
 }

--- a/src/live/bootstrapper.js
+++ b/src/live/bootstrapper.js
@@ -15,10 +15,10 @@ class LiveModeBootstrapper extends Bootstrapper {
         cacheProxy.preventCaching();
     }
 
-    _getTests () {
+    _getTests (id) {
         this._mockRequire();
 
-        return super._getTests()
+        return super._getTests(id)
             .then(result => {
                 this._restoreRequire();
 

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -17,9 +17,13 @@ import Test from '../api/structure/test';
 import Fixture from '../api/structure/fixture';
 import TestRunErrorFormattableAdapter from '../errors/test-run/formattable-adapter';
 import { CommandBase } from '../test-run/commands/base';
+
 import {
-    ReporterPlugin, ReporterPluginSource, ReporterSource,
+    ReporterPlugin,
+    ReporterPluginSource,
+    ReporterSource,
 } from './interfaces';
+
 import { getPluginFactory, processReporterName } from '../utils/reporter';
 import resolvePathRelativelyCwd from '../utils/resolve-path-relatively-cwd';
 import makeDir from 'make-dir';

--- a/src/runner/fixture-hook-controller.ts
+++ b/src/runner/fixture-hook-controller.ts
@@ -136,7 +136,7 @@ export default class FixtureHookController {
         await this._runFixtureAfterHook(item, fixture.globalAfterFn, testRun);
 
         if (item.fixtureCtx) {
-            await testRun.compilerService?.removeFixtureCtx({
+            await testRun.compilerService?.removeFixtureCtxFromState({
                 fixtureId: fixture.id,
             });
         }

--- a/src/services/compiler/host.ts
+++ b/src/services/compiler/host.ts
@@ -64,6 +64,7 @@ import {
     AddUnexpectedErrorArguments,
     CheckWindowArgument,
     RemoveFixtureCtxArguments,
+    RemoveUnitsFromStateArguments,
 } from './interfaces';
 
 import { UncaughtExceptionError, UnhandledPromiseRejectionError } from '../../errors/test-run';
@@ -149,8 +150,9 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
             this.executeAssertionFn,
             this.addUnexpectedError,
             this.checkWindow,
-            this.removeTestRun,
-            this.removeFixtureCtx,
+            this.removeTestRunFromState,
+            this.removeFixtureCtxFromState,
+            this.removeUnitsFromState,
         ], this);
     }
 
@@ -370,10 +372,10 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
             .executeCommand(command, callsite);
     }
 
-    public async getTests ({ sourceList, compilerOptions }: CompilerArguments): Promise<Test[]> {
+    public async getTests ({ sourceList, compilerOptions, runnableConfigurationId }: CompilerArguments): Promise<Test[]> {
         const { proxy } = await this._getRuntime();
 
-        const units = await proxy.call(this.getTests, { sourceList, compilerOptions });
+        const units = await proxy.call(this.getTests, { sourceList, compilerOptions, runnableConfigurationId });
 
         return restoreTestStructure(
             units,
@@ -540,15 +542,21 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
         return proxy.call(this.checkWindow, { testRunId, commandId, url, title });
     }
 
-    public async removeTestRun ({ testRunId }: TestRunLocator): Promise<void> {
+    public async removeTestRunFromState ({ testRunId }: TestRunLocator): Promise<void> {
         const { proxy } = await this._getRuntime();
 
-        return proxy.call(this.removeTestRun, { testRunId });
+        return proxy.call(this.removeTestRunFromState, { testRunId });
     }
 
-    public async removeFixtureCtx ({ fixtureId }: RemoveFixtureCtxArguments): Promise<void> {
+    public async removeFixtureCtxFromState ({ fixtureId }: RemoveFixtureCtxArguments): Promise<void> {
         const { proxy } = await this._getRuntime();
 
-        return proxy.call(this.removeFixtureCtx, { fixtureId });
+        return proxy.call(this.removeFixtureCtxFromState, { fixtureId });
+    }
+
+    public async removeUnitsFromState ({ runnableConfigurationId }: RemoveUnitsFromStateArguments): Promise<void> {
+        const { proxy } = await this._getRuntime();
+
+        return proxy.call(this.removeUnitsFromState, { runnableConfigurationId });
     }
 }

--- a/src/services/compiler/interfaces.ts
+++ b/src/services/compiler/interfaces.ts
@@ -144,3 +144,7 @@ export interface RemoveFixtureCtxArguments {
     fixtureId: string;
 }
 
+export interface RemoveUnitsFromStateArguments {
+    runnableConfigurationId: string;
+}
+

--- a/src/services/compiler/protocol.ts
+++ b/src/services/compiler/protocol.ts
@@ -26,6 +26,7 @@ import {
     AddUnexpectedErrorArguments,
     CheckWindowArgument,
     RemoveFixtureCtxArguments,
+    RemoveUnitsFromStateArguments,
 } from './interfaces';
 
 export const BEFORE_AFTER_PROPERTIES      = ['beforeFn', 'afterFn'] as const;
@@ -87,6 +88,7 @@ export interface CompilerProtocol extends TestRunDispatcherProtocol {
     executeAssertionFn ({ testRunId, commandId }: CommandLocator): Promise<unknown>;
     addUnexpectedError ({ type, message }: AddUnexpectedErrorArguments): Promise<void>;
     checkWindow ({ url, title }: CheckWindowArgument): Promise<boolean>;
-    removeTestRun({ testRunId }: TestRunLocator): Promise<void>;
-    removeFixtureCtx ({ fixtureId }: RemoveFixtureCtxArguments): Promise<void>;
+    removeTestRunFromState({ testRunId }: TestRunLocator): Promise<void>;
+    removeFixtureCtxFromState ({ fixtureId }: RemoveFixtureCtxArguments): Promise<void>;
+    removeUnitsFromState ({ runnableConfigurationId }: RemoveUnitsFromStateArguments): Promise<void>;
 }

--- a/src/services/compiler/service.ts
+++ b/src/services/compiler/service.ts
@@ -548,6 +548,8 @@ class CompilerService implements CompilerProtocol {
 
         for (const unitId of unitIds)
             delete this.state.units[unitId];
+
+        delete this._runnableConfigurationUnitsRelations[runnableConfigurationId];
     }
 }
 

--- a/src/services/compiler/service.ts
+++ b/src/services/compiler/service.ts
@@ -53,6 +53,7 @@ import {
     AddUnexpectedErrorArguments,
     CheckWindowArgument,
     RemoveFixtureCtxArguments,
+    RemoveUnitsFromStateArguments,
 } from './interfaces';
 
 import { CompilerArguments } from '../../compiler/interfaces';
@@ -90,6 +91,7 @@ import { formatError } from '../../utils/handle-errors';
 import { SwitchToWindowPredicateError } from '../../shared/errors';
 import MessageBus from '../../utils/message-bus';
 import { WarningLogMessage } from '../../notifications/warning-log';
+import { uniq } from 'lodash';
 
 setupSourceMapSupport();
 
@@ -120,6 +122,7 @@ interface InitTestRunProxyData {
 class CompilerService implements CompilerProtocol {
     private readonly proxy: IPCProxy;
     private readonly state: ServiceState;
+    private readonly _runnableConfigurationUnitsRelations: { [id: string]: string[] };
 
     public constructor () {
         process.title = ProcessTitle.service;
@@ -129,6 +132,8 @@ class CompilerService implements CompilerProtocol {
 
         this.proxy = new IPCProxy(new ServiceTransport(input, output, SERVICE_SYNC_FD));
         this.state = this._initState();
+
+        this._runnableConfigurationUnitsRelations = {};
 
         this._registerErrorHandlers();
         this._setupRoutes();
@@ -208,8 +213,9 @@ class CompilerService implements CompilerProtocol {
             this.executeAsyncJsExpression,
             this.addUnexpectedError,
             this.checkWindow,
-            this.removeTestRun,
-            this.removeFixtureCtx,
+            this.removeTestRunFromState,
+            this.removeFixtureCtxFromState,
+            this.removeUnitsFromState,
         ], this);
     }
 
@@ -294,6 +300,14 @@ class CompilerService implements CompilerProtocol {
         userVariables.value = value;
     }
 
+    private _getUnitIds (tests: Test[]): string[] {
+        const testIds     = tests.map(test => test.id);
+        const fixtureIds  = tests.map(test => test.fixture?.id) as string[];
+        const testFileIds = tests.map(test => test.testFile.id);
+
+        return uniq([...testIds, ...fixtureIds, ...testFileIds]);
+    }
+
     public async setOptions ({ value }: SetOptionsArguments): Promise<void> {
         this.state.options = value;
 
@@ -308,11 +322,14 @@ class CompilerService implements CompilerProtocol {
         await Compiler.cleanUp();
     }
 
-    public async getTests ({ sourceList, compilerOptions }: CompilerArguments): Promise<Units> {
+    public async getTests ({ sourceList, compilerOptions, runnableConfigurationId }: CompilerArguments): Promise<Units> {
         const compiler = new Compiler(sourceList, compilerOptions, true);
 
-        const tests = await compiler.getTests();
-        const units = flattenTestStructure(tests);
+        const tests   = await compiler.getTests();
+        const units   = flattenTestStructure(tests);
+        const unitIds = this._getUnitIds(tests);
+
+        this._runnableConfigurationUnitsRelations[runnableConfigurationId] = unitIds;
 
         Object.assign(this.state.units, units);
 
@@ -396,7 +413,11 @@ class CompilerService implements CompilerProtocol {
     }
 
     public async getWarningMessages ({ testRunId }: TestRunLocator): Promise<WarningLogMessage[]> {
-        return this._getTargetTestRun(testRunId).warningLog.messageInfos;
+        // NOTE: In case of raising an error into ReporterPluginHost methods,
+        // TestRun has time to start.
+        const targetTestRun = this._getTargetTestRun(testRunId);
+
+        return targetTestRun ? targetTestRun.warningLog.messageInfos : [];
     }
 
     public async addRequestEventListeners ( { hookId, hookClassName, rules }: AddRequestEventListenersArguments): Promise<void> {
@@ -408,7 +429,12 @@ class CompilerService implements CompilerProtocol {
     }
 
     public async initializeTestRunData ({ testRunId, testId, browser, activeWindowId, messageBus }: InitializeTestRunDataArguments): Promise<void> {
+        // NOTE: In case of raising an error into ReporterPluginHost methods,
+        // TestRun has time to start.
         const test = this.state.units[testId] as Test;
+
+        if (!test)
+            return;
 
         this._initializeTestRunProxy({ testRunId, test, browser, activeWindowId, messageBus });
         this._initializeFixtureCtx(test);
@@ -509,12 +535,19 @@ class CompilerService implements CompilerProtocol {
         }
     }
 
-    public async removeTestRun ({ testRunId }: TestRunLocator): Promise<void> {
+    public async removeTestRunFromState ({ testRunId }: TestRunLocator): Promise<void> {
         delete this.state.testRuns[testRunId];
     }
 
-    public async removeFixtureCtx ({ fixtureId }: RemoveFixtureCtxArguments): Promise<void> {
+    public async removeFixtureCtxFromState ({ fixtureId }: RemoveFixtureCtxArguments): Promise<void> {
         delete this.state.fixtureCtxs[fixtureId];
+    }
+
+    public async removeUnitsFromState ({ runnableConfigurationId }: RemoveUnitsFromStateArguments): Promise<void> {
+        const unitIds = this._runnableConfigurationUnitsRelations[runnableConfigurationId];
+
+        for (const unitId of unitIds)
+            delete this.state.units[unitId];
     }
 }
 

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -638,7 +638,7 @@ export default class TestRun extends AsyncEventEmitter {
                 this.warningLog.addWarning(warning);
             });
 
-            await this.compilerService.removeTestRun({ testRunId: id });
+            await this.compilerService.removeTestRunFromState({ testRunId: id });
         }
 
         testRunTracker.removeActiveTestRun(id);


### PR DESCRIPTION
Changes:
* add an `id` for a runnable configuration and remove appropriate units from service state by runnable configuration id.
* small refactoring