### PR TITLE
fix 'The t.eval() method does not work in the 'execute-async-expression' script' (close #4562)

### DIFF
--- a/src/api/test-run-tracker.ts
+++ b/src/api/test-run-tracker.ts
@@ -48,6 +48,10 @@ class TestRunTracker extends EventEmitter {
         return frames;
     }
 
+    public getMarkedFnName (testRunId: string): string {
+        return `$$testcafe_test_run$$${testRunId}$$`;
+    }
+
     public ensureEnabled (): void {
         if (!this.enabled) {
             global.setTimeout   = this._createContextSwitchingFunctionHook(global.setTimeout, 1);
@@ -64,7 +68,7 @@ class TestRunTracker extends EventEmitter {
 
     public addTrackingMarkerToFunction (testRunId: string, fn: Function): Function {
         const markerFactoryBody = `
-            return function $$testcafe_test_run$$${testRunId}$$ () {
+            return function ${this.getMarkedFnName(testRunId)} () {
                 switch (arguments.length) {
                     case 0: return fn.call(this);
                     case 1: return fn.call(this, arguments[0]);

--- a/test/functional/fixtures/api/raw/code-steps/test.js
+++ b/test/functional/fixtures/api/raw/code-steps/test.js
@@ -31,6 +31,9 @@ describe('[Raw API] Code steps', function () {
             });
     });
 
+    it('Eval (GH-4562)', function () {
+        return runTests('./testcafe-fixtures/eval.testcafe');
+    });
 
     it('Errors on page', function () {
         return runTests('./testcafe-fixtures/code-steps.testcafe', 'Errors on page', { shouldFail: true })

--- a/test/functional/fixtures/api/raw/code-steps/testcafe-fixtures/eval.testcafe
+++ b/test/functional/fixtures/api/raw/code-steps/testcafe-fixtures/eval.testcafe
@@ -1,0 +1,21 @@
+{
+    "fixtures": [
+        {
+            "name": "coded-step-eval",
+            "pageUrl": "about:blank",
+            "tests": [
+                {
+                    "name": "New Test",
+                    "commands": [
+                        {
+                            "type": "execute-async-expression",
+                            "studio": {},
+                            "callsite": "0",
+                            "expression": "await t.eval(() => {\r\n    console.log(123);\r\n});"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Close #4562 