### PR TITLE
feat: added cookies API definitions

### DIFF
--- a/src/errors/test-run/index.js
+++ b/src/errors/test-run/index.js
@@ -238,10 +238,11 @@ export class ActionCookieArgumentError extends TestRunErrorBase {
 }
 
 export class ActionCookieArgumentsError extends TestRunErrorBase {
-    constructor (index) {
+    constructor (index, value) {
         super(TEST_RUN_ERRORS.actionCookieArgumentsError);
 
-        this.index = index;
+        this.index       = index;
+        this.actualValue = value;
     }
 }
 
@@ -252,10 +253,11 @@ export class ActionUrlCookieArgumentError extends TestRunErrorBase {
 }
 
 export class ActionUrlsCookieArgumentError extends TestRunErrorBase {
-    constructor (index) {
+    constructor (index, value) {
         super(TEST_RUN_ERRORS.actionUrlsCookieArgumentError);
 
-        this.index = index;
+        this.index       = index;
+        this.actualValue = value;
     }
 }
 

--- a/src/errors/test-run/templates.js
+++ b/src/errors/test-run/templates.js
@@ -131,23 +131,23 @@ export default {
     `,
 
     [TEST_RUN_ERRORS.actionRequiredCookieArguments]: () => `
-        Cookies argument is required.
+        The mandatory "cookies" argument is missing.
     `,
 
     [TEST_RUN_ERRORS.actionCookieArgumentError]: () => `
-        The "cookie" is expected to be an object, a string or array of objects or strings.
+        The value of the "cookies" argument does not belong to an acceptable data type: Object, String, or Array of objects or strings.
     `,
 
     [TEST_RUN_ERRORS.actionCookieArgumentsError]: err => `
-        The "cookie" at number ${err.index + 1} is expected to be an object or a string.
+        The value of the cookies number ${err.index + 1} does not belong to an acceptable data type: Object or String.
     `,
 
     [TEST_RUN_ERRORS.actionUrlCookieArgumentError]: () => `
-        The "urls" argument isn't valid.
+        Could not parse the url parameter. Check the value for formatting errors.
     `,
 
     [TEST_RUN_ERRORS.actionUrlsCookieArgumentError]: err => `
-        Elements at index ${err.index + 1} of the "urls" argument isn't valid.
+        Could not parse the urls value number ${err.index + 1}. Check the value for formatting errors.
     `,
 
     [TEST_RUN_ERRORS.actionIntegerArgumentError]: err => `
@@ -412,14 +412,14 @@ export default {
     },
 
     [TEST_RUN_ERRORS.actionStringOptionError]: err => `
-        The "${err.optionName}" option is expected to be a string value, but it was ${err.actualValue}.
+        The value of the "${err.optionName}" option belongs to an unsupported data type (${err.actualValue}). The "${err.optionName}" option only accepts String values.
     `,
 
     [TEST_RUN_ERRORS.actionDateOptionError]: err => `
-        The "${err.optionName}" option is expected to be a Date value, but it was ${err.actualValue}.
+        The value of the "${err.optionName}" option belongs to an unsupported data type (${err.actualValue}). The "${err.optionName}" option only accepts Date values.
     `,
 
     [TEST_RUN_ERRORS.actionNumberOptionError]: err => `
-        The "${err.optionName}" option is expected to be a number, but it was ${err.actualValue}.
+        The value of the "${err.optionName}" option belongs to an unsupported data type (${err.actualValue}). The "${err.optionName}" option only accepts Number values.
     `,
 };

--- a/src/errors/test-run/templates.js
+++ b/src/errors/test-run/templates.js
@@ -139,7 +139,7 @@ export default {
     `,
 
     [TEST_RUN_ERRORS.actionCookieArgumentsError]: err => `
-        The value of the cookies number ${err.index + 1} does not belong to an acceptable data type: Object or String.
+        The value of cookie number ${err.index + 1} (${err.actualValue}) does not belong to an acceptable data type: Object or String.
     `,
 
     [TEST_RUN_ERRORS.actionUrlCookieArgumentError]: () => `
@@ -147,7 +147,7 @@ export default {
     `,
 
     [TEST_RUN_ERRORS.actionUrlsCookieArgumentError]: err => `
-        Could not parse the urls value number ${err.index + 1}. Check the value for formatting errors.
+        Could not parse url number ${err.index + 1} (${err.actualValue}). Check the value for formatting errors.
     `,
 
     [TEST_RUN_ERRORS.actionIntegerArgumentError]: err => `
@@ -412,14 +412,14 @@ export default {
     },
 
     [TEST_RUN_ERRORS.actionStringOptionError]: err => `
-        The value of the "${err.optionName}" option belongs to an unsupported data type (${err.actualValue}). The "${err.optionName}" option only accepts String values.
+        The value of the "${err.optionName}" option belongs to an unsupported data type (${err.actualValue}). The "${err.optionName}" option only accepts String type values.
     `,
 
     [TEST_RUN_ERRORS.actionDateOptionError]: err => `
-        The value of the "${err.optionName}" option belongs to an unsupported data type (${err.actualValue}). The "${err.optionName}" option only accepts Date values.
+        The value of the "${err.optionName}" option belongs to an unsupported data type (${err.actualValue}). The "${err.optionName}" option only accepts Date type values.
     `,
 
     [TEST_RUN_ERRORS.actionNumberOptionError]: err => `
-        The value of the "${err.optionName}" option belongs to an unsupported data type (${err.actualValue}). The "${err.optionName}" option only accepts Number values.
+        The value of the "${err.optionName}" option belongs to an unsupported data type (${err.actualValue}). The "${err.optionName}" option only accepts Number type values.
     `,
 };

--- a/src/test-run/commands/validations/argument.js
+++ b/src/test-run/commands/validations/argument.js
@@ -146,7 +146,7 @@ export function cookiesArgument (name, val) {
         if (!isValidCookie(value)) {
             throw cookiesLength === 1
                 ? new ActionCookieArgumentError()
-                : new ActionCookieArgumentsError(i);
+                : new ActionCookieArgumentsError(i, value);
         }
     }
 }
@@ -174,7 +174,7 @@ export function urlsArgument (name, val) {
         if (!isValidUrl(value)) {
             throw castVal.length === 1
                 ? new ActionUrlCookieArgumentError()
-                : new ActionUrlsCookieArgumentError(i);
+                : new ActionUrlsCookieArgumentError(i, value);
         }
     }
 }

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -363,12 +363,8 @@ describe('Compiler', function () {
         it('Should have definitions for all TestController methods', async function () {
             this.timeout(60000);
 
-            //TODO: Delete when definitions will be ready. Definitions will be ready in the last part of the feature
-            const exceptions = ['getCookies', 'setCookies', 'deleteCookies'];
-
             const apiMethods = TestController.API_LIST
                 .filter(prop => !prop.accessor)
-                .filter(prop => !exceptions.includes(prop.apiProp))
                 .map(prop => prop.apiProp);
 
             const possibleErrors = apiMethods.map(method => `Property '${method}' does not exist on type 'TestController'`);

--- a/test/server/data/expected-test-run-errors/action-cookie-argument-error
+++ b/test/server/data/expected-test-run-errors/action-cookie-argument-error
@@ -1,5 +1,5 @@
-The "cookie" is expected to be an object, a string or array of objects or
-strings.
+The value of the "cookies" argument does not belong to an acceptable data
+type: Object, String, or Array of objects or strings.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/data/expected-test-run-errors/action-cookie-arguments-error
+++ b/test/server/data/expected-test-run-errors/action-cookie-arguments-error
@@ -1,4 +1,5 @@
-The "cookie" at number 1 is expected to be an object or a string.
+The value of the cookies number 1 does not belong to an acceptable data type:
+Object or String.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/data/expected-test-run-errors/action-cookie-arguments-error
+++ b/test/server/data/expected-test-run-errors/action-cookie-arguments-error
@@ -1,5 +1,5 @@
-The value of the cookies number 1 does not belong to an acceptable data type:
-Object or String.
+The value of cookie number 1 (false) does not belong to an acceptable data
+type: Object or String.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/data/expected-test-run-errors/action-date-option-error
+++ b/test/server/data/expected-test-run-errors/action-date-option-error
@@ -1,5 +1,5 @@
 The value of the "expires" option belongs to an unsupported data type
-(string). The "expires" option only accepts Date values.
+(string). The "expires" option only accepts Date type values.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/data/expected-test-run-errors/action-date-option-error
+++ b/test/server/data/expected-test-run-errors/action-date-option-error
@@ -1,4 +1,5 @@
-The "expires" option is expected to be a Date value, but it was string.
+The value of the "expires" option belongs to an unsupported data type
+(string). The "expires" option only accepts Date values.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/data/expected-test-run-errors/action-number-option-error
+++ b/test/server/data/expected-test-run-errors/action-number-option-error
@@ -1,5 +1,5 @@
 The value of the "maxAge" option belongs to an unsupported data type
-(object). The "maxAge" option only accepts Number values.
+(object). The "maxAge" option only accepts Number type values.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/data/expected-test-run-errors/action-number-option-error
+++ b/test/server/data/expected-test-run-errors/action-number-option-error
@@ -1,4 +1,5 @@
-The "maxAge" option is expected to be a number, but it was object.
+The value of the "maxAge" option belongs to an unsupported data type
+(object). The "maxAge" option only accepts Number values.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/data/expected-test-run-errors/action-required-cookie-arguments
+++ b/test/server/data/expected-test-run-errors/action-required-cookie-arguments
@@ -1,4 +1,4 @@
-Cookies argument is required.
+The mandatory "cookies" argument is missing.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/data/expected-test-run-errors/action-string-option-error
+++ b/test/server/data/expected-test-run-errors/action-string-option-error
@@ -1,5 +1,5 @@
 The value of the "name" option belongs to an unsupported data type (object).
-The "name" option only accepts String values.
+The "name" option only accepts String type values.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/data/expected-test-run-errors/action-string-option-error
+++ b/test/server/data/expected-test-run-errors/action-string-option-error
@@ -1,4 +1,5 @@
-The "name" option is expected to be a string value, but it was object.
+The value of the "name" option belongs to an unsupported data type (object).
+The "name" option only accepts String values.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/data/expected-test-run-errors/action-url-cookie-argument-error
+++ b/test/server/data/expected-test-run-errors/action-url-cookie-argument-error
@@ -1,4 +1,4 @@
-The "urls" argument isn't valid.
+Could not parse the url parameter. Check the value for formatting errors.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/data/expected-test-run-errors/action-urls-cookie-argument-error
+++ b/test/server/data/expected-test-run-errors/action-urls-cookie-argument-error
@@ -1,5 +1,4 @@
-Could not parse the urls value number 1. Check the value for formatting
-errors.
+Could not parse url number 1 (crash). Check the value for formatting errors.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/data/expected-test-run-errors/action-urls-cookie-argument-error
+++ b/test/server/data/expected-test-run-errors/action-urls-cookie-argument-error
@@ -1,4 +1,5 @@
-Elements at index 1 of the "urls" argument isn't valid.
+Could not parse the urls value number 1. Check the value for formatting
+errors.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/test-run-commands-test.js
+++ b/test/server/test-run-commands-test.js
@@ -3309,6 +3309,7 @@ describe('Test run commands', () => {
                     });
                 },
                 {
+                    actualValue:     void 0,
                     index:           1,
                     isTestCafeError: true,
                     code:            'E87',
@@ -3341,6 +3342,7 @@ describe('Test run commands', () => {
                     });
                 },
                 {
+                    actualValue:     'url.url',
                     index:           1,
                     isTestCafeError: true,
                     code:            'E89',
@@ -3393,6 +3395,7 @@ describe('Test run commands', () => {
                     });
                 },
                 {
+                    actualValue:     void 0,
                     index:           1,
                     isTestCafeError: true,
                     code:            'E87',
@@ -3415,7 +3418,7 @@ describe('Test run commands', () => {
             );
         });
 
-        it('Should validate GetCookiesCommand', function () {
+        it('Should validate DeleteCookiesCommand', function () {
             assertThrow(
                 function () {
                     return createCommand({
@@ -3446,6 +3449,7 @@ describe('Test run commands', () => {
                 },
                 {
                     index:           1,
+                    actualValue:     void 0,
                     isTestCafeError: true,
                     code:            'E87',
                     callsite:        null,
@@ -3478,6 +3482,7 @@ describe('Test run commands', () => {
                 },
                 {
                     index:           1,
+                    actualValue:     'url.url',
                     isTestCafeError: true,
                     code:            'E89',
                     callsite:        null,

--- a/test/server/test-run-error-formatting-test.js
+++ b/test/server/test-run-error-formatting-test.js
@@ -768,7 +768,7 @@ describe('Error formatting', () => {
         });
 
         it('Should format "actionCookieArgumentsError"', () => {
-            assertErrorMessage('action-cookie-arguments-error', new ActionCookieArgumentsError(0));
+            assertErrorMessage('action-cookie-arguments-error', new ActionCookieArgumentsError(0, false));
         });
 
         it('Should format "actionUrlCookieArgumentError"', () => {
@@ -776,7 +776,7 @@ describe('Error formatting', () => {
         });
 
         it('Should format "ActionUrlsCookieArgumentError"', () => {
-            assertErrorMessage('action-urls-cookie-argument-error', new ActionUrlsCookieArgumentError(0));
+            assertErrorMessage('action-urls-cookie-argument-error', new ActionUrlsCookieArgumentError(0, 'crash'));
         });
 
         it('Should format "actionRequiredSetCookieArgumentsAreMissedError"', () => {

--- a/ts-defs-src/test-api/action-options.d.ts
+++ b/ts-defs-src/test-api/action-options.d.ts
@@ -174,3 +174,42 @@ interface ResizeToFitDeviceOptions {
      */
     portraitOrientation?: boolean;
 }
+
+interface CookieOptions {
+    /**
+     * Specifies the name of the cookie.
+     */
+    name?: string;
+    /**
+     * Specifies the value of the cookie.
+     */
+    value?: string;
+    /**
+     * Specifies the domain which will be matched with the cookie.
+     */
+    domain?: string;
+    /**
+     * Specifies the path which will be matched with the cookie.
+     */
+    path?: string;
+    /**
+     * Specifies the cookie expiration date defines the time, when the cookie will be automatically deleted it.
+     */
+    expires?: Date;
+    /**
+     * Specifies the cookie’s expiration in seconds from the current moment.
+     */
+    maxAge?: number | 'Infinity' | '-Infinity';
+    /**
+     * Specifies that the cookie should be transferred only over HTTPS.
+     */
+    secure?: boolean;
+    /**
+     * Specifies that the JavaScript shouldn't have access to the cookie.
+     */
+    httpOnly?: boolean;
+    /**
+     * Forbids the browser to send the cookie with requests coming from outside the site. This helps to prevent XSRF attacks..
+     */
+    sameSite?: string;
+}

--- a/ts-defs-src/test-api/action-options.d.ts
+++ b/ts-defs-src/test-api/action-options.d.ts
@@ -177,39 +177,39 @@ interface ResizeToFitDeviceOptions {
 
 interface CookieOptions {
     /**
-     * Specifies the name of the cookie.
+     * The name of the cookie.
      */
     name?: string;
     /**
-     * Specifies the value of the cookie.
+     * The value of the cookie.
      */
     value?: string;
     /**
-     * Specifies the domain which will be matched with the cookie.
+     * The domain attribute of the cookie.
      */
     domain?: string;
     /**
-     * Specifies the path which will be matched with the cookie.
+     * The path attribute of the cookie. The path must exist on the server to send the Cookie header.
      */
     path?: string;
     /**
-     * Specifies the cookie expiration date defines the time, when the cookie will be automatically deleted it.
+     * The date and time at which the cookie expires. The browser does not serve the cookie if the client clock is set to a point beyond the cookie expiration time.
      */
     expires?: Date;
     /**
-     * Specifies the cookie’s expiration in seconds from the current moment.
+     * Cookie expiration time in seconds, relative to the time the cookie is served.
      */
     maxAge?: number | 'Infinity' | '-Infinity';
     /**
-     * Specifies that the cookie should be transferred only over HTTPS.
+     * If the "secure" attribute is "true", the browser only serves the cookie over HTTPS.
      */
     secure?: boolean;
     /**
-     * Specifies that the JavaScript shouldn't have access to the cookie.
+     * Prohibits client-side scripts from accessing the cookie. Helps prevent XSS attacks.
      */
     httpOnly?: boolean;
     /**
-     * Forbids the browser to send the cookie with requests coming from outside the site. This helps to prevent XSRF attacks..
+     * Prohibits the browser from serving the cookie in response to cross-site requests. Helps prevent XSRF attacks.
      */
     sameSite?: string;
 }

--- a/ts-defs-src/test-api/test-controller.d.ts
+++ b/ts-defs-src/test-api/test-controller.d.ts
@@ -485,6 +485,45 @@ interface TestController {
      * @param hooks - The set of RequestHook subclasses.
      */
     removeRequestHooks(...hooks: object[]): TestControllerPromise;
+    /**
+     * Returns cookies associated with the specified cookie objects. If there are no parameters, this method returns all cookies.
+     *
+     * @param cookies - The cookie objects.
+     */
+    getCookies(cookies?: CookieOptions | CookieOptions[]): Promise<CookieOptions[]>;
+    /**
+     * Returns cookies with the specified names and URL contexts.
+     *
+     * @param names - The cookie names.
+     * @param urls - The URL.
+     */
+    getCookies(names: string | string[], urls?: string | string[]): Promise<CookieOptions[]>;
+    /**
+     * Sets the specified cookie objects.
+     *
+     * @param cookies - The cookie objects.
+     */
+    setCookies(cookies?: CookieOptions | CookieOptions[]): TestControllerPromise;
+    /**
+     * Sets cookies' name-value pairs to the specified URL contexts.
+     *
+     * @param nameValueObjects - The cookies' name-value pairs.
+     * @param url - The URL.
+     */
+    setCookies(nameValueObjects: Record<string, string> | Record<string, string>[], url: string): TestControllerPromise;
+    /**
+     * Deletes cookies. If there are no parameters, this method deletes all cookies.
+     *
+     * @param cookies - The cookies.
+     */
+    deleteCookies(cookies?: CookieOptions | CookieOptions[]): TestControllerPromise;
+    /**
+     * Deletes cookies associated with the URL contexts. If there are no parameters, this method deletes all cookies.
+     *
+     * @param names - The cookie names.
+     * @param urls - The URL.
+     */
+    deleteCookies(names: string | string[], urls?: string | string[]): TestControllerPromise;
 }
 
 interface TestControllerPromise<T=any> extends TestController, Promise<T> {

--- a/ts-defs-src/test-api/test-controller.d.ts
+++ b/ts-defs-src/test-api/test-controller.d.ts
@@ -119,7 +119,7 @@ interface TestController {
      * @param options - The options which will be passed to EventConstructor.
      */
     dispatchEvent(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-                  eventName: string, options?: object): TestControllerPromise;
+        eventName: string, options?: object): TestControllerPromise;
     /**
      * Clicks a webpage element.
      *
@@ -127,7 +127,7 @@ interface TestController {
      * @param options - A set of options that provide additional parameters for the action.
      */
     click(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-          options?: ClickActionOptions): TestControllerPromise;
+        options?: ClickActionOptions): TestControllerPromise;
     /**
      * Right-clicks a webpage element.
      *
@@ -135,7 +135,7 @@ interface TestController {
      * @param options - A set of options that provide additional parameters for the action.
      */
     rightClick(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-               options?: ClickActionOptions): TestControllerPromise;
+        options?: ClickActionOptions): TestControllerPromise;
     /**
      * Double-clicks a webpage element.
      *
@@ -143,7 +143,7 @@ interface TestController {
      * @param options - A set of options that provide additional parameters for the action.
      */
     doubleClick(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-                options?: ClickActionOptions): TestControllerPromise;
+        options?: ClickActionOptions): TestControllerPromise;
     /**
      * Hovers the mouse pointer over a webpage element.
      *
@@ -151,8 +151,8 @@ interface TestController {
      * @param options - A set of options that provide additional parameters for the action.
      */
     hover(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-          options?: MouseActionOptions): TestControllerPromise;
-     /**
+        options?: MouseActionOptions): TestControllerPromise;
+    /**
      * Scrolls the document element to the { scrollLeft, scrollTop } position.
      *
      * @param scrollLeft - The position along the horizontal axis of the document.
@@ -176,7 +176,7 @@ interface TestController {
      * @param options - A set of options that provide additional parameters for the action.
      */
     scroll(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-         scrollLeft: number, scrollTop: number, options?: OffsetOptions): TestControllerPromise;
+        scrollLeft: number, scrollTop: number, options?: OffsetOptions): TestControllerPromise;
 
     /**
      * Scrolls the specified element to the predefined position.
@@ -186,7 +186,7 @@ interface TestController {
      * @param options - A set of options that provide additional parameters for the action.
      */
     scroll(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-         position: ScrollPosition, options?: OffsetOptions): TestControllerPromise;
+        position: ScrollPosition, options?: OffsetOptions): TestControllerPromise;
 
     /**
      * Scrolls the document element by the given offset.
@@ -204,7 +204,7 @@ interface TestController {
      * @param options - A set of options that provide additional parameters for the action.
      */
     scrollBy(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-         x: number, y: number, options?: OffsetOptions): TestControllerPromise;
+        x: number, y: number, options?: OffsetOptions): TestControllerPromise;
 
     /**
      * Scrolls the specified element into view.
@@ -212,7 +212,7 @@ interface TestController {
      * @param options - A set of options that provide additional parameters for the action.
      */
     scrollIntoView(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-         options?: OffsetOptions): TestControllerPromise;
+        options?: OffsetOptions): TestControllerPromise;
 
     /**
      * Drags an element by an offset.
@@ -223,9 +223,9 @@ interface TestController {
      * @param options - A set of options that provide additional parameters for the action.
      */
     drag(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-         dragOffsetX: number,
-         dragOffsetY: number,
-         options?: MouseActionOptions): TestControllerPromise;
+        dragOffsetX: number,
+        dragOffsetY: number,
+        options?: MouseActionOptions): TestControllerPromise;
     /**
      * Drags an element onto another one.
      *
@@ -234,8 +234,8 @@ interface TestController {
      * @param options - A set of options that provide additional parameters for the action.
      */
     dragToElement(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-                  destinationSelector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-                  options?: DragToElementOptions): TestControllerPromise;
+        destinationSelector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
+        options?: DragToElementOptions): TestControllerPromise;
     /**
      * Types the specified text into an input element.
      *
@@ -244,8 +244,8 @@ interface TestController {
      * @param options - A set of options that provide additional parameters for the action.
      */
     typeText(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-             text: string,
-             options?: TypeActionOptions): TestControllerPromise;
+        text: string,
+        options?: TypeActionOptions): TestControllerPromise;
     /**
      * Selects text in input elements.
      *
@@ -255,9 +255,9 @@ interface TestController {
      * @param options - A set of options that provide additional parameters for the action.
      */
     selectText(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-               startPos?: number,
-               endPos?: number,
-               options?: ActionOptions): TestControllerPromise;
+        startPos?: number,
+        endPos?: number,
+        options?: ActionOptions): TestControllerPromise;
     /**
      * Selects `<textarea>` content.
      *
@@ -269,11 +269,11 @@ interface TestController {
      * @param options
      */
     selectTextAreaContent(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-                          startLine?: number,
-                          startPos?: number,
-                          endLine?: number,
-                          endPos?: number,
-                          options?: ActionOptions): TestControllerPromise;
+        startLine?: number,
+        startPos?: number,
+        endLine?: number,
+        endPos?: number,
+        options?: ActionOptions): TestControllerPromise;
     /**
      * Performs selection within editable content
      *
@@ -282,8 +282,8 @@ interface TestController {
      * @param options - A set of options that provide additional parameters for the action.
      */
     selectEditableContent(startSelector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-                          endSelector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-                          options?: ActionOptions): TestControllerPromise;
+        endSelector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
+        options?: ActionOptions): TestControllerPromise;
     /**
      * Presses the specified keyboard keys.
      *
@@ -311,7 +311,7 @@ interface TestController {
      * @param filePath - The path to the uploaded file, or several such paths. Relative paths resolve from the folder with the test file.
      */
     setFilesToUpload(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-                     filePath: String | String[]): TestControllerPromise;
+        filePath: string | string[]): TestControllerPromise;
     /**
      * Removes all file paths from the specified file upload input.
      *
@@ -341,8 +341,8 @@ interface TestController {
      * If path doesn't have .png extension, it will be added automatically.
      */
     takeElementScreenshot(selector: string | Selector | NodeSnapshot | SelectorPromise | ((...args: any[]) => Node | Node[] | NodeList | HTMLCollection),
-                          path?:    string,
-                          options?: TakeElementScreenshotOptions): TestControllerPromise;
+        path?: string,
+        options?: TakeElementScreenshotOptions): TestControllerPromise;
     /**
      * Sets the browser window size.
      *
@@ -435,7 +435,7 @@ interface TestController {
      * @param options - Handler options.
      */
     setNativeDialogHandler(fn: ((type: 'alert' | 'confirm' | 'beforeunload' | 'prompt', text: string, url: string) => any) | null,
-                           options?: ClientFunctionOptions): TestControllerPromise;
+        options?: ClientFunctionOptions): TestControllerPromise;
     /**
      * Returns a stack of history entries (i.e., an array in which the latest dialog has an index of 0). Each entry
      * corresponds to a certain native dialog that appears in the main window or in an `<iframe>`.

--- a/ts-defs-src/test-api/test-controller.d.ts
+++ b/ts-defs-src/test-api/test-controller.d.ts
@@ -486,42 +486,42 @@ interface TestController {
      */
     removeRequestHooks(...hooks: object[]): TestControllerPromise;
     /**
-     * Returns cookies associated with the specified cookie objects. If there are no parameters, this method returns all cookies.
+     * Returns cookies from the specified cookie objects. If there are no parameters, the method returns all the cookies.
      *
-     * @param cookies - The cookie objects.
+     * @param cookies - cookie objects.
      */
     getCookies(cookies?: CookieOptions | CookieOptions[]): Promise<CookieOptions[]>;
     /**
-     * Returns cookies with the specified names and URL contexts.
+     * Returns cookies with the specified names and URLs.
      *
-     * @param names - The cookie names.
-     * @param urls - The URL.
+     * @param names - Cookie names.
+     * @param urls - URLs.
      */
     getCookies(names: string | string[], urls?: string | string[]): Promise<CookieOptions[]>;
     /**
-     * Sets the specified cookie objects.
+     * Creates cookies with the specified parameters.
      *
-     * @param cookies - The cookie objects.
+     * @param cookies - Cookie objects.
      */
     setCookies(cookies?: CookieOptions | CookieOptions[]): TestControllerPromise;
     /**
-     * Sets cookies' name-value pairs to the specified URL contexts.
+     * Assigns the specified URL to the specified cookie name-value pairs.
      *
-     * @param nameValueObjects - The cookies' name-value pairs.
-     * @param url - The URL.
+     * @param nameValueObjects - Cookie name-value pairs (Objects).
+     * @param url - Cookie URL.
      */
     setCookies(nameValueObjects: Record<string, string> | Record<string, string>[], url?: string): TestControllerPromise;
     /**
-     * Deletes cookies. If there are no parameters, this method deletes all cookies.
+     * Deletes cookies with the specified parameters. If there are no parameters, this method deletes all cookies.
      *
-     * @param cookies - The cookies.
+     * @param cookies - Cookies.
      */
     deleteCookies(cookies?: CookieOptions | CookieOptions[]): TestControllerPromise;
     /**
-     * Deletes cookies associated with the URL contexts. If there are no parameters, this method deletes all cookies.
+     * Deletes cookies associated with the specified URLs. If there are no parameters, this method deletes all cookies.
      *
-     * @param names - The cookie names.
-     * @param urls - The URL.
+     * @param names - Cookie names.
+     * @param urls - URLs.
      */
     deleteCookies(names: string | string[], urls?: string | string[]): TestControllerPromise;
 }

--- a/ts-defs-src/test-api/test-controller.d.ts
+++ b/ts-defs-src/test-api/test-controller.d.ts
@@ -510,7 +510,7 @@ interface TestController {
      * @param nameValueObjects - The cookies' name-value pairs.
      * @param url - The URL.
      */
-    setCookies(nameValueObjects: Record<string, string> | Record<string, string>[], url: string): TestControllerPromise;
+    setCookies(nameValueObjects: Record<string, string> | Record<string, string>[], url?: string): TestControllerPromise;
     /**
      * Deletes cookies. If there are no parameters, this method deletes all cookies.
      *

--- a/ts-defs-src/test-api/test-controller.d.ts
+++ b/ts-defs-src/test-api/test-controller.d.ts
@@ -512,13 +512,13 @@ interface TestController {
      */
     setCookies(nameValueObjects: Record<string, string> | Record<string, string>[], url?: string): TestControllerPromise;
     /**
-     * Deletes cookies with the specified parameters. If there are no parameters, this method deletes all cookies.
+     * Deletes cookies with the specified parameters. If there are no parameters, this method empties the browser's cookie storage.
      *
      * @param cookies - Cookies.
      */
     deleteCookies(cookies?: CookieOptions | CookieOptions[]): TestControllerPromise;
     /**
-     * Deletes cookies associated with the specified URLs. If there are no parameters, this method deletes all cookies.
+     * Deletes cookies associated with the specified URLs. If there are no parameters, this method empties the browser's cookie storage.
      *
      * @param names - Cookie names.
      * @param urls - URLs.


### PR DESCRIPTION
## Purpose
Add definitions of the Cookies API functionality.

## Approach
1. Add interfaces for the Cookies API functionality.
2. Fix test
3. Refactor errors messages
[actionRequiredCookieArguments](https://github.com/DevExpress/testcafe/blob/e00140550089bd5ad29cdec174709720dd772590/src/errors/test-run/templates.js#L133)
[actionCookieArgumentError](https://github.com/DevExpress/testcafe/blob/e00140550089bd5ad29cdec174709720dd772590/src/errors/test-run/templates.js#L137)
[actionCookieArgumentsError](https://github.com/DevExpress/testcafe/blob/e00140550089bd5ad29cdec174709720dd772590/src/errors/test-run/templates.js#L141)
[actionUrlCookieArgumentError
](https://github.com/DevExpress/testcafe/blob/e00140550089bd5ad29cdec174709720dd772590/src/errors/test-run/templates.js#L145)[actionUrlsCookieArgumentError](https://github.com/DevExpress/testcafe/blob/e00140550089bd5ad29cdec174709720dd772590/src/errors/test-run/templates.js#L149)
[actionStringOptionError](https://github.com/DevExpress/testcafe/blob/e00140550089bd5ad29cdec174709720dd772590/src/errors/test-run/templates.js#L414)
[actionDateOptionError](https://github.com/DevExpress/testcafe/blob/e00140550089bd5ad29cdec174709720dd772590/src/errors/test-run/templates.js#L418)
[actionNumberOptionError](https://github.com/DevExpress/testcafe/blob/e00140550089bd5ad29cdec174709720dd772590/src/errors/test-run/templates.js#L422)


## References
[Firt part](https://github.com/DevExpress/testcafe/pull/6841)
[Second part](https://github.com/DevExpress/testcafe/pull/6892)

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
- [ ] Write documentation
