### PR TITLE
Disable sourcemaps support in main process in case of 'experimentalDebug' mode

### DIFF
--- a/src/services/compiler/service.ts
+++ b/src/services/compiler/service.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import Compiler from '../../compiler';
 import TestRunProxy from './test-run-proxy';
 import TestController from '../../api/test-controller';
@@ -551,6 +552,10 @@ class CompilerService implements CompilerProtocol {
             delete this.state.units[unitId];
 
         delete this._runnableConfigurationUnitsRelations[runnableConfigurationId];
+
+        console.log('process heapUsed', Math.round(process.memoryUsage().heapUsed / 1024 / 1024), 'Mb'); //eslint-disable-line
+        console.log('all freeMemory', Math.round(os.freemem() / 1024 / 1024), 'Mb');//eslint-disable-line
+        console.log('all totalmem()', Math.round(os.totalmem() / 1024 / 1024), 'Mb');//eslint-disable-line
     }
 }
 

--- a/src/testcafe.js
+++ b/src/testcafe.js
@@ -23,8 +23,8 @@ export default class TestCafe {
     constructor (configuration) {
         const experimentalDebug = configuration.getOption(OPTION_NAMES.experimentalDebug);
 
-        //if (!experimentalDebug)
-        setupSourceMapSupport();
+        if (!experimentalDebug)
+            setupSourceMapSupport();
 
         errorHandlers.registerErrorHandlers();
 

--- a/src/testcafe.js
+++ b/src/testcafe.js
@@ -21,9 +21,9 @@ require('coffeescript');
 
 export default class TestCafe {
     constructor (configuration) {
-        const isExperimentalDebug = configuration.getOption(OPTION_NAMES.experimentalDebug);
+        const experimentalDebug = configuration.getOption(OPTION_NAMES.experimentalDebug);
 
-        if (isExperimentalDebug)
+        if (!experimentalDebug)
             setupSourceMapSupport();
 
         errorHandlers.registerErrorHandlers();
@@ -36,7 +36,7 @@ export default class TestCafe {
         this.runners                  = [];
         this.configuration            = configuration;
 
-        if (isExperimentalDebug) {
+        if (experimentalDebug) {
             const developmentMode = configuration.getOption(OPTION_NAMES.developmentMode);
             const v8Flags         = configuration.getOption(OPTION_NAMES.v8Flags);
 

--- a/src/testcafe.js
+++ b/src/testcafe.js
@@ -21,7 +21,11 @@ require('coffeescript');
 
 export default class TestCafe {
     constructor (configuration) {
-        setupSourceMapSupport();
+        const isExperimentalDebug = configuration.getOption(OPTION_NAMES.experimentalDebug);
+
+        if (isExperimentalDebug)
+            setupSourceMapSupport();
+
         errorHandlers.registerErrorHandlers();
 
         const { hostname, port1, port2, options } = configuration.startOptions;
@@ -32,7 +36,7 @@ export default class TestCafe {
         this.runners                  = [];
         this.configuration            = configuration;
 
-        if (configuration.getOption(OPTION_NAMES.experimentalDebug)) {
+        if (isExperimentalDebug) {
             const developmentMode = configuration.getOption(OPTION_NAMES.developmentMode);
             const v8Flags         = configuration.getOption(OPTION_NAMES.v8Flags);
 

--- a/src/testcafe.js
+++ b/src/testcafe.js
@@ -23,8 +23,8 @@ export default class TestCafe {
     constructor (configuration) {
         const experimentalDebug = configuration.getOption(OPTION_NAMES.experimentalDebug);
 
-        if (!experimentalDebug)
-            setupSourceMapSupport();
+        //if (!experimentalDebug)
+        setupSourceMapSupport();
 
         errorHandlers.registerErrorHandlers();
 


### PR DESCRIPTION
The `source-maps-support` module caches the content of files with source maps (files from the `node_modules` folder, own TestCafe's files). We can disable this module in the `main` process to decrease the memory usage due to the source maps for test errors are rendered in the `service` process.