### PR TITLE
feat: Change execution order of global hooks (close #7005)

### DIFF
--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -628,11 +628,11 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     private async _runAfterHook (): Promise<boolean> {
-        if (this.test.globalAfterFn)
-            await this._executeTestFn(TestRunPhase.inTestAfterHook, this.test.globalAfterFn, this.executionTimeout);
-
         if (this.test.afterFn)
-            return await this._executeTestFn(TestRunPhase.inTestAfterHook, this.test.afterFn, this.executionTimeout);
+            await this._executeTestFn(TestRunPhase.inTestAfterHook, this.test.afterFn, this.executionTimeout);
+
+        if (this.test.globalAfterFn)
+            return await this._executeTestFn(TestRunPhase.inTestAfterHook, this.test.globalAfterFn, this.executionTimeout);
 
         if (this.test.fixture?.afterEachFn)
             return await this._executeTestFn(TestRunPhase.inFixtureAfterEachHook, this.test.fixture?.afterEachFn, this.executionTimeout);

--- a/test/functional/fixtures/api/es-next/global-hooks/data/execution-flow-config.js
+++ b/test/functional/fixtures/api/es-next/global-hooks/data/execution-flow-config.js
@@ -15,27 +15,26 @@ module.exports = {
     hooks: {
         fixture: {
             before: async () => {
-                flowInfoStorage.add('globalFixtureBefore');
+                flowInfoStorage.safeAdd('globalFixtureBefore');
             },
             after: async () => {
-                flowInfoStorage.add('globalFixtureAfter');
+                flowInfoStorage.safeAdd('globalFixtureAfter');
             },
         },
         test: {
             before: async () => {
-                flowInfoStorage.add('globalTestBefore');
+                flowInfoStorage.safeAdd('globalTestBefore');
             },
             after: async () => {
-                flowInfoStorage.add('globalTestAfter');
+                flowInfoStorage.safeAdd('globalTestAfter');
             },
         },
         testRun: {
             before: async () => {
-                flowInfoStorage.add('globalTestRunBefore');
+                flowInfoStorage.safeAdd('globalTestRunBefore');
             },
             after: async () => {
-                flowInfoStorage.add('globalTestRunAfter');
-                flowInfoStorage.save();
+                flowInfoStorage.safeAdd('globalTestRunAfter');
             },
         },
     },

--- a/test/functional/fixtures/api/es-next/global-hooks/data/execution-flow-config.js
+++ b/test/functional/fixtures/api/es-next/global-hooks/data/execution-flow-config.js
@@ -1,0 +1,44 @@
+const flowInfoStorage = require('../utils/flow-info-storage');
+const config          = require('../../../../../config');
+const path            = require('path');
+
+module.exports = {
+    hostname:          config.testCafe.hostname,
+    port1:             1335,
+    port2:             1336,
+    developmentMode:   config.devMode,
+    retryTestPages:    config.retryTestPages,
+    experimentalDebug: !!process.env.EXPERIMENTAL_DEBUG,
+    isProxyless:       config.isProxyless,
+    src:               path.resolve('./test/functional/fixtures/api/es-next/global-hooks/testcafe-fixtures/flow-info-test.js'),
+
+    hooks: {
+        fixture: {
+            before: async () => {
+                flowInfoStorage.add('globalFixtureBefore');
+            },
+            after: async () => {
+                flowInfoStorage.add('globalFixtureAfter');
+            },
+        },
+        test: {
+            before: async () => {
+                flowInfoStorage.add('globalTestBefore');
+            },
+            after: async () => {
+                flowInfoStorage.add('globalTestAfter');
+            },
+        },
+        testRun: {
+            before: async () => {
+                flowInfoStorage.add('globalTestRunBefore');
+            },
+            after: async () => {
+                flowInfoStorage.add('globalTestRunAfter');
+                flowInfoStorage.save();
+            },
+        },
+    },
+    ...config.currentEnvironment,
+    browsers: 'chrome:headless',
+};

--- a/test/functional/fixtures/api/es-next/global-hooks/test.js
+++ b/test/functional/fixtures/api/es-next/global-hooks/test.js
@@ -3,6 +3,7 @@ const createTestCafe             = require('../../../../../../lib');
 const config                     = require('../../../../config');
 const { createSimpleTestStream } = require('../../../../utils/stream');
 const { expect }                 = require('chai');
+const flowInfoStorage            = require('./utils/flow-info-storage');
 
 let cafe = null;
 
@@ -36,130 +37,165 @@ const runTestsLocal = (testName) => {
 const isLocalChrome = config.useLocalBrowsers && config.browsers.some(browser => browser.alias.includes('chrome'));
 
 if (isLocalChrome) {
-    describe('[API] fixture global before/after hooks', () => {
-        before(async () => {
-            cafe = await createTestCafe({
-                configFile: path.resolve('./test/functional/fixtures/api/es-next/global-hooks/data/fixture-config.js'),
+    describe('Global hooks', function () {
+        describe('[API] fixture global before/after hooks', () => {
+            before(async () => {
+                cafe = await createTestCafe({
+                    configFile: path.resolve('./test/functional/fixtures/api/es-next/global-hooks/data/fixture-config.js'),
+                });
+            });
+
+            after(function () {
+                cafe.close();
+            });
+
+            beforeEach(() => {
+                global.fixtureBefore = 0;
+                global.fixtureAfter  = 0;
+            });
+
+            afterEach(() => {
+                delete global.fixtureBefore;
+                delete global.fixtureAfter;
+            });
+
+            it('Should run hooks for all fixture', async () => {
+                return runTestsLocal('Test1');
+            });
+
+            it('Should run all hooks for fixture', async () => {
+                return runTestsLocal('Test2');
+            });
+
+            it('Should run hooks in the right order', async () => {
+                return runTestsLocal('Test3');
             });
         });
 
-        after(function () {
-            cafe.close();
-        });
+        describe('[API] test global before/after hooks', () => {
+            before(async () => {
+                cafe = await createTestCafe({
+                    configFile: path.resolve('./test/functional/fixtures/api/es-next/global-hooks/data/test-config.js'),
+                });
+            });
 
-        beforeEach(() => {
-            global.fixtureBefore = 0;
-            global.fixtureAfter  = 0;
-        });
+            after(function () {
+                cafe.close();
+            });
 
-        afterEach(() => {
-            delete global.fixtureBefore;
-            delete global.fixtureAfter;
-        });
+            it('Should run global hooks for all tests', () => {
+                return runTestsLocal('Test1');
+            });
 
-        it('Should run hooks for all fixture', async () => {
-            return runTestsLocal('Test1');
-        });
-
-        it('Should run all hooks for fixture', async () => {
-            return runTestsLocal('Test2');
-        });
-
-        it('Should run hooks in the right order', async () => {
-            return runTestsLocal('Test3');
-        });
-    });
-
-    describe('[API] test global before/after hooks', () => {
-        before(async () => {
-            cafe = await createTestCafe({
-                configFile: path.resolve('./test/functional/fixtures/api/es-next/global-hooks/data/test-config.js'),
+            it('Should run all hooks in the right order', () => {
+                return runTestsLocal('Test2');
             });
         });
 
-        after(function () {
-            cafe.close();
-        });
+        describe('[API] testRun global before/after hooks', () => {
 
-        it('Should run global hooks for all tests', () => {
-            return runTestsLocal('Test1');
-        });
-
-        it('Should run all hooks in the right order', () => {
-            return runTestsLocal('Test2');
-        });
-    });
-
-    describe('[API] testRun global before/after hooks', () => {
-
-        before(async () => {
-            cafe = await createTestCafe({
-                configFile: path.resolve('./test/functional/fixtures/api/es-next/global-hooks/data/test-run-config.js'),
+            before(async () => {
+                cafe = await createTestCafe({
+                    configFile: path.resolve('./test/functional/fixtures/api/es-next/global-hooks/data/test-run-config.js'),
+                });
             });
-        });
 
-        afterEach(function () {
-            cafe.close();
-        });
+            afterEach(function () {
+                cafe.close();
+            });
 
-        it('Should run hooks for all tests', async () => {
-            await runTestsLocal('');
-        });
+            it('Should run hooks for all tests', async () => {
+                await runTestsLocal('');
+            });
 
-        it('Should fail all tests in fixture if testRun.before hooks fails', async () => {
-            return runTests('./testcafe-fixtures/test-run-test.js', null, {
-                shouldFail: true,
-                only:       'chrome',
-                hooks:      {
-                    testRun: {
-                        before: async () => {
-                            throw new Error('$$before$$');
+            it('Should fail all tests in fixture if testRun.before hooks fails', async () => {
+                return runTests('./testcafe-fixtures/test-run-test.js', null, {
+                    shouldFail: true,
+                    only:       'chrome',
+                    hooks:      {
+                        testRun: {
+                            before: async () => {
+                                throw new Error('$$before$$');
+                            },
                         },
                     },
-                },
-            }).catch(errs => {
+                }).catch(errs => {
 
-                expect(errs.length).eql(3);
+                    expect(errs.length).eql(3);
 
-                errs.forEach(err => {
-                    expect(err).contains('Error in testRun.before hook');
-                    expect(err).contains('$$before$$');
+                    errs.forEach(err => {
+                        expect(err).contains('Error in testRun.before hook');
+                        expect(err).contains('$$before$$');
+                    });
                 });
             });
         });
-    });
 
+        describe('[API] Request Hooks', () => {
+            describe('RequestMock', () => {
+                before(async () => {
+                    cafe = await createTestCafe({
+                        configFile: path.resolve('./test/functional/fixtures/api/es-next/global-hooks/data/request-mock-config.js'),
+                    });
+                });
 
-    describe('[API] Request Hooks', () => {
-        describe('RequestMock', () => {
-            before(async () => {
-                cafe = await createTestCafe({
-                    configFile: path.resolve('./test/functional/fixtures/api/es-next/global-hooks/data/request-mock-config.js'),
+                after(function () {
+                    cafe.close();
+                });
+
+                it('Should mock requests', () => {
+                    return runTestsLocal('test');
                 });
             });
 
-            after(function () {
-                cafe.close();
-            });
+            describe('RequestLogger', () => {
+                before(async () => {
+                    cafe = await createTestCafe({
+                        configFile: path.resolve('./test/functional/fixtures/api/es-next/global-hooks/data/request-logger-config.js'),
+                    });
+                });
 
-            it('Should mock requests', () => {
-                return runTestsLocal('test');
+                after(function () {
+                    cafe.close();
+                });
+
+                it('Should log requests', () => {
+                    return runTestsLocal('test');
+                });
             });
         });
 
-        describe('RequestLogger', () => {
+        describe('Hooks execution glow', () => {
             before(async () => {
                 cafe = await createTestCafe({
-                    configFile: path.resolve('./test/functional/fixtures/api/es-next/global-hooks/data/request-logger-config.js'),
+                    configFile: path.resolve('./test/functional/fixtures/api/es-next/global-hooks/data/execution-flow-config.js'),
                 });
             });
 
-            after(function () {
-                cafe.close();
+            after(() => {
+                return cafe.close();
             });
 
-            it('Should log requests', () => {
-                return runTestsLocal('test');
+            afterEach(() => {
+                flowInfoStorage.delete();
+            });
+
+            it('Completed', async () => {
+                await runTestsLocal();
+
+                expect(flowInfoStorage.getData()).eql([
+                    'globalTestRunBefore',
+                    'globalFixtureBefore',
+                    'localFixtureBefore',
+                    'globalTestBefore',
+                    'localTestBefore',
+                    'test body',
+                    'localTestAfter',
+                    'globalTestAfter',
+                    'localFixtureAfter',
+                    'globalFixtureAfter',
+                    'globalTestRunAfter',
+                ]);
             });
         });
     });

--- a/test/functional/fixtures/api/es-next/global-hooks/test.js
+++ b/test/functional/fixtures/api/es-next/global-hooks/test.js
@@ -165,7 +165,7 @@ if (isLocalChrome) {
             });
         });
 
-        describe('Hooks execution glow', () => {
+        describe('Hooks execution flow', () => {
             before(async () => {
                 cafe = await createTestCafe({
                     configFile: path.resolve('./test/functional/fixtures/api/es-next/global-hooks/data/execution-flow-config.js'),

--- a/test/functional/fixtures/api/es-next/global-hooks/testcafe-fixtures/flow-info-test.js
+++ b/test/functional/fixtures/api/es-next/global-hooks/testcafe-fixtures/flow-info-test.js
@@ -2,19 +2,19 @@ import flowInfoStorage from '../utils/flow-info-storage.js';
 
 fixture ('Fixture')
     .before(async function () {
-        flowInfoStorage.add('localFixtureBefore');
+        flowInfoStorage.safeAdd('localFixtureBefore');
     })
     .after(async function () {
-        flowInfoStorage.add('localFixtureAfter');
+        flowInfoStorage.safeAdd('localFixtureAfter');
     });
 
 test
     .before(async function () {
-        flowInfoStorage.add('localTestBefore');
+        flowInfoStorage.safeAdd('localTestBefore');
     })
     .after(async function () {
-        flowInfoStorage.add('localTestAfter');
+        flowInfoStorage.safeAdd('localTestAfter');
     })
     ('Test', async () => {
-        flowInfoStorage.add('test body');
+        flowInfoStorage.safeAdd('test body');
     });

--- a/test/functional/fixtures/api/es-next/global-hooks/testcafe-fixtures/flow-info-test.js
+++ b/test/functional/fixtures/api/es-next/global-hooks/testcafe-fixtures/flow-info-test.js
@@ -1,0 +1,20 @@
+import flowInfoStorage from '../utils/flow-info-storage.js';
+
+fixture ('Fixture')
+    .before(async function () {
+        flowInfoStorage.add('localFixtureBefore');
+    })
+    .after(async function () {
+        flowInfoStorage.add('localFixtureAfter');
+    });
+
+test
+    .before(async function () {
+        flowInfoStorage.add('localTestBefore');
+    })
+    .after(async function () {
+        flowInfoStorage.add('localTestAfter');
+    })
+    ('Test', async () => {
+        flowInfoStorage.add('test body');
+    });

--- a/test/functional/fixtures/api/es-next/global-hooks/utils/flow-info-storage.js
+++ b/test/functional/fixtures/api/es-next/global-hooks/utils/flow-info-storage.js
@@ -1,0 +1,4 @@
+const FileStorage = require('../../../../../utils/file-storage');
+
+module.exports = new FileStorage('flow-info.json', __dirname);
+

--- a/test/functional/fixtures/api/es-next/hooks/test.js
+++ b/test/functional/fixtures/api/es-next/hooks/test.js
@@ -72,7 +72,7 @@ describe('[API] t.ctx', () => {
                 const browsers = [];
 
                 Object.keys(errs).forEach(browser => {
-                    const dataJson = errs[browser][0].match(/###(.+)###/)[1];
+                    const dataJson = errs[browser][1].match(/###(.+)###/)[1];
                     const data     = JSON.parse(dataJson);
 
                     // NOTE: check context assignment

--- a/test/functional/utils/file-storage.js
+++ b/test/functional/utils/file-storage.js
@@ -8,6 +8,10 @@ class FileStorage {
         this.data     = [];
     }
 
+    load () {
+        this.data = this.getData();
+    }
+
     add (val) {
         this.data.push(val);
     }
@@ -23,7 +27,7 @@ class FileStorage {
             return JSON.parse(dataStr);
         }
         catch (err) {
-            return null;
+            return [];
         }
     }
 
@@ -38,6 +42,12 @@ class FileStorage {
 
     save () {
         fs.writeFileSync(this.fullPath, JSON.stringify(this.data));
+    }
+
+    safeAdd (val) {
+        this.load();
+        this.add(val);
+        this.save();
     }
 }
 


### PR DESCRIPTION
Changes:
* change execution order of the `localTestAfter` and `globalTestAfter` hooks.
* move all tests to the root `describe('Global hooks')` function.