### PR TITLE
fix: added condition to repeat getting tab list while it is empty

### DIFF
--- a/src/browser/provider/built-in/dedicated/chrome/local-chrome.js
+++ b/src/browser/provider/built-in/dedicated/chrome/local-chrome.js
@@ -8,7 +8,7 @@ import delay from '../../../../../utils/delay';
 
 const browserStarter = new BrowserStarter();
 
-const LIST_TABS_TIMEOUT = 5000;
+const LIST_TABS_TIMEOUT = 10000;
 const LIST_TABS_DELAY   = 500;
 
 export async function start (pageUrl, { browserName, config, cdpPort, tempProfileDir, inDocker }) {
@@ -36,7 +36,7 @@ export async function startOnDocker (pageUrl, { browserName, config, cdpPort, te
     const timer         = new Timer(LIST_TABS_TIMEOUT);
 
     //NOTE: We should repeat getting 'List' after a while because we can get an error if the browser isn't ready.
-    while (error && !timer.expired) {
+    while ((error || !tabs.length) && !timer.expired) {
         await delay(LIST_TABS_DELAY);
 
         ({ tabs, error } = await tryListTabs(cdpPort));

--- a/src/compiler/test-file/test-file-parser-base.js
+++ b/src/compiler/test-file/test-file-parser-base.js
@@ -16,6 +16,8 @@ function getLoc (loc) {
     // Since this is useless information, we remove it.
     delete locCopy.filename;
     delete locCopy.identifierName;
+    delete locCopy.start.index;
+    delete locCopy.end.index;
 
     return locCopy;
 }

--- a/test/server/parse-fixture-test.js
+++ b/test/server/parse-fixture-test.js
@@ -27,17 +27,6 @@ function Loc (lineStart, columnStart, lineEnd, columnEnd) {
     this.end   = { column: columnEnd, line: lineEnd };
 }
 
-function lazyEql (target, expected) {
-    Object.keys(expected).forEach(key => {
-        expect(target[key], `Target should have property '${key}'`).exist;
-
-        if (typeof expected[key] === 'object')
-            lazyEql(target[key], expected[key]);
-        else
-            expect(expected[key]).eql(target[key], `Target property '${key}' should be equal ${expected[key]}`);
-    });
-}
-
 function testFixtureParser (dir, expectedStructure, fileParser, codeParser) {
     const dirPath  = path.join(__dirname, dir);
     const fileList = fs.readdirSync(dirPath).sort();
@@ -49,8 +38,8 @@ function testFixtureParser (dir, expectedStructure, fileParser, codeParser) {
 
         return fileParser(filePath)
             .then(function (structure) {
-                lazyEql(structure, expected);
-                lazyEql(codeParser(fileContent), expected);
+                expect(structure).eql(expected);
+                expect(codeParser(fileContent)).eql(expected);
 
                 Object.values(structure).forEach(fixture => {
                     expect(fixture.loc).not.undefined;

--- a/test/server/parse-fixture-test.js
+++ b/test/server/parse-fixture-test.js
@@ -27,6 +27,17 @@ function Loc (lineStart, columnStart, lineEnd, columnEnd) {
     this.end   = { column: columnEnd, line: lineEnd };
 }
 
+function lazyEql (target, expected) {
+    Object.keys(expected).forEach(key => {
+        expect(target[key], `Target should have property '${key}'`).exist;
+
+        if (typeof expected[key] === 'object')
+            lazyEql(target[key], expected[key]);
+        else
+            expect(expected[key]).eql(target[key], `Target property '${key}' should be equal ${expected[key]}`);
+    });
+}
+
 function testFixtureParser (dir, expectedStructure, fileParser, codeParser) {
     const dirPath  = path.join(__dirname, dir);
     const fileList = fs.readdirSync(dirPath).sort();
@@ -38,8 +49,8 @@ function testFixtureParser (dir, expectedStructure, fileParser, codeParser) {
 
         return fileParser(filePath)
             .then(function (structure) {
-                expect(structure).eql(expected);
-                expect(codeParser(fileContent)).eql(expected);
+                lazyEql(structure, expected);
+                lazyEql(codeParser(fileContent), expected);
 
                 Object.values(structure).forEach(fixture => {
                     expect(fixture.loc).not.undefined;


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
We try to get a tabs list of the browser until errors are disappeared. But errors are appearing while the browser isn't ready. After that, the browser in docker doesn't have enough time to get the list of tabs.

## Approach
Try to get the list of the tabs while it is empty.

Additionally refactored tests with checking parsed files with tests because babel added a new property 'index' for parsed files.

## References
https://teams.microsoft.com/l/message/19:5eb4e942f0f946188ab14b3d8bf960f3@thread.skype/1641979833965?tenantId=e4d60396-9352-4ae8-b84c-e69244584fa4&groupId=f74b7d18-34a4-4c78-b7d5-b56e55ce3236&parentMessageId=1641979833965&teamName=Teams%20Collaborations&channelName=TestCafe&createdTime=1641979833965

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
