### PR TITLE
release: fixed after hooks order for test

### DIFF
--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -627,17 +627,14 @@ export default class TestRun extends AsyncEventEmitter {
         return true;
     }
 
-    private async _runAfterHook (): Promise<boolean> {
+    private async _runAfterHook (): Promise<void> {
         if (this.test.afterFn)
             await this._executeTestFn(TestRunPhase.inTestAfterHook, this.test.afterFn, this.executionTimeout);
+        else if (this.test.fixture?.afterEachFn)
+            await this._executeTestFn(TestRunPhase.inFixtureAfterEachHook, this.test.fixture?.afterEachFn, this.executionTimeout);
 
         if (this.test.globalAfterFn)
-            return await this._executeTestFn(TestRunPhase.inTestAfterHook, this.test.globalAfterFn, this.executionTimeout);
-
-        if (this.test.fixture?.afterEachFn)
-            return await this._executeTestFn(TestRunPhase.inFixtureAfterEachHook, this.test.fixture?.afterEachFn, this.executionTimeout);
-
-        return true;
+            await this._executeTestFn(TestRunPhase.inTestAfterHook, this.test.globalAfterFn, this.executionTimeout);
     }
 
     private async _finalizeTestRun (id: string): Promise<void> {

--- a/test/functional/fixtures/api/es-next/global-hooks/test.js
+++ b/test/functional/fixtures/api/es-next/global-hooks/test.js
@@ -180,8 +180,44 @@ if (isLocalChrome) {
                 flowInfoStorage.delete();
             });
 
-            it('Completed', async () => {
-                await runTestsLocal();
+            it('Test with local hooks', async () => {
+                await runTestsLocal('Test with local hooks');
+
+                expect(flowInfoStorage.getData()).eql([
+                    'globalTestRunBefore',
+                    'globalFixtureBefore',
+                    'localFixtureBefore',
+                    'globalTestBefore',
+                    'localTestBefore',
+                    'test body',
+                    'localTestAfter',
+                    'globalTestAfter',
+                    'localFixtureAfter',
+                    'globalFixtureAfter',
+                    'globalTestRunAfter',
+                ]);
+            });
+
+            it('Test with each hooks', async () => {
+                await runTestsLocal('Test with each hooks');
+
+                expect(flowInfoStorage.getData()).eql([
+                    'globalTestRunBefore',
+                    'globalFixtureBefore',
+                    'localFixtureBefore',
+                    'globalTestBefore',
+                    'eachTestBefore',
+                    'test body',
+                    'eachTestAfter',
+                    'globalTestAfter',
+                    'localFixtureAfter',
+                    'globalFixtureAfter',
+                    'globalTestRunAfter',
+                ]);
+            });
+
+            it('Test with all hooks', async () => {
+                await runTestsLocal('Test with all hooks');
 
                 expect(flowInfoStorage.getData()).eql([
                     'globalTestRunBefore',

--- a/test/functional/fixtures/api/es-next/global-hooks/testcafe-fixtures/flow-info-test.js
+++ b/test/functional/fixtures/api/es-next/global-hooks/testcafe-fixtures/flow-info-test.js
@@ -15,6 +15,49 @@ test
     .after(async function () {
         flowInfoStorage.safeAdd('localTestAfter');
     })
-    ('Test', async () => {
+    ('Test with local hooks', async () => {
+        flowInfoStorage.safeAdd('test body');
+    });
+
+fixture ('Fixture')
+    .before(async function () {
+        flowInfoStorage.safeAdd('localFixtureBefore');
+    })
+    .after(async function () {
+        flowInfoStorage.safeAdd('localFixtureAfter');
+    })
+    .beforeEach(async function () {
+        flowInfoStorage.safeAdd('eachTestBefore');
+    })
+    .afterEach(async function () {
+        flowInfoStorage.safeAdd('eachTestAfter');
+    });
+
+test('Test with each hooks', async () => {
+    flowInfoStorage.safeAdd('test body');
+});
+
+fixture ('Fixture')
+    .before(async function () {
+        flowInfoStorage.safeAdd('localFixtureBefore');
+    })
+    .after(async function () {
+        flowInfoStorage.safeAdd('localFixtureAfter');
+    })
+    .beforeEach(async function () {
+        flowInfoStorage.safeAdd('eachTestBefore');
+    })
+    .afterEach(async function () {
+        flowInfoStorage.safeAdd('eachTestAfter');
+    });
+
+test
+    .before(async function () {
+        flowInfoStorage.safeAdd('localTestBefore');
+    })
+    .after(async function () {
+        flowInfoStorage.safeAdd('localTestAfter');
+    })
+    ('Test with all hooks', async () => {
         flowInfoStorage.safeAdd('test body');
     });

--- a/test/functional/fixtures/api/es-next/hooks/test.js
+++ b/test/functional/fixtures/api/es-next/hooks/test.js
@@ -72,7 +72,7 @@ describe('[API] t.ctx', () => {
                 const browsers = [];
 
                 Object.keys(errs).forEach(browser => {
-                    const dataJson = errs[browser][1].match(/###(.+)###/)[1];
+                    const dataJson = errs[browser][0].match(/###(.+)###/)[1];
                     const data     = JSON.parse(dataJson);
 
                     // NOTE: check context assignment


### PR DESCRIPTION
[closes DevExpress/testcafe#7049]

## Purpose
Fix order of the after hooks for tests. The order should be as follows:
1. If `test.after` exists run it
2. Else if `fixture.afterEach` exists run it
3. Run `global.test.after`  in any case

## Approach
1. Add tests
2. Change order of the hooks

## References
https://github.com/DevExpress/testcafe/issues/7049

## Pre-Merge TODO
- [X] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
