### PR TITLE
feat: upgraded click mechanism on element if offset options isn't set and center isn't available

### DIFF
--- a/src/client/automation/visible-element-automation.ts
+++ b/src/client/automation/visible-element-automation.ts
@@ -29,6 +29,8 @@ import ensureMouseEventAfterScroll from './utils/ensure-mouse-event-after-scroll
 import WARNING_TYPES from '../../shared/warnings/types';
 
 
+const AVAILABLE_OFFSET_DEEP = 2;
+
 interface ElementStateArgsBase {
     element: HTMLElement | null;
     clientPoint: AxisValues<number> | null;
@@ -175,10 +177,10 @@ export default class VisibleElementAutomation extends SharedEventEmitter {
         return isTarget;
     }
 
-    private _getCheckedPoints (centerPoint: AxisValues<number>, deep: number): AxisValues<number>[] {
+    private _getCheckedPoints (centerPoint: AxisValues<number>): AxisValues<number>[] {
         const points = [centerPoint];
-        const stepX  = centerPoint.x / deep;
-        const stepY  = centerPoint.y / deep;
+        const stepX  = centerPoint.x / AVAILABLE_OFFSET_DEEP;
+        const stepY  = centerPoint.y / AVAILABLE_OFFSET_DEEP;
         const maxX   = centerPoint.x * 2;
         const maxY   = centerPoint.y * 2;
 
@@ -190,8 +192,8 @@ export default class VisibleElementAutomation extends SharedEventEmitter {
         return points;
     }
 
-    private async _getAvailableOffset (expectedElement: HTMLElement | null, centerPoint: AxisValues<number>, deep = 2): Promise<AxisValues<number> | null> {
-        const checkedPoints = this._getCheckedPoints(centerPoint, deep);
+    private async _getAvailableOffset (expectedElement: HTMLElement | null, centerPoint: AxisValues<number>): Promise<AxisValues<number> | null> {
+        const checkedPoints = this._getCheckedPoints(centerPoint);
 
         let screenPoint = null;
         let clientPoint = null;

--- a/src/client/automation/visible-element-automation.ts
+++ b/src/client/automation/visible-element-automation.ts
@@ -169,8 +169,17 @@ export default class VisibleElementAutomation extends SharedEventEmitter {
         return { x, y };
     }
 
-        offsetX = offsetX || offsetX === 0 ? offsetX : defaultOffsets.offsetX;
-        offsetY = offsetY || offsetY === 0 ? offsetY : defaultOffsets.offsetY;
+    private async _isTargetElement ( element: HTMLElement, expectedElement: HTMLElement | null): Promise<boolean> {
+        let isTarget = !expectedElement || element === expectedElement || element === this.element;
+
+        if (!isTarget && element) {
+            // NOTE: perform an operation with searching in dom only if necessary
+            isTarget = await this._contains(this.element, element);
+        }
+
+        return isTarget;
+    }
+
 
         return { offsetX, offsetY };
     }
@@ -199,12 +208,7 @@ export default class VisibleElementAutomation extends SharedEventEmitter {
             });
         }
 
-        let isTarget = !expectedElement || element === expectedElement || element === this.element;
-
-        if (!isTarget) {
-            // NOTE: perform an operation with searching in dom only if necessary
-            isTarget = await this._contains(this.element, element);
-        }
+        const isTarget = await this._isTargetElement(element, expectedElement);
 
         const offsetPositionChanged = screenPointBeforeAction.x !== screenPointAfterAction.x ||
                                     screenPointBeforeAction.y !== screenPointAfterAction.y;

--- a/src/client/automation/visible-element-automation.ts
+++ b/src/client/automation/visible-element-automation.ts
@@ -186,7 +186,7 @@ export default class VisibleElementAutomation extends SharedEventEmitter {
             for (let x = stepX; x < maxX; x += stepX)
                 points.push(AxisValues.create({ x, y }));
         }
-
+        
         return points;
     }
 
@@ -220,8 +220,8 @@ export default class VisibleElementAutomation extends SharedEventEmitter {
         if (this.options.isDefaultOffset) {
             const availableOffset = await this._getAvailableOffset(expectedElement, elementOffset);
 
-            // eslint-disable-next-line no-restricted-globals
-            Object.assign(elementOffset, availableOffset);
+            elementOffset.x = availableOffset?.x || elementOffset.x;
+            elementOffset.y = availableOffset?.y || elementOffset.y;
 
             this.options.offsetX = elementOffset.x;
             this.options.offsetY = elementOffset.y;

--- a/src/client/automation/visible-element-automation.ts
+++ b/src/client/automation/visible-element-automation.ts
@@ -186,7 +186,7 @@ export default class VisibleElementAutomation extends SharedEventEmitter {
             for (let x = stepX; x < maxX; x += stepX)
                 points.push(AxisValues.create({ x, y }));
         }
-        
+
         return points;
     }
 

--- a/src/client/automation/visible-element-automation.ts
+++ b/src/client/automation/visible-element-automation.ts
@@ -41,6 +41,11 @@ interface ElementStateArgs extends ElementStateArgsBase {
     inMoving: boolean;
 }
 
+interface PointOptions {
+    x: number;
+    y: number;
+}
+
 class ElementState implements ElementStateArgs {
     public element: HTMLElement | null;
     public clientPoint: AxisValues<number> | null;
@@ -153,10 +158,16 @@ export default class VisibleElementAutomation extends SharedEventEmitter {
             });
     }
 
-    private _getElementOffset (): { offsetX: number; offsetY: number } {
+    private _getElementOffset (): PointOptions {
         const defaultOffsets = getOffsetOptions(this.element);
 
-        let { offsetX, offsetY } = this.options;
+        const { offsetX, offsetY } = this.options;
+
+        const y = offsetY || offsetY === 0 ? offsetY : defaultOffsets.offsetY;
+        const x = offsetX || offsetX === 0 ? offsetX : defaultOffsets.offsetX;
+
+        return { x, y };
+    }
 
         offsetX = offsetX || offsetX === 0 ? offsetX : defaultOffsets.offsetX;
         offsetY = offsetY || offsetY === 0 ? offsetY : defaultOffsets.offsetY;
@@ -165,7 +176,7 @@ export default class VisibleElementAutomation extends SharedEventEmitter {
     }
 
     private async _wrapAction (action: () => Promise<unknown>): Promise<ElementState> {
-        const { offsetX: x, offsetY: y } = this._getElementOffset();
+        let { x, y } = this._getElementOffset();
         const screenPointBeforeAction    = await getAutomationPoint(this.element, { x, y });
         const clientPositionBeforeAction = await positionUtils.getClientPosition(this.element);
 

--- a/src/client/automation/visible-element-automation.ts
+++ b/src/client/automation/visible-element-automation.ts
@@ -217,15 +217,14 @@ export default class VisibleElementAutomation extends SharedEventEmitter {
 
         await action();
 
-        if (this.options.defaultOffset) {
+        if (this.options.isDefaultOffset) {
             const availableOffset = await this._getAvailableOffset(expectedElement, elementOffset);
 
             // eslint-disable-next-line no-restricted-globals
             Object.assign(elementOffset, availableOffset);
 
-            this.options.offsetX       = elementOffset.x;
-            this.options.offsetY       = elementOffset.y;
-            this.options.defaultOffset = false;
+            this.options.offsetX = elementOffset.x;
+            this.options.offsetY = elementOffset.y;
         }
 
         const screenPointAfterAction    = await getAutomationPoint(this.element, elementOffset);

--- a/src/client/driver/command-executors/action-executor/index.ts
+++ b/src/client/driver/command-executors/action-executor/index.ts
@@ -113,7 +113,7 @@ export default class ActionExecutor extends EventEmitter {
             const { offsetX, offsetY } = getOffsetOptions(this._elements[0], opts.offsetX, opts.offsetY);
 
             // @ts-ignore TODO
-            opts.defaultOffset = !opts.offsetX && !opts.offsetY;
+            opts.isDefaultOffset = !opts.offsetX && !opts.offsetY;
             // @ts-ignore TODO
             opts.offsetX = offsetX;
             // @ts-ignore TODO

--- a/src/client/driver/command-executors/action-executor/index.ts
+++ b/src/client/driver/command-executors/action-executor/index.ts
@@ -113,6 +113,8 @@ export default class ActionExecutor extends EventEmitter {
             const { offsetX, offsetY } = getOffsetOptions(this._elements[0], opts.offsetX, opts.offsetY);
 
             // @ts-ignore TODO
+            opts.defaultOffset = !opts.offsetX && !opts.offsetY;
+            // @ts-ignore TODO
             opts.offsetX = offsetX;
             // @ts-ignore TODO
             opts.offsetY = offsetY;

--- a/src/test-run/commands/options.d.ts
+++ b/src/test-run/commands/options.d.ts
@@ -13,7 +13,7 @@ export class ActionOptions {
 export class OffsetOptions extends ActionOptions {
     public offsetX: number;
     public offsetY: number;
-    public defaultOffset?: boolean;
+    public isDefaultOffset?: boolean;
 }
 
 export class MouseOptions extends OffsetOptions {

--- a/src/test-run/commands/options.d.ts
+++ b/src/test-run/commands/options.d.ts
@@ -13,6 +13,7 @@ export class ActionOptions {
 export class OffsetOptions extends ActionOptions {
     public offsetX: number;
     public offsetY: number;
+    public defaultOffset?: boolean;
 }
 
 export class MouseOptions extends OffsetOptions {

--- a/src/test-run/commands/options.js
+++ b/src/test-run/commands/options.js
@@ -68,9 +68,8 @@ export class OffsetOptions extends ActionOptions {
     constructor (obj, validate) {
         super();
 
-        this.offsetX         = null;
-        this.offsetY         = null;
-        this.isDefaultOffset = null;
+        this.offsetX = null;
+        this.offsetY = null;
 
         this._assignFrom(obj, validate);
     }

--- a/src/test-run/commands/options.js
+++ b/src/test-run/commands/options.js
@@ -68,8 +68,9 @@ export class OffsetOptions extends ActionOptions {
     constructor (obj, validate) {
         super();
 
-        this.offsetX = null;
-        this.offsetY = null;
+        this.offsetX         = null;
+        this.offsetY         = null;
+        this.isDefaultOffset = null;
 
         this._assignFrom(obj, validate);
     }
@@ -78,6 +79,7 @@ export class OffsetOptions extends ActionOptions {
         return [
             { name: 'offsetX', type: integerOption },
             { name: 'offsetY', type: integerOption },
+            { name: 'isDefaultOffset', type: booleanOption },
         ];
     }
 }

--- a/test/client/fixtures/automation/click-test.js
+++ b/test/client/fixtures/automation/click-test.js
@@ -578,65 +578,65 @@ $(document).ready(function () {
             });
     });
 
-    // TODO: fix test timeout for iOS
+    // TODO: stabilize test on iOS
     (isIOS ? QUnit.skip : asyncTest)('click on covered element', function () {
+        $el.css({ display: 'none' });
+
         const clickOffsets = [];
-        const el           = $el[0];
+        const $target      = addDiv(150, 150);
+        const target       = $target[0];
+        const elOffset     = $target.offset();
 
-        $el.css({ width: '100px', height: '100px', margin: 0 });
+        addDiv(elOffset.left + 50, elOffset.top + 50)
+            .css({ backgroundColor: 'red' })
+            .width(50)
+            .height(50);
 
-        const elOffset = $el.offset();
-
-        addDiv(elOffset.left + 35, elOffset.top + 35)
-            .width(30)
-            .height(30);
-
-        $el.click(function (e) {
+        $target.click(function (e) {
             clickOffsets.push({ x: Math.round(e.pageX - elOffset.left), y: Math.round(e.pageY - elOffset.top) });
         });
 
-
         Promise.resolve()
             .then(function () {
-                const click = new ClickAutomation(el, new ClickOptions({ offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
+                const click = new ClickAutomation(target, new ClickOptions({ offsetX: 75, offsetY: 75, isDefaultOffset: true }), window, cursor);
 
                 return click.run();
             })
             .then(function () {
-                const click = new ClickAutomation(el, new ClickOptions({ offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
+                const click = new ClickAutomation(target, new ClickOptions({ offsetX: 75, offsetY: 75, isDefaultOffset: true }), window, cursor);
 
                 addDiv(elOffset.left, elOffset.top)
                     .css({ backgroundColor: 'red' })
-                    .width(60)
-                    .height(60);
+                    .width(80)
+                    .height(80);
 
                 return click.run();
             })
             .then(function () {
-                const click = new ClickAutomation(el, new ClickOptions({ offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
+                const click = new ClickAutomation(target, new ClickOptions({ offsetX: 75, offsetY: 75, isDefaultOffset: true }), window, cursor);
 
-                addDiv(elOffset.left + 40, elOffset.top)
+                addDiv(elOffset.left + 70, elOffset.top)
                     .css({ backgroundColor: 'red' })
-                    .width(60)
-                    .height(60);
+                    .width(80)
+                    .height(80);
 
                 return click.run();
             })
             .then(function () {
-                const click = new ClickAutomation(el, new ClickOptions({ offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
+                const click = new ClickAutomation(target, new ClickOptions({ offsetX: 75, offsetY: 75, isDefaultOffset: true }), window, cursor);
 
-                addDiv(elOffset.left, elOffset.top + 40)
+                addDiv(elOffset.left, elOffset.top + 70)
                     .css({ backgroundColor: 'red' })
-                    .width(60)
-                    .height(60);
+                    .width(80)
+                    .height(80);
 
                 return click.run();
             })
             .then(function () {
-                deepEqual(clickOffsets[0], { x: 25, y: 25 }, 'click in the upper left corner');
-                deepEqual(clickOffsets[1], { x: 75, y: 25 }, 'click in the upper right corner');
-                deepEqual(clickOffsets[2], { x: 25, y: 75 }, 'click in the lower left corner');
-                deepEqual(clickOffsets[3], { x: 75, y: 75 }, 'click in the lower right corner');
+                deepEqual(clickOffsets[0], { x: 37, y: 37 }, 'click in the upper left corner');
+                deepEqual(clickOffsets[1], { x: 112, y: 37 }, 'click in the upper right corner');
+                deepEqual(clickOffsets[2], { x: 37, y: 112 }, 'click in the lower left corner');
+                deepEqual(clickOffsets[3], { x: 112, y: 112 }, 'click in the lower right corner');
 
                 startNext();
             });

--- a/test/client/fixtures/automation/click-test.js
+++ b/test/client/fixtures/automation/click-test.js
@@ -593,7 +593,7 @@ $(document).ready(function () {
             .height(50);
 
         $target.click(function (e) {
-            clickOffsets.push({ x: Math.round(e.pageX - elOffset.left), y: Math.round(e.pageY - elOffset.top) });
+            clickOffsets.push({ x: Math.floor(e.pageX - elOffset.left), y: Math.floor(e.pageY - elOffset.top) });
         });
 
         Promise.resolve()

--- a/test/client/fixtures/automation/click-test.js
+++ b/test/client/fixtures/automation/click-test.js
@@ -580,8 +580,8 @@ $(document).ready(function () {
 
     // TODO: fix test timeout for iOS
     (isIOS ? QUnit.skip : asyncTest)('click on covered element', function () {
-        let clickOffsets = [];
-        const el         = $el[0]
+        const clickOffsets = [];
+        const el           = $el[0];
 
         $el.css({ width: '100px', height: '100px', margin: 0 });
 
@@ -598,12 +598,12 @@ $(document).ready(function () {
 
         Promise.resolve()
             .then(() => {
-                const click = new ClickAutomation(el, new ClickOptions({offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
+                const click = new ClickAutomation(el, new ClickOptions({ offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
 
                 return click.run();
             })
             .then(() => {
-                const click = new ClickAutomation(el, new ClickOptions({offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
+                const click = new ClickAutomation(el, new ClickOptions({ offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
 
                 addDiv(elOffset.left, elOffset.top)
                     .css({ backgroundColor: 'red' })
@@ -613,7 +613,7 @@ $(document).ready(function () {
                 return click.run();
             })
             .then(() => {
-                const click = new ClickAutomation(el, new ClickOptions({offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
+                const click = new ClickAutomation(el, new ClickOptions({ offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
 
                 addDiv(elOffset.left + 40, elOffset.top)
                     .css({ backgroundColor: 'red' })
@@ -623,7 +623,7 @@ $(document).ready(function () {
                 return click.run();
             })
             .then(() => {
-                const click = new ClickAutomation(el, new ClickOptions({offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
+                const click = new ClickAutomation(el, new ClickOptions({ offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
 
                 addDiv(elOffset.left, elOffset.top + 40)
                     .css({ backgroundColor: 'red' })
@@ -633,10 +633,10 @@ $(document).ready(function () {
                 return click.run();
             })
             .then(function () {
-                deepEqual(clickOffsets[0], { x: 25, y: 25}, 'click in the upper left corner');
-                deepEqual(clickOffsets[1], { x: 75, y: 25}, 'click in the upper right corner');
-                deepEqual(clickOffsets[2], { x: 25, y: 75}, 'click in the lower left corner');
-                deepEqual(clickOffsets[3], { x: 75, y: 75}, 'click in the lower right corner');
+                deepEqual(clickOffsets[0], { x: 25, y: 25 }, 'click in the upper left corner');
+                deepEqual(clickOffsets[1], { x: 75, y: 25 }, 'click in the upper right corner');
+                deepEqual(clickOffsets[2], { x: 25, y: 75 }, 'click in the lower left corner');
+                deepEqual(clickOffsets[3], { x: 75, y: 75 }, 'click in the lower right corner');
 
                 startNext();
             });

--- a/test/client/fixtures/automation/click-test.js
+++ b/test/client/fixtures/automation/click-test.js
@@ -592,17 +592,17 @@ $(document).ready(function () {
             .height(30);
 
         $el.click(function (e) {
-            clickOffsets.push({ x: e.pageX - elOffset.left, y: e.pageY - elOffset.top });
+            clickOffsets.push({ x: Math.round(e.pageX - elOffset.left), y: Math.round(e.pageY - elOffset.top) });
         });
 
 
         Promise.resolve()
-            .then(() => {
+            .then(function () {
                 const click = new ClickAutomation(el, new ClickOptions({ offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
 
                 return click.run();
             })
-            .then(() => {
+            .then(function () {
                 const click = new ClickAutomation(el, new ClickOptions({ offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
 
                 addDiv(elOffset.left, elOffset.top)
@@ -612,7 +612,7 @@ $(document).ready(function () {
 
                 return click.run();
             })
-            .then(() => {
+            .then(function () {
                 const click = new ClickAutomation(el, new ClickOptions({ offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
 
                 addDiv(elOffset.left + 40, elOffset.top)
@@ -622,7 +622,7 @@ $(document).ready(function () {
 
                 return click.run();
             })
-            .then(() => {
+            .then(function () {
                 const click = new ClickAutomation(el, new ClickOptions({ offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
 
                 addDiv(elOffset.left, elOffset.top + 40)

--- a/test/client/fixtures/automation/click-test.js
+++ b/test/client/fixtures/automation/click-test.js
@@ -578,6 +578,70 @@ $(document).ready(function () {
             });
     });
 
+    // TODO: fix test timeout for iOS
+    (isIOS ? QUnit.skip : asyncTest)('click on covered element', function () {
+        let clickOffsets = [];
+        const el         = $el[0]
+
+        $el.css({ width: '100px', height: '100px', margin: 0 });
+
+        const elOffset = $el.offset();
+
+        addDiv(elOffset.left + 35, elOffset.top + 35)
+            .width(30)
+            .height(30);
+
+        $el.click(function (e) {
+            clickOffsets.push({ x: e.pageX - elOffset.left, y: e.pageY - elOffset.top });
+        });
+
+
+        Promise.resolve()
+            .then(() => {
+                const click = new ClickAutomation(el, new ClickOptions({offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
+
+                return click.run();
+            })
+            .then(() => {
+                const click = new ClickAutomation(el, new ClickOptions({offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
+
+                addDiv(elOffset.left, elOffset.top)
+                    .css({ backgroundColor: 'red' })
+                    .width(60)
+                    .height(60);
+
+                return click.run();
+            })
+            .then(() => {
+                const click = new ClickAutomation(el, new ClickOptions({offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
+
+                addDiv(elOffset.left + 40, elOffset.top)
+                    .css({ backgroundColor: 'red' })
+                    .width(60)
+                    .height(60);
+
+                return click.run();
+            })
+            .then(() => {
+                const click = new ClickAutomation(el, new ClickOptions({offsetX: 50, offsetY: 50, isDefaultOffset: true }), window, cursor);
+
+                addDiv(elOffset.left, elOffset.top + 40)
+                    .css({ backgroundColor: 'red' })
+                    .width(60)
+                    .height(60);
+
+                return click.run();
+            })
+            .then(function () {
+                deepEqual(clickOffsets[0], { x: 25, y: 25}, 'click in the upper left corner');
+                deepEqual(clickOffsets[1], { x: 75, y: 25}, 'click in the upper right corner');
+                deepEqual(clickOffsets[2], { x: 25, y: 75}, 'click in the lower left corner');
+                deepEqual(clickOffsets[3], { x: 75, y: 75}, 'click in the lower right corner');
+
+                startNext();
+            });
+    });
+
     asyncTest('cancel bubble', function () {
         let divClicked = false;
         let btnClicked = false;

--- a/test/functional/fixtures/api/es-next/click/pages/index.html
+++ b/test/functional/fixtures/api/es-next/click/pages/index.html
@@ -32,5 +32,26 @@
         status.textContent = 'Clicked!';
     });
 </script>
+<!--Click shifted element-->
+<div id="shifted-element" style="background: green; width: 100px; height: 100px; transform: translateX(-60px);"></div>
+<script>
+    document.querySelector('#shifted-element').addEventListener('click', function () {
+        const rect = document.querySelector('#shifted-element').getBoundingClientRect();
+
+        window.clickOffset = { x: e.pageX - rect.left, y: e.pageY - rect.top };
+    });
+</script>
+<!--Click overlapped element-->
+<div style="position: relative;">
+    <div id="overlapped-center" style="background: blue; width: 100px; height: 100px; position: absolute;"></div>
+    <div style="background: red; width: 60px; height: 60px; position: absolute;"></div>
+</div>
+<script>
+    document.querySelector('#overlapped-center').addEventListener('click', function () {
+        const rect = document.querySelector('#overlapped-center').getBoundingClientRect();
+
+        window.clickOffset = { x: e.pageX - rect.left, y: e.pageY - rect.top };
+    });
+</script>
 </body>
 </html>

--- a/test/functional/fixtures/api/es-next/click/pages/index.html
+++ b/test/functional/fixtures/api/es-next/click/pages/index.html
@@ -35,10 +35,10 @@
 <!--Click shifted element-->
 <div id="shifted-element" style="background: green; width: 100px; height: 100px; transform: translateX(-60px);"></div>
 <script>
-    document.querySelector('#shifted-element').addEventListener('click', function () {
+    document.querySelector('#shifted-element').addEventListener('click', function (e) {
         const rect = document.querySelector('#shifted-element').getBoundingClientRect();
 
-        window.clickOffset = { x: e.pageX - rect.left, y: e.pageY - rect.top };
+        window.clickOffset = { x: e.pageX - Math.round(rect.left), y: e.pageY - Math.round(rect.top) };
     });
 </script>
 <!--Click overlapped element-->
@@ -47,10 +47,10 @@
     <div style="background: red; width: 60px; height: 60px; position: absolute;"></div>
 </div>
 <script>
-    document.querySelector('#overlapped-center').addEventListener('click', function () {
+    document.querySelector('#overlapped-center').addEventListener('click', function (e) {
         const rect = document.querySelector('#overlapped-center').getBoundingClientRect();
 
-        window.clickOffset = { x: e.pageX - rect.left, y: e.pageY - rect.top };
+        window.clickOffset = { x: e.pageX - Math.round(rect.left), y: e.pageY - Math.round(rect.top) };
     });
 </script>
 </body>

--- a/test/functional/fixtures/api/es-next/click/test.js
+++ b/test/functional/fixtures/api/es-next/click/test.js
@@ -121,6 +121,14 @@ describe('[API] t.click()', function () {
         );
     });
 
+    it('Should click on a more than half-shifted element', async function () {
+        await runTests('./testcafe-fixtures/click-test.js', 'Click on a more than half-shifted element', { only: 'chrome' });
+    });
+
+    it('Should click on an element with overlapped center', async function () {
+        await runTests('./testcafe-fixtures/click-test.js', 'Click on an element with overlapped center', { only: 'chrome' });
+    });
+
     describe('[Regression](GH-628)', function () {
         it('Should click on an "option" element', function () {
             return runTests('./testcafe-fixtures/click-on-select-child-test.js', 'Click on an "option" element');

--- a/test/functional/fixtures/api/es-next/click/testcafe-fixtures/click-test.js
+++ b/test/functional/fixtures/api/es-next/click/testcafe-fixtures/click-test.js
@@ -87,7 +87,7 @@ test('Selector returns text node', async t => {
 test('Click on a more than half-shifted element', async t => {
     await t.click('#shifted-element');
 
-    const expectedClickOffset = { x: 75, y: 75 };
+    const expectedClickOffset = { x: 75, y: 25 };
     const actualClickOffset   = await getClickOffset();
 
     expect(actualClickOffset.x).eql(expectedClickOffset.x);
@@ -97,7 +97,7 @@ test('Click on a more than half-shifted element', async t => {
 test('Click on an element with overlapped center', async t => {
     await t.click('#overlapped-center');
 
-    const expectedClickOffset = { x: 75, y: 75 };
+    const expectedClickOffset = { x: 75, y: 25 };
     const actualClickOffset   = await getClickOffset();
 
     expect(actualClickOffset.x).eql(expectedClickOffset.x);

--- a/test/functional/fixtures/api/es-next/click/testcafe-fixtures/click-test.js
+++ b/test/functional/fixtures/api/es-next/click/testcafe-fixtures/click-test.js
@@ -83,6 +83,27 @@ test('Selector returns text node', async t => {
     await t.click(getNode);
 });
 
+
+test('Click on a more than half-shifted element', async t => {
+    await t.click('#shifted-element');
+
+    const expectedClickOffset = { x: 75, y: 75 };
+    const actualClickOffset   = await getClickOffset();
+
+    expect(actualClickOffset.x).eql(expectedClickOffset.x);
+    expect(actualClickOffset.y).eql(expectedClickOffset.y);
+});
+
+test('Click on an element with overlapped center', async t => {
+    await t.click('#overlapped-center');
+
+    const expectedClickOffset = { x: 75, y: 75 };
+    const actualClickOffset   = await getClickOffset();
+
+    expect(actualClickOffset.x).eql(expectedClickOffset.x);
+    expect(actualClickOffset.y).eql(expectedClickOffset.y);
+});
+
 test('Click overlapped element', async t => {
     await t.click('.child1');
 }).page('http://localhost:3000/fixtures/api/es-next/click/pages/overlapped.html');

--- a/test/server/test-run-command-options-test.js
+++ b/test/server/test-run-command-options-test.js
@@ -318,6 +318,7 @@ describe('Test run command options', function () {
                     propertyName:        'invalidProp',
                     availableProperties: [
                         'caretPos',
+                        'isDefaultOffset',
                         'modifiers',
                         'offsetX',
                         'offsetY',


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

[closes #7309]

## Purpose
Click on the available point of the element.

## Approach
1. Research ways to find uncovered and visible points of the element
2. Add tests
3. Add a searching available point of the element if the element is partly covered or hidden
4. Replace the default click offset with available

## References
https://github.com/DevExpress/testcafe/issues/7309

## Pre-Merge TODO
- [X] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
