### PR TITLE
fix: fixed merging dashboard options

### DIFF
--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -10,6 +10,7 @@ import {
     isFunction,
     uniq,
     castArray,
+    merge,
 } from 'lodash';
 
 import Bootstrapper from './bootstrapper';
@@ -543,14 +544,11 @@ export default class Runner extends EventEmitter {
     }
 
     async _getDashboardOptions () {
-        let options = this.configuration.getOption(OPTION_NAMES.dashboard);
+        const storageOptions = await this._loadDashboardOptionsFromStorage();
+        const configOptions  = this.configuration.getOption(OPTION_NAMES.dashboard);
+        const envOptions     = getEnvOptions();
 
-        if (!options)
-            options = await this._loadDashboardOptionsFromStorage();
-
-        this._mergeEnvDashboardOptions(options);
-
-        return options;
+        return merge({}, storageOptions, configOptions, envOptions);
     }
 
     async _loadDashboardOptionsFromStorage () {
@@ -559,15 +557,6 @@ export default class Runner extends EventEmitter {
         await storage.load();
 
         return storage.options;
-    }
-
-    _mergeEnvDashboardOptions (options) {
-        const envDashboardOptions = getEnvOptions();
-
-        for (const key in envDashboardOptions) {
-            if (envDashboardOptions[key])
-                options[key] = envDashboardOptions[key];
-        }
     }
 
     async _prepareClientScripts (tests, clientScripts) {


### PR DESCRIPTION
[closes DevExpress/testcafe#7090]

## Purpose
Made merging dashboard options in the correct priority

## Approach
1. Added tests
2. Get storage options
3. Get config options
4. Get environment options
5. Merge options in the following order: storage options -> config options -> environment options

## References
https://github.com/DevExpress/testcafe/issues/7090

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
