### PR TITLE
fix: forced stdin and stdout formats for ffmpeg

### DIFF
--- a/src/video-recorder/process.js
+++ b/src/video-recorder/process.js
@@ -8,6 +8,10 @@ import delay from '../utils/delay';
 const DEBUG_LOGGER_PREFIX = 'testcafe:video-recorder:process:';
 
 const DEFAULT_OPTIONS = {
+
+    // NOTE: use to force stdin and stdout formats
+    'f': 'image2pipe',
+
     // NOTE: don't ask confirmation for rewriting the output file
     'y': true,
 


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

[closes #7216]

## Purpose
Fix an error when running tests with video records on Unix systems. It throws the error that screencast files have invalid format data. 

## Approach
1. Research the problem
2. Force input and output formats because sometimes `ffmpeg` recognize wrong formats and cannot read data.

## References
https://github.com/DevExpress/testcafe/issues/7216

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
