### PR TITLE
Fix multiple debug in headless mode warnings (closes #6605)

### DIFF
--- a/test/functional/fixtures/regression/gh-2846/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-2846/testcafe-fixtures/index.js
@@ -2,4 +2,7 @@ fixture `GH-2846`;
 
 test(`Debug`, async t => {
     await t.debug();
+
+    // NOTE: for https://github.com/DevExpress/testcafe/issues/6605
+    await t.wait(1);
 });


### PR DESCRIPTION
The `_enqueueSetBreakpointCommand` method is called from multiple places, so it's not suitable for emitting a warning. I moved the warning to the `_internalExecuteCommand` method.