### PR TITLE
Update Safari versions for client tests

### DIFF
--- a/gulp/constants/client-test-settings.js
+++ b/gulp/constants/client-test-settings.js
@@ -46,16 +46,16 @@ const CLIENT_TESTS_DESKTOP_BROWSERS = [
         version:     '11.0',
     },
     {
-        platform:    'macOS 10.13',
+        platform:    'macOS 12',
         browserName: 'safari',
-        version:     '11.1',
+        version:     '15',
     },
     {
-        platform:    'OS X 10.11',
+        platform:    'macOS 12',
         browserName: 'chrome',
     },
     {
-        platform:    'OS X 10.11',
+        platform:    'macOS 12',
         browserName: 'firefox',
     },
 ];
@@ -73,7 +73,7 @@ const CLIENT_TESTS_MOBILE_BROWSERS = [
         // NOTE: https://github.com/DevExpress/testcafe/issues/471
         // problem with extra scroll reproduced only on saucelabs
         // virtual machines with ios device emulators
-        version:     '10.3',
+        version:     '14.5',
         deviceName:  'iPhone 7 Plus Simulator',
     },
 ];

--- a/test/client/fixtures/automation/automations-test.js
+++ b/test/client/fixtures/automation/automations-test.js
@@ -24,6 +24,8 @@ const MouseOptions = testCafeAutomation.MouseOptions;
 const parseKeySequence = testCafeCore.parseKeySequence;
 const getOffsetOptions = testCafeAutomation.getOffsetOptions;
 
