### PR TITLE
Debug mode optimization (part 2)

### DIFF
--- a/src/runner/fixture-hook-controller.ts
+++ b/src/runner/fixture-hook-controller.ts
@@ -136,8 +136,8 @@ export default class FixtureHookController {
         await this._runFixtureAfterHook(item, fixture.globalAfterFn, testRun);
 
         if (item.fixtureCtx) {
-            await testRun.compilerService?.removeFixtureCtxFromState({
-                fixtureId: fixture.id,
+            await testRun.compilerService?.removeFixtureCtxsFromState({
+                fixtureIds: [fixture.id],
             });
         }
 

--- a/src/services/compiler/host.ts
+++ b/src/services/compiler/host.ts
@@ -63,7 +63,7 @@ import {
     CommandLocator,
     AddUnexpectedErrorArguments,
     CheckWindowArgument,
-    RemoveFixtureCtxArguments,
+    RemoveFixtureCtxsArguments,
     RemoveUnitsFromStateArguments,
 } from './interfaces';
 
@@ -151,7 +151,7 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
             this.addUnexpectedError,
             this.checkWindow,
             this.removeTestRunFromState,
-            this.removeFixtureCtxFromState,
+            this.removeFixtureCtxsFromState,
             this.removeUnitsFromState,
         ], this);
     }
@@ -548,10 +548,10 @@ export default class CompilerHost extends AsyncEventEmitter implements CompilerP
         return proxy.call(this.removeTestRunFromState, { testRunId });
     }
 
-    public async removeFixtureCtxFromState ({ fixtureId }: RemoveFixtureCtxArguments): Promise<void> {
+    public async removeFixtureCtxsFromState ({ fixtureIds }: RemoveFixtureCtxsArguments): Promise<void> {
         const { proxy } = await this._getRuntime();
 
-        return proxy.call(this.removeFixtureCtxFromState, { fixtureId });
+        return proxy.call(this.removeFixtureCtxsFromState, { fixtureIds });
     }
 
     public async removeUnitsFromState ({ runnableConfigurationId }: RemoveUnitsFromStateArguments): Promise<void> {

--- a/src/services/compiler/interfaces.ts
+++ b/src/services/compiler/interfaces.ts
@@ -140,8 +140,8 @@ export interface CheckWindowArgument extends TestRunLocator {
     title: string;
 }
 
-export interface RemoveFixtureCtxArguments {
-    fixtureId: string;
+export interface RemoveFixtureCtxsArguments {
+    fixtureIds: string[];
 }
 
 export interface RemoveUnitsFromStateArguments {

--- a/src/services/compiler/protocol.ts
+++ b/src/services/compiler/protocol.ts
@@ -25,7 +25,7 @@ import {
     CommandLocator,
     AddUnexpectedErrorArguments,
     CheckWindowArgument,
-    RemoveFixtureCtxArguments,
+    RemoveFixtureCtxsArguments,
     RemoveUnitsFromStateArguments,
 } from './interfaces';
 
@@ -89,6 +89,6 @@ export interface CompilerProtocol extends TestRunDispatcherProtocol {
     addUnexpectedError ({ type, message }: AddUnexpectedErrorArguments): Promise<void>;
     checkWindow ({ url, title }: CheckWindowArgument): Promise<boolean>;
     removeTestRunFromState({ testRunId }: TestRunLocator): Promise<void>;
-    removeFixtureCtxFromState ({ fixtureId }: RemoveFixtureCtxArguments): Promise<void>;
+    removeFixtureCtxsFromState ({ fixtureIds }: RemoveFixtureCtxsArguments): Promise<void>;
     removeUnitsFromState ({ runnableConfigurationId }: RemoveUnitsFromStateArguments): Promise<void>;
 }

--- a/src/services/compiler/service.ts
+++ b/src/services/compiler/service.ts
@@ -52,7 +52,7 @@ import {
     CommandLocator,
     AddUnexpectedErrorArguments,
     CheckWindowArgument,
-    RemoveFixtureCtxArguments,
+    RemoveFixtureCtxsArguments,
     RemoveUnitsFromStateArguments,
 } from './interfaces';
 
@@ -214,7 +214,7 @@ class CompilerService implements CompilerProtocol {
             this.addUnexpectedError,
             this.checkWindow,
             this.removeTestRunFromState,
-            this.removeFixtureCtxFromState,
+            this.removeFixtureCtxsFromState,
             this.removeUnitsFromState,
         ], this);
     }
@@ -539,8 +539,9 @@ class CompilerService implements CompilerProtocol {
         delete this.state.testRuns[testRunId];
     }
 
-    public async removeFixtureCtxFromState ({ fixtureId }: RemoveFixtureCtxArguments): Promise<void> {
-        delete this.state.fixtureCtxs[fixtureId];
+    public async removeFixtureCtxsFromState ({ fixtureIds }: RemoveFixtureCtxsArguments): Promise<void> {
+        for (const fixtureId of fixtureIds)
+            delete this.state.fixtureCtxs[fixtureId];
     }
 
     public async removeUnitsFromState ({ runnableConfigurationId }: RemoveUnitsFromStateArguments): Promise<void> {


### PR DESCRIPTION
Changes:
In some cases (browser restart, stop task on first fail, etc.), the fixture contexts may not be deleted.
We remove all fixture context at the end of test execution to clean forgotten contexts.