### PR TITLE
Fix: Incorrect cloud provider links are shown in report errors when running test in concurrency mode(closes #4346)

### DIFF
--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -30,6 +30,7 @@ import makeDir from 'make-dir';
 import path from 'path';
 import fs from 'fs';
 import MessageBus from '../utils/message-bus';
+import BrowserConnection from '../browser/connection';
 
 interface PendingPromise {
     resolve: Function | null;
@@ -64,10 +65,10 @@ interface TestInfo {
     pendingStarts: number;
     pendingTestRunDonePromise: PendingPromise;
     pendingTestRunStartPromise: PendingPromise;
-    browsers: BrowserInfo[];
+    browsers: BrowserRunInfo[];
 }
 
-interface BrowserInfo extends Browser {
+interface BrowserRunInfo extends Browser {
     testRunId: string;
     quarantineAttemptsTestRunIds?: string[];
 }
@@ -435,7 +436,9 @@ export default class Reporter {
         };
 
         const startTime              = task.startTime;
-        const browserConnectionsInfo = task.browserConnectionGroups.map(group => group[0].connectionInfo);
+        const browserConnectionsInfo = ([] as BrowserConnection[])
+            .concat(...task.browserConnectionGroups)
+            .map(connection => connection.connectionInfo);
         const first                  = this.taskInfo.testQueue[0];
 
         const taskProperties = {
@@ -514,7 +517,7 @@ export default class Reporter {
 
         const reportItem                    = this._getTestItemForTestRun(this.taskInfo, testRun) as TestInfo;
         const isTestRunStoppedTaskExecution = !!testRun.errs.length && this.taskInfo.stopOnFirstFail;
-        const browser: BrowserInfo          = Object.assign({ testRunId: testRun.id }, testRun.browser);
+        const browser: BrowserRunInfo       = Object.assign({ testRunId: testRun.id }, testRun.browser);
 
         reportItem.browsers.push(browser);
 

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -152,7 +152,7 @@ export default class Bootstrapper {
 
         return browserInfo
             .map(browser => times(this.concurrency, () => new BrowserConnection(
-                this.browserConnectionGateway, browser, false, this.disableMultipleWindows, this.proxyless, this.messageBus)));
+                this.browserConnectionGateway, { ...browser }, false, this.disableMultipleWindows, this.proxyless, this.messageBus)));
     }
 
     private _getBrowserSetOptions (): BrowserSetOptions {

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -116,13 +116,13 @@ if (config.useLocalBrowsers) {
             const reporter    = createReporter({
                 reportTaskStart: (_, userAgents) => {
                     scope.userAgents = userAgents;
-                }
+                },
             });
 
             return run('chrome:headless', concurrency, './testcafe-fixtures/concurrent-test.js', reporter)
-                .then(()=>{
+                .then(() => {
                     expect(scope.userAgents.length).eql(concurrency);
-                })
+                });
         });
 
         // TODO: this test doesn't work on CI due to big resource demands

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -110,6 +110,21 @@ if (config.useLocalBrowsers) {
                 });
         });
 
+        it('Report TaskStart event handler should contain links to all opened browsers', async () => {
+            const concurrency = 2;
+            const scope       = {};
+            const reporter    = createReporter({
+                reportTaskStart: (_, userAgents) => {
+                    scope.userAgents = userAgents;
+                }
+            });
+
+            return run('chrome:headless', concurrency, './testcafe-fixtures/concurrent-test.js', reporter)
+                .then(()=>{
+                    expect(scope.userAgents.length).eql(concurrency);
+                })
+        });
+
         // TODO: this test doesn't work on CI due to big resource demands
         if (!isCI) {
             it('Should run tests concurrently in different browser kinds', function () {


### PR DESCRIPTION
## Purpose
When running tests in concurrency mode:
- Only the last opened session link is passed to all the report errors.
- Also, only the last opened session link is passed to the report task start handler.


## Approach
Previously we used the same reference of the "browserInfo" object in all the "browserConnection" objects. As a result, the browserMetaInfo was rewritten in all the "browserConnections".
After fix: Different "browserInfo" references are passed to different "browserConnections".

## References
[Show all links to all cloud test sessions in concurrency mode #4346](https://github.com/DevExpress/testcafe/issues/4346)

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
