### PR TITLE
fix: fixed working of the global request logger 

### DIFF
--- a/src/configuration/configuration-base.ts
+++ b/src/configuration/configuration-base.ts
@@ -38,9 +38,7 @@ export default class Configuration {
         const result = Object.create(null);
 
         Object.entries(obj).forEach(([key, value]) => {
-            const option = new Option(key, value);
-
-            result[key] = option;
+            result[key] = new Option(key, value);
         });
 
         return result;

--- a/src/configuration/configuration-base.ts
+++ b/src/configuration/configuration-base.ts
@@ -129,8 +129,17 @@ export default class Configuration {
         return result;
     }
 
-    public clone (): Configuration {
-        return cloneDeep(this);
+    public clone (nonClonedOptions?: string | string[]): Configuration {
+        const configuration = cloneDeep(this);
+
+        if (nonClonedOptions) {
+            castArray(nonClonedOptions).forEach(key => {
+                if (configuration._options[key])
+                    configuration._options[key].value = this._options[key].value;
+            });
+        }
+
+        return configuration;
     }
 
     public get filePath (): string | undefined {

--- a/src/testcafe.js
+++ b/src/testcafe.js
@@ -72,7 +72,7 @@ export default class TestCafe {
         const newRunner = new Ctor({
             proxy:                    this.proxy,
             browserConnectionGateway: this.browserConnectionGateway,
-            configuration:            this.configuration.clone(),
+            configuration:            this.configuration.clone(OPTION_NAMES.hooks),
             compilerService:          this.compilerService,
         });
 

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -477,6 +477,40 @@ describe('TestCafeConfiguration', function () {
                 });
             });
         });
+
+        describe('Clone', () => {
+            it('Should clone configuration', async () => {
+                const configuration = new TestCafeConfiguration();
+
+                await configuration.init({
+                    userVariables: {
+                        url: 'localhos',
+                    },
+                });
+
+                const clone = configuration.clone();
+
+                expect(configuration.getOption('userVariables')).not.equal(clone.getOption('userVariables'));
+            });
+
+            it('Should clone configuration except an "hooks" option', async () => {
+                const configuration = new TestCafeConfiguration();
+
+                await configuration.init({
+                    hooks: {
+                        request: 'request',
+                    },
+                    userVariables: {
+                        url: 'localhost',
+                    },
+                });
+
+                const clone = configuration.clone(OptionNames.hooks);
+
+                expect(configuration.getOption('userVariables')).not.equal(clone.getOption('userVariables'));
+                expect(configuration.getOption('hooks')).to.equal(clone.getOption('hooks'));
+            });
+        });
     });
 
     describe('Default values', function () {


### PR DESCRIPTION
[closes DevExpress/testcafe#6945]

## Purpose
Global request loggers are cloned with configuration during the creating runner. It is the reason why we can't get any results from the global loggers in tests.

## Approach
1. Add tests for the cloning testcafe configuration
2. Add recovering the hooks after the cloning configuration during the creating runner

## References
https://github.com/DevExpress/testcafe/issues/6945

## Pre-Merge TODO
- [X] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
