### PR TITLE
fix: SkipJsErrors RegExp parsed incorrectly if it is passed through CLI(closes #7301)

### DIFF
--- a/src/utils/make-reg-exp.js
+++ b/src/utils/make-reg-exp.js
@@ -9,7 +9,7 @@ export function parseRegExpString (regExp) {
     const parsedRegExpWithFlags = regExp.match(SPLIT_INPUT_AND_FLAGS_REG_EXP);
 
     if (parsedRegExpWithFlags)
-        return makeRegExp(parsedRegExpWithFlags[1], parsedRegExpWithFlags[2]);
+        return RegExp(parsedRegExpWithFlags[1], parsedRegExpWithFlags[2]);
 
     return makeRegExp(regExp);
 }

--- a/test/functional/fixtures/page-js-errors/test.js
+++ b/test/functional/fixtures/page-js-errors/test.js
@@ -102,8 +102,8 @@ const expectFailAttempt = (errors, expectedMessage) => {
             return runTests('./testcafe-fixtures/test-controller.js', 'Should skip JS errors with SkipJsErrorsCallbackOptions');
         });
 
-        it('Should skip JS errors if SkipJsErrorsCallbackOptions.message prop is string containing RegExp', async () => {
-            return runTests('./testcafe-fixtures/test-controller.js', 'Should skip JS errors if SkipJsErrorsCallbackOptions.message prop is string containing RegExp');
+        it('Should skip JS errors if some SkipJsErrorsCallbackOptions prop is string containing RegExp', async () => {
+            return runTests('./testcafe-fixtures/test-controller.js', 'Should skip JS errors if some SkipJsErrorsCallbackOptions prop is string containing RegExp');
         });
 
         it('Should skip JS errors with callback function returning Promise', async () => {

--- a/test/functional/fixtures/page-js-errors/test.js
+++ b/test/functional/fixtures/page-js-errors/test.js
@@ -102,6 +102,10 @@ const expectFailAttempt = (errors, expectedMessage) => {
             return runTests('./testcafe-fixtures/test-controller.js', 'Should skip JS errors with SkipJsErrorsCallbackOptions');
         });
 
+        it('Should skip JS errors with SkipJsErrorsCallbackOptions containing RegExp enclosed in quotes', async () => {
+            return runTests('./testcafe-fixtures/test-controller.js', 'Should skip JS errors with SkipJsErrorsCallbackOptions containing RegExp enclosed in quotes');
+        });
+
         it('Should skip JS errors with callback function returning Promise', async () => {
             return runTests('./testcafe-fixtures/test-controller.js', 'Should skip JS errors with callback function returning Promise', { skip: ['ie'] });
         });

--- a/test/functional/fixtures/page-js-errors/test.js
+++ b/test/functional/fixtures/page-js-errors/test.js
@@ -102,8 +102,8 @@ const expectFailAttempt = (errors, expectedMessage) => {
             return runTests('./testcafe-fixtures/test-controller.js', 'Should skip JS errors with SkipJsErrorsCallbackOptions');
         });
 
-        it('Should skip JS errors with SkipJsErrorsCallbackOptions containing RegExp enclosed in quotes', async () => {
-            return runTests('./testcafe-fixtures/test-controller.js', 'Should skip JS errors with SkipJsErrorsCallbackOptions containing RegExp enclosed in quotes');
+        it('Should skip JS errors if SkipJsErrorsCallbackOptions.message prop is string containing RegExp', async () => {
+            return runTests('./testcafe-fixtures/test-controller.js', 'Should skip JS errors if SkipJsErrorsCallbackOptions.message prop is string containing RegExp');
         });
 
         it('Should skip JS errors with callback function returning Promise', async () => {

--- a/test/functional/fixtures/page-js-errors/testcafe-fixtures/test-controller.js
+++ b/test/functional/fixtures/page-js-errors/testcafe-fixtures/test-controller.js
@@ -39,7 +39,7 @@ test('Should skip JS errors without param', async t => {
     await t.skipJsErrors();
 });
 
-test('Should skip JS errors with SkipJsErrorsCallbackOptions containing RegExp enclosed in quotes', async t => {
+test('Should skip JS errors if SkipJsErrorsCallbackOptions.message prop is string containing RegExp', async t => {
     await t.skipJsErrors({
         message: `${ CLIENT_ERROR_REGEXP }`,
     })

--- a/test/functional/fixtures/page-js-errors/testcafe-fixtures/test-controller.js
+++ b/test/functional/fixtures/page-js-errors/testcafe-fixtures/test-controller.js
@@ -39,7 +39,7 @@ test('Should skip JS errors without param', async t => {
     await t.skipJsErrors();
 });
 
-test('Should skip JS errors if SkipJsErrorsCallbackOptions.message prop is string containing RegExp', async t => {
+test('Should skip JS errors if some SkipJsErrorsCallbackOptions prop is string containing RegExp', async t => {
     await t.skipJsErrors({
         message: `${ CLIENT_ERROR_REGEXP }`,
     })

--- a/test/functional/fixtures/page-js-errors/testcafe-fixtures/test-controller.js
+++ b/test/functional/fixtures/page-js-errors/testcafe-fixtures/test-controller.js
@@ -1,4 +1,10 @@
-const { CLIENT_ERROR_MESSAGE, CLIENT_PAGE_URL, CLIENT_PAGE_URL_REGEXP, SKIP_JS_ERRORS_CALLBACK_OPTIONS } = require('../constants');
+const {
+    CLIENT_ERROR_MESSAGE,
+    CLIENT_PAGE_URL,
+    CLIENT_PAGE_URL_REGEXP,
+    SKIP_JS_ERRORS_CALLBACK_OPTIONS,
+    CLIENT_ERROR_REGEXP,
+} = require('../constants');
 
 fixture`TestController method`
     .page('http://localhost:3000/fixtures/page-js-errors/pages/skip-js-errors.html');
@@ -22,7 +28,7 @@ test('Should skip JS errors with SkipJsErrorsCallbackOptions', async t => {
 });
 
 test('Should skip JS errors with callback function returning Promise', async t => {
-    const asyncFunc       = () =>
+    const asyncFunc = () =>
         new Promise(resolve => setTimeout(() => resolve(true), 3000));
 
     await t.skipJsErrors(asyncFunc)
@@ -31,6 +37,13 @@ test('Should skip JS errors with callback function returning Promise', async t =
 
 test('Should skip JS errors without param', async t => {
     await t.skipJsErrors();
+});
+
+test('Should skip JS errors with SkipJsErrorsCallbackOptions containing RegExp enclosed in quotes', async t => {
+    await t.skipJsErrors({
+        message: `${ CLIENT_ERROR_REGEXP }`,
+    })
+        .click('button');
 });
 
 test('Should correctly skip JS errors with multiple method calls', async t => {


### PR DESCRIPTION
## Purpose
RegExp parsed incorrectly when passing it via CLI or as a string argument. After parsing the string into source and flags, we pass the source to a function that escapes all characters associated with the RegExp. We should escape characters only if the user sets a non-regex value.

## Approach
Do not escape chars in the string if it is a regular expression string.

## References
[#7301](https://github.com/DevExpress/testcafe/issues/7301)

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
