### PR TITLE
fix: prevented waiting element in the second time if an error was raised in the first 

### DIFF
--- a/src/client-functions/selectors/selector-builder.js
+++ b/src/client-functions/selectors/selector-builder.js
@@ -156,7 +156,7 @@ export default class SelectorBuilder extends ClientFunctionBuilder {
             apiFnChain:                this.options.apiFnChain,
             visibilityCheck:           !!this.options.visibilityCheck,
             timeout:                   this.options.timeout,
-            separatedErrors:           this.options.separatedErrors,
+            strictError:               this.options.strictError,
         });
     }
 

--- a/src/client-functions/selectors/selector-builder.js
+++ b/src/client-functions/selectors/selector-builder.js
@@ -156,6 +156,7 @@ export default class SelectorBuilder extends ClientFunctionBuilder {
             apiFnChain:                this.options.apiFnChain,
             visibilityCheck:           !!this.options.visibilityCheck,
             timeout:                   this.options.timeout,
+            separatedErrors:           this.options.separatedErrors,
         });
     }
 

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -112,9 +112,9 @@ import SelectorExecutor from './command-executors/client-functions/selector-exec
 import SelectorElementActionTransform from './command-executors/client-functions/replicator/transforms/selector-element-action-transform';
 import BarriersComplex from '../../shared/barriers/complex-barrier';
 import createErrorCtorCallback, {
-    createCannotObtainInfoErrorCtor,
-    createInvisibleErrorCtor,
-    createNotFoundErrorCtor,
+    getCannotObtainInfoErrorCtor,
+    getInvisibleErrorCtor,
+    getNotFoundErrorCtor,
 } from '../../shared/errors/selector-error-ctor-callback';
 import './command-executors/actions-initializer';
 
