### PR TITLE
feat: added the `fixture` option to the `testRunInfo` of the `reportTestDone` method

### DIFF
--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -68,6 +68,12 @@ interface TestInfo {
     browsers: BrowserRunInfo[];
 }
 
+interface FixtureInfo {
+    id: string;
+    name: string | null;
+    path: string;
+}
+
 interface BrowserRunInfo extends Browser {
     testRunId: string;
     quarantineAttemptsTestRunIds?: string[];
@@ -85,6 +91,7 @@ interface TestRunInfo {
     skipped: boolean;
     browsers: unknown[];
     testId: string;
+    fixture: FixtureInfo;
 }
 
 interface PluginMethodArguments {
@@ -301,6 +308,11 @@ export default class Reporter {
             skipped:        reportItem.test.skip,
             browsers:       reportItem.browsers,
             testId:         reportItem.test.id,
+            fixture:        {
+                id:   reportItem.fixture.id,
+                name: reportItem.fixture.name,
+                path: reportItem.fixture.path,
+            },
         };
     }
 

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -336,10 +336,7 @@ export default class Reporter {
                 ],
             });
 
-            if (!nextReportItem)
-                continue;
-
-            if (nextReportItem.fixture === currentFixture)
+            if (!nextReportItem || nextReportItem.fixture === currentFixture)
                 continue;
 
             await this.dispatchToPlugin({

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -31,6 +31,7 @@ import path from 'path';
 import fs from 'fs';
 import MessageBus from '../utils/message-bus';
 import BrowserConnection from '../browser/connection';
+import { Dictionary } from '../configuration/interfaces';
 
 interface PendingPromise {
     resolve: Function | null;
@@ -72,6 +73,7 @@ interface FixtureInfo {
     id: string;
     name: string | null;
     path: string;
+    meta: Dictionary<string>;
 }
 
 interface BrowserRunInfo extends Browser {
@@ -312,6 +314,7 @@ export default class Reporter {
                 id:   reportItem.fixture.id,
                 name: reportItem.fixture.name,
                 path: reportItem.fixture.path,
+                meta: reportItem.fixture.meta,
             },
         };
     }

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -761,6 +761,9 @@ describe('Reporter', () => {
                             id:   'fid1',
                             name: 'fixture1',
                             path: './file1.js',
+                            meta: {
+                                run: 'run-001',
+                            },
                         },
                     },
                     {
@@ -851,6 +854,9 @@ describe('Reporter', () => {
                             id:   'fid1',
                             name: 'fixture1',
                             path: './file1.js',
+                            meta: {
+                                run: 'run-001',
+                            },
                         },
                     },
                     {
@@ -913,6 +919,9 @@ describe('Reporter', () => {
                             id:   'fid1',
                             name: 'fixture1',
                             path: './file1.js',
+                            meta: {
+                                run: 'run-001',
+                            },
                         },
                     },
                     {
@@ -985,6 +994,9 @@ describe('Reporter', () => {
                             id:   'fid2',
                             name: 'fixture2',
                             path: './file1.js',
+                            meta: {
+                                run: 'run-002',
+                            },
                         },
                     },
                     {
@@ -1047,6 +1059,9 @@ describe('Reporter', () => {
                             id:   'fid2',
                             name: 'fixture2',
                             path: './file1.js',
+                            meta: {
+                                run: 'run-002',
+                            },
                         },
                     },
                     {
@@ -1123,6 +1138,7 @@ describe('Reporter', () => {
                             id:   'fid3',
                             name: 'fixture3',
                             path: './file2.js',
+                            meta: null,
                         },
                     },
                     {
@@ -1185,6 +1201,7 @@ describe('Reporter', () => {
                             id:   'fid3',
                             name: 'fixture3',
                             path: './file2.js',
+                            meta: null,
                         },
                     },
                     {
@@ -1247,6 +1264,7 @@ describe('Reporter', () => {
                             id:   'fid3',
                             name: 'fixture3',
                             path: './file2.js',
+                            meta: null,
                         },
                     },
                     {

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -757,6 +757,11 @@ describe('Reporter', () => {
                                 ],
                             },
                         ],
+                        fixture: {
+                            id:   'fid1',
+                            name: 'fixture1',
+                            path: './file1.js',
+                        },
                     },
                     {
                         run: 'run-001',
@@ -842,6 +847,11 @@ describe('Reporter', () => {
                                 testRunId: 'f1t2ff',
                             },
                         ],
+                        fixture: {
+                            id:   'fid1',
+                            name: 'fixture1',
+                            path: './file1.js',
+                        },
                     },
                     {
                         run: 'run-001',
@@ -899,6 +909,11 @@ describe('Reporter', () => {
                                 testRunId: 'f1t3ff',
                             },
                         ],
+                        fixture: {
+                            id:   'fid1',
+                            name: 'fixture1',
+                            path: './file1.js',
+                        },
                     },
                     {
                         run: 'run-001',
@@ -966,6 +981,11 @@ describe('Reporter', () => {
                                 testRunId: 'f2t1ff',
                             },
                         ],
+                        fixture: {
+                            id:   'fid2',
+                            name: 'fixture2',
+                            path: './file1.js',
+                        },
                     },
                     {
                         run: 'run-001',
@@ -1023,6 +1043,11 @@ describe('Reporter', () => {
                                 testRunId: 'f2t2ff',
                             },
                         ],
+                        fixture: {
+                            id:   'fid2',
+                            name: 'fixture2',
+                            path: './file1.js',
+                        },
                     },
                     {
                         run: 'run-001',
@@ -1094,6 +1119,11 @@ describe('Reporter', () => {
                                 testRunId: 'f3t1ff',
                             },
                         ],
+                        fixture: {
+                            id:   'fid3',
+                            name: 'fixture3',
+                            path: './file2.js',
+                        },
                     },
                     {
                         run: 'run-001',
@@ -1151,6 +1181,11 @@ describe('Reporter', () => {
                                 testRunId: 'f3t2ff',
                             },
                         ],
+                        fixture: {
+                            id:   'fid3',
+                            name: 'fixture3',
+                            path: './file2.js',
+                        },
                     },
                     {
                         run: 'run-001',
@@ -1208,6 +1243,11 @@ describe('Reporter', () => {
                                 testRunId: 'f3t3ff',
                             },
                         ],
+                        fixture: {
+                            id:   'fid3',
+                            name: 'fixture3',
+                            path: './file2.js',
+                        },
                     },
                     {
                         run: 'run-001',


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->
[closes DevExpress/testcafe#7118]

## Purpose
Pass the 'fixture' object that contains `id`, `name`, `path` and `meta` to the reporter.reportTestDone method.

## Approach
1. Add the `fixture` option to the `testRunInfo`
2. Fix tests

## References
https://github.com/DevExpress/testcafe/issues/7118

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
