### PR TITLE
fix: fixed incorrect Page URL visited when running tests in parallel in one file with Role

### DIFF
--- a/src/role/role.ts
+++ b/src/role/role.ts
@@ -6,7 +6,7 @@ import nanoid from 'nanoid';
 import TestRun from '../test-run';
 import TestCafeErrorList from '../errors/error-list';
 
-interface RedirectUrl {
+export interface RedirectUrl {
     [testId: string]: string;
 }
 
@@ -105,13 +105,12 @@ export default class Role extends EventEmitter {
     public async setCurrentUrlAsRedirectUrl (testRun: TestRun): Promise<void> {
         const currentUrl = await testRun.getCurrentUrl();
 
-        if (!this.redirectUrl)
-            this.redirectUrl = {};
-
         if (this.opts.preserveUrl)
             this.redirectUrl = currentUrl;
-        else if (typeof this.redirectUrl === 'object')
-            this.redirectUrl[testRun.test.id] = currentUrl;
+        else {
+            this.redirectUrl = this.redirectUrl || {};
+            (this.redirectUrl as RedirectUrl)[testRun.test.id] = currentUrl;
+        }
 
         await testRun.compilerService?.updateRoleProperty({
             roleId: this.id,

--- a/src/test-run/bookmark.ts
+++ b/src/test-run/bookmark.ts
@@ -84,7 +84,7 @@ export default class TestRunBookmark {
             await this.testRun.executeCommand(new SwitchToMainWindowCommand() as CommandBase);
 
         if (!this.role.opts.preserveUrl)
-            await this.role.setCurrentUrlAsRedirectUrl(this.testRun);
+            await this.role.setCurrentUrlAsRedirectUrls(this.testRun);
     }
 
     private async _restoreDialogHandler (): Promise<void> {
@@ -158,7 +158,8 @@ export default class TestRunBookmark {
 
             const preserveUrl = this.role.opts.preserveUrl;
 
-            await this._restorePage(this.role.redirectUrl as string, stateSnapshot);
+            if (this.role.redirectUrls)
+                await this._restorePage(this.role.redirectUrls[this.testRun.test.id], stateSnapshot);
 
             if (!preserveUrl)
                 await this._restoreWorkingFrame();

--- a/src/test-run/bookmark.ts
+++ b/src/test-run/bookmark.ts
@@ -13,7 +13,7 @@ import {
 import { CurrentIframeNotFoundError, CurrentIframeIsNotLoadedError } from '../errors/test-run';
 import TestRun from './index';
 import { ExecuteClientFunctionCommand, ExecuteSelectorCommand } from './commands/observation';
-import Role from '../role/role';
+import Role, { RedirectUrl } from '../role/role';
 import { DEFAULT_SPEED_VALUE } from '../configuration/default-values';
 import BrowserConsoleMessages from './browser-console-messages';
 import { CommandBase } from './commands/base';
@@ -158,13 +158,11 @@ export default class TestRunBookmark {
 
             const preserveUrl = this.role.opts.preserveUrl;
 
-            if (this.role.redirectUrl) {
-                const redirectUrl = typeof this.role.redirectUrl === 'string'
-                    ? this.role.redirectUrl
-                    : this.role.redirectUrl[this.testRun.test.id];
+            const redirectUrl = preserveUrl
+                ? this.role.redirectUrl as string
+                : (this.role.redirectUrl as RedirectUrl)[this.testRun.test.id];
 
-                await this._restorePage(redirectUrl, stateSnapshot);
-            }
+            await this._restorePage(redirectUrl, stateSnapshot);
 
             if (!preserveUrl)
                 await this._restoreWorkingFrame();

--- a/src/test-run/bookmark.ts
+++ b/src/test-run/bookmark.ts
@@ -84,7 +84,7 @@ export default class TestRunBookmark {
             await this.testRun.executeCommand(new SwitchToMainWindowCommand() as CommandBase);
 
         if (!this.role.opts.preserveUrl)
-            await this.role.setCurrentUrlAsRedirectUrls(this.testRun);
+            await this.role.setCurrentUrlAsRedirectUrl(this.testRun);
     }
 
     private async _restoreDialogHandler (): Promise<void> {
@@ -158,8 +158,13 @@ export default class TestRunBookmark {
 
             const preserveUrl = this.role.opts.preserveUrl;
 
-            if (this.role.redirectUrls)
-                await this._restorePage(this.role.redirectUrls[this.testRun.test.id], stateSnapshot);
+            if (this.role.redirectUrl) {
+                const redirectUrl = typeof this.role.redirectUrl === 'string'
+                    ? this.role.redirectUrl
+                    : this.role.redirectUrl[this.testRun.test.id];
+
+                await this._restorePage(redirectUrl, stateSnapshot);
+            }
 
             if (!preserveUrl)
                 await this._restoreWorkingFrame();

--- a/test/functional/fixtures/concurrency/pages/first-page.html
+++ b/test/functional/fixtures/concurrency/pages/first-page.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<div id="someDiv">Hey</div>
+</body>
+</html>

--- a/test/functional/fixtures/concurrency/pages/first-page.html
+++ b/test/functional/fixtures/concurrency/pages/first-page.html
@@ -5,6 +5,6 @@
     <title>Title</title>
 </head>
 <body>
-<div id="someDiv">Hey</div>
+<h1>First page</h1>
 </body>
 </html>

--- a/test/functional/fixtures/concurrency/pages/second-page.html
+++ b/test/functional/fixtures/concurrency/pages/second-page.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<div id="someDiv">Hey</div>
+</body>
+</html>

--- a/test/functional/fixtures/concurrency/pages/second-page.html
+++ b/test/functional/fixtures/concurrency/pages/second-page.html
@@ -5,6 +5,6 @@
     <title>Title</title>
 </head>
 <body>
-<div id="someDiv">Hey</div>
+<h1>Second page</h1>
 </body>
 </html>

--- a/test/functional/fixtures/concurrency/test-info.js
+++ b/test/functional/fixtures/concurrency/test-info.js
@@ -1,5 +1,3 @@
 const FileStorage = require('../../utils/file-storage');
 
-const testInfo = new FileStorage('test-info.json', __dirname);
-
-module.exports = testInfo;
+module.exports = new FileStorage('test-info.json', __dirname);

--- a/test/functional/fixtures/concurrency/test-info.js
+++ b/test/functional/fixtures/concurrency/test-info.js
@@ -1,0 +1,5 @@
+const FileStorage = require('../../utils/file-storage');
+
+const testInfo = new FileStorage('test-info.json', __dirname);
+
+module.exports = testInfo;

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -3,7 +3,7 @@ const { expect }         = require('chai');
 const isCI               = require('is-ci');
 const config             = require('../../config');
 const { createReporter } = require('../../utils/reporter');
-const timeline           = require('./timeline');
+const testInfo           = require('./test-info');
 
 
 if (config.useLocalBrowsers) {
@@ -82,20 +82,20 @@ if (config.useLocalBrowsers) {
         });
 
         afterEach(() => {
-            timeline.delete();
+            testInfo.delete();
         });
 
         it('Should run tests sequentially if concurrency = 1', function () {
             return run('chrome:headless --no-sandbox', 1, './testcafe-fixtures/sequential-test.js')
                 .then(() => {
-                    expect(timeline.getData()).eql(['long started', 'long finished', 'short started', 'short finished']);
+                    expect(testInfo.getData()).eql(['long started', 'long finished', 'short started', 'short finished']);
                 });
         });
 
         it('Should run tests concurrently if concurrency > 1', function () {
             return run('chrome:headless --no-sandbox', 2, './testcafe-fixtures/concurrent-test.js')
                 .then(() => {
-                    expect(timeline.getData()).eql(['test started', 'test started', 'short finished', 'long finished']);
+                    expect(testInfo.getData()).eql(['test started', 'test started', 'short finished', 'long finished']);
                 });
         });
 
@@ -104,7 +104,7 @@ if (config.useLocalBrowsers) {
             it('Should run tests concurrently in different browser kinds', function () {
                 return run(['chrome:headless --no-sandbox', 'chrome:headless --no-sandbox --user-agent="TestAgent"'], 2, './testcafe-fixtures/multibrowser-concurrent-test.js')
                     .then(() => {
-                        const timelineData = timeline.getData();
+                        const timelineData = testInfo.getData();
 
                         expect(Object.keys(timelineData).length).gt(1);
 
@@ -118,7 +118,7 @@ if (config.useLocalBrowsers) {
             it('Should run tests concurrently with Role', function () {
                 return run('chrome:headless --no-sandbox', 2, './testcafe-fixtures/role-test.js')
                     .then(() => {
-                        expect(timeline.getData()).eql(['/fixtures/concurrency/pages/first-page.html', '/fixtures/concurrency/pages/second-page.html']);
+                        expect(testInfo.getData()).eql(['/fixtures/concurrency/pages/first-page.html', '/fixtures/concurrency/pages/second-page.html']);
                     });
             });
         }

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -115,9 +115,9 @@ if (config.useLocalBrowsers) {
         }
 
         it('Should run tests concurrently with Role', function () {
-            return run('chrome:headless', 2, './testcafe-fixtures/role-test.js')
+            return run('chrome:headless --no-sandbox', 2, './testcafe-fixtures/role-test.js')
                 .then(() => {
-                    expect(timeline.getData()).eql(['test started', 'test started', 'short finished', 'long finished']);
+                    expect(timeline.getData()).eql(['/fixtures/concurrency/pages/first-page.html', '/fixtures/concurrency/pages/second-page.html']);
                 });
         });
 

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -114,6 +114,13 @@ if (config.useLocalBrowsers) {
             });
         }
 
+        it('Should run tests concurrently with Role', function () {
+            return run('chrome:headless', 2, './testcafe-fixtures/role-test.js')
+                .then(() => {
+                    expect(timeline.getData()).eql(['test started', 'test started', 'short finished', 'long finished']);
+                });
+        });
+
         it('Should report fixture start correctly if second fixture finishes before first', function () {
             return run('chrome:headless --no-sandbox', 2, ['./testcafe-fixtures/multifixture-test-a.js', './testcafe-fixtures/multifixture-test-b.js'], customReporter)
                 .then(failedCount => {

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -114,12 +114,14 @@ if (config.useLocalBrowsers) {
             });
         }
 
-        it('Should run tests concurrently with Role', function () {
-            return run('chrome:headless --no-sandbox', 2, './testcafe-fixtures/role-test.js')
-                .then(() => {
-                    expect(timeline.getData()).eql(['/fixtures/concurrency/pages/first-page.html', '/fixtures/concurrency/pages/second-page.html']);
-                });
-        });
+        if (!config.proxyless) {
+            it('Should run tests concurrently with Role', function () {
+                return run('chrome:headless --no-sandbox', 2, './testcafe-fixtures/role-test.js')
+                    .then(() => {
+                        expect(timeline.getData()).eql(['/fixtures/concurrency/pages/first-page.html', '/fixtures/concurrency/pages/second-page.html']);
+                    });
+            });
+        }
 
         it('Should report fixture start correctly if second fixture finishes before first', function () {
             return run('chrome:headless --no-sandbox', 2, ['./testcafe-fixtures/multifixture-test-a.js', './testcafe-fixtures/multifixture-test-b.js'], customReporter)

--- a/test/functional/fixtures/concurrency/testcafe-fixtures/concurrent-test.js
+++ b/test/functional/fixtures/concurrency/testcafe-fixtures/concurrent-test.js
@@ -1,24 +1,24 @@
-import timeline from '../timeline';
+import testInfo from '../test-info';
 
 fixture `Concurrent`
     .page`../pages/index.html`
     .after(() => {
-        timeline.save();
-        timeline.clear();
+        testInfo.save();
+        testInfo.clear();
     });
 
 test('Long test', async t => {
-    timeline.add('test started');
+    testInfo.add('test started');
 
     await t.wait(10000);
 
-    timeline.add('long finished');
+    testInfo.add('long finished');
 });
 
 test('Short test', async t => {
-    timeline.add('test started');
+    testInfo.add('test started');
 
     await t.wait(1000);
 
-    timeline.add('short finished');
+    testInfo.add('short finished');
 });

--- a/test/functional/fixtures/concurrency/testcafe-fixtures/multibrowser-concurrent-test.js
+++ b/test/functional/fixtures/concurrency/testcafe-fixtures/multibrowser-concurrent-test.js
@@ -1,4 +1,4 @@
-import timeline from '../timeline';
+import testInfo from '../test-info';
 import { ClientFunction } from 'testcafe';
 
 const getUserAgent = ClientFunction(() => navigator.userAgent);
@@ -13,9 +13,9 @@ fixture `Concurrent`
             data[t.ctx.userAgent] = [];
     })
     .after(() => {
-        timeline.setData(data);
-        timeline.save();
-        timeline.clear();
+        testInfo.setData(data);
+        testInfo.save();
+        testInfo.clear();
     });
 
 test('Long test', async t => {

--- a/test/functional/fixtures/concurrency/testcafe-fixtures/role-test.js
+++ b/test/functional/fixtures/concurrency/testcafe-fixtures/role-test.js
@@ -5,7 +5,6 @@ const DEMO_ROLE = Role('http://localhost:3000/fixtures/concurrency/pages/index.h
 });
 
 fixture`F1`
-    .page('http://localhost:3000/fixtures/concurrency/pages/first-page.html')
     .beforeEach(async t => {
         await t.useRole(DEMO_ROLE);
     })
@@ -14,20 +13,10 @@ fixture`F1`
         timeline.clear();
     });
 
-test('T1', async t => {
-    const location = await t.eval(() => window.location.pathname);
+test('T1', async (t) => {
+    timeline.add(await t.eval(() => window.location.pathname));
+}).page('http://localhost:3000/fixtures/concurrency/pages/first-page.html');
 
-    timeline.add(location);
-});
-
-fixture`F2`
-    .page('http://localhost:3000/fixtures/concurrency/pages/second-page.html')
-    .beforeEach(async t => {
-        await t.useRole(DEMO_ROLE);
-    });
-
-test('T2', async t => {
-    const location = await t.eval(() => window.location.pathname);
-
-    timeline.add(location);
-});
+test('T2', async (t) => {
+    timeline.add(await t.eval(() => window.location.pathname));
+}).page('http://localhost:3000/fixtures/concurrency/pages/second-page.html');

--- a/test/functional/fixtures/concurrency/testcafe-fixtures/role-test.js
+++ b/test/functional/fixtures/concurrency/testcafe-fixtures/role-test.js
@@ -1,0 +1,50 @@
+/* eslint-disable no-shadow */
+import {
+    ClientFunction, Role, Selector, t,
+} from 'testcafe';
+
+const setAuthCookie = ClientFunction(auth => {
+    return new Promise(resolve => {
+        document.cookie = `demo_auth=${auth}; path=/`;
+        resolve();
+    });
+});
+
+const roleWrapper = USER => {
+    return Role(
+        'https://en.wikipedia.org/',
+        async () => {
+            await setAuthCookie(USER.auth);
+            await t.eval(() => window.location.reload());
+            await t.expect(Selector('.mp-topbanner').exists).notOk();
+        },
+        t,
+        { preserveUrl: false, USER },
+    );
+};
+
+const DEMO_ROLE = roleWrapper({ auth: '123456' });
+
+fixture`F1`
+    .page('https://en.wikipedia.org/wiki/United_States')
+    .beforeEach(async t => {
+        await t.useRole(DEMO_ROLE).wait(1000);
+    });
+
+test('T1', async t => {
+    const location = await t.eval(() => window.location.pathname);
+
+    await t.expect(location).eql('/wiki/United_States');
+});
+
+fixture`F2`
+    .page('https://en.wikipedia.org/wiki/Canada')
+    .beforeEach(async t => {
+        await t.useRole(DEMO_ROLE).wait(1000);
+    });
+
+test('T2', async t => {
+    const location = await t.eval(() => window.location.pathname);
+
+    await t.expect(location).eql('/wiki/Canada');
+});

--- a/test/functional/fixtures/concurrency/testcafe-fixtures/role-test.js
+++ b/test/functional/fixtures/concurrency/testcafe-fixtures/role-test.js
@@ -1,5 +1,5 @@
 import { Role } from 'testcafe';
-import timeline from '../timeline';
+import testInfo from '../test-info';
 
 const DEMO_ROLE = Role('http://localhost:3000/fixtures/concurrency/pages/index.html', async () => {
 });
@@ -9,14 +9,14 @@ fixture`F1`
         await t.useRole(DEMO_ROLE);
     })
     .after(() => {
-        timeline.save();
-        timeline.clear();
+        testInfo.save();
+        testInfo.clear();
     });
 
 test('T1', async (t) => {
-    timeline.add(await t.eval(() => window.location.pathname));
+    testInfo.add(await t.eval(() => window.location.pathname));
 }).page('http://localhost:3000/fixtures/concurrency/pages/first-page.html');
 
 test('T2', async (t) => {
-    timeline.add(await t.eval(() => window.location.pathname));
+    testInfo.add(await t.eval(() => window.location.pathname));
 }).page('http://localhost:3000/fixtures/concurrency/pages/second-page.html');

--- a/test/functional/fixtures/concurrency/testcafe-fixtures/sequential-test.js
+++ b/test/functional/fixtures/concurrency/testcafe-fixtures/sequential-test.js
@@ -1,24 +1,24 @@
-import timeline from '../timeline';
+import testInfo from '../test-info';
 
 fixture `Sequential`
     .page`../pages/index.html`
     .after(() => {
-        timeline.save();
-        timeline.clear();
+        testInfo.save();
+        testInfo.clear();
     });
 
 test('Long test', async t => {
-    timeline.add('long started');
+    testInfo.add('long started');
 
     await t.wait(10000);
 
-    timeline.add('long finished');
+    testInfo.add('long finished');
 });
 
 test('Short test', async t => {
-    timeline.add('short started');
+    testInfo.add('short started');
 
     await t.wait(1000);
 
-    timeline.add('short finished');
+    testInfo.add('short finished');
 });

--- a/test/functional/fixtures/concurrency/timeline.js
+++ b/test/functional/fixtures/concurrency/timeline.js
@@ -1,5 +1,0 @@
-const FileStorage = require('../../utils/file-storage');
-
-const timeline = new FileStorage('timeline.json', __dirname);
-
-module.exports = timeline;

--- a/test/server/ipc-serialization-test.js
+++ b/test/server/ipc-serialization-test.js
@@ -10,7 +10,7 @@ describe('IPC serialization', () => {
         const role = new Role('https://example.com', initFn, opts);
 
         role.phase         = RolePhase.pendingInitialization;
-        role.redirectUrl   = 'https://redirect-url.com';
+        role.redirectUrls   = { 1: 'https://redirect-url.com' };
         role.stateSnapshot = { cookie: 'key=value' };
         role.initErr       = new Error();
 
@@ -22,7 +22,7 @@ describe('IPC serialization', () => {
         expect(role.loginUrl).eql(deserializedRole.loginUrl);
         expect(role._initFn).eql(deserializedRole._initFn);
         expect(role.opts).deep.equal(deserializedRole.opts);
-        expect(role.redirectUrl).eql(deserializedRole.redirectUrl);
+        expect(role.redirectUrls).eql(deserializedRole.redirectUrls);
         expect(role.stateSnapshot).eql(deserializedRole.stateSnapshot);
         expect(role.initErr).eql(deserializedRole.initErr);
     });

--- a/test/server/ipc-serialization-test.js
+++ b/test/server/ipc-serialization-test.js
@@ -10,7 +10,7 @@ describe('IPC serialization', () => {
         const role = new Role('https://example.com', initFn, opts);
 
         role.phase         = RolePhase.pendingInitialization;
-        role.redirectUrls   = { 1: 'https://redirect-url.com' };
+        role.redirectUrl   = 'https://redirect-url.com';
         role.stateSnapshot = { cookie: 'key=value' };
         role.initErr       = new Error();
 
@@ -22,7 +22,7 @@ describe('IPC serialization', () => {
         expect(role.loginUrl).eql(deserializedRole.loginUrl);
         expect(role._initFn).eql(deserializedRole._initFn);
         expect(role.opts).deep.equal(deserializedRole.opts);
-        expect(role.redirectUrls).eql(deserializedRole.redirectUrls);
+        expect(role.redirectUrl).eql(deserializedRole.redirectUrl);
         expect(role.stateSnapshot).eql(deserializedRole.stateSnapshot);
         expect(role.initErr).eql(deserializedRole.initErr);
     });


### PR DESCRIPTION
[closes DevExpress/testcafe#6041]

## Purpose
Fix the incorrect URL of the page visited when running tests in parallel in the same file with the role. 
This is because right now one role can only store one `redirectUrl`. And when we use one role in two and more tests with concurrency mode `redirectUrl` is rewritten in one test before the redirect occurs in another one.

## Approach
1. Add the tests to fix
2. Add keeping redirect URL in the Role for each test

## References
https://github.com/DevExpress/testcafe/issues/6041

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
