### PR TITLE
Fix: Invalid browser specified in configuration throws and error when valid browser is specified in CLI(closes #6618)

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -66,12 +66,12 @@ function error (err) {
 }
 
 async function runTests (argParser) {
-    const opts              = argParser.opts;
-    const port1             = opts.ports && opts.ports[0];
-    const port2             = opts.ports && opts.ports[1];
-    const proxy             = opts.proxy;
-    const proxyBypass       = opts.proxyBypass;
-    const configFile        = opts.configFile;
+    const opts        = argParser.opts;
+    const port1       = opts.ports && opts.ports[0];
+    const port2       = opts.ports && opts.ports[1];
+    const proxy       = opts.proxy;
+    const proxyBypass = opts.proxyBypass;
+    const configFile  = opts.configFile;
 
     log.showSpinner();
 
@@ -90,6 +90,7 @@ async function runTests (argParser) {
         configFile,
         disableHttp2,
         v8Flags,
+        fromCli: true,
     });
 
     const correctedBrowsersAndSources = await correctBrowsersAndSources(argParser, testCafe.configuration);
@@ -126,7 +127,6 @@ async function runTests (argParser) {
 
         failed = await runner.run(runOpts);
     }
-
     finally {
         showMessageOnExit = false;
         await testCafe.close();
@@ -149,10 +149,10 @@ async function listBrowsers (providerName) {
         if (providerName === 'locally-installed')
             console.log(browserNames.join('\n'));
         else
-            console.log(browserNames.map(browserName => `"${providerName}:${browserName}"`).join('\n'));
+            console.log(browserNames.map(browserName => `"${ providerName }:${ browserName }"`).join('\n'));
     }
     else
-        console.log(`"${providerName}"`);
+        console.log(`"${ providerName }"`);
 
     exit(0);
 }

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -108,12 +108,12 @@ export default class TestCafeConfiguration extends Configuration {
         await this.asyncMergeOptions(options);
     }
 
-    public async asyncMergeOptions (options?: object): Promise<void> {
+    public async asyncMergeOptions (options?: any): Promise<void> {
         options = options || {};
 
         super.mergeOptions(options);
 
-        if (this._options.browsers)
+        if (!options.fromCli && this._options.browsers)
             this._options.browsers.value = await this._getBrowserInfo();
     }
 

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -1,12 +1,12 @@
 /*eslint-disable no-console */
 const { cloneDeep, noop } = require('lodash');
 
-const { expect }    = require('chai');
-const fs            = require('fs');
-const tmp           = require('tmp');
-const { nanoid }    = require('nanoid');
-const del           = require('del');
-const pathUtil      = require('path');
+const { expect } = require('chai');
+const fs         = require('fs');
+const tmp        = require('tmp');
+const { nanoid } = require('nanoid');
+const del        = require('del');
+const pathUtil   = require('path');
 
 const TestCafeConfiguration                   = require('../../lib/configuration/testcafe-configuration');
 const TypeScriptConfiguration                 = require('../../lib/configuration/typescript-configuration');
@@ -856,6 +856,42 @@ describe('TypeScriptConfiguration', function () {
                     expect(configuration.getOption('src')).eql([ options.src ]);
                     expect(configuration.getOption('browser')).eql(options.browser);
                 });
+        });
+    });
+    describe('[RG-6618] Incorrect browser is specified in config file when running tests from CLI', () => {
+        let configuration;
+        const customConfigFile = 'custom2.testcaferc.json';
+
+        const options = {
+            'browsers': ['incorrectBrowser'],
+        };
+
+        before(async () => {
+            createJSONConfig(customConfigFile, options);
+        });
+
+        after(async () => {
+            await del(configuration.defaultPaths);
+        });
+
+        it('Should success create configuration with incorrect browser value', () => {
+            configuration = new TestCafeConfiguration(customConfigFile);
+
+            return configuration.init({ fromCli: true })
+                .then(() => {
+                    expect(pathUtil.basename(configuration.filePath)).eql(customConfigFile);
+                    expect(configuration.getOption('browsers')).eql(options.browsers);
+                });
+        });
+
+        it('Should throw an error in case of incorrect browser was passed not from CLI', () => {
+            configuration = new TestCafeConfiguration(customConfigFile);
+
+            return configuration.init().then(() => {
+                throw new Error('Promise should be rejected');
+            }).catch(err => {
+                expect(err.message).eql('Cannot find the browser. "incorrectBrowser" is neither a known browser alias, nor a path to an executable file.');
+            });
         });
     });
 });


### PR DESCRIPTION
## Purpose
Browsers specified via CLI should override the browsers specified in the config file. Currently, the error will be thrown If you specify an invalid browser in the config file, despite the fact that a valid browser is specified via CLI.

## References
[#6618](https://github.com/DevExpress/testcafe/issues/6618)