### PR TITLE
fix: more tolerant error handling for errors raised into reporter plugin methods

### DIFF
--- a/src/errors/process-test-fn-error.js
+++ b/src/errors/process-test-fn-error.js
@@ -10,6 +10,10 @@ import {
     UncaughtNonErrorObjectInTestCode,
     ExternalAssertionLibraryError,
 } from './test-run';
+import debug from 'debug';
+
+const debugLog = debug('testcafe:errors');
+
 
 function isAssertionErrorCallsiteFrame (frame) {
     const filename = frame.getFileName();
@@ -22,6 +26,8 @@ function isAssertionErrorCallsiteFrame (frame) {
 }
 
 export default function processTestFnError (err) {
+    debugLog('processTestFnError: %O', err);
+
     if (err && (err.isTestCafeError || err instanceof TestCafeErrorList))
         return err;
 

--- a/src/errors/runtime/index.js
+++ b/src/errors/runtime/index.js
@@ -5,6 +5,7 @@ import renderTemplate from '../../utils/render-template';
 import renderCallsiteSync from '../../utils/render-callsite-sync';
 import { RUNTIME_ERRORS } from '../types';
 import getRenderers from '../../utils/get-renderes';
+import util from 'util';
 
 const ERROR_SEPARATOR = '\n\n';
 
@@ -128,10 +129,22 @@ export class CompositeError extends Error {
 
 export class ReporterPluginError extends GeneralError {
     constructor ({ name, method, originalError }) {
-        const code = RUNTIME_ERRORS.uncaughtErrorInReporter;
+        const code          = RUNTIME_ERRORS.uncaughtErrorInReporter;
+        const preparedStack = ReporterPluginError._prepareStack(originalError);
 
-        super(code, method, name, originalError.stack);
+        super(code, method, name, preparedStack);
     }
+
+    static _prepareStack (err) {
+        if (!err?.stack) {
+            const inspectedObject = util.inspect(err);
+
+            return `No stack trace is available for a raised error.\nRaised error object inspection:\n${inspectedObject}`;
+        }
+
+        return err.stack;
+    }
+
 }
 
 export class TimeoutError extends GeneralError {

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -32,6 +32,7 @@ import fs from 'fs';
 import MessageBus from '../utils/message-bus';
 import BrowserConnection from '../browser/connection';
 import { Dictionary } from '../configuration/interfaces';
+import debug from 'debug';
 
 interface PendingPromise {
     resolve: Function | null;
@@ -121,6 +122,8 @@ interface ReportWarningEventArguments {
     actionId?: string;
 }
 
+const debugLog = debug('testcafe:reporter');
+
 export default class Reporter {
     public readonly plugin: ReporterPluginHost;
     public readonly messageBus: MessageBus;
@@ -174,6 +177,9 @@ export default class Reporter {
                 method,
                 originalError,
             });
+
+            debugLog('Plugin error: %O', uncaughtError);
+            debugLog('Plugin error: initialObject: %O', initialObject);
 
             if (initialObject)
                 await initialObject.emit('error', uncaughtError);


### PR DESCRIPTION
Changes:
* additional logic with the `debug` module
* safe `error.stack` creation