### PR TITLE
fix: fixed start test before task starting finishes

### DIFF
--- a/src/runner/browser-job.ts
+++ b/src/runner/browser-job.ts
@@ -20,10 +20,10 @@ interface BrowserJobResultInfo {
     data?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
-enum StartStatus { none, starting, started }
+enum BrowserJobStatus { initialized, starting, started }
 
 export default class BrowserJob extends AsyncEventEmitter {
-    private _startStatus: StartStatus;
+    private _status: BrowserJobStatus;
     private _startTime: Date;
     private _total: number;
     private _passed: number;
@@ -55,7 +55,7 @@ export default class BrowserJob extends AsyncEventEmitter {
     }: BrowserJobInit) {
         super();
 
-        this._startStatus = StartStatus.none;
+        this._status = BrowserJobStatus.initialized;
         this._startTime = new Date();
 
         this._total                = 0;
@@ -174,7 +174,7 @@ export default class BrowserJob extends AsyncEventEmitter {
     private async _isNextTestRunAvailable (testRunController: TestRunController): Promise<boolean> {
         // NOTE: event task start is currently executing,
         // so test run is temporary blocked
-        if (this._startStatus === StartStatus.starting)
+        if (this._status === BrowserJobStatus.starting)
             return false;
 
         // NOTE: before hook for test run fixture is currently
@@ -220,13 +220,13 @@ export default class BrowserJob extends AsyncEventEmitter {
             this._testRunControllerQueue.shift();
             this._addToCompletionQueue(testRunController);
 
-            if (this._startStatus === StartStatus.none) {
-                this._startStatus = StartStatus.starting;
+            if (this._status === BrowserJobStatus.initialized) {
+                this._status = BrowserJobStatus.starting;
                 this._startTime   = new Date();
 
                 await this.emit('start', this._startTime);
 
-                this._startStatus = StartStatus.started;
+                this._status = BrowserJobStatus.started;
             }
 
             const testRunUrl = await testRunController.start(connection, this._startTime);

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -77,6 +77,17 @@ if (config.useLocalBrowsers) {
             },
         });
 
+        const slowReporter = createReporter({
+            reportTaskStart: async function () {
+                await new Promise(resolve => setTimeout(() => resolve(), 100));
+                this.write('Task start').newline();
+            },
+
+            reportTestStart: async function () {
+                this.write('Test start').newline();
+            },
+        });
+
         beforeEach(function () {
             data = '';
         });
@@ -133,6 +144,19 @@ if (config.useLocalBrowsers) {
                         'Test Long test done',
                         'Fixture Multifixture B started',
                         'Test Short test done',
+                        '',
+                    ]);
+                });
+        });
+
+        it('Should not start any test before report task start finishes', function () {
+            return run('chrome:headless --no-sandbox', 2, './testcafe-fixtures/concurrent-test.js', slowReporter)
+                .then(failedCount => {
+                    expect(failedCount).eql(0);
+                    expect(data.split('\n')).eql([
+                        'Task start',
+                        'Test start',
+                        'Test start',
                         '',
                     ]);
                 });


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR so that you can mark it as 'ready for review' when you are done.
-->
[closes DevExpress/testcafe#7062]

## Purpose
Don't run tests until a task starts running.

## Approach
1. Add test
2. Add waiting until a task starts running 

## References
https://github.com/DevExpress/testcafe/issues/7062

## Pre-Merge TODO
- [X] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
