### PR TITLE
refactor: make dashboards ads more selective

### DIFF
--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -541,7 +541,7 @@ export default class Runner extends EventEmitter {
         this.configuration.mergeOptions({ [OPTION_NAMES.reporter]: reporterOptions });
     }
 
-    async _addDashBoardAdvertisementIfNeeded () {
+    _addDashBoardAdvertisementIfNeeded () {
         const reporterOptions  = this.configuration.getOption(OPTION_NAMES.reporter);
 
         if (!reporterOptions || castArray(reporterOptions).every(reporter => reporter.name === SPEC_REPORTER_NAME))

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -54,6 +54,7 @@ import chalk from 'chalk';
 
 const DEBUG_LOGGER            = debug('testcafe:runner');
 const DASHBOARD_REPORTER_NAME = 'dashboard';
+const SPEC_REPORTER_NAME      = 'spec';
 
 export default class Runner extends EventEmitter {
     constructor ({ proxy, browserConnectionGateway, configuration, compilerService }) {
@@ -534,10 +535,11 @@ export default class Runner extends EventEmitter {
         this.configuration.mergeOptions({ [OPTION_NAMES.reporter]: reporterOptions });
     }
 
-    _addDashBoardAdvertisementIfNeeded () {
-        const reporterOptions = this.configuration.getOption(OPTION_NAMES.reporter);
+    async _addDashBoardAdvertisementIfNeeded () {
+        const dashboardOptions = await this._getDashboardOptions();
+        const reporterOptions  = this.configuration.getOption(OPTION_NAMES.reporter);
 
-        if (!reporterOptions || castArray(reporterOptions).every(reporter => reporter.name !== DASHBOARD_REPORTER_NAME))
+        if (!dashboardOptions?.token && (!reporterOptions || castArray(reporterOptions).every(reporter => reporter.name === SPEC_REPORTER_NAME)))
             this._addAdvertisement(`\n${chalk.bold.red('NEW')}: Try TestCafe Dashboard (https://dashboard.testcafe.io/) to eliminate unstable and failing tests.\n`);
     }
 
@@ -753,7 +755,7 @@ export default class Runner extends EventEmitter {
             .then(() => this._setConfigurationOptions())
             .then(async () => {
                 await this._addDashboardReporterIfNeeded();
-                this._addDashBoardAdvertisementIfNeeded();
+                await this._addDashBoardAdvertisementIfNeeded();
             })
             .then(() => Reporter.getReporterPlugins(this.configuration.getOption(OPTION_NAMES.reporter)))
             .then(reporterPlugins => {

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -542,10 +542,9 @@ export default class Runner extends EventEmitter {
     }
 
     async _addDashBoardAdvertisementIfNeeded () {
-        const dashboardOptions = await this._getDashboardOptions();
         const reporterOptions  = this.configuration.getOption(OPTION_NAMES.reporter);
 
-        if (!dashboardOptions?.token && (!reporterOptions || castArray(reporterOptions).every(reporter => reporter.name === SPEC_REPORTER_NAME)))
+        if (!reporterOptions || castArray(reporterOptions).every(reporter => reporter.name === SPEC_REPORTER_NAME))
             this._addDashboardAdvertisement(`\n${chalk.bold.red('NEW')}: Try TestCafe Dashboard (https://dashboard.testcafe.io/) to eliminate unstable and failing tests.\n`);
     }
 

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -1176,4 +1176,13 @@ describe('Reporter', () => {
                 del(pathReport);
             });
     });
+
+    it('Should set options _hasTaskErrors to the runner if an error occurs', async () => {
+        try {
+            await runTests('testcafe-fixtures/index-test.js', 'Simple command err test', { only: ['chrome'], shouldFail: true });
+        }
+        catch (err) {
+            expect(testCafe.runner._hasTaskErrors).eql(true);
+        }
+    });
 });

--- a/test/functional/fixtures/run-options/stop-on-first-fail/testcafe-fixtures/stop-on-first-fail-test.js
+++ b/test/functional/fixtures/run-options/stop-on-first-fail/testcafe-fixtures/stop-on-first-fail-test.js
@@ -7,7 +7,7 @@ let testRunCount = 0;
 const updateTestRunCount = () => {
     testRunCount++;
 
-    fs.writeFileSync('testRunCount.txt', testRunCount);
+    fs.writeFileSync('testRunCount.txt', testRunCount.toString());
 };
 
 test('test1', async () => {

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -280,6 +280,23 @@ describe('Runner', () => {
                 consoleWrapper.unwrap();
             });
 
+            it('Should not add the dashboard advertisement if dashboard option is added', async () => {
+                consoleWrapper.wrap();
+
+                runner._hasTaskErrors = true;
+                runner.configuration.mergeOptions({
+                    dashboard: TEST_DASHBOARD_SETTINGS,
+                });
+
+                await runner._addDashboardReporterIfNeeded();
+                await runner._addDashBoardAdvertisementIfNeeded();
+                await runner._messageBus.emit('done');
+
+                expect(consoleWrapper.messages.log).eql(null);
+
+                consoleWrapper.unwrap();
+            });
+
             it('Should not add the dashboard advertisement if added reporter different from spec', async () => {
                 consoleWrapper.wrap();
 

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -245,7 +245,7 @@ describe('Runner', () => {
             it('Should add the dashboard advertisement if reporter is not added', async () => {
                 consoleWrapper.wrap();
 
-                runner._addDashBoardAdvertisementIfNeeded();
+                await runner._addDashBoardAdvertisementIfNeeded();
                 await runner._messageBus.emit('done');
 
                 expect(consoleWrapper.messages.log).contains('Try TestCafe Dashboard (https://dashboard.testcafe.io/) to eliminate unstable and failing tests.');
@@ -257,7 +257,7 @@ describe('Runner', () => {
                 consoleWrapper.wrap();
 
                 runner.configuration.mergeOptions({ reporter: { name: 'spec' } });
-                runner._addDashBoardAdvertisementIfNeeded();
+                await runner._addDashBoardAdvertisementIfNeeded();
                 await runner._messageBus.emit('done');
 
                 expect(consoleWrapper.messages.log).contains('Try TestCafe Dashboard (https://dashboard.testcafe.io/) to eliminate unstable and failing tests.');
@@ -269,7 +269,7 @@ describe('Runner', () => {
                 consoleWrapper.wrap();
 
                 runner.configuration.mergeOptions({ reporter: [{ name: 'json' }, { name: 'dashboard' }] });
-                runner._addDashBoardAdvertisementIfNeeded();
+                await runner._addDashBoardAdvertisementIfNeeded();
                 await runner._messageBus.emit('done');
 
                 expect(consoleWrapper.messages.log).eql(null);
@@ -281,7 +281,7 @@ describe('Runner', () => {
                 consoleWrapper.wrap();
 
                 runner.configuration.mergeOptions({ reporter: [{ name: 'spec' }, { name: 'json' }] });
-                runner._addDashBoardAdvertisementIfNeeded();
+                await runner._addDashBoardAdvertisementIfNeeded();
                 await runner._messageBus.emit('done');
 
                 expect(consoleWrapper.messages.log).eql(null);

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -253,10 +253,10 @@ describe('Runner', () => {
                 consoleWrapper.unwrap();
             });
 
-            it('Should add the dashboard advertisement if dashboard reporter is not added', async () => {
+            it('Should add the dashboard advertisement if added only spec reporter', async () => {
                 consoleWrapper.wrap();
 
-                runner.configuration.mergeOptions({ reporter: { name: 'json' } });
+                runner.configuration.mergeOptions({ reporter: { name: 'spec' } });
                 runner._addDashBoardAdvertisementIfNeeded();
                 await runner._messageBus.emit('done');
 
@@ -269,6 +269,18 @@ describe('Runner', () => {
                 consoleWrapper.wrap();
 
                 runner.configuration.mergeOptions({ reporter: [{ name: 'json' }, { name: 'dashboard' }] });
+                runner._addDashBoardAdvertisementIfNeeded();
+                await runner._messageBus.emit('done');
+
+                expect(consoleWrapper.messages.log).eql(null);
+
+                consoleWrapper.unwrap();
+            });
+
+            it('Should not add the dashboard advertisement if added reporter different from spec', async () => {
+                consoleWrapper.wrap();
+
+                runner.configuration.mergeOptions({ reporter: [{ name: 'spec' }, { name: 'json' }] });
                 runner._addDashBoardAdvertisementIfNeeded();
                 await runner._messageBus.emit('done');
 

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -246,7 +246,7 @@ describe('Runner', () => {
                 consoleWrapper.wrap();
 
                 runner._hasTaskErrors = true;
-                await runner._addDashBoardAdvertisementIfNeeded();
+                runner._addDashBoardAdvertisementIfNeeded();
                 await runner._messageBus.emit('done');
 
                 expect(consoleWrapper.messages.log).contains('Try TestCafe Dashboard (https://dashboard.testcafe.io/) to eliminate unstable and failing tests.');
@@ -259,7 +259,7 @@ describe('Runner', () => {
 
                 runner._hasTaskErrors = true;
                 runner.configuration.mergeOptions({ reporter: { name: 'spec' } });
-                await runner._addDashBoardAdvertisementIfNeeded();
+                runner._addDashBoardAdvertisementIfNeeded();
                 await runner._messageBus.emit('done');
 
                 expect(consoleWrapper.messages.log).contains('Try TestCafe Dashboard (https://dashboard.testcafe.io/) to eliminate unstable and failing tests.');
@@ -272,7 +272,7 @@ describe('Runner', () => {
 
                 runner._hasTaskErrors = true;
                 runner.configuration.mergeOptions({ reporter: [{ name: 'json' }, { name: 'dashboard' }] });
-                await runner._addDashBoardAdvertisementIfNeeded();
+                runner._addDashBoardAdvertisementIfNeeded();
                 await runner._messageBus.emit('done');
 
                 expect(consoleWrapper.messages.log).eql(null);
@@ -289,7 +289,7 @@ describe('Runner', () => {
                 });
 
                 await runner._addDashboardReporterIfNeeded();
-                await runner._addDashBoardAdvertisementIfNeeded();
+                runner._addDashBoardAdvertisementIfNeeded();
                 await runner._messageBus.emit('done');
 
                 expect(consoleWrapper.messages.log).eql(null);
@@ -302,7 +302,7 @@ describe('Runner', () => {
 
                 runner._hasTaskErrors = true;
                 runner.configuration.mergeOptions({ reporter: [{ name: 'spec' }, { name: 'json' }] });
-                await runner._addDashBoardAdvertisementIfNeeded();
+                runner._addDashBoardAdvertisementIfNeeded();
                 await runner._messageBus.emit('done');
 
                 expect(consoleWrapper.messages.log).eql(null);

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -242,9 +242,10 @@ describe('Runner', () => {
                 expect(runner.configuration.getOption('reporter')[0]).to.deep.equal({ name: 'dashboard', options: TEST_DASHBOARD_SETTINGS });
             });
 
-            it('Should add the dashboard advertisement if reporter is not added', async () => {
+            it('Should add the dashboard advertisement if error appeared and reporter is not set', async () => {
                 consoleWrapper.wrap();
 
+                runner._hasTaskErrors = true;
                 await runner._addDashBoardAdvertisementIfNeeded();
                 await runner._messageBus.emit('done');
 
@@ -256,6 +257,7 @@ describe('Runner', () => {
             it('Should add the dashboard advertisement if added only spec reporter', async () => {
                 consoleWrapper.wrap();
 
+                runner._hasTaskErrors = true;
                 runner.configuration.mergeOptions({ reporter: { name: 'spec' } });
                 await runner._addDashBoardAdvertisementIfNeeded();
                 await runner._messageBus.emit('done');
@@ -268,6 +270,7 @@ describe('Runner', () => {
             it('Should not add the dashboard advertisement if dashboard reporter is added', async () => {
                 consoleWrapper.wrap();
 
+                runner._hasTaskErrors = true;
                 runner.configuration.mergeOptions({ reporter: [{ name: 'json' }, { name: 'dashboard' }] });
                 await runner._addDashBoardAdvertisementIfNeeded();
                 await runner._messageBus.emit('done');
@@ -280,6 +283,7 @@ describe('Runner', () => {
             it('Should not add the dashboard advertisement if added reporter different from spec', async () => {
                 consoleWrapper.wrap();
 
+                runner._hasTaskErrors = true;
                 runner.configuration.mergeOptions({ reporter: [{ name: 'spec' }, { name: 'json' }] });
                 await runner._addDashBoardAdvertisementIfNeeded();
                 await runner._messageBus.emit('done');


### PR DESCRIPTION
## Purpose
Add new conditions for showing the advertisement:
 - [x] Tests failed
 - [x] `spec` is the only reporter
 - [x] Dashboard was not configured (do not show ads when Dashboard reports are manually switched off)

## Approach
1. Add new tests and refactor previous
2. Implement conditions from purpose before showing the advertisement.

## References
Closes https://github.com/DevExpress/testcafe-marketing/issues/392

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
