### PR TITLE
feat: added `actionId` to the screenshot information

### DIFF
--- a/src/screenshots/capturer.js
+++ b/src/screenshots/capturer.js
@@ -123,7 +123,7 @@ export default class Capturer {
         await this.provider.takeScreenshot(this.browserId, filePath, pageWidth, pageHeight, fullPage);
     }
 
-    async _capture (forError, { pageDimensions, cropDimensions, markSeed, customPath, fullPage, thumbnails } = {}) {
+    async _capture (forError, { actionId, failedActionId, pageDimensions, cropDimensions, markSeed, customPath, fullPage, thumbnails } = {}) {
         if (!this.enabled)
             return null;
 
@@ -191,6 +191,7 @@ export default class Capturer {
             userAgent,
             quarantineAttempt,
             takenOnFail,
+            actionId: failedActionId || actionId,
         };
 
         this.testEntry.screenshots.push(screenshot);

--- a/src/test-run/browser-manipulation-queue.js
+++ b/src/test-run/browser-manipulation-queue.js
@@ -82,6 +82,7 @@ export default class BrowserManipulationQueue {
             case COMMAND_TYPE.takeScreenshotOnFail:
                 return await this._takeScreenshot(() => this.screenshotCapturer.captureError({
                     actionId:       command.actionId,
+                    failedActionId: command.failedActionId,
                     pageDimensions: driverMsg.pageDimensions,
                     markSeed:       command.markSeed,
                     fullPage:       command.fullPage,

--- a/src/test-run/commands/browser-manipulation.js
+++ b/src/test-run/commands/browser-manipulation.js
@@ -9,6 +9,7 @@ import {
     screenshotPathArgument,
     resizeWindowDeviceArgument,
     actionOptions,
+    stringArgument,
 } from './validations/argument';
 
 import { generateScreenshotMark } from '../../screenshots/utils';
@@ -78,6 +79,7 @@ export class TakeScreenshotOnFailCommand extends TakeScreenshotBaseCommand {
     _getAssignableProperties () {
         return [
             { name: 'fullPage', type: booleanArgument, defaultValue: false },
+            { name: 'failedActionId', type: stringArgument },
         ];
     }
 }

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -1124,7 +1124,7 @@ export default class TestRun extends AsyncEventEmitter {
             // if error is TestCafeErrorList we do not need to create an adapter,
             // since error is already was processed in role initializer
             if (!(error instanceof TestCafeErrorList)) {
-                await this._makeScreenshotOnFail();
+                await this._makeScreenshotOnFail(command.actionId);
 
                 errorAdapter = this._createErrorAdapter(processTestFnError(error));
             }
@@ -1251,11 +1251,11 @@ export default class TestRun extends AsyncEventEmitter {
         return new actionCommands.CloseChildWindowOnFileDownloading();
     }
 
-    public async _makeScreenshotOnFail (): Promise<void> {
+    public async _makeScreenshotOnFail (failedActionId?: string): Promise<void> {
         const { screenshots } = this.opts;
 
         if (!this.errScreenshotPath && (screenshots as ScreenshotOptionValue)?.takeOnFails)
-            this.errScreenshotPath = await this._internalExecuteCommand(new browserManipulationCommands.TakeScreenshotOnFailCommand()) as string;
+            this.errScreenshotPath = await this._internalExecuteCommand(new browserManipulationCommands.TakeScreenshotOnFailCommand({ failedActionId })) as string;
     }
 
     private _decorateWithFlag (fn: Function, flagName: string, value: boolean): () => Promise<void> {

--- a/test/functional/fixtures/api/es-next/take-screenshot/test.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/test.js
@@ -25,11 +25,18 @@ const getReporter = function (scope) {
         screenshot.thumbnailPath   = patchScreenshotPath(screenshot.thumbnailPath);
         screenshot.isPassedAttempt = quarantine[screenshot.quarantineAttempt].passed;
         screenshot.testRunId       = scope.testRunIds.includes(screenshot.testRunId);
+        screenshot.actionId        = screenshot.takenOnFail || scope.actionIds.includes(screenshot.actionId);
 
         userAgents[screenshot.userAgent] = true;
     }
 
     return createReporter({
+        reportTestActionStart: (name, { command }) => {
+            if (!scope.actionIds)
+                scope.actionIds = [];
+
+            scope.actionIds.push(command.failedActionId || command.actionId);
+        },
         reportTestDone: (name, testRunInfo) => {
             testRunInfo.screenshots.forEach(screenshot => prepareScreenshot(screenshot, testRunInfo.quarantine));
 
@@ -244,6 +251,7 @@ describe('[API] t.takeScreenshot()', function () {
                         }
 
                         return {
+                            actionId:          true,
                             testRunId:         true,
                             screenshotPath,
                             screenshotData:    true,

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -1114,6 +1114,7 @@ describe('Reporter', () => {
             const screenshots = {};
 
             await runTests('./testcafe-fixtures/index-test.js', 'Take a screenshot on action and on error', {
+                only:               'chrome',
                 reporter:           customReporter(actionIds, screenshots),
                 screenshotsOnFails: true,
             });

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -1094,6 +1094,38 @@ describe('Reporter', () => {
                     return assertionHelper.removeScreenshotDir('screenshots');
                 });
         });
+
+        it('Should put actionId on screenshot information', async () => {
+            function customReporter (actionIds, screenshots) {
+                return createReporter({
+                    reportTestActionDone: async (name, { command }) => {
+                        actionIds.push(command.actionId);
+                    },
+
+                    reportTestDone: async (name, testRunInfo) => {
+                        testRunInfo.screenshots.forEach((screenshot) => {
+                            screenshots[screenshot.actionId] = screenshot.screenshotPath;
+                        });
+                    },
+                });
+            }
+
+            const actionIds = [];
+            const screenshots = {};
+
+            await runTests('./testcafe-fixtures/index-test.js', 'Take a screenshot on action and on error', {
+                reporter:           customReporter(actionIds, screenshots),
+                screenshotsOnFails: true,
+            });
+
+            expect(actionIds.length).eql(2);
+            actionIds.forEach(actionId => {
+                expect(screenshots[actionId]).is.not.empty;
+            });
+
+            assertionHelper.removeScreenshotDir('screenshots');
+        });
+
     });
 
     it('Should call the "init" method of reporters if it\'s defined', function () {

--- a/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/reporter/testcafe-fixtures/index-test.js
@@ -75,6 +75,12 @@ test('Screenshot on action error', async t => {
     await t.click('#unexisting-element');
 });
 
+test('Take a screenshot on action and on error', async t => {
+    await t
+        .takeScreenshot()
+        .click('#unexisting-element');
+});
+
 test('Action done after test done', async t => {
     await t
         .wait(5000)

--- a/test/server/capturer-test.js
+++ b/test/server/capturer-test.js
@@ -95,10 +95,14 @@ describe('Capturer', () => {
             },
         });
 
-        await screenshots.capturer._capture(false, { customPath: 'screenshot.png' });
+        await screenshots.capturer._capture(false, {
+            actionId:   'action-id',
+            customPath: 'screenshot.png',
+        });
 
         expect(screenshots.capturer.testEntry.screenshots[0]).eql({
             testRunId:         'test-run-id',
+            actionId:          'action-id',
             screenshotPath:    join(process.cwd(), 'screenshot.png'),
             screenshotData:    void 0,
             thumbnailPath:     join(process.cwd(), 'thumbnails', 'screenshot.png'),


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->
[closes DevExpress/testcafe#7094]

## Purpose
Add `actionId` to the screenshot information that helps to math screenshots and actions in the dashboard. 

## Approach
1. Add test 
2. Pass `actionId` to the screenshot information
3. In the error case passe  `actionId` from original action

## References
https://github.com/DevExpress/testcafe/issues/7094

## Pre-Merge TODO
- [X] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
