### PR TITLE
fix browser hanging when the test switches between windows after switching to iframe (closes #6085)

### DIFF
--- a/src/client/automation/index.js
+++ b/src/client/automation/index.js
@@ -1,3 +1,6 @@
+// NOTE: Initializer should be the first
+import './shared-adapter-initializer';
+
 import hammerhead from './deps/hammerhead';
 import DispatchEventAutomation from './playback/dispatch-event';
 import SetScrollAutomation from './playback/set-scroll';

--- a/src/client/automation/shared-adapter-initializer.ts
+++ b/src/client/automation/shared-adapter-initializer.ts
@@ -1,0 +1,18 @@
+import hammerhead from './deps/hammerhead';
+import testCafeCore from './deps/testcafe-core';
+import { initializeAdapter } from '../../shared/adapter/index';
+import { ScrollOptions } from '../../test-run/commands/options';
+import { getOffsetOptions } from './utils/offsets';
+
+const { nativeMethods, Promise } = hammerhead;
+const { domUtils, ScrollAutomation } = testCafeCore;
+
+
+initializeAdapter({
+    PromiseCtor:   Promise,
+    nativeMethods: nativeMethods,
+    scroll:        (el: any, scrollOptions: ScrollOptions) => new ScrollAutomation(el, scrollOptions).run(),
+
+    getOffsetOptions: getOffsetOptions,
+    isDomElement:     domUtils.isDomElement,
+});

--- a/src/client/driver/driver-link/messages.js
+++ b/src/client/driver/driver-link/messages.js
@@ -17,6 +17,7 @@ export const TYPE = {
     restoreChildLink:            'driver|restore-child-link',
     childWindowIsLoadedInIFrame: 'driver|child-window-is-loaded-in-iframe',
     childWindowIsOpenedInIFrame: 'driver|child-window-is-opened-in-iframe',
+    stopInternalFromFrame:       'driver|stop-internal-from-iframe',
     hasPendingActionFlags:       'driver|has-pending-action-flags',
 };
 
@@ -147,6 +148,12 @@ export class ChildWindowIsLoadedInFrameMessage extends InterDriverMessage {
 export class ChildWindowIsOpenedInFrameMessage extends InterDriverMessage {
     constructor () {
         super(TYPE.childWindowIsOpenedInIFrame);
+    }
+}
+
+export class StopInternalFromFrameMessage extends InterDriverMessage {
+    constructor () {
+        super(TYPE.stopInternalFromFrame);
     }
 }
 

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -822,6 +822,17 @@ export default class Driver extends serviceUtils.EventEmitter {
             this._onChildWindowOpened({ window: wnd, windowId: msg.windowId });
     }
 
+    _handleStopInternalFromFrame (msg, wnd) {
+        sendConfirmationMessage({
+            requestMsgId: msg.id,
+            window:       wnd,
+        });
+
+        this.contextStorage.setItem(this.EXECUTING_IN_IFRAME_FLAG, false);
+
+        this._stopInternal();
+    }
+
     _initChildDriverListening () {
         messageSandbox.on(messageSandbox.SERVICE_MSG_RECEIVED_EVENT, e => {
             const msg    = e.message;
@@ -836,6 +847,9 @@ export default class Driver extends serviceUtils.EventEmitter {
                     break;
                 case MESSAGE_TYPE.childWindowIsLoadedInIFrame:
                     this._handleChildWindowIsLoadedInIFrame(msg, window);
+                    break;
+                case MESSAGE_TYPE.stopInternalFromFrame:
+                    this._handleStopInternalFromFrame(msg, window);
                     break;
                 case MESSAGE_TYPE.setAsMaster:
                     this._handleSetAsMasterMessage(msg, window);

--- a/src/client/driver/iframe-driver.js
+++ b/src/client/driver/iframe-driver.js
@@ -10,9 +10,13 @@ import Driver from './driver';
 import ContextStorage from './storage';
 import DriverStatus from './status';
 import ParentIframeDriverLink from './driver-link/iframe/parent';
-import { ChildWindowIsOpenedInFrameMessage, TYPE as MESSAGE_TYPE } from './driver-link/messages';
 import IframeNativeDialogTracker from './native-dialog-tracker/iframe';
 
+import {
+    ChildWindowIsOpenedInFrameMessage,
+    StopInternalFromFrameMessage,
+    TYPE as MESSAGE_TYPE,
+} from './driver-link/messages';
 
 const messageSandbox = eventSandbox.message;
 
@@ -38,6 +42,10 @@ export default class IframeDriver extends Driver {
     // to start waiting for the new page is loaded
     _onChildWindowOpened () {
         messageSandbox.sendServiceMsg(new ChildWindowIsOpenedInFrameMessage(), window.top);
+    }
+
+    _stopInternal () {
+        messageSandbox.sendServiceMsg(new StopInternalFromFrameMessage(), window.top);
     }
 
     // Messaging between drivers

--- a/test/functional/fixtures/multiple-windows/pages/i6085/iframe.html
+++ b/test/functional/fixtures/multiple-windows/pages/i6085/iframe.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+</head>
+<body>
+<h1>iframe</h1>
+</body>
+</html>

--- a/test/functional/fixtures/multiple-windows/pages/i6085/index.html
+++ b/test/functional/fixtures/multiple-windows/pages/i6085/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>gh-6085</title>
+</head>
+<body>
+gh-6085
+<iframe src="http://localhost:3000/fixtures/multiple-windows/pages/i6085/iframe.html"></iframe>
+</body>
+</html>

--- a/test/functional/fixtures/multiple-windows/pages/i6085/window.html
+++ b/test/functional/fixtures/multiple-windows/pages/i6085/window.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+</head>
+<body>
+<h1>window</h1>
+</body>
+</html>

--- a/test/functional/fixtures/multiple-windows/test.js
+++ b/test/functional/fixtures/multiple-windows/test.js
@@ -152,6 +152,10 @@ describe('Multiple windows', () => {
         return runTests('testcafe-fixtures/i6680.js');
     });
 
+    it('Should not hang if switching to a window from iframe', () => {
+        return runTests('testcafe-fixtures/i6085.js');
+    });
+
     describe('API', () => {
         it('Open child window', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Open child window', { only: 'chrome' });

--- a/test/functional/fixtures/multiple-windows/testcafe-fixtures/i6085.js
+++ b/test/functional/fixtures/multiple-windows/testcafe-fixtures/i6085.js
@@ -1,0 +1,13 @@
+const newWindowUrl = 'http://localhost:3000/fixtures/multiple-windows/pages/i6085/window.html';
+
+fixture `Should not hang if switching to a window from iframe`
+    .page `http://localhost:3000/fixtures/multiple-windows/pages/i6085/index.html`;
+
+test('Should not hang if switching to a window from iframe', async t => {
+    const newWindow = await t.openWindow(newWindowUrl);
+
+    await t.switchToParentWindow();
+    await t.switchToIframe('iframe');
+    await t.switchToWindow(newWindow);
+    await t.click('h1');
+});


### PR DESCRIPTION
solution:
If we switch to the new window from an iframe we should call `stopInternal` not in the iframe driver but parent driver