### PR TITLE
Don't require unnecessary OS permissions on MacOS

### DIFF
--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -318,11 +318,12 @@ export default class Runner extends EventEmitter {
 
     async _validateBrowsers () {
         const browsers = this.configuration.getOption(OPTION_NAMES.browsers);
+        const disableScreenshots = this.configuration.getOption(OPTION_NAMES.disableScreenshots);
 
         if (!browsers || Array.isArray(browsers) && !browsers.length)
             throw new GeneralError(RUNTIME_ERRORS.browserNotSet);
 
-        if (OS.mac)
+        if (OS.mac && !disableScreenshots)
             await this._checkRequiredPermissions(browsers);
 
         if (OS.linux && !detectDisplay())


### PR DESCRIPTION
## Purpose
Makes it so that disabling screenshots doesn't trigger a permission request for screen recording on MacOS Monterey. This lets users who don't have access to changing permissions still use TestCafe when the permission is not necessary.

## Approach
Changes the validateBrowsers method to not request extra permissions when screenshots are disabled on MacOS

## References
Resolves #7019.


I'm sorry I couldn't update the tests but they don't seem to pass with or without my changes as noted in #7029. This also meant I couldn't really write test-cases.