### PR TITLE
feat: added cookies API (2 part)

### DIFF
--- a/test/functional/fixtures/api/es-next/cookies/test.js
+++ b/test/functional/fixtures/api/es-next/cookies/test.js
@@ -1,3 +1,5 @@
+const config = require('../../../../config');
+
 describe('[API] Cookies', function () {
     it('Should get cookies by name', function () {
         return runTests('./testcafe-fixtures/cookies-test.js', 'Should get cookies by name');
@@ -15,9 +17,11 @@ describe('[API] Cookies', function () {
         return runTests('./testcafe-fixtures/cookies-test.js', 'Should set cookies by key-value');
     });
 
-    it('Should set on the client', function () {
-        return runTests('./testcafe-fixtures/cookies-test.js', 'Should set on the client');
-    });
+    if (!config.proxyless) {
+        it('Should set on the client', function () {
+            return runTests('./testcafe-fixtures/cookies-test.js', 'Should set on the client');
+        });
+    }
 
     it('Should delete cookies by names and url', function () {
         return runTests('./testcafe-fixtures/cookies-test.js', 'Should delete cookies by names and url');
@@ -27,7 +31,9 @@ describe('[API] Cookies', function () {
         return runTests('./testcafe-fixtures/cookies-test.js', 'Should delete cookies by objects');
     });
 
-    it('Should delete on the client', function () {
-        return runTests('./testcafe-fixtures/cookies-test.js', 'Should delete on the client');
-    });
+    if (!config.proxyless) {
+        it('Should delete on the client', function () {
+            return runTests('./testcafe-fixtures/cookies-test.js', 'Should delete on the client');
+        });
+    }
 });

--- a/test/functional/fixtures/api/es-next/cookies/test.js
+++ b/test/functional/fixtures/api/es-next/cookies/test.js
@@ -15,11 +15,19 @@ describe('[API] Cookies', function () {
         return runTests('./testcafe-fixtures/cookies-test.js', 'Should set cookies by key-value');
     });
 
+    it('Should set on the client', function () {
+        return runTests('./testcafe-fixtures/cookies-test.js', 'Should set on the client');
+    });
+
     it('Should delete cookies by names and url', function () {
         return runTests('./testcafe-fixtures/cookies-test.js', 'Should delete cookies by names and url');
     });
 
     it('Should delete cookies by objects', function () {
         return runTests('./testcafe-fixtures/cookies-test.js', 'Should delete cookies by objects');
+    });
+
+    it('Should delete on the client', function () {
+        return runTests('./testcafe-fixtures/cookies-test.js', 'Should delete on the client');
     });
 });

--- a/test/functional/fixtures/api/es-next/cookies/testcafe-fixtures/cookies-test.js
+++ b/test/functional/fixtures/api/es-next/cookies/testcafe-fixtures/cookies-test.js
@@ -156,8 +156,8 @@ fixture`[API] Delete Cookies`
         await t
             .setCookies([
                 { name: 'apiCookie1', value: 'value1', domain: 'domain1.com', path: '/' },
-                { name: 'apiCookie1', value: 'value1', domain: 'domain2.com', path: '/' },
-                { name: 'apiCookie2', value: 'value2', domain: 'domain2.com', path: '/' },
+                { name: 'apiCookie1', value: 'value1', domain: 'localhost', path: '/fixtures/api/es-next/cookies/pages/index.html' },
+                { name: 'apiCookie2', value: 'value2', domain: 'localhost', path: '/fixtures/api/es-next/cookies/pages/index.html' },
                 { name: 'apiCookie3', value: 'value3', domain: 'domain2.com', path: '/path-1' },
                 { name: 'apiCookie4', value: 'value4', domain: 'domain1.com', path: '/path-2' },
                 { name: 'apiCookie5', value: 'value5', domain: 'domain2.com', path: '/path-1' },
@@ -169,14 +169,14 @@ fixture`[API] Delete Cookies`
 
 test('Should delete cookies by names and url', async t => {
     await t.expect((await t.getCookies()).length).eql(6);
-    await t.deleteCookies(['apiCookie1', 'apiCookie2'], 'https://domain2.com/');
+    await t.deleteCookies(['apiCookie1', 'apiCookie2'], 'https://localhost/fixtures/api/es-next/cookies/pages/index.html');
 
     const currentCookies = await t.getCookies();
 
     await t
         .expect(currentCookies.length).eql(4)
-        .expect(currentCookies.some(c => c.name === 'apiCookie1' && c.domain === 'domain2.com')).notOk()
-        .expect(currentCookies.some(c => c.name === 'apiCookie2' && c.domain === 'domain2.com')).notOk()
+        .expect(currentCookies.some(c => c.name === 'apiCookie1' && c.domain === 'localhost')).notOk()
+        .expect(currentCookies.some(c => c.name === 'apiCookie2' && c.domain === 'localhost')).notOk()
         .expect(currentCookies.some(c => c.name === 'apiCookie1' && c.domain === 'domain1.com')).ok();
 });
 
@@ -184,13 +184,14 @@ test('Should delete cookies by objects', async t => {
     await t.expect((await t.getCookies()).length).eql(6);
     await t.deleteCookies(
         { name: 'apiCookie1' },
-        [{ domain: 'domain2.com', path: '/' }],
+        [{ domain: 'domain2.com', path: '/path-1' }],
     );
 
     const currentCookies = await t.getCookies();
 
     await t
-        .expect(currentCookies.length).eql(3)
+        .expect(currentCookies.length).eql(2)
         .expect(currentCookies.some(c => c.name === 'apiCookie1')).notOk()
-        .expect(currentCookies.some(c => c.name === 'apiCookie2')).notOk();
+        .expect(currentCookies.some(c => c.name === 'apiCookie3')).notOk()
+        .expect(currentCookies.some(c => c.name === 'apiCookie5')).notOk();
 });

--- a/test/functional/fixtures/api/es-next/cookies/testcafe-fixtures/cookies-test.js
+++ b/test/functional/fixtures/api/es-next/cookies/testcafe-fixtures/cookies-test.js
@@ -150,6 +150,12 @@ test('Should set cookies by key-value', async t => {
     await t.expect(cookies).eql(expectedCookies);
 });
 
+test('Should set on the client', async (t) => {
+    await t.expect(await t.eval(() => document.cookie)).eql('');
+    await t.setCookies({ name: 'apiCookie13', value: 'value13' });
+    await t.expect(await t.eval(() => document.cookie)).eql('apiCookie13=value13');
+});
+
 fixture`[API] Delete Cookies`
     .page('http://localhost:3000/fixtures/api/es-next/cookies/pages/index.html')
     .beforeEach(async t => {
@@ -194,4 +200,10 @@ test('Should delete cookies by objects', async t => {
         .expect(currentCookies.some(c => c.name === 'apiCookie1')).notOk()
         .expect(currentCookies.some(c => c.name === 'apiCookie3')).notOk()
         .expect(currentCookies.some(c => c.name === 'apiCookie5')).notOk();
+});
+
+test('Should delete on the client', async t => {
+    await t.expect(await t.eval(() => document.cookie)).eql('apiCookie2=value2; apiCookie1=value1');
+    await t.deleteCookies({ domain: 'localhost', path: '/fixtures/api/es-next/cookies/pages/index.html' });
+    await t.expect(await t.eval(() => document.cookie)).eql('');
 });

--- a/test/functional/fixtures/api/es-next/cookies/testcafe-fixtures/cookies-test.js
+++ b/test/functional/fixtures/api/es-next/cookies/testcafe-fixtures/cookies-test.js
@@ -203,7 +203,7 @@ test('Should delete cookies by objects', async t => {
 });
 
 test('Should delete on the client', async t => {
-    await t.expect(await t.eval(() => document.cookie)).eql('apiCookie2=value2; apiCookie1=value1');
+    await t.expect(await t.eval(() => document.cookie)).eql('apiCookie1=value1; apiCookie2=value2');
     await t.deleteCookies({ domain: 'localhost', path: '/fixtures/api/es-next/cookies/pages/index.html' });
     await t.expect(await t.eval(() => document.cookie)).eql('');
 });


### PR DESCRIPTION
## Purpose
Implement synchronization of changing cookies with the client

## Approach
Only add tests for synchronization changed cookies with the client and adapt the old one. The functionality itself has been implemented in the hammerhead.

## References
[First part](https://github.com/DevExpress/testcafe/pull/6841)
[Corresponding PR in the hammerhead](https://github.com/DevExpress/testcafe-hammerhead/pull/2741)

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