@@ -1210,9 +1210,9 @@ export default class Driver extends serviceUtils.EventEmitter {
 
     _onExecuteSelectorCommand (command) {
         const startTime                   = this.contextStorage.getItem(SELECTOR_EXECUTION_START_TIME) || new DateCtor();
-        const elementNotFoundOrNotVisible = createErrorCtorCallback(createCannotObtainInfoErrorCtor());
-        const elementNotFound             = command.separatedErrors ? createErrorCtorCallback(createNotFoundErrorCtor()) : elementNotFoundOrNotVisible;
-        const elementIsInvisible          = command.separatedErrors ? createErrorCtorCallback(createInvisibleErrorCtor()) : elementNotFoundOrNotVisible;
+        const elementNotFoundOrNotVisible = createErrorCtorCallback(getCannotObtainInfoErrorCtor());
+        const elementNotFound             = command.strictError ? createErrorCtorCallback(getNotFoundErrorCtor()) : elementNotFoundOrNotVisible;
+        const elementIsInvisible          = command.strictError ? createErrorCtorCallback(getInvisibleErrorCtor()) : elementNotFoundOrNotVisible;
 
         getExecuteSelectorResultDriverStatus(command,
             this.selectorTimeout,

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -50,7 +50,6 @@ import {
     CurrentIframeIsNotLoadedError,
     CurrentIframeNotFoundError,
     CurrentIframeIsInvisibleError,
-    CannotObtainInfoForElementSpecifiedBySelectorError,
     UncaughtErrorInCustomClientScriptCode,
     UncaughtErrorInCustomClientScriptLoadedFromModule,
     ChildWindowIsNotLoadedError,
@@ -112,7 +111,11 @@ import getExecutorResultDriverStatus from './command-executors/get-executor-resu
 import SelectorExecutor from './command-executors/client-functions/selector-executor';
 import SelectorElementActionTransform from './command-executors/client-functions/replicator/transforms/selector-element-action-transform';
 import BarriersComplex from '../../shared/barriers/complex-barrier';
-import createErrorCtorCallback from '../../shared/errors/selector-error-ctor-callback';
+import createErrorCtorCallback, {
+    createCannotObtainInfoErrorCtor,
+    createInvisibleErrorCtor,
+    createNotFoundErrorCtor,
+} from '../../shared/errors/selector-error-ctor-callback';
 import './command-executors/actions-initializer';
 
 const settings = hammerhead.settings;
@@ -1207,14 +1210,15 @@ export default class Driver extends serviceUtils.EventEmitter {
 
     _onExecuteSelectorCommand (command) {
         const startTime                   = this.contextStorage.getItem(SELECTOR_EXECUTION_START_TIME) || new DateCtor();
-        const elementNotFoundOrNotVisible = fn => new CannotObtainInfoForElementSpecifiedBySelectorError(null, fn);
-        const createError                 = command.needError ? elementNotFoundOrNotVisible : null;
+        const elementNotFoundOrNotVisible = createErrorCtorCallback(createCannotObtainInfoErrorCtor());
+        const elementNotFound             = command.separatedErrors ? createErrorCtorCallback(createNotFoundErrorCtor()) : elementNotFoundOrNotVisible;
+        const elementIsInvisible          = command.separatedErrors ? createErrorCtorCallback(createInvisibleErrorCtor()) : elementNotFoundOrNotVisible;
 
         getExecuteSelectorResultDriverStatus(command,
             this.selectorTimeout,
             startTime,
-            createError,
-            createError,
+            command.needError ? elementNotFound : null,
+            command.needError ? elementIsInvisible : null,
             this.statusBar)
             .then(driverStatus => {
                 this.contextStorage.setItem(SELECTOR_EXECUTION_START_TIME, null);

--- a/src/shared/errors/selector-error-ctor-callback.ts
+++ b/src/shared/errors/selector-error-ctor-callback.ts
@@ -2,6 +2,23 @@ import { AutomationErrorCtor } from '../types';
 import { FnInfo, SelectorErrorCb } from '../../client/driver/command-executors/client-functions/types';
 import * as Errors from './index';
 
+export function createInvisibleErrorCtor (elementName?: string): AutomationErrorCtor | string {
+    return !elementName ? 'ActionElementIsInvisibleError' : {
+        name:     'ActionAdditionalElementIsInvisibleError',
+        firstArg: elementName,
+    };
+}
+
+export function createNotFoundErrorCtor (elementName?: string): AutomationErrorCtor | string {
+    return !elementName ? 'ActionElementNotFoundError' : {
+        name:     'ActionAdditionalElementNotFoundError',
+        firstArg: elementName,
+    };
+}
+
+export function createCannotObtainInfoErrorCtor (): AutomationErrorCtor | string {
+    return 'CannotObtainInfoForElementSpecifiedBySelectorError';
+}
 
 export default function createErrorCtorCallback (errCtor: AutomationErrorCtor | string): SelectorErrorCb {
     // @ts-ignore

--- a/src/shared/errors/selector-error-ctor-callback.ts
+++ b/src/shared/errors/selector-error-ctor-callback.ts
@@ -2,21 +2,21 @@ import { AutomationErrorCtor } from '../types';
 import { FnInfo, SelectorErrorCb } from '../../client/driver/command-executors/client-functions/types';
 import * as Errors from './index';
 
-export function createInvisibleErrorCtor (elementName?: string): AutomationErrorCtor | string {
+export function getInvisibleErrorCtor (elementName?: string): AutomationErrorCtor | string {
     return !elementName ? 'ActionElementIsInvisibleError' : {
         name:     'ActionAdditionalElementIsInvisibleError',
         firstArg: elementName,
     };
 }
 
-export function createNotFoundErrorCtor (elementName?: string): AutomationErrorCtor | string {
+export function getNotFoundErrorCtor (elementName?: string): AutomationErrorCtor | string {
     return !elementName ? 'ActionElementNotFoundError' : {
         name:     'ActionAdditionalElementNotFoundError',
         firstArg: elementName,
     };
 }
 
-export function createCannotObtainInfoErrorCtor (): AutomationErrorCtor | string {
+export function getCannotObtainInfoErrorCtor (): AutomationErrorCtor | string {
     return 'CannotObtainInfoForElementSpecifiedBySelectorError';
 }
 

--- a/src/shared/utils/elements-retriever.ts
+++ b/src/shared/utils/elements-retriever.ts
@@ -6,7 +6,7 @@ import {
     ActionSelectorMatchesWrongNodeTypeError,
     ActionAdditionalSelectorMatchesWrongNodeTypeError,
 } from '../../shared/errors';
-import { createInvisibleErrorCtor, createNotFoundErrorCtor } from '../errors/selector-error-ctor-callback';
+import { getInvisibleErrorCtor, getNotFoundErrorCtor } from '../errors/selector-error-ctor-callback';
 
 
 export default class ElementsRetriever<T> {
@@ -28,8 +28,8 @@ export default class ElementsRetriever<T> {
         this._ensureElementsPromise = this._ensureElementsPromise
             .then(() => {
                 return this._executeSelectorFn(selector, {
-                    invisible: createInvisibleErrorCtor(elementName),
-                    notFound:  createNotFoundErrorCtor(elementName),
+                    invisible: getInvisibleErrorCtor(elementName),
+                    notFound:  getNotFoundErrorCtor(elementName),
                 }, this._ensureElementsStartTime);
             })
             .then(el => {

--- a/src/shared/utils/elements-retriever.ts
+++ b/src/shared/utils/elements-retriever.ts
@@ -6,6 +6,7 @@ import {
     ActionSelectorMatchesWrongNodeTypeError,
     ActionAdditionalSelectorMatchesWrongNodeTypeError,
 } from '../../shared/errors';
+import { createInvisibleErrorCtor, createNotFoundErrorCtor } from '../errors/selector-error-ctor-callback';
 
 
 export default class ElementsRetriever<T> {
@@ -27,14 +28,8 @@ export default class ElementsRetriever<T> {
         this._ensureElementsPromise = this._ensureElementsPromise
             .then(() => {
                 return this._executeSelectorFn(selector, {
-                    invisible: !elementName ? 'ActionElementIsInvisibleError' : {
-                        name:     'ActionAdditionalElementIsInvisibleError',
-                        firstArg: elementName,
-                    },
-                    notFound: !elementName ? 'ActionElementNotFoundError' : {
-                        name:     'ActionAdditionalElementNotFoundError',
-                        firstArg: elementName,
-                    },
+                    invisible: createInvisibleErrorCtor(elementName),
+                    notFound:  createNotFoundErrorCtor(elementName),
                 }, this._ensureElementsStartTime);
             })
             .then(el => {

--- a/src/test-run/commands/actions.js
+++ b/src/test-run/commands/actions.js
@@ -14,7 +14,11 @@ import {
     CookieOptions,
 } from './options';
 
-import { initSelector, initUploadSelector } from './validations/initializers';
+import {
+    initSelector,
+    initTypeSelector,
+    initUploadSelector,
+} from './validations/initializers';
 import { executeJsExpression } from '../execute-js-expression';
 import { isJSExpression } from './utils';
 
@@ -217,7 +221,7 @@ export class TypeTextCommand extends ActionCommandBase {
 
     _getAssignableProperties () {
         return [
-            { name: 'selector', init: initSelector, required: true },
+            { name: 'selector', init: initTypeSelector, required: true },
             { name: 'text', type: nonEmptyStringArgument, required: true },
             { name: 'options', type: actionOptions, init: initTypeOptions, required: true },
         ];

--- a/src/test-run/commands/observation.d.ts
+++ b/src/test-run/commands/observation.d.ts
@@ -21,6 +21,7 @@ export class ExecuteSelectorCommand extends ExecuteClientFunctionCommandBase {
     public apiFnChain: string[];
     public needError: boolean;
     public index: number;
+    public separatedErrors: boolean;
 }
 
 export class WaitCommand extends ActionCommandBase {

--- a/src/test-run/commands/observation.d.ts
+++ b/src/test-run/commands/observation.d.ts
@@ -21,7 +21,7 @@ export class ExecuteSelectorCommand extends ExecuteClientFunctionCommandBase {
     public apiFnChain: string[];
     public needError: boolean;
     public index: number;
-    public separatedErrors: boolean;
+    public strictError: boolean;
 }
 
 export class WaitCommand extends ActionCommandBase {

--- a/src/test-run/commands/observation.js
+++ b/src/test-run/commands/observation.js
@@ -56,7 +56,7 @@ export class ExecuteSelectorCommand extends ExecuteClientFunctionCommandBase {
             { name: 'apiFnChain' },
             { name: 'needError' },
             { name: 'index', defaultValue: 0 },
-            { name: 'separatedErrors' },
+            { name: 'strictError' },
         ]);
     }
 }

--- a/src/test-run/commands/observation.js
+++ b/src/test-run/commands/observation.js
@@ -56,6 +56,7 @@ export class ExecuteSelectorCommand extends ExecuteClientFunctionCommandBase {
             { name: 'apiFnChain' },
             { name: 'needError' },
             { name: 'index', defaultValue: 0 },
+            { name: 'separatedErrors' },
         ]);
     }
 }

--- a/src/test-run/commands/validations/initializers.js
+++ b/src/test-run/commands/validations/initializers.js
@@ -11,6 +11,13 @@ export function initUploadSelector (name, val, initOptions) {
     return initSelector(name, val, initOptions);
 }
 
+export function initTypeSelector (name, val, initOptions) {
+    initOptions.needError       = true;
+    initOptions.separatedErrors = true;
+
+    return initSelector(name, val, initOptions);
+}
+
 export function initSelector (name, val, { testRun, ...options }) {
     if (val instanceof ExecuteSelectorCommand)
         return val;

--- a/src/test-run/commands/validations/initializers.js
+++ b/src/test-run/commands/validations/initializers.js
@@ -12,8 +12,8 @@ export function initUploadSelector (name, val, initOptions) {
 }
 
 export function initTypeSelector (name, val, initOptions) {
-    initOptions.needError       = true;
-    initOptions.separatedErrors = true;
+    initOptions.needError   = true;
+    initOptions.strictError = true;
 
     return initSelector(name, val, initOptions);
 }

--- a/test/functional/fixtures/api/es-next/type/test.js
+++ b/test/functional/fixtures/api/es-next/type/test.js
@@ -43,4 +43,18 @@ describe('[API] t.typeText()', function () {
                 expect(errs[0]).to.contains('> 19 |    await t.typeText(NaN, \'a\');');
             });
     });
+
+    it('Should not get selector the second time if the error was raised in the first.', function () {
+        return runTests('./testcafe-fixtures/type-test.js', 'Not found selector', {
+            shouldFail: true,
+            only:       'chrome',
+        })
+            .catch(function (errs) {
+                expect(testReport.durationMs).lessThan(1100);
+                expect(errs[0]).to.contains(
+                    'The specified selector does not match any element in the DOM tree.'
+                );
+                expect(errs[0]).to.contains('> 31 |    await t.typeText(\'#not-found\', \'a\');');
+            });
+    });
 });

--- a/test/functional/fixtures/api/es-next/type/test.js
+++ b/test/functional/fixtures/api/es-next/type/test.js
@@ -1,3 +1,4 @@
+const config = require('../../../../config');
 const expect = require('chai').expect;
 
 // NOTE: we run tests in chrome only, because we mainly test server API functionality.
@@ -44,17 +45,19 @@ describe('[API] t.typeText()', function () {
             });
     });
 
-    it('Should not get selector the second time if the error was raised in the first.', function () {
-        return runTests('./testcafe-fixtures/type-test.js', 'Not found selector', {
-            shouldFail: true,
-            only:       'chrome',
-        })
-            .catch(function (errs) {
-                expect(testReport.durationMs).lessThan(1100);
-                expect(errs[0]).to.contains(
-                    'The specified selector does not match any element in the DOM tree.'
-                );
-                expect(errs[0]).to.contains('> 31 |    await t.typeText(\'#not-found\', \'a\');');
-            });
-    });
+    if (!config.proxyless) {
+        it('Should not get selector the second time if the error was raised in the first.', function () {
+            return runTests('./testcafe-fixtures/type-test.js', 'Not found selector', {
+                shouldFail: true,
+                only:       'chrome',
+            })
+                .catch(function (errs) {
+                    expect(testReport.durationMs).lessThan(1100);
+                    expect(errs[0]).to.contains(
+                        'The specified selector does not match any element in the DOM tree.'
+                    );
+                    expect(errs[0]).to.contains('> 31 |    await t.typeText(\'#not-found\', \'a\');');
+                });
+        });
+    }
 });

--- a/test/functional/fixtures/api/es-next/type/test.js
+++ b/test/functional/fixtures/api/es-next/type/test.js
@@ -46,13 +46,14 @@ describe('[API] t.typeText()', function () {
     });
 
     if (!config.proxyless) {
-        it('Should not get selector the second time if the error was raised in the first.', function () {
+        it('Should not execute selector twice for non-existing element due to "confidential" option (GH-6623)', function () {
             return runTests('./testcafe-fixtures/type-test.js', 'Not found selector', {
-                shouldFail: true,
-                only:       'chrome',
+                shouldFail:      true,
+                only:            'chrome',
+                selectorTimeout: 3000,
             })
                 .catch(function (errs) {
-                    expect(testReport.durationMs).lessThan(1100);
+                    expect(testReport.durationMs).lessThan(6000);
                     expect(errs[0]).to.contains(
                         'The specified selector does not match any element in the DOM tree.'
                     );

--- a/test/functional/fixtures/api/es-next/type/testcafe-fixtures/type-test.js
+++ b/test/functional/fixtures/api/es-next/type/testcafe-fixtures/type-test.js
@@ -26,3 +26,7 @@ test('Incorrect action text', async t => {
 test('Incorrect action options', async t => {
     await t.typeText('#input', 'a', { replace: null, paste: null });
 });
+
+test('Not found selector', async t => {
+    await t.typeText('#not-found', 'a');
+});

--- a/test/server/test-run-commands-test.js
+++ b/test/server/test-run-commands-test.js
@@ -69,8 +69,11 @@ function assertErrorMessage (fn, expectedErrMessage) {
     expect(actualErr.message).eql(expectedErrMessage);
 }
 
-function makeSelector (str, skipVisibilityCheck) {
-    const builder = new SelectorBuilder(str, { visibilityCheck: !skipVisibilityCheck }, { instantiation: 'Selector' });
+function makeSelector (str, skipVisibilityCheck, needError, separatedErrors) {
+    const builder = new SelectorBuilder(str, {
+        visibilityCheck: !skipVisibilityCheck,
+        needError, separatedErrors,
+    }, { instantiation: 'Selector' });
     const command = builder.getCommand([]);
 
     command.actionId = 'child-command-selector';
@@ -565,7 +568,7 @@ describe('Test run commands', () => {
             expect(JSON.parse(JSON.stringify(command))).eql({
                 type:     TYPE.typeText,
                 actionId: TYPE.typeText,
-                selector: makeSelector('#yo'),
+                selector: makeSelector('#yo', false, true, true),
                 text:     'testText',
 
                 options: {
@@ -598,7 +601,7 @@ describe('Test run commands', () => {
             expect(JSON.parse(JSON.stringify(command))).eql({
                 type:     TYPE.typeText,
                 actionId: TYPE.typeText,
-                selector: makeSelector('#yo'),
+                selector: makeSelector('#yo', false, true, true),
                 text:     'testText',
 
                 options: {

--- a/test/server/test-run-commands-test.js
+++ b/test/server/test-run-commands-test.js
@@ -69,10 +69,10 @@ function assertErrorMessage (fn, expectedErrMessage) {
     expect(actualErr.message).eql(expectedErrMessage);
 }
 
-function makeSelector (str, skipVisibilityCheck, needError, separatedErrors) {
+function makeSelector (str, skipVisibilityCheck, needError, strictError) {
     const builder = new SelectorBuilder(str, {
         visibilityCheck: !skipVisibilityCheck,
-        needError, separatedErrors,
+        needError, strictError,
     }, { instantiation: 'Selector' });
     const command = builder.getCommand([]);
 


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->
[closes DevExpress/testcafe#6623]

## Purpose
Prevent executing selector twice when it isn't available for the `typeText` command.

## Approach
1. Add test
2. Skip typing text if the selector wasn't available during inspection.

## References
https://github.com/DevExpress/testcafe/issues/6623

## Pre-Merge TODO
- [X] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
