### PR TITLE
fix '"Cannot read property 'tests' of null" when using client scripts ' (close #6305)

### DIFF
--- a/src/custom-client-scripts/client-script.ts
+++ b/src/custom-client-scripts/client-script.ts
@@ -61,7 +61,7 @@ export default class ClientScript {
             this.url     = path || this.url;
         }
         catch (e) {
-            throw new GeneralError(RUNTIME_ERRORS.cannotLoadClientScriptFromPath, path);
+            throw new GeneralError(RUNTIME_ERRORS.cannotLoadClientScriptFromPath, path, e.message);
         }
     }
 

--- a/src/errors/runtime/templates.js
+++ b/src/errors/runtime/templates.js
@@ -98,7 +98,7 @@ export default {
     [RUNTIME_ERRORS.clientScriptInitializerIsNotSpecified]:            'Initialize your client script with one of the following: a JavaScript script, a JavaScript file path, or the name of a JavaScript module.',
     [RUNTIME_ERRORS.clientScriptBasePathIsNotSpecified]:               'Specify the base path for the client script file.',
     [RUNTIME_ERRORS.clientScriptInitializerMultipleContentSources]:    'Client scripts can only have one initializer: JavaScript code, a JavaScript file path, or the name of a JavaScript module.',
-    [RUNTIME_ERRORS.cannotLoadClientScriptFromPath]:                   'Cannot load a client script from {path}.',
+    [RUNTIME_ERRORS.cannotLoadClientScriptFromPath]:                   'Cannot load a client script from {path}.\n{errorMessage}',
     [RUNTIME_ERRORS.clientScriptModuleEntryPointPathCalculationError]: 'A client script tried to load a JavaScript module that TestCafe cannot locate:\n\n{errorMessage}.',
     [RUNTIME_ERRORS.methodIsNotAvailableForAnIPCHost]:                 'This method cannot be called on a service host.',
     [RUNTIME_ERRORS.tooLargeIPCPayload]:                               'The specified payload is too large to form an IPC packet.',

--- a/src/live/test-runner.js
+++ b/src/live/test-runner.js
@@ -146,7 +146,7 @@ class LiveModeRunner extends Runner {
     }
 
     async _finishPreviousTestRuns () {
-        if (!this.configurationCache.tests) return;
+        if (!this.configurationCache?.tests) return;
 
         this.testRunController.run();
     }
@@ -155,6 +155,11 @@ class LiveModeRunner extends Runner {
         if (isFirstRun) {
             if (this.bootstrappingError)
                 return Promise.reject(this.bootstrappingError);
+
+            else if (!this.configurationCache) {
+                // NOTE: Such errors handled in process.on('unhandledRejection') handler.
+                return Promise.reject(null);
+            }
 
             return Promise.resolve();
         }

--- a/test/server/custom-client-scripts-test.js
+++ b/test/server/custom-client-scripts-test.js
@@ -187,7 +187,9 @@ describe('Client scripts', () => {
                 expect.fail('Should throw the error');
             })
             .catch(e => {
-                expect(e.message).eql('Cannot load a client script from /non-existing-file.');
+                expect(e.message).contains(
+                    'Cannot load a client script from /non-existing-file.\n' +
+                    'ENOENT: no such file or directory, open');
             });
     });
 


### PR DESCRIPTION
Before fix
![image](https://user-images.githubusercontent.com/4133518/145982273-eb4de879-6d8d-481f-b48d-3a1b20cb220a.png)


After fix
![image](https://user-images.githubusercontent.com/4133518/145981687-9c9988db-8241-419f-b4b1-898aebe1ca98.png)

I didn't write any test because the current behavior is not good: the bootstrapping error handled by [process.on('unhandledRejection')](https://github.com/DevExpress/testcafe/blob/8815cb929ec9eb784e36c7be77df5cfd01312961/src/utils/handle-errors.js#L65) handler. The `ClientScript` error raising refactoring is a separate task. So, I just fix the error message now.

