### PR TITLE
add error-id to formattable-adapter (closes #6646)

### DIFF
--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -4,6 +4,7 @@ import {
     chain,
 } from 'lodash';
 
+import nanoid from 'nanoid';
 import { readSync as read } from 'read-file-relative';
 import promisifyEvent from 'promisify-event';
 import Mustache from 'mustache';
@@ -700,7 +701,14 @@ export default class TestRun extends AsyncEventEmitter {
         return false;
     }
 
+    private _ensureErrorId (err: Error): void {
+        // @ts-ignore
+        err.id = err.id || nanoid(7);
+    }
+
     private _createErrorAdapter (err: Error): TestRunErrorFormattableAdapter {
+        this._ensureErrorId(err);
+
         return new TestRunErrorFormattableAdapter(err, {
             userAgent:      this.browserConnection.userAgent,
             screenshotPath: this.errScreenshotPath || '',

--- a/test/functional/fixtures/regression/gh-6646/pages/index.html
+++ b/test/functional/fixtures/regression/gh-6646/pages/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>gh-6646</title>
+</head>
+<body>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-6646/test.js
+++ b/test/functional/fixtures/regression/gh-6646/test.js
@@ -1,0 +1,37 @@
+const expect = require('chai').expect;
+
+const config             = require('../../../config');
+const { createReporter } = require('../../../utils/reporter');
+
+let testErrors     = null;
+const actionErrors = [];
+
+const reporter = createReporter({
+    reportTestActionDone (name, { err }) {
+        actionErrors.push(err);
+    },
+    reportTestDone (name, testRunInfo) {
+        testErrors = testRunInfo.errs;
+    },
+});
+
+describe('Should pass the "error.id" argument to the reporter', function () {
+    it('Action error', function () {
+        return runTests('./testcafe-fixtures/index.js', 'Action error', {
+            reporter,
+            selectorTimeout: 100,
+        })
+            .then(function () {
+                expect(testErrors.length).eql(config.browsers.length);
+                expect(testErrors.length).eql(actionErrors.length);
+
+                for (const err of testErrors) {
+                    expect(!!err.id).eql(true);
+                    expect(!!testErrors.find(e => e.id === err.id)).eql(true);
+                }
+            });
+    });
+
+});
+
+

--- a/test/functional/fixtures/regression/gh-6646/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-6646/testcafe-fixtures/index.js
@@ -1,0 +1,6 @@
+fixture `Should pass the "error.id" argument to the reporter`
+    .page `http://localhost:3000/fixtures/regression/gh-6646/pages/index.html`;
+
+test(`Action error`, async t => {
+    await t.click('non-existing-element');
+});

--- a/test/server/test-run-error-formatting-test.js
+++ b/test/server/test-run-error-formatting-test.js
@@ -291,6 +291,10 @@ describe('Error formatting', () => {
         it('Base error formattable adapter properties', () => {
             const testRunMock = TestRun.prototype;
 
+            testRunMock._ensureErrorId = err => {
+                err.id = 'error-id';
+            };
+
             Object.assign(testRunMock, {
                 session:           { id: 'test-run-id' },
                 browserConnection: { userAgent: 'chrome' },
@@ -312,6 +316,7 @@ describe('Error formatting', () => {
                 testRunId:      'test-run-id',
                 testRunPhase:   'test-run-phase',
                 callsite:       'callsite',
+                id:             'error-id',
             });
         });
 


### PR DESCRIPTION
We have two actions where we need to pass errors:
`reportTestActionDone` and `reportTestDone`.
The problem is that the error is the same in both cases, but wrapper (TestRunFormattableAdapter) is different, because we create different adapters for each of these events.
So, the approach is add to an error the `error.id` property which will be shared between different error adapters.