### PR TITLE
fix video recording in concurrency mode (closes #7218)

### DIFF
--- a/src/browser/provider/built-in/dedicated/chrome/cdp-client/index.ts
+++ b/src/browser/provider/built-in/dedicated/chrome/cdp-client/index.ts
@@ -53,7 +53,6 @@ export class BrowserClient {
     private readonly debugLogger: debug.Debugger;
     private _videoFramesBuffer: VideoFrameData[];
     private _lastFrame: VideoFrameData | null;
-    private _prevFrame: VideoFrameData | null;
     private _screencastFrameListenerAttached = false;
 
     public constructor (runtimeInfo: RuntimeInfo) {
@@ -64,7 +63,6 @@ export class BrowserClient {
 
         this._videoFramesBuffer = [];
         this._lastFrame         = null;
-        this._prevFrame         = null;
     }
 
     private get _clientKey (): string {
@@ -385,7 +383,6 @@ export class BrowserClient {
 
         this._lastFrame         = null;
         this._videoFramesBuffer = [];
-        this._prevFrame         = null;
     }
 
     public async getVideoFrameData (): Promise<Buffer | null> {
@@ -403,10 +400,8 @@ export class BrowserClient {
         if (!client)
             return null;
 
-        if (this._prevFrame !== currentVideoFrame)
+        if (lastFrameFromBuffer)
             await client.Page.screencastFrameAck({ sessionId: currentVideoFrame.sessionId });
-
-        this._prevFrame = currentVideoFrame;
 
         return Buffer.from(currentVideoFrame.data, 'base64');
     }

--- a/src/browser/provider/built-in/dedicated/chrome/cdp-client/index.ts
+++ b/src/browser/provider/built-in/dedicated/chrome/cdp-client/index.ts
@@ -386,8 +386,8 @@ export class BrowserClient {
     }
 
     public async getVideoFrameData (): Promise<Buffer | null> {
-        const lastFrameFromBuffer = this._videoFramesBuffer.shift();
-        const currentVideoFrame   = lastFrameFromBuffer || this._lastFrame;
+        const firstFrameFromBuffer = this._videoFramesBuffer.shift();
+        const currentVideoFrame    = firstFrameFromBuffer || this._lastFrame;
 
         if (!currentVideoFrame)
             return null;
@@ -400,7 +400,7 @@ export class BrowserClient {
         if (!client)
             return null;
 
-        if (lastFrameFromBuffer)
+        if (firstFrameFromBuffer)
             await client.Page.screencastFrameAck({ sessionId: currentVideoFrame.sessionId });
 
         return Buffer.from(currentVideoFrame.data, 'base64');

--- a/src/video-recorder/process.js
+++ b/src/video-recorder/process.js
@@ -36,7 +36,7 @@ const DEFAULT_OPTIONS = {
 
 const FFMPEG_START_DELAY = 500;
 
-const DELAY_AFTER_EMPTY_FRAME = 50;
+const DELAY_AFTER_EMPTY_FRAME = 20;
 
 export default class VideoRecorder extends AsyncEmitter {
     constructor (basePath, ffmpegPath, connection, customOptions) {


### PR DESCRIPTION
The main idea - call the `client.Page.screencastFrameAck` method for last saved frame only 1 time.