### PR TITLE
feat: added permanent sending screenshots with errors to the dashboard reporter independent on users options

### DIFF
--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -8,6 +8,7 @@ interface ScreenshotOptionValue {
     pathPattern?: string;
     fullPage?: boolean;
     thumbnails?: boolean;
+    autoTakeOnFails?: boolean;
 }
 
 interface QuarantineOptionValue {

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -65,7 +65,7 @@ export default class Task extends AsyncEventEmitter {
 
         this.warningLog.copyFrom(runnerWarningLog);
 
-        const { path, pathPattern, fullPage, thumbnails } = this.opts.screenshots as ScreenshotOptionValue;
+        const { path, pathPattern, fullPage, thumbnails, autoTakeOnFails } = this.opts.screenshots as ScreenshotOptionValue;
 
         this.screenshots = new Screenshots({
             enabled: !this.opts.disableScreenshots,
@@ -74,6 +74,7 @@ export default class Task extends AsyncEventEmitter {
             fullPage,
             thumbnails,
             messageBus,
+            autoTakeOnFails,
         });
 
         this.fixtureHookController = new FixtureHookController(tests, browserConnectionGroups.length);

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -73,6 +73,7 @@ export default class Task extends AsyncEventEmitter {
             pathPattern,
             fullPage,
             thumbnails,
+            messageBus,
         });
 
         this.fixtureHookController = new FixtureHookController(tests, browserConnectionGroups.length);

--- a/src/screenshots/capturer.js
+++ b/src/screenshots/capturer.js
@@ -14,6 +14,7 @@ import {
     readFile,
     readPngFile,
     stat,
+    writeFile,
     writePng,
 } from '../utils/promisified-functions';
 
@@ -171,7 +172,7 @@ export default class Capturer {
                 return;
 
             await makeDir(dirname(screenshotPath));
-            await writePng(screenshotPath, croppedImage ? croppedImage : image);
+            await writeFile(screenshotPath, screenshotData);
 
             if (thumbnails)
                 await generateThumbnail(screenshotPath, thumbnailPath);

--- a/src/screenshots/capturer.js
+++ b/src/screenshots/capturer.js
@@ -11,17 +11,19 @@ import WARNING_MESSAGE from '../notifications/warning-message';
 import escapeUserAgent from '../utils/escape-user-agent';
 import correctFilePath from '../utils/correct-file-path';
 import {
+    readFile,
     readPngFile,
     stat,
     writePng,
 } from '../utils/promisified-functions';
 
 import DEFAULT_SCREENSHOT_EXTENSION from './default-extension';
+import makeDir from 'make-dir';
 
 
 export default class Capturer {
     // TODO: refactor to use dictionary
-    constructor (baseScreenshotsPath, testEntry, connection, pathPattern, fullPage, thumbnails, warningLog) {
+    constructor (baseScreenshotsPath, testEntry, connection, pathPattern, fullPage, thumbnails, warningLog, tempDirectoryPath, autoTakeOnFails) {
         this.enabled             = !!baseScreenshotsPath;
         this.baseScreenshotsPath = baseScreenshotsPath;
         this.testEntry           = testEntry;
@@ -31,6 +33,8 @@ export default class Capturer {
         this.pathPattern         = pathPattern;
         this.fullPage            = fullPage;
         this.thumbnails          = thumbnails;
+        this.tempDirectoryPath   = tempDirectoryPath;
+        this.autoTakeOnFails     = autoTakeOnFails;
     }
 
     static _getDimensionWithoutScrollbar (fullDimension, documentDimension, bodyDimension) {
@@ -126,6 +130,8 @@ export default class Capturer {
 
         const screenshotPath = customPath ? this._getCustomScreenshotPath(customPath) : this._getScreenshotPath(forError);
         const thumbnailPath  = this._getThumbnailPath(screenshotPath);
+        const tempPath       = screenshotPath.replace(this.baseScreenshotsPath, this.tempDirectoryPath);
+        let screenshotData;
 
         if (isInQueue(screenshotPath))
             this.warningLog.addWarning(WARNING_MESSAGE.screenshotRewritingError, screenshotPath);
@@ -136,7 +142,7 @@ export default class Capturer {
             const { width: pageWidth, height: pageHeight } = clientAreaDimensions || {};
 
             const takeScreenshotOptions = {
-                filePath: screenshotPath,
+                filePath: tempPath,
                 pageWidth,
                 pageHeight,
                 fullPage,
@@ -144,20 +150,28 @@ export default class Capturer {
 
             await this._takeScreenshot(takeScreenshotOptions);
 
-            if (!await Capturer._isScreenshotCaptured(screenshotPath))
+            if (!await Capturer._isScreenshotCaptured(tempPath))
                 return;
 
-            const image = await readPngFile(screenshotPath);
+            const image = await readPngFile(tempPath);
 
             const croppedImage = await cropScreenshot(image, {
                 markSeed,
                 clientAreaDimensions,
-                path:           screenshotPath,
+                path:           tempPath,
                 cropDimensions: Capturer._getCropDimensions(cropDimensions, pageDimensions),
             });
 
             if (croppedImage)
-                await writePng(screenshotPath, croppedImage);
+                await writePng(tempPath, croppedImage);
+
+            screenshotData = await readFile(tempPath);
+
+            if (forError && this.autoTakeOnFails)
+                return;
+
+            await makeDir(dirname(screenshotPath));
+            await writePng(screenshotPath, croppedImage ? croppedImage : image);
 
             if (thumbnails)
                 await generateThumbnail(screenshotPath, thumbnailPath);
@@ -171,6 +185,7 @@ export default class Capturer {
         const screenshot = {
             testRunId,
             screenshotPath,
+            screenshotData,
             thumbnailPath,
             userAgent,
             quarantineAttempt,

--- a/src/screenshots/index.js
+++ b/src/screenshots/index.js
@@ -4,9 +4,16 @@ import Capturer from './capturer';
 import PathPattern from '../utils/path-pattern';
 import getCommonPath from '../utils/get-common-path';
 import DEFAULT_SCREENSHOT_EXTENSION from './default-extension';
+import createSafeListener from '../utils/create-safe-listener';
+import debug from 'debug';
+import { EventEmitter } from 'events';
 
-export default class Screenshots {
-    constructor ({ enabled, path, pathPattern, fullPage, thumbnails }) {
+const DEBUG_LOGGER = debug('testcafe:screenshots');
+
+export default class Screenshots extends EventEmitter {
+    constructor ({ enabled, path, pathPattern, fullPage, thumbnails, messageBus }) {
+        super();
+
         this.enabled            = enabled;
         this.screenshotsPath    = path;
         this.screenshotsPattern = pathPattern;
@@ -14,6 +21,23 @@ export default class Screenshots {
         this.thumbnails         = thumbnails;
         this.testEntries        = [];
         this.now                = moment();
+
+        this._assignEventHandlers(messageBus);
+    }
+
+    _createSafeListener (listener) {
+        return createSafeListener(this, listener, DEBUG_LOGGER);
+    }
+
+    _assignEventHandlers (messageBus) {
+        messageBus.once('start', this._createSafeListener(this._onMessageBusStart));
+        messageBus.once('done', this._createSafeListener(this._onMessageBusDone));
+    }
+
+    async _onMessageBusStart () {
+    }
+
+    async _onMessageBusDone () {
     }
 
     _addTestEntry (test) {

--- a/src/utils/create-safe-listener.ts
+++ b/src/utils/create-safe-listener.ts
@@ -1,0 +1,17 @@
+import { Debugger } from 'debug';
+
+function createSafeListener (ctx: unknown, listener: Function, debugLogger: Debugger): Function {
+    return async (...args: []) => {
+        try {
+            return await listener.apply(ctx, args);
+        }
+        catch (error) {
+            if (error instanceof Error)
+                debugLogger(listener && listener.name, error);
+
+            return void 0;
+        }
+    };
+}
+
+export default createSafeListener;

--- a/src/video-recorder/recorder.js
+++ b/src/video-recorder/recorder.js
@@ -14,6 +14,7 @@ import {
 
 import TestRunVideoRecorder from './test-run-video-recorder';
 import { EventEmitter } from 'events';
+import createSafeListener from '../utils/create-safe-listener';
 
 const DEBUG_LOGGER = debug('testcafe:video-recorder');
 
@@ -45,16 +46,7 @@ export default class VideoRecorder extends EventEmitter {
     }
 
     _createSafeListener (listener) {
-        return async (...args) => {
-            try {
-                return await listener.apply(this, args);
-            }
-            catch (error) {
-                DEBUG_LOGGER(listener && listener.name, error);
-
-                return void 0;
-            }
-        };
+        return createSafeListener(this, listener, DEBUG_LOGGER);
     }
 
     _assignEventHandlers (browserJob) {

--- a/test/functional/fixtures/api/es-next/take-screenshot/test.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/test.js
@@ -21,6 +21,7 @@ const getReporter = function (scope) {
 
     function prepareScreenshot (screenshot, quarantine) {
         screenshot.screenshotPath  = patchScreenshotPath(screenshot.screenshotPath);
+        screenshot.screenshotData  = Buffer.isBuffer(screenshot.screenshotData);
         screenshot.thumbnailPath   = patchScreenshotPath(screenshot.thumbnailPath);
         screenshot.isPassedAttempt = quarantine[screenshot.quarantineAttempt].passed;
         screenshot.testRunId       = scope.testRunIds.includes(screenshot.testRunId);
@@ -245,6 +246,7 @@ describe('[API] t.takeScreenshot()', function () {
                         return {
                             testRunId:         true,
                             screenshotPath,
+                            screenshotData:    true,
                             thumbnailPath,
                             takenOnFail,
                             quarantineAttempt: attempt,

--- a/test/functional/fixtures/screenshots-on-fails/test.js
+++ b/test/functional/fixtures/screenshots-on-fails/test.js
@@ -155,7 +155,7 @@ describe('Screenshots on fails', function () {
 
                 expect(assertionHelper.isScreenshotDirExists()).eql(true);
                 expect(Buffer.isBuffer(testDoneScreenshots[0].screenshotData)).eql(true);
-                expect(testDoneScreenshots[0].screenshotData.length).eql(6611);
+                expect(testDoneScreenshots[0].screenshotData.length).greaterThan(1000);
             });
 
             it("Shouldn't save screenshot data to the directory", async () => {
@@ -171,7 +171,7 @@ describe('Screenshots on fails', function () {
 
                 expect(assertionHelper.isScreenshotDirExists()).eql(false);
                 expect(Buffer.isBuffer(testDoneScreenshots[0].screenshotData)).eql(true);
-                expect(testDoneScreenshots[0].screenshotData.length).eql(6611);
+                expect(testDoneScreenshots[0].screenshotData.length).greaterThan(1000);
                 delete testCafe.configuration._options.screenshots;
             });
         });

--- a/test/functional/fixtures/screenshots-on-fails/test.js
+++ b/test/functional/fixtures/screenshots-on-fails/test.js
@@ -1,6 +1,8 @@
-const expect          = require('chai').expect;
-const config          = require('../../config.js');
-const assertionHelper = require('../../assertion-helper.js');
+const expect             = require('chai').expect;
+const config             = require('../../config.js');
+const assertionHelper    = require('../../assertion-helper.js');
+const { isBuffer }       = require('lodash');
+const { createReporter } = require('../../utils/reporter');
 
 const SCREENSHOT_PATH_MESSAGE_TEXT       = 'Screenshot: ___test-screenshots___';
 const REPORT_SCREENSHOT_PATH_TEXT_RE     = /___test-screenshots___[\\/]\d{4,4}-\d{2,2}-\d{2,2}_\d{2,2}-\d{2,2}-\d{2,2}[\\/]test-1/;
@@ -127,6 +129,52 @@ describe('Screenshots on fails', function () {
                         'or set the "disableScreenshots" option to "false" in the API or configuration file.',
                     ]);
                 });
+        });
+
+        describe('Send screenshot data to the method reportTestDone every time', () => {
+            let testDoneScreenshots;
+
+            const customReporter = createReporter({
+                reportTestDone: (name, testRunInfo) => {
+                    testDoneScreenshots = testRunInfo.screenshots;
+                },
+            });
+
+            beforeEach(() => {
+                testDoneScreenshots = null;
+            });
+
+            it('Should save screenshot data to the property screenshotData', async () => {
+                await runTests('testcafe-fixtures/screenshots-on-fails.js', 'Screenshot on the ensureElement method fail', {
+                    only:               'chrome',
+                    shouldFail:         true,
+                    screenshotsOnFails: true,
+                    setScreenshotPath:  true,
+                    selectorTimeout:    0,
+                    reporter:           customReporter,
+                });
+
+                expect(assertionHelper.isScreenshotDirExists()).eql(true);
+                expect(isBuffer(testDoneScreenshots[0].screenshotData)).eql(true);
+                expect(testDoneScreenshots[0].screenshotData.length).eql(6611);
+            });
+
+            it("Shouldn't save screenshot data to the directory", async () => {
+                testCafe.configuration.mergeOptions({ screenshots: { autoTakeOnFails: true } });
+                await runTests('testcafe-fixtures/screenshots-on-fails.js', 'Screenshot on the ensureElement method fail', {
+                    only:               'chrome',
+                    shouldFail:         true,
+                    screenshotsOnFails: true,
+                    setScreenshotPath:  true,
+                    selectorTimeout:    0,
+                    reporter:           customReporter,
+                });
+
+                expect(assertionHelper.isScreenshotDirExists()).eql(false);
+                expect(isBuffer(testDoneScreenshots[0].screenshotData)).eql(true);
+                expect(testDoneScreenshots[0].screenshotData.length).eql(6611);
+                delete testCafe.configuration._options.screenshots;
+            });
         });
 
         it('Should crop screenshots to a page viewport area', function () {

--- a/test/functional/fixtures/screenshots-on-fails/test.js
+++ b/test/functional/fixtures/screenshots-on-fails/test.js
@@ -1,7 +1,6 @@
 const expect             = require('chai').expect;
 const config             = require('../../config.js');
 const assertionHelper    = require('../../assertion-helper.js');
-const { isBuffer }       = require('lodash');
 const { createReporter } = require('../../utils/reporter');
 
 const SCREENSHOT_PATH_MESSAGE_TEXT       = 'Screenshot: ___test-screenshots___';
@@ -155,7 +154,7 @@ describe('Screenshots on fails', function () {
                 });
 
                 expect(assertionHelper.isScreenshotDirExists()).eql(true);
-                expect(isBuffer(testDoneScreenshots[0].screenshotData)).eql(true);
+                expect(Buffer.isBuffer(testDoneScreenshots[0].screenshotData)).eql(true);
                 expect(testDoneScreenshots[0].screenshotData.length).eql(6611);
             });
 
@@ -171,7 +170,7 @@ describe('Screenshots on fails', function () {
                 });
 
                 expect(assertionHelper.isScreenshotDirExists()).eql(false);
-                expect(isBuffer(testDoneScreenshots[0].screenshotData)).eql(true);
+                expect(Buffer.isBuffer(testDoneScreenshots[0].screenshotData)).eql(true);
                 expect(testDoneScreenshots[0].screenshotData.length).eql(6611);
                 delete testCafe.configuration._options.screenshots;
             });

--- a/test/server/capturer-test.js
+++ b/test/server/capturer-test.js
@@ -23,6 +23,8 @@ class ScreenshotsMock extends Screenshots {
         super(options);
     }
 
+    _assignEventHandlers () {}
+
     createCapturerFor (test, testIndex, quarantine, connection, warningLog) {
         this.capturer = super.createCapturerFor(test, testIndex, quarantine, connection, warningLog);
 
@@ -98,6 +100,7 @@ describe('Capturer', () => {
         expect(screenshots.capturer.testEntry.screenshots[0]).eql({
             testRunId:         'test-run-id',
             screenshotPath:    join(process.cwd(), 'screenshot.png'),
+            screenshotData:    void 0,
             thumbnailPath:     join(process.cwd(), 'thumbnails', 'screenshot.png'),
             userAgent:         'user-agent',
             quarantineAttempt: 1,

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -351,6 +351,7 @@ describe('Runner', () => {
             expect(runner._getScreenshotOptions()).eql({
                 path:        'path1',
                 pathPattern: 'pattern1',
+                takeOnFails: false,
             });
         });
 
@@ -366,6 +367,7 @@ describe('Runner', () => {
             expect(runner._getScreenshotOptions()).eql({
                 path:        'path2',
                 pathPattern: 'pattern2',
+                takeOnFails: false,
             });
         });
 

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -215,6 +215,25 @@ describe('Runner', () => {
                 expect(e.message).eql("Specify a file name or a writable stream as the reporter's output target.");
             }
         });
+
+        describe('Dashboard', () => {
+            const TEST_DASHBOARD_SETTINGS = {
+                token:      'test-token',
+                sendReport: true,
+            };
+
+            it('Should turn on screenshots flags autoTakeOnFails and takeOnFails', async () => {
+                runner._loadDashboardOptionsFromStorage = () => {
+                    return TEST_DASHBOARD_SETTINGS;
+                };
+
+                await runner._addDashboardReporterIfNeeded();
+                await runner._turnOnScreenshotsIfNeeded();
+
+                expect(runner.configuration.getOption('screenshots').autoTakeOnFails).to.equal(true);
+                expect(runner.configuration.getOption('screenshots').takeOnFails).to.equal(true);
+            });
+        });
     });
 
     describe('.screenshots()', () => {


### PR DESCRIPTION
[closes DevExpress/testcafe-marketing#401]

## Purpose
To send screenshots with errors to the dashboard reporter every time.

## Approach
1. Add test
2. Save screenshots to the temp directory
3. Reed screenshots from the temp directory
4. Send buffer with data to the method reporterTestDone
5. Save screenshots to the `screenshotPath` if the options `takeOnFails` was turned on

## References
https://github.com/DevExpress/testcafe-marketing/issues/401

https://github.com/DevExpress/testcafe-reporter-dashboard/pull/90

## Pre-Merge TODO
- [X] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