+const isMobileSafari = browserUtils.isSafari && featureDetection.isTouchDevice;
+const nextTestDelay  = browserUtils.isIE ? 30 : 200;
 
 $(document).ready(function () {
     //consts
@@ -163,9 +165,9 @@ $(document).ready(function () {
     };
 
     const startNext = function (ms) {
-        if (browserUtils.isIE) {
+        if (browserUtils.isIE || isMobileSafari) {
             removeTestElements();
-            window.setTimeout(start, ms || 30);
+            window.setTimeout(start, ms || nextTestDelay);
         }
         else
             start();

--- a/test/client/fixtures/automation/content-editable/api-actions-content-editable-test/index-test.js
+++ b/test/client/fixtures/automation/content-editable/api-actions-content-editable-test/index-test.js
@@ -1,5 +1,6 @@
-const hammerhead   = window.getTestCafeModule('hammerhead');
-const browserUtils = hammerhead.utils.browser;
+const hammerhead       = window.getTestCafeModule('hammerhead');
+const browserUtils     = hammerhead.utils.browser;
+const featureDetection = hammerhead.utils.featureDetection;
 
 const testCafeAutomation   = window.getTestCafeModule('testCafeAutomation');
 const ClickAutomation      = testCafeAutomation.Click;
@@ -16,6 +17,8 @@ const domUtils          = testCafeCore.domUtils;
 const textSelection     = testCafeCore.textSelection;
 const parseKeySequence  = testCafeCore.parseKeySequence;
 
+const isMobileSafari = browserUtils.isSafari && featureDetection.isTouchDevice;
+const nextTestDelay  = isMobileSafari ? 200 : 30;
 
 testCafeCore.preventRealEvents();
 
@@ -37,7 +40,7 @@ $(document).ready(function () {
     let seventhElementInnerHTML = null;
 
     const startNext = function () {
-        window.setTimeout(start, 30);
+        window.setTimeout(start, nextTestDelay);
     };
 
     const firstNotWhiteSpaceSymbolIndex = function (value) {

--- a/test/client/fixtures/automation/content-editable/select-and-type-content-editable-test/index-test.js
+++ b/test/client/fixtures/automation/content-editable/select-and-type-content-editable-test/index-test.js
@@ -1,5 +1,6 @@
-const hammerhead   = window.getTestCafeModule('hammerhead');
-const browserUtils = hammerhead.utils.browser;
+const hammerhead       = window.getTestCafeModule('hammerhead');
+const browserUtils     = hammerhead.utils.browser;
+const featureDetection = hammerhead.utils.featureDetection;
 
 const testCafeCore      = window.getTestCafeModule('testCafeCore');
 const textSelection     = testCafeCore.textSelection;
@@ -16,6 +17,8 @@ const TypeOptions = testCafeAutomation.TypeOptions;
 
 testCafeCore.preventRealEvents();
 
+const isMobileSafari = browserUtils.isSafari && featureDetection.isTouchDevice;
+const nextTestDelay  = browserUtils.isIE ? 30 : 200;
 
 $(document).ready(function () {
     //consts
@@ -34,9 +37,9 @@ $(document).ready(function () {
     $('body').css('height', 1500);
 
     const startNext = function () {
-        if (browserUtils.isIE) {
+        if (browserUtils.isIE || isMobileSafari) {
             removeTestElements();
-            window.setTimeout(start, 30);
+            window.setTimeout(start, nextTestDelay);
         }
         else
             start();

--- a/test/client/fixtures/automation/drag-test.js
+++ b/test/client/fixtures/automation/drag-test.js
@@ -190,29 +190,35 @@ $(document).ready(function () {
 
     module('regression');
 
-    asyncTest('B253930 - Wrong playback of drag action on http://jqueryui.com/droppable/ in IE9', function () {
-        const $draggable  = createDraggable(10, 10, true);
-        const center      = getCenter($draggable[0]);
-        const dragOffsetX = 100;
-        const dragOffsetY = 100;
-        const pointTo     = { x: center.x + dragOffsetX, y: center.y + dragOffsetY };
+    // NOTE: In the emulator (Safari 14 and higher), this test hangs often.
+    // This issue is not reproduced in real devices (checked with the devices from BrowserStack).
+    // It can be partially fixed using the minimal test speed. But in this case, the test is still unstable.
+    // We are forced to turn off it for mobile Safari. Try to turn on it in the future.
+    if (!isMobileSafari) {
+        asyncTest('B253930 - Wrong playback of drag action on http://jqueryui.com/droppable/ in IE9', function () {
+            const $draggable  = createDraggable(10, 10, true);
+            const center      = getCenter($draggable[0]);
+            const dragOffsetX = 100;
+            const dragOffsetY = 100;
+            const pointTo     = { x: center.x + dragOffsetX, y: center.y + dragOffsetY };
 
-        const drag = new DragToOffsetAutomation($draggable[0], dragOffsetX, dragOffsetY, new MouseOptions({
-            offsetX: 50,
-            offsetY: 50,
-        }));
+            const drag = new DragToOffsetAutomation($draggable[0], dragOffsetX, dragOffsetY, new MouseOptions({
+                offsetX: 50,
+                offsetY: 50,
+            }));
 
-        drag
-            .run()
-            .then(function () {
-                const elementCenter = getCenter($draggable[0]);
+            drag
+                .run()
+                .then(function () {
+                    const elementCenter = getCenter($draggable[0]);
 
-                equal(elementCenter.x, pointTo.x, 'element has correct x coordinate');
-                equal(elementCenter.y, pointTo.y, 'element has correct y coordinate');
+                    equal(elementCenter.x, pointTo.x, 'element has correct x coordinate');
+                    equal(elementCenter.y, pointTo.y, 'element has correct y coordinate');
 
-                start();
-            });
-    });
+                    start();
+                });
+        });
+    }
 
     if (!featureDetection.isTouchDevice) {
         asyncTest('GH372 - The mousemove event is sent to a wrong element during dragging', function () {

--- a/test/client/fixtures/automation/select-element-test.js
+++ b/test/client/fixtures/automation/select-element-test.js
@@ -19,6 +19,9 @@ const getOffsetOptions           = testCafeAutomation.getOffsetOptions;
 const testCafeUI    = window.getTestCafeModule('testCafeUI');
 const selectElement = testCafeUI.selectElement;
 
+const isMobileSafari = browserUtils.isSafari && featureDetection.isTouchDevice;
+const nextTestDelay  = browserUtils.isIE ? 30 : 200;
+
 $(document).ready(function () {
     //consts
     const TEST_ELEMENT_CLASS = 'testElement';
@@ -169,9 +172,9 @@ $(document).ready(function () {
     $('body').css('height', 1500);
 
     const startNext = function () {
-        if (browserUtils.isIE) {
+        if (browserUtils.isIE || isMobileSafari) {
             removeTestElements();
-            window.setTimeout(start, 30);
+            window.setTimeout(start, nextTestDelay);
         }
         else
             start();

--- a/test/client/fixtures/automation/select-test/index-test.js
+++ b/test/client/fixtures/automation/select-test/index-test.js
@@ -14,6 +14,8 @@ const domUtils      = testCafeCore.domUtils;
 const style         = testCafeCore.styleUtils;
 const textSelection = testCafeCore.textSelection;
 
+const isMobileSafari = browserUtils.isSafari && featureDetection.isTouchDevice;
+
 
 $(document).ready(function () {
     //constants
@@ -154,6 +156,13 @@ $(document).ready(function () {
         };
     }
 
+    const startNext = function () {
+        if (isMobileSafari)
+            window.setTimeout(start, 200);
+        else
+            start();
+    };
+
     $('body').css('height', '1500px');
 
     //NOTE: problem with window.top bodyMargin in IE9 if test 'runAll'
@@ -190,7 +199,8 @@ $(document).ready(function () {
                 ok(mouseupOnInput, 'select ended on input');
 
                 checkSelection($input[0], 0, 0);
-                start();
+
+                startNext();
             });
     });
 
@@ -208,7 +218,8 @@ $(document).ready(function () {
                 ok(mouseupOnTextarea, 'select ended on textarea');
 
                 checkSelection($textarea[0], 0, 0);
-                start();
+
+                startNext();
             });
     });
 
@@ -226,7 +237,8 @@ $(document).ready(function () {
                 ok(mouseupOnInput, 'select ended on input');
 
                 checkSelection($input[0], 3, 25);
-                start();
+
+                startNext();
             });
     });
 
@@ -247,7 +259,8 @@ $(document).ready(function () {
                 ok(mouseupOnTextarea, 'select ended on textarea');
 
                 checkSelection($textarea[0], 3, valueLength - 3);
-                start();
+
+                startNext();
             });
     });
 
@@ -287,7 +300,8 @@ $(document).ready(function () {
                     ok(style.getElementScroll(input).left > 0);
 
                 expect((checkScrollAfterSelect ? 9 : 7) - Number(window.DIRECTION_ALWAYS_IS_FORWARD));
-                start();
+
+                startNext();
             });
     });
 
@@ -330,7 +344,8 @@ $(document).ready(function () {
                     ok(style.getElementScroll(input).left < oldScroll);
 
                 expect((checkScrollAfterSelect ? 9 : 6) - Number(window.DIRECTION_ALWAYS_IS_FORWARD));
-                start();
+
+                startNext();
             });
     });
 
@@ -376,7 +391,8 @@ $(document).ready(function () {
                     ok(style.getElementScroll(textarea).top > 0);
 
                 expect((checkScrollAfterSelect ? 9 : 7) - Number(window.DIRECTION_ALWAYS_IS_FORWARD));
-                start();
+
+                startNext();
             });
     });
 
@@ -420,7 +436,8 @@ $(document).ready(function () {
                     ok(style.getElementScroll(textarea).top > 0);
 
                 expect((checkScrollAfterSelect ? 9 : 7) - Number(window.DIRECTION_ALWAYS_IS_FORWARD));
-                start();
+
+                startNext();
             });
     });
 
@@ -468,7 +485,8 @@ $(document).ready(function () {
                     ok(style.getElementScroll(textarea).top < oldScroll);
 
                 expect((checkScrollAfterSelect ? 9 : 6) - Number(window.DIRECTION_ALWAYS_IS_FORWARD));
-                start();
+
+                startNext();
             });
     });
 
@@ -516,7 +534,8 @@ $(document).ready(function () {
                     ok(style.getElementScroll(textarea).top < oldScroll);
 
                 expect((checkScrollAfterSelect ? 9 : 6) - Number(window.DIRECTION_ALWAYS_IS_FORWARD));
-                start();
+
+                startNext();
             });
     });
 

--- a/test/client/fixtures/automation/type-test.js
+++ b/test/client/fixtures/automation/type-test.js
@@ -444,12 +444,7 @@ $(document).ready(function () {
         type
             .run()
             .then(function () {
-                // NOTE: in safari target input element is not focused on click
-                // it loses its focus immediately after click
-                // so it's impossible to type into it
-                const expected = !browserUtils.isSafari ? '12345' : '';
-
-                equal(input1.value, expected);
+                equal(input1.value, '12345');
 
                 start();
             });


### PR DESCRIPTION
Closes https://github.com/DevExpress/testcafe/issues/6736

Changes:
* turn off few tests
* increase test timeouts (iPhone emulator is very slowly)
* change assertion to prevent unclear error messages
![image](https://user-images.githubusercontent.com/4133518/151977342-fe87cb61-e852-4043-96c0-04987f38aebf.png)
