### PR TITLE
fix: fixed expanding disabled select

### DIFF
--- a/src/client/ui/select-element.js
+++ b/src/client/ui/select-element.js
@@ -144,7 +144,7 @@ function createChildren (children, parent) {
 export function expandOptionList (select) {
     const selectChildren = select.children;
 
-    if (!selectChildren.length)
+    if (!selectChildren.length || select.disabled)
         return;
 
     //NOTE: check is option list expanded

--- a/test/functional/fixtures/regression/gh-5616/pages/index.html
+++ b/test/functional/fixtures/regression/gh-5616/pages/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>gh-5616</title>
+</head>
+<body>
+<select disabled>
+    <option>Option 1</option>
+    <option>Option 2</option>
+    <option>Option 3</option>
+</select>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-5616/test.js
+++ b/test/functional/fixtures/regression/gh-5616/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-5616)', function () {
+    it('Element "select" shouldn\'t be opened', function () {
+        return runTests('testcafe-fixtures/index.js');
+    });
+});

--- a/test/functional/fixtures/regression/gh-5616/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-5616/testcafe-fixtures/index.js
@@ -1,0 +1,9 @@
+import { Selector } from 'testcafe';
+
+fixture`Click on "select" element`
+    .page('http://localhost:3000/fixtures/regression/gh-5616/pages/index.html');
+
+test('Element "select" shouldn\'t be opened', async (t) => {
+    await t.click('select');
+    await t.expect(Selector('option').filterVisible().count).eql(0);
+});


### PR DESCRIPTION
[closes DevExpress/testcafe#5616]

## Purpose
The ability to describe requests hooks for all tests.

## Approach
1. Add the tests to fix
2. Add conditions for not expanding disabled select

## References
https://github.com/DevExpress/testcafe/issues/5616

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
