### PR TITLE
Fix skipJsErrors API, fix TS warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "time-limit-promise": "^1.0.2",
     "tmp": "0.0.28",
     "tree-kill": "^1.2.2",
-    "typescript": "^4.7.4",
+    "typescript": "4.7.4",
     "unquote": "^1.1.1"
   },
   "devDependencies": {

--- a/src/compiler/test-file/formats/typescript/compiler.ts
+++ b/src/compiler/test-file/formats/typescript/compiler.ts
@@ -18,14 +18,9 @@ import TypeScript, {
     VisitResult,
     Visitor,
     Node,
-    createStringLiteral,
     visitEachChild,
     visitNode,
     TransformerFactory,
-    createExpressionStatement,
-    createCall,
-    createIdentifier,
-    updateSourceFileNode,
     SourceFile,
     addSyntheticLeadingComment,
 } from 'typescript';
@@ -34,6 +29,8 @@ import { Dictionary, TypeScriptCompilerOptions } from '../../../../configuration
 import { OptionalCompilerArguments } from '../../../interfaces';
 
 declare type TypeScriptInstance = typeof TypeScript;
+
+const tsFactory = TypeScript.factory;
 
 interface TestFileInfo {
     filename: string;
@@ -52,7 +49,7 @@ function testcafeImportPathReplacer<T extends Node> (): TransformerFactory<T> {
         const visit: Visitor = (node): VisitResult<Node> => {
             // @ts-ignore
             if (node.parent?.kind === SyntaxKind.ImportDeclaration && node.kind === SyntaxKind.StringLiteral && node.text === 'testcafe')
-                return createStringLiteral(EXPORTABLE_LIB_PATH);
+                return tsFactory.createStringLiteral(EXPORTABLE_LIB_PATH);
 
             return visitEachChild(node, child => visit(child), context);
         };
@@ -64,16 +61,16 @@ function testcafeImportPathReplacer<T extends Node> (): TransformerFactory<T> {
 function disableV8OptimizationCodeAppender<T extends Node> (): TransformerFactory<T> {
     return () => {
         const visit: Visitor = (node): VisitResult<Node> => {
-            const evalStatement = createExpressionStatement(createCall(
-                createIdentifier('eval'),
+            const evalStatement = tsFactory.createExpressionStatement(tsFactory.createCallExpression(
+                tsFactory.createIdentifier('eval'),
                 void 0,
-                [createStringLiteral('')]
+                [tsFactory.createStringLiteral('')]
             ));
 
             const evalStatementWithComment = addSyntheticLeadingComment(evalStatement, SyntaxKind.MultiLineCommentTrivia, DISABLE_V8_OPTIMIZATION_NOTE, true);
 
             // @ts-ignore
-            return updateSourceFileNode(node, [...node.statements, evalStatementWithComment]);
+            return tsFactory.updateSourceFile(node, [...node.statements, evalStatementWithComment]);
         };
 
         return node => visitNode(node, visit);

--- a/src/errors/test-run/templates.js
+++ b/src/errors/test-run/templates.js
@@ -13,6 +13,7 @@ const EXTERNAL_LINKS = {
     createNewIssue:      'https://github.com/DevExpress/testcafe/issues/new?template=bug-report.md',
     troubleshootNetwork: 'https://go.devexpress.com/TestCafe_FAQ_ARequestHasFailed.aspx',
     viewportSizes:       'https://github.com/DevExpress/device-specs/blob/master/viewport-sizes.json',
+    skipJsErrorsRecipes: 'https://testcafe.io/documentation/404038/recipes/debugging/skip-javascript-errors',
 };
 
 export default {
@@ -44,7 +45,7 @@ export default {
     [TEST_RUN_ERRORS.uncaughtErrorOnPage]: err => `
         A JavaScript error occurred on ${formatUrl(err.pageDestUrl)}.
         Repeat test actions in the browser and check the console for errors.
-        Enable the “skipJsErrors” option to ignore JavaScript errors during test execution. Learn more: https://testcafe.io/documentation/404038/recipes/debugging/skip-javascript-errors
+        Enable the “skipJsErrors” option to ignore JavaScript errors during test execution. Learn more: ${formatUrl(EXTERNAL_LINKS.skipJsErrorsRecipes)}
         If the website only throws this error when you test it with TestCafe, please create a new issue at:
         ${formatUrl(EXTERNAL_LINKS.createNewIssue)}.
 

--- a/src/errors/test-run/templates.js
+++ b/src/errors/test-run/templates.js
@@ -44,7 +44,7 @@ export default {
     [TEST_RUN_ERRORS.uncaughtErrorOnPage]: err => `
         A JavaScript error occurred on ${formatUrl(err.pageDestUrl)}.
         Repeat test actions in the browser and check the console for errors.
-        To ignore client-side JavaScript errors, enable the "--skip-js-errors" CLI option, or set the "skipJsErrors" configuration file property to "true".
+        Enable the “skipJsErrors” option to ignore JavaScript errors during test execution. Learn more: https://testcafe.io/documentation/404038/recipes/debugging/skip-javascript-errors
         If the website only throws this error when you test it with TestCafe, please create a new issue at:
         ${formatUrl(EXTERNAL_LINKS.createNewIssue)}.
 

--- a/test/server/data/expected-test-run-errors/uncaught-js-error-on-page
+++ b/test/server/data/expected-test-run-errors/uncaught-js-error-on-page
@@ -1,6 +1,6 @@
 A JavaScript error occurred on "http://example.org".
 Repeat test actions in the browser and check the console for errors.
-To ignore client-side JavaScript errors, enable the "--skip-js-errors" CLI option, or set the "skipJsErrors" configuration file property to "true".
+Enable the “skipJsErrors” option to ignore JavaScript errors during test execution. Learn more: https://testcafe.io/documentation/404038/recipes/debugging/skip-javascript-errors
 If the website only throws this error when you test it with TestCafe, please create a new issue at:
 "https://github.com/DevExpress/testcafe/issues/new?template=bug-report.md".
 

--- a/test/server/data/expected-test-run-errors/uncaught-js-error-on-page
+++ b/test/server/data/expected-test-run-errors/uncaught-js-error-on-page
@@ -1,6 +1,6 @@
 A JavaScript error occurred on "http://example.org".
 Repeat test actions in the browser and check the console for errors.
-Enable the “skipJsErrors” option to ignore JavaScript errors during test execution. Learn more: https://testcafe.io/documentation/404038/recipes/debugging/skip-javascript-errors
+Enable the “skipJsErrors” option to ignore JavaScript errors during test execution. Learn more: "https://testcafe.io/documentation/404038/recipes/debugging/skip-javascript-errors"
 If the website only throws this error when you test it with TestCafe, please create a new issue at:
 "https://github.com/DevExpress/testcafe/issues/new?template=bug-report.md".
 

--- a/ts-defs-src/test-api/test-controller.d.ts
+++ b/ts-defs-src/test-api/test-controller.d.ts
@@ -539,7 +539,7 @@ interface TestController {
      *
      * @param options - Error skipping conditions: a Boolean flag, an Object with options, or a callback function that defines custom error skipping logic.
      */
-    skipJsErrors (options?: boolean | SkipJsErrorsOptionsObject | SkipJsErrorsCallback | SkipJsErrorsCallbackWithOptionsObject): this;
+    skipJsErrors (options?: boolean | SkipJsErrorsOptionsObject | SkipJsErrorsCallback | SkipJsErrorsCallbackWithOptionsObject): TestControllerPromise;
 }
 
 interface TestControllerPromise<T=any> extends TestController, Promise<T> {


### PR DESCRIPTION
## Purpose
- [x] Incorrect skipJsErrors type in TestController definitions
- [x] Update error message containing skipJsErrors option description
- [x] TypeScript version should be set exactly
- [x] Update deprecated TS methods 