### PR TITLE
add times codes for attempts to video in quarantine mode (closes #6478)

### DIFF
--- a/src/runner/browser-job.ts
+++ b/src/runner/browser-job.ts
@@ -128,9 +128,11 @@ export default class BrowserJob extends AsyncEventEmitter {
         remove(this._completionQueue, testRunInfo);
     }
 
-    private _onTestRunRestart (testRunController: TestRunController): void {
+    private async _onTestRunRestart (testRunController: TestRunController): Promise<void> {
         this._removeFromCompletionQueue(testRunController);
         this._testRunControllerQueue.unshift(testRunController);
+
+        await this.emit('test-run-restart', testRunController);
     }
 
     private async _onTestRunDone (testRunController: TestRunController): Promise<void> {

--- a/src/video-recorder/interfaces.ts
+++ b/src/video-recorder/interfaces.ts
@@ -2,6 +2,7 @@ export interface TestRunVideoInfo {
     testRunId: string;
     videoPath: string;
     singleFile: boolean;
+    timecodes?: number[];
 }
 
 export interface TestVideoInfo {
@@ -12,6 +13,7 @@ export interface TestRunVideoSavedEventArgs {
     testRun: { id: string; test: { id: string } };
     videoPath: string;
     singleFile: boolean;
+    timecodes?: number[];
 }
 
 export interface VideoOptions {

--- a/src/video-recorder/test-run-video-recorder.js
+++ b/src/video-recorder/test-run-video-recorder.js
@@ -21,6 +21,9 @@ export default class TestRunVideoRecorder {
         this.path            = path;
         this.ffmpegPath      = ffmpegPath;
         this.encodingOptions = encodingOptions;
+
+        this.start     = null;
+        this.timecodes = null;
     }
 
     get testRunInfo () {
@@ -28,6 +31,7 @@ export default class TestRunVideoRecorder {
             testIndex:       this.index,
             fixture:         this.test.fixture.name,
             test:            this.test.name,
+            timecodes:       this.timecodes,
             alias:           this._connection.browserInfo.alias,
             parsedUserAgent: this._connection.browserInfo.parsedUserAgent,
         };
@@ -43,6 +47,8 @@ export default class TestRunVideoRecorder {
 
     async startCapturing () {
         await this.videoRecorder.startCapturing();
+
+        this.start = Date.now();
     }
 
     async finishCapturing () {
@@ -64,6 +70,16 @@ export default class TestRunVideoRecorder {
 
     async isVideoEnabled () {
         return !this.test.skip;
+    }
+
+    onTestRunRestart () {
+        this.timecodes = this.timecodes || [0];
+
+        this._addTimeCode();
+    }
+
+    _addTimeCode () {
+        this.timecodes.push(Date.now() - this.start);
     }
 
     _createVideoRecorderProcess () {

--- a/src/video-recorder/videos.ts
+++ b/src/video-recorder/videos.ts
@@ -37,7 +37,7 @@ export default class Videos {
         return new VideoRecorder(browserJob, videoPath, options, videoEncodingOptions, warningLog);
     }
 
-    private _addTestRunVideoInfo ({ testRun, videoPath, singleFile }: TestRunVideoSavedEventArgs): void {
+    private _addTestRunVideoInfo ({ testRun, videoPath, singleFile, timecodes }: TestRunVideoSavedEventArgs): void {
         const testId: string         = testRun.test.id;
         let testVideo: TestVideoInfo = this.testVideoInfos[testId];
 
@@ -47,10 +47,15 @@ export default class Videos {
             this.testVideoInfos[testId] = testVideo;
         }
 
-        testVideo.recordings.push({
+        const recording: TestRunVideoInfo = {
             testRunId: testRun.id,
             videoPath,
             singleFile,
-        });
+        };
+
+        if (timecodes)
+            recording.timecodes = timecodes;
+
+        testVideo.recordings.push(recording);
     }
 }

--- a/test/functional/fixtures/video-recording/test.js
+++ b/test/functional/fixtures/video-recording/test.js
@@ -1,29 +1,22 @@
-const expect          = require('chai').expect;
-const path            = require('path');
-const { uniq }        = require('lodash');
-const config          = require('../../config');
-const assertionHelper = require('../../assertion-helper.js');
+const expect             = require('chai').expect;
+const path               = require('path');
+const { uniq }           = require('lodash');
+const config             = require('../../config');
+const assertionHelper    = require('../../assertion-helper.js');
+const { createReporter } = require('../../utils/reporter');
 
 function customReporter (errs, videos) {
-    return () => {
-        return {
-            async reportTaskStart () {
-            },
-            async reportFixtureStart () {
-            },
-            async reportTestDone (name, testRunInfo) {
-                testRunInfo.errs.forEach(err => {
-                    errs[err.errMsg] = true;
-                });
+    return createReporter({
+        async reportTestDone (name, testRunInfo) {
+            testRunInfo.errs.forEach(err => {
+                errs[err.errMsg] = true;
+            });
 
-                testRunInfo.videos.forEach(video => {
-                    videos.push(video);
-                });
-            },
-            async reportTaskDone () {
-            },
-        };
-    };
+            testRunInfo.videos.forEach(video => {
+                videos.push(video);
+            });
+        },
+    });
 }
 
 function checkVideoPaths (videoLog, videoPaths) {
@@ -152,11 +145,11 @@ if (config.useLocalBrowsers) {
                 });
         });
 
-        it('Should record video with quarantine mode enabled', () => {
+        it('Should record video with quarantine mode enabled (multiple attempts)', () => {
             const errs   = {};
             const videos = [];
 
-            return runTests('./testcafe-fixtures/quarantine-test.js', '', {
+            return runTests('./testcafe-fixtures/quarantine-test.js', 'quarantine with attempts', {
                 only:           'chrome',
                 quarantineMode: true,
                 setVideoPath:   true,
@@ -164,7 +157,25 @@ if (config.useLocalBrowsers) {
             })
                 .then(assertionHelper.getVideoFilesList)
                 .then(videoFiles => {
-                    expect(videoFiles.length).to.equal(2);
+                    expect(videoFiles.length).to.equal(1);
+
+                    checkVideoPaths(videos, videoFiles);
+                });
+        });
+
+        it('Should record video with quarantine mode enabled (no attempts)', () => {
+            const errs   = {};
+            const videos = [];
+
+            return runTests('./testcafe-fixtures/quarantine-test.js', 'quarantine without attempts', {
+                only:           'chrome',
+                quarantineMode: true,
+                setVideoPath:   true,
+                reporter:       customReporter(errs, videos),
+            })
+                .then(assertionHelper.getVideoFilesList)
+                .then(videoFiles => {
+                    expect(videoFiles.length).to.equal(1);
 
                     checkVideoPaths(videos, videoFiles);
                 });

--- a/test/functional/fixtures/video-recording/test.js
+++ b/test/functional/fixtures/video-recording/test.js
@@ -157,7 +157,10 @@ if (config.useLocalBrowsers) {
             })
                 .then(assertionHelper.getVideoFilesList)
                 .then(videoFiles => {
-                    expect(videoFiles.length).to.equal(1);
+                    expect(videoFiles.length).eql(1);
+                    expect(videos[0].timecodes.length).eql(4);
+                    expect(videos[0].timecodes[0]).eql(0);
+                    expect(videos[0].timecodes.filter(tc => tc > 0).length).eql(3);
 
                     checkVideoPaths(videos, videoFiles);
                 });

--- a/test/server/video-recorder-test.js
+++ b/test/server/video-recorder-test.js
@@ -1,5 +1,3 @@
-
-
 const { expect }           = require('chai');
 const { noop }             = require('lodash');
 const TestRun              = require('../../lib/test-run/index');
@@ -44,6 +42,10 @@ class TestRunVideoRecorderMock extends TestRunVideoRecorder {
 
     _createVideoRecorderProcess () {
         return new VideoRecorderProcessMock();
+    }
+
+    _addTimeCode () {
+        this.timecodes.push(10);
     }
 }
 
@@ -114,8 +116,9 @@ function createTestRunMock (warningLog) {
         opts: { videoPath: 'path' },
 
         browserConnection: {
-            id:       'connectionId',
-            provider: {
+            id:          'connectionId',
+            browserInfo: {},
+            provider:    {
                 hasCustomActionForBrowser: () => {
                     return {
                         hasGetVideoFrameData: true,
@@ -127,7 +130,7 @@ function createTestRunMock (warningLog) {
 
     return {
         testRun,
-        test:  { skip: false },
+        test:  { skip: false, fixture: { name: 'Fixture' } },
         index: 0,
     };
 }
@@ -267,10 +270,12 @@ describe('Video Recorder', () => {
                     recordings: [{
                         testRunId:  'test-run-1',
                         videoPath:  'path-test-run-1',
+                        timecodes:  [0, 10],
                         singleFile: false,
                     }, {
                         testRunId:  'test-run-2',
                         videoPath:  'path-test-run-2',
+                        timecodes:  [0, 10],
                         singleFile: false,
                     }],
                 },
@@ -278,10 +283,12 @@ describe('Video Recorder', () => {
                     recordings: [{
                         testRunId:  'test-run-3',
                         videoPath:  'path-test-run-3',
+                        timecodes:  [0, 10],
                         singleFile: false,
                     }, {
                         testRunId:  'test-run-4',
                         videoPath:  'path-test-run-4',
+                        timecodes:  [0, 10],
                         singleFile: false,
                     }],
                 },
@@ -291,12 +298,20 @@ describe('Video Recorder', () => {
 
         return browserJobMock.emit('start')
             .then(() => browserJobMock.emit('test-run-create', testRunMock1))
+            .then(() => browserJobMock.emit('test-run-ready', testRunMock1))
+            .then(() => browserJobMock.emit('test-run-restart', testRunMock1))
             .then(() => browserJobMock.emit('test-run-before-done', testRunMock1))
             .then(() => browserJobMock.emit('test-run-create', testRunMock2))
+            .then(() => browserJobMock.emit('test-run-ready', testRunMock2))
+            .then(() => browserJobMock.emit('test-run-restart', testRunMock2))
             .then(() => browserJobMock.emit('test-run-before-done', testRunMock2))
             .then(() => browserJobMock.emit('test-run-create', testRunMock3))
+            .then(() => browserJobMock.emit('test-run-ready', testRunMock3))
+            .then(() => browserJobMock.emit('test-run-restart', testRunMock3))
             .then(() => browserJobMock.emit('test-run-before-done', testRunMock3))
             .then(() => browserJobMock.emit('test-run-create', testRunMock4))
+            .then(() => browserJobMock.emit('test-run-ready', testRunMock4))
+            .then(() => browserJobMock.emit('test-run-restart', testRunMock4))
             .then(() => browserJobMock.emit('test-run-before-done', testRunMock4))
             .then(() => {
                 expect(videos1).eql(expectedLog1);


### PR DESCRIPTION
JFI: TestCafe is recording video in real time. This means that we can just use Date.now() to get correct timecode. 