### PR TITLE
fix: 'Memory leak on running more than 11 tests' (close #7188)

### DIFF
--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -128,6 +128,12 @@ export default {
         await browserClient.startCapturingVideo();
     },
 
+    async stopCapturingVideo (browserId) {
+        const { browserClient } = this.openedBrowsers[browserId];
+
+        await browserClient.stopCapturingVideo();
+    },
+
     async getVideoFrameData (browserId) {
         const { browserClient } = this.openedBrowsers[browserId];
 

--- a/src/browser/provider/index.ts
+++ b/src/browser/provider/index.ts
@@ -417,6 +417,10 @@ export default class BrowserProvider {
         await this.plugin.startCapturingVideo(browserId);
     }
 
+    public async stopCapturingVideo (browserId: string): Promise<void> {
+        await this.plugin.stopCapturingVideo(browserId);
+    }
+
     public async hasCustomActionForBrowser (browserId: string): Promise<any> {
         return this.plugin.hasCustomActionForBrowser(browserId);
     }

--- a/src/browser/provider/plugin-host.js
+++ b/src/browser/provider/plugin-host.js
@@ -143,6 +143,9 @@ export default class BrowserProviderPluginHost {
     async startCapturingVideo (/*browserId*/) {
     }
 
+    async stopCapturingVideo (/*browserId*/) {
+    }
+
     async getVideoFrameData (browserId) {
         const browserAlias = BrowserConnection.getById(browserId).browserInfo.alias;
 

--- a/src/video-recorder/process.js
+++ b/src/video-recorder/process.js
@@ -130,6 +130,10 @@ export default class VideoRecorder extends AsyncEmitter {
         await this.connection.provider.startCapturingVideo(this.connection.id);
     }
 
+    async _stopCapturing () {
+        await this.connection.provider.stopCapturingVideo(this.connection.id);
+    }
+
     async init () {
         this.ffmpegProcess = spawn(this.ffmpegPath, this.optionsList, { stdio: 'pipe' });
 
@@ -183,6 +187,7 @@ export default class VideoRecorder extends AsyncEmitter {
 
         this.closed = true;
 
+        await this._stopCapturing();
         await this.capturingPromise;
         await this.dispose();
     }


### PR DESCRIPTION
Closes https://github.com/DevExpress/testcafe/issues/7188

Fixes:
* memory leak on running more than 11 tests
* next test contains the last video frame of the previous test