### PR TITLE
fix: send reports to dashboard by default

### DIFF
--- a/src/dashboard/config-storage.ts
+++ b/src/dashboard/config-storage.ts
@@ -9,7 +9,9 @@ export interface DashboardConfigOptions {
 
 const DEFAULT_DASHBOARD_OPTIONS: DashboardConfigOptions = {
     token:      '',
-    sendReport: false,
+
+    // NOTE: we should send reports to the dashboard until it is disabled explicitly
+    sendReport: true,
 };
 
 export default class DashboardConfigStorage {

--- a/src/dashboard/config-storage.ts
+++ b/src/dashboard/config-storage.ts
@@ -8,7 +8,7 @@ export interface DashboardConfigOptions {
 }
 
 const DEFAULT_DASHBOARD_OPTIONS: DashboardConfigOptions = {
-    token:      '',
+    token: '',
 
     // NOTE: we should send reports to the dashboard until it is disabled explicitly
     sendReport: true,

--- a/src/dashboard/config-storage.ts
+++ b/src/dashboard/config-storage.ts
@@ -1,5 +1,7 @@
 import { SafeStorage } from 'testcafe-safe-storage';
 
+
+// TODO: make this properties required
 export interface DashboardConfigOptions {
     token?: string;
     sendReport?: boolean;

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -525,7 +525,9 @@ export default class Runner extends EventEmitter {
         const dashboardOptions = await this._getDashboardOptions();
         let reporterOptions    = this.configuration.getOption(OPTION_NAMES.reporter);
 
-        if (!dashboardOptions.sendReport)
+        // NOTE: we should send reports when sendReport is undefined
+        // TODO: make this option binary instead of tri-state
+        if (dashboardOptions.sendReport === false)
             return;
 
         if (!reporterOptions)

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -527,7 +527,7 @@ export default class Runner extends EventEmitter {
 
         // NOTE: we should send reports when sendReport is undefined
         // TODO: make this option binary instead of tri-state
-        if (dashboardOptions.sendReport === false)
+        if (!dashboardOptions.token || dashboardOptions.sendReport === false)
             return;
 
         if (!reporterOptions)

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -243,7 +243,7 @@ describe('Runner', () => {
 
                 await runner._addDashboardReporterIfNeeded();
 
-                expect(runner.configuration.getOption('reporter')[0]).to.deep.equal({ name: 'dashboard', options: TEST_DASHBOARD_SETTINGS });
+                expect(runner.configuration.getOption('reporter')[0].name).to.deep.equal('dashboard');
             });
 
             it('Should not add the "dashboard" reporter if the "sendReport" option is false', async () => {
@@ -257,7 +257,7 @@ describe('Runner', () => {
 
                 await runner._addDashboardReporterIfNeeded();
 
-                expect(runner.configuration.getOption('reporter')[0]).to.be.undefined;
+                expect(runner.configuration.getOption('reporter')).to.be.undefined;
             });
 
             it("Should add the 'dashboard' reporter if its options are specified in configuration storage", async () => {

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -222,7 +222,7 @@ describe('Runner', () => {
                 sendReport: true,
             };
 
-            it("Should add the 'dashboard' reporter if its options are specified", async () => {
+            it('Should add the "dashboard" reporter if its options are specified', async () => {
                 runner.configuration.mergeOptions({
                     dashboard: TEST_DASHBOARD_SETTINGS,
                 });
@@ -230,6 +230,34 @@ describe('Runner', () => {
                 await runner._addDashboardReporterIfNeeded();
 
                 expect(runner.configuration.getOption('reporter')[0]).to.deep.equal({ name: 'dashboard', options: TEST_DASHBOARD_SETTINGS });
+            });
+
+            it('Should add the "dashboard" reporter if the "sendReport" option is undefined', async () => {
+                runner.configuration.mergeOptions({
+                    dashboard: {
+                        ...TEST_DASHBOARD_SETTINGS,
+
+                        sendReport: void 0
+                    },
+                });
+
+                await runner._addDashboardReporterIfNeeded();
+
+                expect(runner.configuration.getOption('reporter')[0]).to.deep.equal({ name: 'dashboard', options: TEST_DASHBOARD_SETTINGS });
+            });
+
+            it('Should not add the "dashboard" reporter if the "sendReport" option is false', async () => {
+                runner.configuration.mergeOptions({
+                    dashboard: { 
+                        ...TEST_DASHBOARD_SETTINGS,
+                        
+                        sendReport: false
+                    },
+                });
+
+                await runner._addDashboardReporterIfNeeded();
+
+                expect(runner.configuration.getOption('reporter')[0]).to.be.undefined;
             });
 
             it("Should add the 'dashboard' reporter if its options are specified in configuration storage", async () => {

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -237,7 +237,7 @@ describe('Runner', () => {
                     dashboard: {
                         ...TEST_DASHBOARD_SETTINGS,
 
-                        sendReport: void 0
+                        sendReport: void 0,
                     },
                 });
 
@@ -248,10 +248,10 @@ describe('Runner', () => {
 
             it('Should not add the "dashboard" reporter if the "sendReport" option is false', async () => {
                 runner.configuration.mergeOptions({
-                    dashboard: { 
+                    dashboard: {
                         ...TEST_DASHBOARD_SETTINGS,
-                        
-                        sendReport: false
+
+                        sendReport: false,
                     },
                 });
 


### PR DESCRIPTION
We should send reports to the dashboard when it is not disabled explicitly. This means we should not add the dashboard reporter only if `sendReport` is strictly equal to `false`.