### PR TITLE
fix: create correct raw-callsite for hooks 

### DIFF
--- a/src/compiler/test-file/formats/raw.js
+++ b/src/compiler/test-file/formats/raw.js
@@ -13,12 +13,12 @@ export default class RawTestFileCompiler extends TestFileCompilerBase {
         return async t => {
             for (let i = 0; i < commands.length; i++) {
                 const {
-                    actionId: initActionId,
                     callsite: initCallsite,
+                    actionId,
                     ...commandObj
                 } = commands[i];
-                const actionId = initActionId || parseInt(initCallsite, 10);
-                const callsite = actionId ? new RawCommandCallsiteRecord(actionId, commands) : initCallsite || initActionId;
+
+                const callsite = actionId ? new RawCommandCallsiteRecord(actionId, commands) : initCallsite || actionId;
 
                 try {
                     const command = createCommandFromObject(commandObj, t.testRun);
@@ -26,8 +26,8 @@ export default class RawTestFileCompiler extends TestFileCompilerBase {
                     await t.testRun.executeCommand(command, callsite);
                 }
                 catch (err) {
-                    err.callsite  = callsite;
-                    err.actionId  = initActionId;
+                    err.callsite = callsite;
+                    err.actionId = actionId;
                     throw err;
                 }
             }

--- a/src/utils/raw-command-callsite-record.ts
+++ b/src/utils/raw-command-callsite-record.ts
@@ -84,10 +84,10 @@ export const renderers = {
 };
 
 export class RawCommandCallsiteRecord {
-    public readonly actionId: number;
+    public readonly actionId: string;
     private readonly _list: Command[];
 
-    public constructor (actionId: number, list: Command[]) {
+    public constructor (actionId: string, list: Command[]) {
         this.actionId = actionId;
         this._list    = list;
     }

--- a/test/functional/fixtures/api/raw/test-controller/test.js
+++ b/test/functional/fixtures/api/raw/test-controller/test.js
@@ -2,8 +2,9 @@ const { expect } = require('chai');
 
 // NOTE: we run tests in chrome only, because we mainly test server API functionality.
 // Actions functionality is tested in lower-level raw API.
-describe('[Raw API] TestController', () => {
-    it('Should produce correct callsites for chained calls in raw test', () => {
+/* eslint-disable */
+describe.only('[Raw API] TestController', () => {
+    it('Should produce correct callsites for chained calls', () => {
         return runTests('./testcafe-fixtures/test-controller-test.testcafe', 'Chaining callsites', {
             shouldFail: true,
             only:       'chrome',
@@ -17,7 +18,21 @@ describe('[Raw API] TestController', () => {
             });
     });
 
-    it('Should produce correct callsites with assertions for chained calls in raw test', () => {
+    it('Should produce correct callsites for chained calls in hooks', () => {
+        return runTests('./testcafe-fixtures/hooks-test.testcafe', 'Chaining callsites in hooks', {
+            shouldFail: true,
+            only:       'chrome',
+        })
+            .catch(errs => {
+                expect(errs[0]).to.contains(
+                    ' 2 |Click (Selector(\'#btn2\'))' +
+                    ' > 3 |Click (Selector(\'#errorrr\'))' +
+                    ' 4 |Click (Selector(\'#btn3\'))'
+                );
+            });
+    });
+
+    it('Should produce correct callsites with assertions for chained calls', () => {
         return runTests('./testcafe-fixtures/test-controller-test.testcafe', 'Chaining callsites with assertions', {
             shouldFail: true,
             only:       'chrome',

--- a/test/functional/fixtures/api/raw/test-controller/test.js
+++ b/test/functional/fixtures/api/raw/test-controller/test.js
@@ -2,8 +2,7 @@ const { expect } = require('chai');
 
 // NOTE: we run tests in chrome only, because we mainly test server API functionality.
 // Actions functionality is tested in lower-level raw API.
-/* eslint-disable */
-describe.only('[Raw API] TestController', () => {
+describe('[Raw API] TestController', () => {
     it('Should produce correct callsites for chained calls', () => {
         return runTests('./testcafe-fixtures/test-controller-test.testcafe', 'Chaining callsites', {
             shouldFail: true,

--- a/test/functional/fixtures/api/raw/test-controller/testcafe-fixtures/hooks-test.testcafe
+++ b/test/functional/fixtures/api/raw/test-controller/testcafe-fixtures/hooks-test.testcafe
@@ -1,0 +1,44 @@
+{
+    "fixtures":[
+        {
+            "name":"[API] TestController",
+            "pageUrl":"http://localhost:3000/fixtures/api/es-next/test-controller/pages/index.html",
+            "tests":[
+                {
+                    "name":"Chaining callsites in hooks",
+                    "commands":[]
+                }
+            ],
+            "beforeEachCommands":[
+                {
+                    "selector": {"type":"js-expr","value":"Selector('#btn1')"},
+                    "studio": {"selectors":[{"rawSelector":{"type":"js-expr","value":"Selector('#btn1')"},"ruleType":"id"},{"rawSelector":{"type":"js-expr","value":"Selector('form input')"},"ruleType":"$dom$"}],"useOffsets":false,"offsetX":18,"offsetY":12},
+                    "options": {},
+                    "type": "click",
+                    "actionId": "0"
+                },
+                {
+                    "selector": {"type":"js-expr","value":"Selector('#btn2')"},
+                    "studio": {"selectors":[{"rawSelector":{"type":"js-expr","value":"Selector('#btn2')"},"ruleType":"id"},{"rawSelector":{"type":"js-expr","value":"Selector('form input').nth(1)"},"ruleType":"$dom$"}],"useOffsets":false,"offsetX":30,"offsetY":12},
+                    "options": {},
+                    "type": "click",
+                    "actionId": "1"
+                },
+                {
+                    "selector": {"type":"js-expr","value":"Selector('#errorrr')"},
+                    "studio": {"selectors":[{"rawSelector":{"type":"js-expr","value":"Selector('#error')"},"ruleType":"id"},{"rawSelector":{"type":"js-expr","value":"Selector('form input').nth(3)"},"ruleType":"$dom$"}],"useOffsets":false,"offsetX":14,"offsetY":10},
+                    "options":{},
+                    "type":"click",
+                    "actionId":"2"
+                },
+                {
+                    "selector":{"type":"js-expr","value":"Selector('#btn3')"},
+                    "studio":{"selectors":[{"rawSelector":{"type":"js-expr","value":"Selector('#btn3')"},"ruleType":"id"},{"rawSelector":{"type":"js-expr","value":"Selector('form input').nth(2)"},"ruleType":"$dom$"}],"useOffsets":false,"offsetX":28,"offsetY":8},
+                    "options":{},
+                    "type":"click",
+                    "actionId":"3"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

[closes #7089]

## Purpose
`actionId` for hooks in raw-tests has a prefix, that is why it is impossible to parse it as Integer and impossible to create a callsite. It needs to use `actionId` without parsing.

## Approach
1. Add test for error in hooks
2. Fix using actionId

## References
https://github.com/DevExpress/testcafe/issues/7089

## Pre-Merge TODO
- [X] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
