### PR TITLE
do not dispose temp profile on browser restart (closes #4554)

### DIFF
--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -59,7 +59,7 @@ interface ProviderMetaInfoOptions {
     appendToUserAgent?: boolean;
 }
 
-export interface BrowserCloseData {
+export interface BrowserClosingInfo {
     isRestarting?: boolean;
 }
 
@@ -217,7 +217,7 @@ export default class BrowserConnection extends EventEmitter {
         }
     }
 
-    private async _closeBrowser (data: BrowserCloseData = {}): Promise<void> {
+    private async _closeBrowser (data: BrowserClosingInfo = {}): Promise<void> {
         if (!this.idle)
             await promisifyEvent(this, 'idle');
 

--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -73,7 +73,7 @@ export default {
         this._setUserAgentMetaInfoForEmulatingDevice(browserId, runtimeInfo.config);
     },
 
-    async closeBrowser (browserId) {
+    async closeBrowser (browserId, data = {}) {
         const runtimeInfo = this.openedBrowsers[browserId];
 
         if (runtimeInfo.browserClient.isHeadlessTab())
@@ -84,7 +84,7 @@ export default {
         if (OS.mac || runtimeInfo.config.headless)
             await stopLocalChrome(runtimeInfo);
 
-        if (runtimeInfo.tempProfileDir)
+        if (runtimeInfo.tempProfileDir && !data.isRestarting)
             await runtimeInfo.tempProfileDir.dispose();
 
         delete this.openedBrowsers[browserId];

--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -73,7 +73,7 @@ export default {
         this._setUserAgentMetaInfoForEmulatingDevice(browserId, runtimeInfo.config);
     },
 
-    async closeBrowser (browserId, data = {}) {
+    async closeBrowser (browserId, closingInfo = {}) {
         const runtimeInfo = this.openedBrowsers[browserId];
 
         if (runtimeInfo.browserClient.isHeadlessTab())
@@ -84,7 +84,7 @@ export default {
         if (OS.mac || runtimeInfo.config.headless)
             await stopLocalChrome(runtimeInfo);
 
-        if (runtimeInfo.tempProfileDir && !data.isRestarting)
+        if (runtimeInfo.tempProfileDir && !closingInfo.isRestarting)
             await runtimeInfo.tempProfileDir.dispose();
 
         delete this.openedBrowsers[browserId];

--- a/src/browser/provider/index.ts
+++ b/src/browser/provider/index.ts
@@ -3,7 +3,7 @@ import browserTools from 'testcafe-browser-tools';
 import OS from 'os-family';
 import { dirname } from 'path';
 import makeDir from 'make-dir';
-import BrowserConnection from '../connection';
+import BrowserConnection, { BrowserCloseData } from '../connection';
 import delay from '../../utils/delay';
 import {
     GET_IS_SERVICE_WORKER_ENABLED,
@@ -322,14 +322,14 @@ export default class BrowserProvider {
             await this._ensureBrowserWindowParameters(browserId);
     }
 
-    public async closeBrowser (browserId: string): Promise<void> {
+    public async closeBrowser (browserId: string, data: BrowserCloseData): Promise<void> {
         const canUseDefaultWindowActions = await this.canUseDefaultWindowActions(browserId);
         const customActionsInfo          = await this.hasCustomActionForBrowser(browserId);
         const hasCustomCloseBrowser      = customActionsInfo.hasCloseBrowser;
         const usePluginsCloseBrowser     = hasCustomCloseBrowser || !canUseDefaultWindowActions;
 
         if (usePluginsCloseBrowser)
-            await this.plugin.closeBrowser(browserId);
+            await this.plugin.closeBrowser(browserId, data);
         else
             await this._closeLocalBrowser(browserId);
 

--- a/src/browser/provider/index.ts
+++ b/src/browser/provider/index.ts
@@ -3,7 +3,7 @@ import browserTools from 'testcafe-browser-tools';
 import OS from 'os-family';
 import { dirname } from 'path';
 import makeDir from 'make-dir';
-import BrowserConnection, { BrowserCloseData } from '../connection';
+import BrowserConnection, { BrowserClosingInfo } from '../connection';
 import delay from '../../utils/delay';
 import {
     GET_IS_SERVICE_WORKER_ENABLED,
@@ -322,7 +322,7 @@ export default class BrowserProvider {
             await this._ensureBrowserWindowParameters(browserId);
     }
 
-    public async closeBrowser (browserId: string, data: BrowserCloseData): Promise<void> {
+    public async closeBrowser (browserId: string, data: BrowserClosingInfo): Promise<void> {
         const canUseDefaultWindowActions = await this.canUseDefaultWindowActions(browserId);
         const customActionsInfo          = await this.hasCustomActionForBrowser(browserId);
         const hasCustomCloseBrowser      = customActionsInfo.hasCloseBrowser;


### PR DESCRIPTION
It looks like a Chrome bug. If smth deletes Chrome temp profile folders when multiple Chrome instances are running, it breaks Chrome cache and leads to ERR_CACHE_READ_FAILURE.
I found a hint here: https://stackoverflow.com/questions/36741489/err-cache-read-failure-in-google-chrome

The solution: do not remove temp profile directories when browser is restarting.

All these temp direcotries will be removed when TestCafe finishes 