### PR TITLE
fix: fixed the error of start chromium under the docker

### DIFF
--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -3,7 +3,11 @@ import { parse as parseUrl } from 'url';
 import dedicatedProviderBase from '../base';
 import ChromeRunTimeInfo from './runtime-info';
 import getConfig from './config';
-import { start as startLocalChrome, stop as stopLocalChrome } from './local-chrome';
+import {
+    start as startLocalChrome,
+    startOnDocker as startLocalChromeOnDocker,
+    stop as stopLocalChrome,
+} from './local-chrome';
 import { GET_WINDOW_DIMENSIONS_INFO_SCRIPT } from '../../../utils/client-functions';
 import { BrowserClient } from './cdp-client';
 
@@ -51,7 +55,10 @@ export default {
             reportWarning:            (...args) => this.reportWarning(browserId, ...args),
         };
 
-        await startLocalChrome(pageUrl, runtimeInfo);
+        if (runtimeInfo.inDocker)
+            await startLocalChromeOnDocker(pageUrl, runtimeInfo);
+        else
+            await startLocalChrome(pageUrl, runtimeInfo);
 
         await this.waitForConnectionReady(browserId);
 

--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -55,6 +55,7 @@ export default {
             reportWarning:            (...args) => this.reportWarning(browserId, ...args),
         };
 
+        //NOTE: A not-working tab is opened when the browser start in the docker so we should create a new tab.
         if (runtimeInfo.inDocker)
             await startLocalChromeOnDocker(pageUrl, runtimeInfo);
         else

--- a/src/browser/provider/built-in/dedicated/chrome/local-chrome.js
+++ b/src/browser/provider/built-in/dedicated/chrome/local-chrome.js
@@ -17,7 +17,7 @@ export async function start (pageUrl, { browserName, config, cdpPort, tempProfil
 
 export async function startOnDocker (pageUrl, { browserName, config, cdpPort, tempProfileDir, inDocker }) {
     await start('', { browserName, config, cdpPort, tempProfileDir, inDocker });
-    await new Promise(resolve => setTimeout(() => resolve(), 500));
+    // await new Promise(resolve => setTimeout(() => resolve(), 100));
 
     const tabs       = await remoteChrome.List({ port: cdpPort });
     const target     = tabs.filter(t => t.type === 'page')[0];

--- a/src/browser/provider/built-in/dedicated/chrome/local-chrome.js
+++ b/src/browser/provider/built-in/dedicated/chrome/local-chrome.js
@@ -3,9 +3,13 @@ import { killBrowserProcess } from '../../../../../utils/process';
 import BrowserStarter from '../../../utils/browser-starter';
 import { buildChromeArgs } from './build-chrome-args';
 import remoteChrome from 'chrome-remote-interface';
-import timeLimit from 'time-limit-promise';
+import Timer from '../../../../../utils/timer';
+import delay from '../../../../../utils/delay';
 
 const browserStarter = new BrowserStarter();
+
+const LIST_TABS_TIMEOUT = 5000;
+const LIST_TABS_DELAY   = 500;
 
 export async function start (pageUrl, { browserName, config, cdpPort, tempProfileDir, inDocker }) {
     const chromeInfo           = await browserTools.getBrowserInfo(config.path || browserName);
@@ -16,26 +20,31 @@ export async function start (pageUrl, { browserName, config, cdpPort, tempProfil
     await browserStarter.startBrowser(chromeOpenParameters, pageUrl);
 }
 
+async function tryListTabs (cdpPort) {
+    try {
+        return { tabs: await remoteChrome.List({ port: cdpPort }) };
+    }
+    catch (error) {
+        return { error };
+    }
+}
+
 export async function startOnDocker (pageUrl, { browserName, config, cdpPort, tempProfileDir, inDocker }) {
     await start('', { browserName, config, cdpPort, tempProfileDir, inDocker });
-    const error = new Error();
+
+    let { tabs, error } = await tryListTabs(cdpPort);
+    const timer         = new Timer(LIST_TABS_TIMEOUT);
 
     //NOTE: We should repeat getting 'List' after a while because we can get an error if the browser isn't ready.
-    const promise = new Promise(resolve => {
-        async function getTabs () {
-            try {
-                resolve(await remoteChrome.List({ port: cdpPort }));
-            }
-            catch (e) {
-                error.message = e.message;
-                setTimeout(() => getTabs(), 500);
-            }
-        }
+    while (error && !timer.expired) {
+        await delay(LIST_TABS_DELAY);
 
-        getTabs();
-    });
+        ({ tabs, error } = await tryListTabs(cdpPort));
+    }
 
-    const tabs       = await timeLimit(promise, 5000, { rejectWith: error });
+    if (error)
+        throw error;
+
     const target     = tabs.filter(t => t.type === 'page')[0];
     const { Target } = await remoteChrome({ target, port: cdpPort });
 

--- a/src/browser/provider/built-in/dedicated/chrome/local-chrome.js
+++ b/src/browser/provider/built-in/dedicated/chrome/local-chrome.js
@@ -40,6 +40,7 @@ export async function startOnDocker (pageUrl, { browserName, config, cdpPort, te
     const { Target } = await remoteChrome({ target, port: cdpPort });
 
     await Target.createTarget({ url: pageUrl });
+    await remoteChrome.Close({ id: target.id, port: cdpPort });
 }
 
 export async function stop ({ browserId }) {

--- a/src/browser/provider/built-in/dedicated/chrome/local-chrome.js
+++ b/src/browser/provider/built-in/dedicated/chrome/local-chrome.js
@@ -2,6 +2,7 @@ import browserTools from 'testcafe-browser-tools';
 import { killBrowserProcess } from '../../../../../utils/process';
 import BrowserStarter from '../../../utils/browser-starter';
 import { buildChromeArgs } from './build-chrome-args';
+import remoteChrome from 'chrome-remote-interface';
 
 const browserStarter = new BrowserStarter();
 
@@ -12,6 +13,17 @@ export async function start (pageUrl, { browserName, config, cdpPort, tempProfil
     chromeOpenParameters.cmd = buildChromeArgs({ config, cdpPort, platformArgs: chromeOpenParameters.cmd, tempProfileDir, inDocker });
 
     await browserStarter.startBrowser(chromeOpenParameters, pageUrl);
+}
+
+export async function startOnDocker (pageUrl, { browserName, config, cdpPort, tempProfileDir, inDocker }) {
+    await start('', { browserName, config, cdpPort, tempProfileDir, inDocker });
+    await new Promise(resolve => setTimeout(() => resolve(), 500));
+
+    const tabs       = await remoteChrome.List({ port: cdpPort });
+    const target     = tabs.filter(t => t.type === 'page')[0];
+    const { Target } = await remoteChrome({ target, port: cdpPort });
+
+    await Target.createTarget({ url: pageUrl });
 }
 
 export async function stop ({ browserId }) {


### PR DESCRIPTION
[closes DevExpress/testcafe#6436]

## Purpose
Fix the error of start chromium under the docker

## Approach
Create new tab after start chromium and before init

## References
https://github.com/DevExpress/testcafe/issues/6436

## Pre-Merge TODO
- [ ] Make sure that existing tests do not fail
