### PR TITLE
fix: removed unnecessary disposing a temp directory for screenshots

### DIFF
--- a/src/screenshots/index.js
+++ b/src/screenshots/index.js
@@ -36,15 +36,10 @@ export default class Screenshots extends EventEmitter {
 
     _assignEventHandlers (messageBus) {
         messageBus.once('start', this._createSafeListener(this._onMessageBusStart));
-        messageBus.once('done', this._createSafeListener(this._onMessageBusDone));
     }
 
     async _onMessageBusStart () {
         await this.tempDirectory.init();
-    }
-
-    async _onMessageBusDone () {
-        await this.tempDirectory.dispose();
     }
 
     _addTestEntry (test) {


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Fixed studio hanging. Delete unnecessary disposing of a temp directory for screenshots, because it already happens [there ](https://github.com/DevExpress/testcafe/blob/431f048c4f6569ceb061f566863e88f740697cf9/src/utils/temp-directory/cleanup-process/worker.js#L64). If we try to remove it again process hangs of waiting response.

## Approach
1. Research problem
2. Fix removing temp dir for screenshots

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
