### PR TITLE
fix: added definitions for the testExecutionTimeout and runExecutionTimeout

### DIFF
--- a/ts-defs-src/runner-api/options.d.ts
+++ b/ts-defs-src/runner-api/options.d.ts
@@ -257,6 +257,9 @@ interface RunOptions {
      * Time (in milliseconds). If TestCafe is idle for the specified length of time, TestCafe terminates the test run. Applies to actions inside and outside tests.
      */
     runExecutionTimeout: number;
+    /**
+     * Disables support for multi-window testing in Chrome and Firefox. Use this option if you encounter compatibility issues with your existing tests.
+     */
     disableMultipleWindows: boolean;
 }
 

--- a/ts-defs-src/runner-api/options.d.ts
+++ b/ts-defs-src/runner-api/options.d.ts
@@ -249,6 +249,14 @@ interface RunOptions {
      * Prevents TestCafe from taking screenshots. When this option is specified, screenshots are not taken whenever a test fails or when t.takeScreenshot or t.takeElementScreenshot is executed.
      */
     disableScreenshots: boolean;
+    /**
+     * Time (in milliseconds). If a test is unresponsive for the specified length of time, TestCafe terminates it. Only applies to test contents.
+     */
+    testExecutionTimeout: number;
+    /**
+     * Time (in milliseconds). If TestCafe is idle for the specified length of time, TestCafe terminates the test run. Applies to actions inside and outside tests.
+     */
+    runExecutionTimeout: number;
     disableMultipleWindows: boolean;
 }
 

--- a/ts-defs-src/runner-api/options.d.ts
+++ b/ts-defs-src/runner-api/options.d.ts
@@ -26,12 +26,12 @@ interface BrowserConnection {
     once(event: 'ready', callback: Function): void;
 }
 
-interface BrowserDescriptor { 
-    path: string; 
-    cmd?: string; 
+interface BrowserDescriptor {
+    path: string;
+    cmd?: string;
 }
 
-type BrowserOption  = string | BrowserConnection | BrowserDescriptor;
+type BrowserOption = string | BrowserConnection | BrowserDescriptor;
 type BrowserOptions = BrowserOption | BrowserOption [];
 
 type CompilerOptions = {
@@ -67,18 +67,18 @@ interface FilterDescriptor {
     fixture?: string;
     fixtureGrep?: string;
     testMeta?: Metadata;
-    fixtureMeta?: Metadata;    
+    fixtureMeta?: Metadata;
 }
 
-interface ReporterDescriptor { 
+interface ReporterDescriptor {
     name: string;
-    output?: string | NodeJS.WritableStream; 
+    output?: string | NodeJS.WritableStream;
 }
 
-type ReporterOption  = string | ReporterDescriptor;
+type ReporterOption = string | ReporterDescriptor;
 type ReporterOptions = ReporterOption | ReporterOptions [];
 
-type SourceOption  = string;
+type SourceOption = string;
 type SourceOptions = SourceOption | SourceOption [];
 
 interface ScreenshotsOptions extends TakeScreenshotOptions {
@@ -261,7 +261,7 @@ interface StartOptions {
     retryTestPages: boolean;
     cache: boolean;
     configFile: string;
-    disableHttp2: boolean;    
+    disableHttp2: boolean;
 }
 
 interface ColorOutputOptions {


### PR DESCRIPTION
[closes DevExpress/testcafe#6713]

## Purpose
Fix definitions for the testExecutionTimeout and runExecutionTimeout

## Approach
Add definitions

## References
https://github.com/DevExpress/testcafe/issues/6713

## Pre-Merge TODO
- [x] Make sure that existing tests do not fail
