### PR TITLE
test: SUBTITLES should contains defenitions of all test run phases

### DIFF
--- a/src/errors/test-run/utils.js
+++ b/src/errors/test-run/utils.js
@@ -3,7 +3,7 @@ import { escape as escapeHtml, repeat } from 'lodash';
 import TEST_RUN_PHASE from '../../test-run/phase';
 import { TEST_RUN_ERRORS } from '../types';
 
-const SUBTITLES = {
+export const SUBTITLES = {
     [TEST_RUN_PHASE.initial]:                 '',
     [TEST_RUN_PHASE.inTestRunBeforeHook]:     '<span class="subtitle">Error in testRun.before hook</span>\n',
     [TEST_RUN_PHASE.inFixtureBeforeHook]:     '<span class="subtitle">Error in fixture.before hook</span>\n',

--- a/test/server/util-test.js
+++ b/test/server/util-test.js
@@ -23,9 +23,11 @@ const { parseUserAgent }               = require('../../lib/utils/parse-user-age
 const diff                             = require('../../lib/utils/diff');
 const { generateScreenshotMark }       = require('../../lib/screenshots/utils');
 const getViewPortWidth                 = require('../../lib/utils/get-viewport-width');
+const TEST_RUN_PHASE                   = require('../../lib/test-run/phase');
 const {
     replaceLeadingSpacesWithNbsp,
     markup,
+    SUBTITLES,
 } = require('../../lib/errors/test-run/utils');
 const {
     buildChromeArgs,
@@ -346,6 +348,11 @@ describe('Utils', () => {
                                    '<strong>Browser:</strong> <span class="user-agent">Chrome 104.0.5112.81 / Windows 10</span>\n\n0';
 
             expect(markup(err, msgMarkup)).eql(expectedResult);
+        });
+
+        it('SUBTITLES should contains defenitions of all test run phases', () => {
+            for (const phase in TEST_RUN_PHASE)
+                expect(phase in SUBTITLES).to.be.ok;
         });
 
         it('Replace leading spaces with &nbsp', () => {

--- a/test/server/util-test.js
+++ b/test/server/util-test.js
@@ -350,7 +350,7 @@ describe('Utils', () => {
             expect(markup(err, msgMarkup)).eql(expectedResult);
         });
 
-        it('SUBTITLES should contains defenitions of all test run phases', () => {
+        it('SUBTITLES should contains definitions of all test run phases', () => {
             for (const phase in TEST_RUN_PHASE)
                 expect(phase in SUBTITLES).to.be.ok;
         });


### PR DESCRIPTION
In addition to https://github.com/DevExpress/testcafe/pull/7227.
Reason: we need to make sure that the definitions for the various phases are not forgotten in the future.