### PR TITLE
feat: Integrate dashboard reporter (closes #6657)

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "testcafe-browser-tools": "2.0.16",
     "testcafe-hammerhead": "24.5.7",
     "testcafe-legacy-api": "5.1.2",
+    "testcafe-reporter-dashboard": "0.2.4-rc.1",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.1.0",
     "testcafe-reporter-minimal": "^2.1.0",

--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -15,6 +15,7 @@ import {
     getMetaOptions,
     getGrepOptions,
     getCompilerOptions,
+    getDashboardOptions,
 } from '../utils/get-options';
 
 import getFilterFn from '../utils/get-filter-fn';
@@ -80,6 +81,7 @@ interface CommandLineOptions {
     configFile?: string;
     proxyless?: boolean;
     v8Flags?: string[];
+    dashboardOptions? : string | Dictionary<string | boolean | number>;
 }
 
 export default class CLIArgumentParser {
@@ -171,6 +173,7 @@ export default class CLIArgumentParser {
             .option('--disable-multiple-windows', 'disable multiple windows mode')
             .option('--disable-http2', 'disable the HTTP/2 proxy backend and force the proxy to use only HTTP/1.1 requests')
             .option('--cache', 'cache web assets between test runs')
+            .option('--dashboard-token <token>', 'specify Dashboard Authentication token')
 
             // NOTE: these options will be handled by chalk internally
             .option('--color', 'force colors in command line')
@@ -178,7 +181,9 @@ export default class CLIArgumentParser {
 
             // NOTE: temporary hide experimental options from --help command
             .addOption(new Option('--proxyless', 'experimental').hideHelp())
-            .addOption(new Option('--experimental-debug', 'enable experimental debug mode').hideHelp());
+            .addOption(new Option('--experimental-debug', 'enable experimental debug mode').hideHelp())
+
+            .option('--dashboard-options <option=value[,...]>', 'specify Dashboard options');
     }
 
     private _parseList (val: string): string[] {
@@ -382,6 +387,11 @@ export default class CLIArgumentParser {
         this.opts.compilerOptions = resultCompilerOptions;
     }
 
+    private async _parseDashboardOptions (): Promise<void> {
+        if (this.opts.dashboardOptions)
+            this.opts.dashboardOptions = await getDashboardOptions(this.opts.dashboardOptions as string);
+    }
+
     private _parseListBrowsers (): void {
         const listBrowserOption = this.opts.listBrowsers;
 
@@ -447,6 +457,7 @@ export default class CLIArgumentParser {
         await this._parseCompilerOptions();
         await this._parseSslOptions();
         await this._parseReporters();
+        await this._parseDashboardOptions();
     }
 
     public getRunOptions (): RunnerRunOptions {

--- a/src/cli/argument-parser.ts
+++ b/src/cli/argument-parser.ts
@@ -81,7 +81,7 @@ interface CommandLineOptions {
     configFile?: string;
     proxyless?: boolean;
     v8Flags?: string[];
-    dashboardOptions? : string | Dictionary<string | boolean | number>;
+    dashboard? : string | Dictionary<string | boolean | number>;
 }
 
 export default class CLIArgumentParser {
@@ -173,7 +173,6 @@ export default class CLIArgumentParser {
             .option('--disable-multiple-windows', 'disable multiple windows mode')
             .option('--disable-http2', 'disable the HTTP/2 proxy backend and force the proxy to use only HTTP/1.1 requests')
             .option('--cache', 'cache web assets between test runs')
-            .option('--dashboard-token <token>', 'specify Dashboard Authentication token')
 
             // NOTE: these options will be handled by chalk internally
             .option('--color', 'force colors in command line')
@@ -183,7 +182,7 @@ export default class CLIArgumentParser {
             .addOption(new Option('--proxyless', 'experimental').hideHelp())
             .addOption(new Option('--experimental-debug', 'enable experimental debug mode').hideHelp())
 
-            .option('--dashboard-options <option=value[,...]>', 'specify Dashboard options');
+            .option('-D, --dashboard <option=value[,...]>', 'specify Dashboard options');
     }
 
     private _parseList (val: string): string[] {
@@ -388,8 +387,8 @@ export default class CLIArgumentParser {
     }
 
     private async _parseDashboardOptions (): Promise<void> {
-        if (this.opts.dashboardOptions)
-            this.opts.dashboardOptions = await getDashboardOptions(this.opts.dashboardOptions as string);
+        if (this.opts.dashboard)
+            this.opts.dashboard = await getDashboardOptions(this.opts.dashboard as string);
     }
 
     private _parseListBrowsers (): void {

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -116,7 +116,8 @@ async function runTests (argParser) {
         .screenshots(opts.screenshots)
         .startApp(opts.app, opts.appInitDelay)
         .clientScripts(argParser.opts.clientScripts)
-        .compilerOptions(argParser.opts.compilerOptions);
+        .compilerOptions(argParser.opts.compilerOptions)
+        .dashboard(argParser.opts.dashboard);
 
     runner.once('done-bootstrapping', () => log.hideSpinner());
 

--- a/src/configuration/option-names.ts
+++ b/src/configuration/option-names.ts
@@ -53,6 +53,7 @@ enum OptionNames {
     userVariables = 'userVariables',
     v8Flags = 'v8Flags',
     hooks = 'hooks',
+    dashboard = 'dashboard',
 }
 
 export default OptionNames;

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -219,13 +219,13 @@ export default class Reporter {
         if (!reporters.length)
             Reporter._addDefaultReporter(reporters);
 
-        return Promise.all(reporters.map(async ({ name, output }) => {
+        return Promise.all(reporters.map(async ({ name, output, options }) => {
             const pluginFactory = getPluginFactory(name);
             const processedName = processReporterName(name);
             const outStream     = output ? await Reporter._ensureOutStream(output) : void 0;
 
             return {
-                plugin: pluginFactory(),
+                plugin: pluginFactory(options),
                 name:   processedName,
                 outStream,
             };

--- a/src/reporter/interfaces.ts
+++ b/src/reporter/interfaces.ts
@@ -14,6 +14,7 @@ export interface ReporterPlugin {
 export interface ReporterSource {
     name: string;
     output?: string | WritableStream;
+    options?: Record<string, any>;
 }
 
 export interface ReporterPluginSource {
@@ -23,5 +24,5 @@ export interface ReporterPluginSource {
 }
 
 export interface ReporterPluginFactory {
-    (): ReporterPlugin;
+    (options?: Record<string, any>): ReporterPlugin;
 }

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -504,7 +504,7 @@ export default class Runner extends EventEmitter {
         const { _options } = this;
 
         if (!_options.dashboard)
-            return;
+            return Promise.resolve();
 
         if (!_options.reporter)
             _options.reporter = [];
@@ -515,6 +515,8 @@ export default class Runner extends EventEmitter {
             _options.reporter.push({ name: DASHBOARD_REPORTER_NAME, options: _options.dashboard });
         else
             dashboardReporter.options = _options.dashboard;
+
+        return Promise.resolve();
     }
 
     async _prepareClientScripts (tests, clientScripts) {
@@ -708,10 +710,9 @@ export default class Runner extends EventEmitter {
 
         this._options = Object.assign(this._options, options);
 
-        this._addDashboardReporterIfNeeded();
-
         const runTaskPromise = Promise.resolve()
             .then(() => this._setConfigurationOptions())
+            .then(() => this._addDashboardReporterIfNeeded())
             .then(() => Reporter.getReporterPlugins(this.configuration.getOption(OPTION_NAMES.reporter)))
             .then(reporterPlugins => {
                 reporters = reporterPlugins.map(reporter => new Reporter(reporter.plugin, this._messageBus, reporter.outStream, reporter.name));

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -505,7 +505,7 @@ export default class Runner extends EventEmitter {
         let reporterOptions    = this.configuration.getOption(OPTION_NAMES.reporter);
 
         if (!dashboardOptions)
-            return Promise.resolve();
+            return;
 
         if (!reporterOptions)
             reporterOptions = [];
@@ -518,8 +518,6 @@ export default class Runner extends EventEmitter {
             dashboardReporter.options = dashboardOptions;
 
         this.configuration.mergeOptions({ [OPTION_NAMES.reporter]: reporterOptions });
-
-        return Promise.resolve();
     }
 
     async _prepareClientScripts (tests, clientScripts) {

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -501,20 +501,21 @@ export default class Runner extends EventEmitter {
     }
 
     _addDashboardReporterIfNeeded () {
-        const { _options } = this;
+        const dashboardOptions = this.configuration.getOption(OPTION_NAMES.dashboard);
+        let reporterOptions    = this.configuration.getOption(OPTION_NAMES.reporter);
 
-        if (!_options.dashboard)
+        if (!dashboardOptions)
             return Promise.resolve();
 
-        if (!_options.reporter)
-            _options.reporter = [];
+        if (!reporterOptions)
+            reporterOptions = [];
 
-        const dashboardReporter = _options.reporter.find(reporter => reporter.name === DASHBOARD_REPORTER_NAME);
+        const dashboardReporter = reporterOptions.find(reporter => reporter.name === DASHBOARD_REPORTER_NAME);
 
         if (!dashboardReporter)
-            _options.reporter.push({ name: DASHBOARD_REPORTER_NAME, options: _options.dashboard });
+            reporterOptions.push({ name: DASHBOARD_REPORTER_NAME, options: _options.dashboard });
         else
-            dashboardReporter.options = _options.dashboard;
+            dashboardReporter.options = dashboardOptions;
 
         return Promise.resolve();
     }

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -513,9 +513,11 @@ export default class Runner extends EventEmitter {
         const dashboardReporter = reporterOptions.find(reporter => reporter.name === DASHBOARD_REPORTER_NAME);
 
         if (!dashboardReporter)
-            reporterOptions.push({ name: DASHBOARD_REPORTER_NAME, options: _options.dashboard });
+            reporterOptions.push({ name: DASHBOARD_REPORTER_NAME, options: dashboardOptions });
         else
             dashboardReporter.options = dashboardOptions;
+
+        this.configuration.mergeOptions({ [OPTION_NAMES.reporter]: reporterOptions });
 
         return Promise.resolve();
     }

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -509,8 +509,12 @@ export default class Runner extends EventEmitter {
         if (!_options.reporter)
             _options.reporter = [];
 
-        if (!_options.reporter.some(reporter => reporter.name === DASHBOARD_REPORTER_NAME))
+        const dashboardReporter = _options.reporter.find(reporter => reporter.name === DASHBOARD_REPORTER_NAME);
+
+        if (!dashboardReporter)
             _options.reporter.push({ name: DASHBOARD_REPORTER_NAME, options: _options.dashboard });
+        else
+            dashboardReporter.options = _options.dashboard;
     }
 
     async _prepareClientScripts (tests, clientScripts) {

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -510,7 +510,7 @@ export default class Runner extends EventEmitter {
             _options.reporter = [];
 
         if (!_options.reporter.some(reporter => reporter.name === DASHBOARD_REPORTER_NAME))
-            _options.reporter.push({ name: DASHBOARD_REPORTER_NAME });
+            _options.reporter.push({ name: DASHBOARD_REPORTER_NAME, options: _options.dashboard });
     }
 
     async _prepareClientScripts (tests, clientScripts) {
@@ -684,6 +684,12 @@ export default class Runner extends EventEmitter {
 
     compilerOptions (opts) {
         this._options[OPTION_NAMES.compilerOptions] = opts;
+
+        return this;
+    }
+
+    dashboard (opts) {
+        this._options[OPTION_NAMES.dashboard] = opts;
 
         return this;
     }

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -48,7 +48,8 @@ import { validateQuarantineOptions } from '../utils/get-options/quarantine';
 import logEntry from '../utils/log-entry';
 import MessageBus from '../utils/message-bus';
 
-const DEBUG_LOGGER = debug('testcafe:runner');
+const DEBUG_LOGGER            = debug('testcafe:runner');
+const DASHBOARD_REPORTER_NAME = 'dashboard';
 
 export default class Runner extends EventEmitter {
     constructor ({ proxy, browserConnectionGateway, configuration, compilerService }) {
@@ -499,6 +500,19 @@ export default class Runner extends EventEmitter {
         this.bootstrapper.hooks                  = this.configuration.getOption(OPTION_NAMES.hooks);
     }
 
+    _addDashboardReporterIfNeeded () {
+        const { _options } = this;
+
+        if (!_options.dashboard)
+            return;
+
+        if (!_options.reporter)
+            _options.reporter = [];
+
+        if (!_options.reporter.some(reporter => reporter.name === DASHBOARD_REPORTER_NAME))
+            _options.reporter.push({ name: DASHBOARD_REPORTER_NAME });
+    }
+
     async _prepareClientScripts (tests, clientScripts) {
         return Promise.all(tests.map(async test => {
             if (test.isLegacy)
@@ -683,6 +697,8 @@ export default class Runner extends EventEmitter {
         const messageBusErrorPromise = promisifyEvent(this._messageBus, 'error');
 
         this._options = Object.assign(this._options, options);
+
+        this._addDashboardReporterIfNeeded();
 
         const runTaskPromise = Promise.resolve()
             .then(() => this._setConfigurationOptions())

--- a/src/utils/get-options/dashboard.ts
+++ b/src/utils/get-options/dashboard.ts
@@ -1,7 +1,7 @@
 import baseGetOptions from './base';
 import { Dictionary } from '../../configuration/interfaces';
 
-const STRING_OPTION_NAMES = ['buildId'];
+const STRING_OPTION_NAMES = ['buildId', 'token'];
 
 export default async function (options: string): Promise<Dictionary<number | string | boolean>> {
     return baseGetOptions(options, {

--- a/src/utils/get-options/dashboard.ts
+++ b/src/utils/get-options/dashboard.ts
@@ -1,0 +1,15 @@
+import baseGetOptions from './base';
+import { Dictionary } from '../../configuration/interfaces';
+
+const STRING_OPTION_NAMES = ['buildId'];
+
+export default async function (options: string): Promise<Dictionary<number | string | boolean>> {
+    return baseGetOptions(options, {
+        async onOptionParsed (key: string, value: string) {
+            if (key && STRING_OPTION_NAMES.includes(key))
+                return String(value);
+
+            return value;
+        },
+    });
+}

--- a/src/utils/get-options/index.ts
+++ b/src/utils/get-options/index.ts
@@ -5,6 +5,7 @@ import getVideoOptions from './video';
 import getMetaOptions from './meta';
 import getGrepOptions from './grep';
 import getCompilerOptions from './compiler';
+import getDashboardOptions from './dashboard';
 
 export {
     getSSLOptions,
@@ -14,4 +15,5 @@ export {
     getMetaOptions,
     getGrepOptions,
     getCompilerOptions,
+    getDashboardOptions,
 };

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -753,7 +753,7 @@ describe('CLI argument parser', function () {
     });
 
     it('Should parse command line arguments', function () {
-        return parse('-r list -S -q -e --hostname myhost --proxy localhost:1234 --proxy-bypass localhost:5678 --qr-code --app run-app --speed 0.5 --debug-on-fail --disable-page-reloads --retry-test-pages --dev --sf --disable-page-caching --disable-http2 --proxyless ie test/server/data/file-list/file-1.js')
+        return parse('-r list -S -q -e --hostname myhost --proxy localhost:1234 --proxy-bypass localhost:5678 --qr-code --app run-app --speed 0.5 --debug-on-fail --disable-page-reloads --retry-test-pages --dev --sf --disable-page-caching --disable-http2 --proxyless ie test/server/data/file-list/file-1.js --dashboard token=qwe.rty,noVideoUpload=true')
             .then(parser => {
                 expect(parser.opts.browsers).eql(['ie']);
                 expect(parser.opts.src).eql(['test/server/data/file-list/file-1.js']);
@@ -778,6 +778,7 @@ describe('CLI argument parser', function () {
                 expect(parser.opts.retryTestPages).to.be.ok;
                 expect(parser.opts.disableHttp2).to.be.ok;
                 expect(parser.opts.proxyless).to.be.ok;
+                expect(parser.opts.dashboard).eql({ token: 'qwe.rty', noVideoUpload: true });
             });
     });
 

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -853,6 +853,8 @@ describe('CLI argument parser', function () {
             { long: '--cache' },
             { long: '--disable-http2' },
             { long: '--proxyless' },
+            { long: '--dashboard-token' },
+            { long: '--dashboard-options' },
         ];
 
         const parser  = new CliArgumentParser('');
@@ -869,7 +871,7 @@ describe('CLI argument parser', function () {
         }
 
         const expectedRunOptionsCount   = 21;
-        const expectedOtherOptionsCount = 36;
+        const expectedOtherOptionsCount = 38;
         const otherOptionsCount         = options.length - expectedRunOptionsCount;
 
         expect(runOptionNames.length).eql(expectedRunOptionsCount, ADD_TO_RUN_OPTIONS_WARNING);
@@ -921,5 +923,17 @@ describe('CLI argument parser', function () {
                 expect(runOpts.disableMultipleWindows).eql(true);
                 expect(runOpts.browsers).to.be.undefined;
             });
+    });
+
+    describe('Dashboard options', () => {
+        it('should parse dashboard arguments', async () => {
+            const parser = await parse('--dashboard-token 12345 --dashboard-options noVideoUpload=true,buildId=1');
+
+            expect(parser.opts.dashboardToken).equal('12345');
+            expect(parser.opts.dashboardOptions).to.be.ok;
+
+            expect(parser.opts.dashboardOptions.buildId).equal('1');
+            expect(parser.opts.dashboardOptions.noVideoUpload).equal(true);
+        });
     });
 });

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -853,8 +853,7 @@ describe('CLI argument parser', function () {
             { long: '--cache' },
             { long: '--disable-http2' },
             { long: '--proxyless' },
-            { long: '--dashboard-token' },
-            { long: '--dashboard-options' },
+            { long: '--dashboard', short: '-D' },
         ];
 
         const parser  = new CliArgumentParser('');
@@ -871,7 +870,7 @@ describe('CLI argument parser', function () {
         }
 
         const expectedRunOptionsCount   = 21;
-        const expectedOtherOptionsCount = 38;
+        const expectedOtherOptionsCount = 37;
         const otherOptionsCount         = options.length - expectedRunOptionsCount;
 
         expect(runOptionNames.length).eql(expectedRunOptionsCount, ADD_TO_RUN_OPTIONS_WARNING);
@@ -927,13 +926,12 @@ describe('CLI argument parser', function () {
 
     describe('Dashboard options', () => {
         it('should parse dashboard arguments', async () => {
-            const parser = await parse('--dashboard-token 12345 --dashboard-options noVideoUpload=true,buildId=1');
+            const parser = await parse('--dashboard token=12345,noVideoUpload=true,buildId=1');
 
-            expect(parser.opts.dashboardToken).equal('12345');
-            expect(parser.opts.dashboardOptions).to.be.ok;
-
-            expect(parser.opts.dashboardOptions.buildId).equal('1');
-            expect(parser.opts.dashboardOptions.noVideoUpload).equal(true);
+            expect(parser.opts.dashboard).to.be.ok;
+            expect(parser.opts.dashboard.token).equal('12345');
+            expect(parser.opts.dashboard.buildId).equal('1');
+            expect(parser.opts.dashboard.noVideoUpload).equal(true);
         });
     });
 });

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -79,6 +79,10 @@ describe('TestCafeConfiguration', function () {
             'clientScripts': 'test-client-script.js',
             'disableHttp2':  true,
             'proxyless':     true,
+            'dashboard':     {
+                'token':         'qwe.rty',
+                'noVideoUpload': true,
+            },
         });
     });
 
@@ -128,6 +132,7 @@ describe('TestCafeConfiguration', function () {
                         expect(testCafeConfiguration.getOption('clientScripts')).eql([ 'test-client-script.js' ]);
                         expect(testCafeConfiguration.getOption('disableHttp2')).to.be.true;
                         expect(testCafeConfiguration.getOption('proxyless')).to.be.true;
+                        expect(testCafeConfiguration.getOption('dashboard')).eql({ token: 'qwe.rty', noVideoUpload: true });
                     });
             });
 

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -229,11 +229,12 @@ describe('Runner', () => {
                 delete runner._options.dashboard;
             });
 
-            it('Should add the dashboard reporter if its options are specified', () => {
-                runner._options.dashboard = {};
-                runner._addDashboardReporterIfNeeded();
+            it('Should add the dashboard reporter if its options are specified', async () => {
+                runner.configuration.mergeOptions({ dashboard: { token: 'foo' } });
 
-                expect(runner._options.reporter[0].name).eql('dashboard');
+                await runner._addDashboardReporterIfNeeded();
+
+                expect(runner.configuration.getOption('reporter')[0]).to.deep.equal({ name: 'dashboard', options: { token: 'foo' } });
             });
         });
     });

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -167,6 +167,7 @@ describe('Runner', () => {
             runner._runTask = ({ reporters }) => {
                 const reporterPlugin = reporters[0].plugin;
 
+                expect(reporterPlugin.name).eql('spec');
                 expect(reporterPlugin.reportFixtureStart).to.be.a('function');
                 expect(reporterPlugin.reportTestDone).to.be.a('function');
                 expect(reporterPlugin.reportTaskStart).to.be.a('function');
@@ -214,6 +215,28 @@ describe('Runner', () => {
             catch (e) {
                 expect(e.message).eql("Specify a file name or a writable stream as the reporter's output target.");
             }
+        });
+
+        it('Should add the dashboard reporter if its options are specified', () => {
+            const storedRunTaskFn = runner._runTask;
+
+            runner._runTask = ({ reporters }) => {
+                console.log(reporters);
+
+                expect(reporters).to.have.length(1);
+
+                expect(reporters[0].plugin.name).eql('dashboard');
+                // expect(reporters[0].plugin.name).eql('spec');                
+
+                runner._runTask = storedRunTaskFn;
+
+                return Promise.resolve({});
+            };
+
+            return runner
+                .browsers(connection)
+                .src('test/server/data/test-suites/basic/testfile2.js')
+                .run({ dashboard: {} });
         });
     });
 

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -29,7 +29,6 @@ const createConfigFile = (configPath, options) => {
     fs.writeFileSync(configPath, JSON.stringify(options));
 };
 
-
 describe('Runner', () => {
     let testCafe                  = null;
     let runner                    = null;
@@ -217,26 +216,25 @@ describe('Runner', () => {
             }
         });
 
-        it('Should add the dashboard reporter if its options are specified', () => {
-            const storedRunTaskFn = runner._runTask;
+        describe('._addDashboardReporterIfNeeded', () => {
+            let sourceReporter = null;
 
-            runner._runTask = ({ reporters }) => {
-                console.log(reporters);
+            beforeEach(() => {
+                sourceReporter = runner._options.reporter;
+            });
 
-                expect(reporters).to.have.length(1);
+            afterEach(() => {
+                runner._options.reporter = sourceReporter;
 
-                expect(reporters[0].plugin.name).eql('dashboard');
-                // expect(reporters[0].plugin.name).eql('spec');                
+                delete runner._options.dashboard;
+            });
 
-                runner._runTask = storedRunTaskFn;
+            it('Should add the dashboard reporter if its options are specified', () => {
+                runner._options.dashboard = {};
+                runner._addDashboardReporterIfNeeded();
 
-                return Promise.resolve({});
-            };
-
-            return runner
-                .browsers(connection)
-                .src('test/server/data/test-suites/basic/testfile2.js')
-                .run({ dashboard: {} });
+                expect(runner._options.reporter[0].name).eql('dashboard');
+            });
         });
     });
 


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Integrate testcafe-reporter-dashboard with TestCafe. Develop an API.

## Approach
Pass options object to the reporter via plugin constructor aguments

## References
https://github.com/DevExpress/testcafe/issues/6657

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
