### PR TITLE
Proxyless: support file protocol, 'disablePageReloads' option

### DIFF
--- a/gulp/constants/functional-test-globs.js
+++ b/gulp/constants/functional-test-globs.js
@@ -28,9 +28,13 @@ const DEBUG_GLOB_2 = [
 ];
 
 const PROXYLESS_TESTS_GLOB = [
+    ...SCREENSHOT_TESTS_GLOB,
     'test/functional/fixtures/app-command/test.js',
     'test/functional/fixtures/driver/test.js',
     'test/functional/fixtures/page-error/test.js',
+    'test/functional/fixtures/page-js-errors/test.js',
+    'test/functional/fixtures/api/es-next/disable-reloads/test.js',
+    'test/functional/fixtures/quarantine/test.js',
 ];
 
 module.exports = {

--- a/src/browser/connection/service-routes.ts
+++ b/src/browser/connection/service-routes.ts
@@ -1,7 +1,16 @@
 export default {
     connect:                  '/browser/connect',
     connectWithTrailingSlash: '/browser/connect/',
+    heartbeat:                '/browser/heartbeat',
+    status:                   '/browser/status',
+    statusDone:               '/browser/status-done',
+    initScript:               '/browser/init-script',
+    idle:                     '/browser/idle',
+    idleForced:               '/browser/idle-forced',
+    activeWindowId:           '/browser/active-window-id',
+    closeWindow:              '/browser/close-window',
     serviceWorker:            '/service-worker.js',
+    openFileProtocol:         '/browser/open-file-protocol',
 
     assets: {
         index:  '/browser/assets/index.js',

--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -11,6 +11,7 @@ import {
 import { GET_WINDOW_DIMENSIONS_INFO_SCRIPT } from '../../../utils/client-functions';
 import { BrowserClient } from './cdp-client';
 import ResourceInjector from '../../../../../proxyless/resource-injector';
+import { navigateTo } from '../../../../../proxyless/cdp-utils';
 
 const MIN_AVAILABLE_DIMENSION = 50;
 
@@ -162,5 +163,12 @@ export default {
 
             await this.resizeWindow(browserId, newWidth, newHeight, outerWidth, outerHeight);
         }
+    },
+
+    async openFileProtocol (browserId, url) {
+        const { browserClient } = this.openedBrowsers[browserId];
+        const cdpClient         = await browserClient.getActiveClient();
+
+        await navigateTo(cdpClient, url);
     },
 };

--- a/src/browser/provider/index.ts
+++ b/src/browser/provider/index.ts
@@ -443,6 +443,7 @@ export default class BrowserProvider {
     public async openFileProtocol (browserId: string, url: string): Promise<void> {
         await this.plugin.openFileProtocol(browserId, url);
     }
+
     public async closeBrowserChildWindow (browserId: string): Promise<void> {
         await this.plugin.closeBrowserChildWindow(browserId);
     }

--- a/src/browser/provider/index.ts
+++ b/src/browser/provider/index.ts
@@ -440,6 +440,9 @@ export default class BrowserProvider {
         this.plugin.setActiveWindowId(browserId, val);
     }
 
+    public async openFileProtocol (browserId: string, url: string): Promise<void> {
+        await this.plugin.openFileProtocol(browserId, url);
+    }
     public async closeBrowserChildWindow (browserId: string): Promise<void> {
         await this.plugin.closeBrowserChildWindow(browserId);
     }

--- a/src/client/browser/idle-page/index.html.mustache
+++ b/src/client/browser/idle-page/index.html.mustache
@@ -28,10 +28,10 @@
 
 <script type="text/javascript">
     var idlePage = new IdlePage({
-            statusUrl:     '{{{statusUrl}}}',
-            heartbeatUrl:  '{{{heartbeatUrl}}}',
-            initScriptUrl: '{{{initScriptUrl}}}',
-            idlePageUrl:   '{{{idlePageUrl}}}'
+            statusUrl:           '{{{statusUrl}}}',
+            heartbeatUrl:        '{{{heartbeatUrl}}}',
+            initScriptUrl:       '{{{initScriptUrl}}}',
+            openFileProtocolUrl: '{{{openFileProtocolUrl}}}',
         },
         {
             retryTestPages: {{{retryTestPages}}},

--- a/src/client/browser/idle-page/index.js
+++ b/src/client/browser/idle-page/index.js
@@ -19,8 +19,8 @@ class IdlePage {
 
     async _pollStatus () {
         const urls = {
-            statusUrl:   this.communicationUrls.statusUrl,
-            idlePageUrl: this.communicationUrls.idlePageUrl,
+            statusUrl:           this.communicationUrls.statusUrl,
+            openFileProtocolUrl: this.communicationUrls.openFileProtocolUrl,
         };
 
         let { command } = await browser.checkStatus(urls, createXHR, { proxyless: this.options.proxyless });

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -1456,6 +1456,7 @@ export default class Driver extends serviceUtils.EventEmitter {
 
     _onSetTestSpeedCommand (command) {
         this.speed = command.speed;
+
         this._onReady(new DriverStatus({ isCommandResult: true }));
     }
 
@@ -1871,7 +1872,7 @@ export default class Driver extends serviceUtils.EventEmitter {
 
         this.statusBar.on(this.statusBar.UNLOCK_PAGE_BTN_CLICK, disableRealEventsPreventing);
 
-        this.speed = this.options.initialSpeed;
+        this.speed = this.options.speed;
 
         this._initConsoleMessages();
         this._initParentWindowLink();

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -386,7 +386,7 @@ export default class Driver extends serviceUtils.EventEmitter {
 
         Promise.resolve()
             .then(() => {
-                return browser.setActiveWindowId(this.communicationUrls.browserActiveWindowId, hammerhead.createNativeXHR, this.windowId);
+                return browser.setActiveWindowId(this.communicationUrls.activeWindowId, hammerhead.createNativeXHR, this.windowId);
             })
             .then(() => {
                 this._startInternal({
@@ -662,7 +662,7 @@ export default class Driver extends serviceUtils.EventEmitter {
         if (!this.closing) {
             this.closing = true;
 
-            await browser.closeWindow(this.communicationUrls.browserCloseWindowUrl, hammerhead.createNativeXHR, this.windowId);
+            await browser.closeWindow(this.communicationUrls.closeWindow, hammerhead.createNativeXHR, this.windowId);
         }
 
         childWindowToClose.driverWindow.close();
@@ -757,7 +757,7 @@ export default class Driver extends serviceUtils.EventEmitter {
 
         Promise.resolve()
             .then(() => {
-                return browser.setActiveWindowId(this.communicationUrls.browserActiveWindowId, hammerhead.createNativeXHR, this.windowId);
+                return browser.setActiveWindowId(this.communicationUrls.activeWindowId, hammerhead.createNativeXHR, this.windowId);
             })
             .then(() => {
                 this._startInternal({

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -119,8 +119,7 @@ import './command-executors/action-executor/actions-initializer';
 import { shouldSkipJsError } from './process-skip-js-errors';
 
 
-const settings = hammerhead.settings;
-
+const settings       = hammerhead.settings;
 const transport      = hammerhead.transport;
 const Promise        = hammerhead.Promise;
 const messageSandbox = hammerhead.eventSandbox.message;
@@ -1489,14 +1488,13 @@ export default class Driver extends serviceUtils.EventEmitter {
                 if (isSessionChange) {
                     storages.clear();
                     storages.lock();
-                }
-                else
-                    this.contextStorage.setItem(TEST_DONE_SENT_FLAG, false);
 
-                if (isSessionChange)
                     browser.redirect(command, hammerhead.createNativeXHR, this.communicationUrls.openFileProtocolUrl);
-                else
+                }
+                else {
+                    this.contextStorage.setItem(TEST_DONE_SENT_FLAG, false);
                     this._onReady({ isCommandResult: false });
+                }
             })
             .catch(() => {
                 return delay(CHECK_STATUS_RETRY_DELAY);

--- a/src/client/driver/iframe-driver.js
+++ b/src/client/driver/iframe-driver.js
@@ -120,7 +120,7 @@ export default class IframeDriver extends Driver {
 
     // API
     start () {
-        this.nativeDialogsTracker = new IframeNativeDialogTracker(this.dialogHandler);
+        this.nativeDialogsTracker = new IframeNativeDialogTracker(this.options.dialogHandler);
         this.statusBar            = new IframeStatusBar();
 
         const initializePromise   = this._init();

--- a/src/client/test-run/index.js.mustache
+++ b/src/client/test-run/index.js.mustache
@@ -24,6 +24,7 @@
     var browserStatusUrl           = origin + {{{browserStatusRelativeUrl}}};
     var browserStatusDoneUrl       = origin + {{{browserStatusDoneRelativeUrl}}};
     var browserIdleUrl             = origin + {{{browserIdleRelativeUrl}}};
+    var browserOpenFileProtocolUrl = origin + {{{browserOpenFileProtocolRelativeUrl}}};
     var browserActiveWindowIdUrl   = origin + {{{browserActiveWindowIdUrl}}};
     var browserCloseWindowUrl      = origin + {{{browserCloseWindowUrl}}};
     var skipJsErrors               = {{{skipJsErrors}}};
@@ -35,8 +36,20 @@
 
     var ClientDriver = window['%testCafeDriver%'];
     var driver       = new ClientDriver(testRunId,
-        { heartbeat: browserHeartbeatUrl, status: browserStatusUrl, statusDone: browserStatusDoneUrl, idle: browserIdleUrl, activeWindowId: browserActiveWindowIdUrl, closeWindow: browserCloseWindowUrl },
-        { userAgent: userAgent, fixtureName: fixtureName, testName: testName },
+        {
+            heartbeat:           browserHeartbeatUrl,
+            status:              browserStatusUrl,
+            statusDone:          browserStatusDoneUrl,
+            idle:                browserIdleUrl,
+            activeWindowId:      browserActiveWindowIdUrl,
+            closeWindow:         browserCloseWindowUrl,
+            openFileProtocolUrl: browserOpenFileProtocolUrl,
+        },
+        {
+            userAgent:   userAgent,
+            fixtureName: fixtureName,
+            testName:    testName,
+        },
         {
             selectorTimeout:            selectorTimeout,
             pageLoadTimeout:            pageLoadTimeout,
@@ -46,7 +59,7 @@
             retryTestPages:             retryTestPages,
             speed:                      speed,
             canUseDefaultWindowActions: canUseDefaultWindowActions,
-            proxyless:                  proxyless
+            proxyless:                  proxyless,
         }
     );
 

--- a/src/proxyless/cdp-utils.ts
+++ b/src/proxyless/cdp-utils.ts
@@ -1,0 +1,16 @@
+import { ProtocolApi } from 'chrome-remote-interface';
+import { StatusCodes } from 'http-status-codes';
+
+export async function redirect (client: ProtocolApi, requestId: string, url: string): Promise<void> {
+    await client.Fetch.fulfillRequest({
+        requestId,
+        responseCode:    StatusCodes.MOVED_PERMANENTLY,
+        responseHeaders: [
+            { name: 'location', value: url },
+        ],
+    });
+}
+
+export async function navigateTo (client: ProtocolApi, url: string): Promise<void> {
+    await client.Page.navigate({ url });
+}

--- a/src/proxyless/resource-injector.ts
+++ b/src/proxyless/resource-injector.ts
@@ -20,6 +20,7 @@ import debug from 'debug';
 import { StatusCodes } from 'http-status-codes';
 import { PageLoadError } from '../errors/test-run';
 import ERROR_ROUTE from './error-route';
+import { redirect, navigateTo } from './cdp-utils';
 
 
 const ALL_DOCUMENT_RESPONSES = {
@@ -121,21 +122,11 @@ export default class ResourceInjector {
 
         currentTestRun.pendingPageError = new PageLoadError(err, url);
 
-        await client.Page.navigate({ url: this._errorPageUrl });
-    }
-
-    private async _redirect (client: ProtocolApi, requestId: string, url: string): Promise<void> {
-        await client.Fetch.fulfillRequest({
-            requestId,
-            responseCode:    StatusCodes.MOVED_PERMANENTLY,
-            responseHeaders: [
-                { name: 'location', value: url },
-            ],
-        });
+        await navigateTo(client, this._errorPageUrl);
     }
 
     private async _redirectToIdlePage (client: ProtocolApi, requestId: string): Promise<void> {
-        await this._redirect(client, requestId, this._idlePageUrl);
+        await redirect(client, requestId, this._idlePageUrl);
     }
 
     private async _handleHTTPPages (client: ProtocolApi): Promise<void> {

--- a/src/runner/browser-job.ts
+++ b/src/runner/browser-job.ts
@@ -17,6 +17,7 @@ import TestRunHookController from './test-run-hook-controller';
 import TestRun from '../test-run';
 // @ts-ignore
 import { TestRun as LegacyTestRun } from 'testcafe-legacy-api';
+import { NextTestRunInfo } from '../shared/types';
 
 interface BrowserJobResultInfo {
     status: BrowserJobResult;
@@ -214,7 +215,7 @@ export default class BrowserJob extends AsyncEventEmitter {
         return this._completionQueue.length ? this._completionQueue[0].testRun : null;
     }
 
-    public async popNextTestRunUrl (connection: BrowserConnection): Promise<string | null> {
+    public async popNextTestRunInfo (connection: BrowserConnection): Promise<NextTestRunInfo | null> {
         while (this._testRunControllerQueue.length) {
             const testRunController = this._testRunControllerQueue[0];
 
@@ -238,8 +239,12 @@ export default class BrowserJob extends AsyncEventEmitter {
 
             const testRunUrl = await testRunController.start(connection, this._startTime);
 
-            if (testRunUrl)
-                return testRunUrl;
+            if (testRunUrl) {
+                return {
+                    testRunId: testRunController.testRun.id,
+                    url:       testRunUrl,
+                };
+            }
         }
 
         return null;

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -39,3 +39,9 @@ interface AutomationErrorCtors {
 
 export type ExecuteSelectorFn<T> = (selector: ExecuteSelectorCommand, errCtors: AutomationErrorCtors, startTime: number) => Promise<T>;
 
+interface NextTestRunInfo {
+    testRunId: string;
+    url: string;
+}
+
+

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -339,6 +339,7 @@ export default class TestRun extends AsyncEventEmitter {
         this.runExecutionTimeout   = this._getRunExecutionTimeout(opts);
 
         this._addInjectables();
+        this._initRequestHooks();
     }
 
     private _getPageLoadTimeout (test: Test, opts: Dictionary<OptionValue>): number {

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -287,6 +287,8 @@ export default class TestRun extends AsyncEventEmitter {
         this.requestTimeout = this._getRequestTimeout(test, opts);
 
         this.session = SessionController.getSession(this);
+        // Take proxylessRequestHookEventEmitter.
+        // Use the tracker for it.
 
         this.consoleMessages = new BrowserConsoleMessages();
 
@@ -339,7 +341,6 @@ export default class TestRun extends AsyncEventEmitter {
         this.runExecutionTimeout   = this._getRunExecutionTimeout(opts);
 
         this._addInjectables();
-        this._initRequestHooks();
     }
 
     private _getPageLoadTimeout (test: Test, opts: Dictionary<OptionValue>): number {
@@ -546,27 +547,28 @@ export default class TestRun extends AsyncEventEmitter {
         const skipJsErrors = this._prepareSkipJsErrorsOption();
 
         return Mustache.render(TEST_RUN_TEMPLATE, {
-            testRunId:                    JSON.stringify(this.session.id),
-            browserId:                    JSON.stringify(this.browserConnection.id),
-            browserHeartbeatRelativeUrl:  JSON.stringify(this.browserConnection.heartbeatRelativeUrl),
-            browserStatusRelativeUrl:     JSON.stringify(this.browserConnection.statusRelativeUrl),
-            browserStatusDoneRelativeUrl: JSON.stringify(this.browserConnection.statusDoneRelativeUrl),
-            browserIdleRelativeUrl:       JSON.stringify(this.browserConnection.idleRelativeUrl),
-            browserActiveWindowIdUrl:     JSON.stringify(this.browserConnection.activeWindowIdUrl),
-            browserCloseWindowUrl:        JSON.stringify(this.browserConnection.closeWindowUrl),
-            userAgent:                    JSON.stringify(this.browserConnection.userAgent),
-            testName:                     JSON.stringify(this.test.name),
-            fixtureName:                  JSON.stringify((this.test.fixture as Fixture).name),
-            selectorTimeout:              this.opts.selectorTimeout,
-            pageLoadTimeout:              this.pageLoadTimeout,
-            childWindowReadyTimeout:      CHILD_WINDOW_READY_TIMEOUT,
-            skipJsErrors:                 JSON.stringify(skipJsErrors),
-            retryTestPages:               this.opts.retryTestPages,
-            speed:                        this.speed,
-            dialogHandler:                JSON.stringify(this.activeDialogHandler),
-            canUseDefaultWindowActions:   JSON.stringify(await this.browserConnection.canUseDefaultWindowActions()),
-            proxyless:                    JSON.stringify(this.opts.proxyless),
-            domain:                       JSON.stringify(this.browserConnection.browserConnectionGateway.proxy.server1Info.domain),
+            testRunId:                          JSON.stringify(this.session.id),
+            browserId:                          JSON.stringify(this.browserConnection.id),
+            browserHeartbeatRelativeUrl:        JSON.stringify(this.browserConnection.heartbeatRelativeUrl),
+            browserStatusRelativeUrl:           JSON.stringify(this.browserConnection.statusRelativeUrl),
+            browserStatusDoneRelativeUrl:       JSON.stringify(this.browserConnection.statusDoneRelativeUrl),
+            browserIdleRelativeUrl:             JSON.stringify(this.browserConnection.idleRelativeUrl),
+            browserActiveWindowIdUrl:           JSON.stringify(this.browserConnection.activeWindowIdUrl),
+            browserCloseWindowUrl:              JSON.stringify(this.browserConnection.closeWindowUrl),
+            browserOpenFileProtocolRelativeUrl: JSON.stringify(this.browserConnection.openFileProtocolRelativeUrl),
+            userAgent:                          JSON.stringify(this.browserConnection.userAgent),
+            testName:                           JSON.stringify(this.test.name),
+            fixtureName:                        JSON.stringify((this.test.fixture as Fixture).name),
+            selectorTimeout:                    this.opts.selectorTimeout,
+            pageLoadTimeout:                    this.pageLoadTimeout,
+            childWindowReadyTimeout:            CHILD_WINDOW_READY_TIMEOUT,
+            skipJsErrors:                       JSON.stringify(skipJsErrors),
+            retryTestPages:                     this.opts.retryTestPages,
+            speed:                              this.speed,
+            dialogHandler:                      JSON.stringify(this.activeDialogHandler),
+            canUseDefaultWindowActions:         JSON.stringify(await this.browserConnection.canUseDefaultWindowActions()),
+            proxyless:                          JSON.stringify(this.opts.proxyless),
+            domain:                             JSON.stringify(this.browserConnection.browserConnectionGateway.proxy.server1Info.domain),
         });
     }
 

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -287,8 +287,6 @@ export default class TestRun extends AsyncEventEmitter {
         this.requestTimeout = this._getRequestTimeout(test, opts);
 
         this.session = SessionController.getSession(this);
-        // Take proxylessRequestHookEventEmitter.
-        // Use the tracker for it.
 
         this.consoleMessages = new BrowserConsoleMessages();
 

--- a/test/functional/fixtures/api/es-next/cookies/test.js
+++ b/test/functional/fixtures/api/es-next/cookies/test.js
@@ -1,5 +1,3 @@
-const config = require('../../../../config');
-
 describe('[API] Cookies', function () {
     it('Should get cookies by name', function () {
         return runTests('./testcafe-fixtures/cookies-test.js', 'Should get cookies by name');
@@ -17,11 +15,9 @@ describe('[API] Cookies', function () {
         return runTests('./testcafe-fixtures/cookies-test.js', 'Should set cookies by key-value');
     });
 
-    if (!config.proxyless) {
-        it('Should set on the client', function () {
-            return runTests('./testcafe-fixtures/cookies-test.js', 'Should set on the client');
-        });
-    }
+    it('Should set on the client', function () {
+        return runTests('./testcafe-fixtures/cookies-test.js', 'Should set on the client');
+    });
 
     it('Should delete cookies by names and url', function () {
         return runTests('./testcafe-fixtures/cookies-test.js', 'Should delete cookies by names and url');
@@ -31,9 +27,7 @@ describe('[API] Cookies', function () {
         return runTests('./testcafe-fixtures/cookies-test.js', 'Should delete cookies by objects');
     });
 
-    if (!config.proxyless) {
-        it('Should delete on the client', function () {
-            return runTests('./testcafe-fixtures/cookies-test.js', 'Should delete on the client');
-        });
-    }
+    it('Should delete on the client', function () {
+        return runTests('./testcafe-fixtures/cookies-test.js', 'Should delete on the client');
+    });
 });

--- a/test/functional/fixtures/api/es-next/disable-reloads/test.js
+++ b/test/functional/fixtures/api/es-next/disable-reloads/test.js
@@ -7,15 +7,15 @@ const config = require('../../../../config');
         return runTests('./testcafe-fixtures/default-test.js');
     });
 
-    it('Shouldn\'t reload test pages when the Runner\'s disablePageReloads option is specified', () => {
+    it("Shouldn't reload test pages when the Runner's disablePageReloads option is specified", () => {
         return runTests('./testcafe-fixtures/globally-disabled-reloads-test.js', '', { disablePageReloads: true });
     });
 
-    it('Shouldn\'t reload test pages when the fixture.disablePageReloads option is specified', () => {
+    it("Shouldn't reload test pages when the fixture.disablePageReloads option is specified", () => {
         return runTests('./testcafe-fixtures/fixture-disabled-reloads-test.js');
     });
 
-    it('Shouldn\'t reload test pages when the test.disablePageReloads option is specified', () => {
+    it("Shouldn't reload test pages when the test.disablePageReloads option is specified", () => {
         return runTests('./testcafe-fixtures/test-disabled-reloads-test.js');
     });
 
@@ -27,7 +27,7 @@ const config = require('../../../../config');
         return runTests('./testcafe-fixtures/test-enabled-reloads-test.js');
     });
 
-    it('Shouldn\'t reload test pages when the fixture.enablePageReloads and the test.disablePageReloads options are specified', () => {
+    it("Shouldn't reload test pages when the fixture.enablePageReloads and the test.disablePageReloads options are specified", () => {
         return runTests('./testcafe-fixtures/fixture-enabled-test-disabled-reloads-test.js', '', { disablePageReloads: true });
     });
 });

--- a/test/functional/fixtures/api/es-next/disable-reloads/testcafe-fixtures/helpers.js
+++ b/test/functional/fixtures/api/es-next/disable-reloads/testcafe-fixtures/helpers.js
@@ -3,6 +3,13 @@ import { ClientFunction } from 'testcafe';
 
 export const setPageTestData = ClientFunction(() => {
     window.testData = 'yo';
+
+    window.localStorage.setItem('testData', 'yo');
 });
 
-export const checkPageTestData = ClientFunction(() => window.testData === 'yo');
+export const checkPageTestData = ClientFunction(() => {
+    const isLocalStorageNotCleared = window.localStorage.getItem('testData') === 'yo';
+    const isPageNotReloaded        = window.testData === 'yo';
+
+    return isLocalStorageNotCleared && isPageNotReloaded;
+});

--- a/test/functional/fixtures/api/es-next/request/test.js
+++ b/test/functional/fixtures/api/es-next/request/test.js
@@ -93,15 +93,13 @@ describe('Request', () => {
             return runTests('testcafe-fixtures/request-test.js', 'Should send request with cookies');
         });
 
-        if (!config.proxyless) {
-            it('Should not set cookies to the client from response', function () {
-                return runTests('testcafe-fixtures/request-test.js', 'Should not set cookies to the client from response');
-            });
+        it('Should not set cookies to the client from response', function () {
+            return runTests('testcafe-fixtures/request-test.js', 'Should not set cookies to the client from response');
+        });
 
-            it('Should set cookies to the client from response', function () {
-                return runTests('testcafe-fixtures/request-test.js', 'Should set cookies to the client from response');
-            });
-        }
+        it('Should set cookies to the client from response', function () {
+            return runTests('testcafe-fixtures/request-test.js', 'Should set cookies to the client from response');
+        });
 
         it('Should return parsed json', function () {
             return runTests('testcafe-fixtures/request-test.js', 'Should return parsed json');

--- a/test/functional/fixtures/api/es-next/take-screenshot/test.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/test.js
@@ -50,6 +50,8 @@ const getReporter = function (scope) {
     });
 };
 
+const itFn = config.proxyless ? it.skip : it;
+
 describe('[API] t.takeScreenshot()', function () {
     afterEach(assertionHelper.removeScreenshotDir);
 
@@ -551,7 +553,7 @@ describe('[API] t.takeElementScreenshot()', function () {
                 });
         });
 
-        it('Should capture screenshot of the element inside a same-domain iframe', function () {
+        itFn('Should capture screenshot of the element inside a same-domain iframe', function () {
             return runTests('./testcafe-fixtures/take-element-screenshot.js', 'Same-domain iframe',
                 { setScreenshotPath: true })
                 .then(function () {
@@ -562,7 +564,7 @@ describe('[API] t.takeElementScreenshot()', function () {
                 });
         });
 
-        it('Should capture screenshot of the element inside a nested iframe', function () {
+        itFn('Should capture screenshot of the element inside a nested iframe', function () {
             return runTests('./testcafe-fixtures/take-element-screenshot.js', 'Nested iframes',
                 { setScreenshotPath: true })
                 .then(function () {
@@ -573,7 +575,7 @@ describe('[API] t.takeElementScreenshot()', function () {
                 });
         });
 
-        it('Should capture screenshot of the element inside a cross-domain iframe', function () {
+        itFn('Should capture screenshot of the element inside a cross-domain iframe', function () {
             return runTests('./testcafe-fixtures/take-element-screenshot.js', 'Cross-domain iframe',
                 { setScreenshotPath: true })
                 .then(function () {
@@ -584,7 +586,7 @@ describe('[API] t.takeElementScreenshot()', function () {
                 });
         });
 
-        it("Shouldn't scroll parent frames multiple times", function () {
+        itFn("Shouldn't scroll parent frames multiple times", function () {
             return runTests('./testcafe-fixtures/take-element-screenshot.js', 'Rescroll parents',
                 { setScreenshotPath: true })
                 .then(function () {

--- a/test/functional/fixtures/api/es-next/take-screenshot/test.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/test.js
@@ -5,6 +5,7 @@ const config                    = require('../../../../config.js');
 const assertionHelper           = require('../../../../assertion-helper.js');
 const { createReporter }        = require('../../../../utils/reporter');
 const { createWarningReporter } = require('../../../../utils/warning-reporter');
+const skipInProxyless           = require('../../../../utils/skip-in-proxyless');
 
 const SCREENSHOTS_PATH                   = path.resolve(assertionHelper.SCREENSHOTS_PATH);
 const THUMBNAILS_DIR_NAME                = assertionHelper.THUMBNAILS_DIR_NAME;
@@ -49,8 +50,6 @@ const getReporter = function (scope) {
         },
     });
 };
-
-const itFn = config.proxyless ? it.skip : it;
 
 describe('[API] t.takeScreenshot()', function () {
     afterEach(assertionHelper.removeScreenshotDir);
@@ -553,7 +552,7 @@ describe('[API] t.takeElementScreenshot()', function () {
                 });
         });
 
-        itFn('Should capture screenshot of the element inside a same-domain iframe', function () {
+        skipInProxyless('Should capture screenshot of the element inside a same-domain iframe', function () {
             return runTests('./testcafe-fixtures/take-element-screenshot.js', 'Same-domain iframe',
                 { setScreenshotPath: true })
                 .then(function () {
@@ -564,7 +563,7 @@ describe('[API] t.takeElementScreenshot()', function () {
                 });
         });
 
-        itFn('Should capture screenshot of the element inside a nested iframe', function () {
+        skipInProxyless('Should capture screenshot of the element inside a nested iframe', function () {
             return runTests('./testcafe-fixtures/take-element-screenshot.js', 'Nested iframes',
                 { setScreenshotPath: true })
                 .then(function () {
@@ -575,7 +574,7 @@ describe('[API] t.takeElementScreenshot()', function () {
                 });
         });
 
-        itFn('Should capture screenshot of the element inside a cross-domain iframe', function () {
+        skipInProxyless('Should capture screenshot of the element inside a cross-domain iframe', function () {
             return runTests('./testcafe-fixtures/take-element-screenshot.js', 'Cross-domain iframe',
                 { setScreenshotPath: true })
                 .then(function () {
@@ -586,7 +585,7 @@ describe('[API] t.takeElementScreenshot()', function () {
                 });
         });
 
-        itFn("Shouldn't scroll parent frames multiple times", function () {
+        skipInProxyless("Shouldn't scroll parent frames multiple times", function () {
             return runTests('./testcafe-fixtures/take-element-screenshot.js', 'Rescroll parents',
                 { setScreenshotPath: true })
                 .then(function () {

--- a/test/functional/fixtures/api/es-next/type/test.js
+++ b/test/functional/fixtures/api/es-next/type/test.js
@@ -1,5 +1,4 @@
-const config = require('../../../../config');
-const expect = require('chai').expect;
+const { expect } = require('chai');
 
 // NOTE: we run tests in chrome only, because we mainly test server API functionality.
 // Actions functionality is tested in lower-level raw API.
@@ -45,20 +44,18 @@ describe('[API] t.typeText()', function () {
             });
     });
 
-    if (!config.proxyless) {
-        it('Should not execute selector twice for non-existing element due to "confidential" option (GH-6623)', function () {
-            return runTests('./testcafe-fixtures/type-test.js', 'Not found selector', {
-                shouldFail:      true,
-                only:            'chrome',
-                selectorTimeout: 3000,
-            })
-                .catch(function (errs) {
-                    expect(testReport.durationMs).lessThan(6000);
-                    expect(errs[0]).to.contains(
-                        'The specified selector does not match any element in the DOM tree.'
-                    );
-                    expect(errs[0]).to.contains('> 31 |    await t.typeText(\'#not-found\', \'a\');');
-                });
-        });
-    }
+    it('Should not execute selector twice for non-existing element due to "confidential" option (GH-6623)', function () {
+        return runTests('./testcafe-fixtures/type-test.js', 'Not found selector', {
+            shouldFail:      true,
+            only:            'chrome',
+            selectorTimeout: 3000,
+        })
+            .catch(function (errs) {
+                expect(testReport.durationMs).lessThan(6000);
+                expect(errs[0]).to.contains(
+                    'The specified selector does not match any element in the DOM tree.'
+                );
+                expect(errs[0]).to.contains('> 31 |    await t.typeText(\'#not-found\', \'a\');');
+            });
+    });
 });

--- a/test/functional/fixtures/browser-provider/browser-reconnect/test.js
+++ b/test/functional/fixtures/browser-provider/browser-reconnect/test.js
@@ -63,7 +63,7 @@ function run (pathToTest, filter, initializeConnection = initializeConnectionLow
         });
 }
 
-if (config.useLocalBrowsers && !config.proxyless) {
+if (config.useLocalBrowsers) {
     // TODO: make tests stable for IE and Windows
     (config.hasBrowser('ie') ? describe.skip : describe)('Browser reconnect', function () {
         it('Should restart browser when it does not respond', function () {

--- a/test/functional/fixtures/browser-provider/chrome-emulation/test.js
+++ b/test/functional/fixtures/browser-provider/chrome-emulation/test.js
@@ -25,11 +25,9 @@ if (config.useLocalBrowsers && config.hasBrowser('chrome')) {
                 expect(failedCount).eql(0);
             }
 
-            if (!config.proxyless) {
-                it('headless', () => {
-                    return checkTouchEmulation('chrome:headless:emulation:device=iphone 6 --no-sandbox');
-                });
-            }
+            it('headless', () => {
+                return checkTouchEmulation('chrome:headless:emulation:device=iphone 6 --no-sandbox');
+            });
 
             if (!isLinuxWithoutGUI) {
                 it('non-headless', () => {

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -140,15 +140,13 @@ if (config.useLocalBrowsers) {
             });
         }
 
-        if (!config.proxyless) {
-            // TODO: stabilize test on Firefox
-            (config.hasBrowser('firefox') ? it.skip : it)('Should run tests concurrently with Role', function () {
-                return run('chrome:headless --no-sandbox', 2, './testcafe-fixtures/role-test.js')
-                    .then(() => {
-                        expect(testInfo.getData()).eql(['/fixtures/concurrency/pages/first-page.html', '/fixtures/concurrency/pages/second-page.html']);
-                    });
-            });
-        }
+        // TODO: stabilize test on Firefox
+        (config.hasBrowser('firefox') ? it.skip : it)('Should run tests concurrently with Role', function () {
+            return run('chrome:headless --no-sandbox', 2, './testcafe-fixtures/role-test.js')
+                .then(() => {
+                    expect(testInfo.getData()).eql(['/fixtures/concurrency/pages/first-page.html', '/fixtures/concurrency/pages/second-page.html']);
+                });
+        });
 
         it('Should report fixture start correctly if second fixture finishes before first', function () {
             return run('chrome:headless --no-sandbox', 2, ['./testcafe-fixtures/multifixture-test-a.js', './testcafe-fixtures/multifixture-test-b.js'], customReporter)

--- a/test/functional/fixtures/ui/test.js
+++ b/test/functional/fixtures/ui/test.js
@@ -1,11 +1,7 @@
-const config = require('../../config');
-
 describe('TestCafe UI', () => {
-    if (!config.proxyless) {
-        it('Should display correct status', () => {
-            return runTests('./testcafe-fixtures/status-bar-test.js', 'Show status prefix', { assertionTimeout: 3000 });
-        });
-    }
+    it('Should display correct status', () => {
+        return runTests('./testcafe-fixtures/status-bar-test.js', 'Show status prefix', { assertionTimeout: 3000 });
+    });
 
     it('Hide elements when resizing the window', () => {
         return runTests('./testcafe-fixtures/status-bar-test.js', 'Hide elements when resizing the window', { skip: ['android', 'ipad', 'iphone', 'edge'] });

--- a/test/functional/utils/skip-in-proxyless.js
+++ b/test/functional/utils/skip-in-proxyless.js
@@ -1,0 +1,4 @@
+const config = require('../config');
+
+module.exports = config.proxyless ? it.skip : it;
+


### PR DESCRIPTION
[Closes DevExpress/testcafe-private#19]

Changes:
* support file protocol in `proxyless` mode.
* support the `disablePageReloads` option in `proxyless` mode.
* move service routes to the separate file and use in necessary places.
* refactoring