### PR TITLE
proxyless: more fixes

### DIFF
--- a/gulp/constants/functional-test-globs.js
+++ b/gulp/constants/functional-test-globs.js
@@ -39,6 +39,7 @@ const PROXYLESS_TESTS_GLOB = [
     'test/functional/fixtures/concurrency/test.js',
     'test/functional/fixtures/api/es-next/request-hooks/test.js',
     'test/functional/fixtures/api/es-next/iframe-switching/test.js',
+    'test/functional/fixtures/api/es-next/console/test.js',
 ];
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.23",
-    "testcafe-hammerhead": "28.1.0",
+    "testcafe-hammerhead": "28.2.0",
     "testcafe-legacy-api": "5.1.6",
     "testcafe-reporter-dashboard": "^0.2.7",
     "testcafe-reporter-json": "^2.1.0",

--- a/src/browser/connection/gateway.ts
+++ b/src/browser/connection/gateway.ts
@@ -67,8 +67,8 @@ export default class BrowserConnectionGateway {
         this._dispatch(`${SERVICE_ROUTES.statusDone}/{id}`, proxy, BrowserConnectionGateway._onStatusRequestOnTestDone, 'GET', this.proxyless);
         this._dispatch(`${SERVICE_ROUTES.initScript}/{id}`, proxy, BrowserConnectionGateway._onInitScriptRequest);
         this._dispatch(`${SERVICE_ROUTES.initScript}/{id}`, proxy, BrowserConnectionGateway._onInitScriptResponse, 'POST');
-        this._dispatch(`${SERVICE_ROUTES.activeWindowId}/{id}`, proxy, BrowserConnectionGateway._onGetActiveWindowIdRequest);
-        this._dispatch(`${SERVICE_ROUTES.activeWindowId}/{id}`, proxy, BrowserConnectionGateway._onSetActiveWindowIdRequest, 'POST');
+        this._dispatch(`${SERVICE_ROUTES.activeWindowId}/{id}`, proxy, BrowserConnectionGateway._onGetActiveWindowIdRequest, 'GET', this.proxyless);
+        this._dispatch(`${SERVICE_ROUTES.activeWindowId}/{id}`, proxy, BrowserConnectionGateway._onSetActiveWindowIdRequest, 'POST', this.proxyless);
         this._dispatch(`${SERVICE_ROUTES.closeWindow}/{id}`, proxy, BrowserConnectionGateway._onCloseWindowRequest, 'POST');
         this._dispatch(`${SERVICE_ROUTES.openFileProtocol}/{id}`, proxy, BrowserConnectionGateway._onOpenFileProtocolRequest, 'POST');
 

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -259,6 +259,9 @@ export default class Driver extends serviceUtils.EventEmitter {
     }
 
     _getCurrentWindowId () {
+        if (this.options.proxyless)
+            return this.runInfo.activeWindowId;
+
         const currentUrl     = window.location.toString();
         const parsedProxyUrl = hammerhead.utils.url.parseProxyUrl(currentUrl);
 

--- a/src/client/test-run/index.js.mustache
+++ b/src/client/test-run/index.js.mustache
@@ -15,6 +15,7 @@
 
     var testRunId                  = {{{testRunId}}};
     var browserId                  = {{{browserId}}};
+    var activeWindowId             = {{{activeWindowId}}};
     var selectorTimeout            = {{{selectorTimeout}}};
     var pageLoadTimeout            = {{{pageLoadTimeout}}};
     var childWindowReadyTimeout    = {{{childWindowReadyTimeout}}};
@@ -46,9 +47,10 @@
             openFileProtocolUrl: browserOpenFileProtocolUrl,
         },
         {
-            userAgent:   userAgent,
-            fixtureName: fixtureName,
-            testName:    testName,
+            userAgent:      userAgent,
+            fixtureName:    fixtureName,
+            testName:       testName,
+            activeWindowId: activeWindowId,
         },
         {
             selectorTimeout:            selectorTimeout,

--- a/src/proxyless/request-hooks/event-provider.ts
+++ b/src/proxyless/request-hooks/event-provider.ts
@@ -7,6 +7,7 @@ import ProxylessEventFactory from './event-factory';
 import { ProtocolApi } from 'chrome-remote-interface';
 import { getResponseAsBuffer } from '../utils/string';
 import BrowserConnection from '../../browser/connection';
+import { isPreflightRequest } from '../utils/cdp';
 
 interface ContextData {
     pipelineContext: ProxylessPipelineContext;
@@ -70,8 +71,8 @@ export default class ProxylessRequestHookEventProvider extends RequestHookEventP
     }
 
     private static async _setResponseBody ({ pipelineContext, resourceBody, eventFactory, event, client }: { pipelineContext: ProxylessPipelineContext, resourceBody: Buffer | null, eventFactory: ProxylessEventFactory, event: RequestPausedEvent, client: ProtocolApi }): Promise<void> {
-        if (resourceBody?.length) {
-            eventFactory.setResponseBody(resourceBody);
+        if (resourceBody?.length || isPreflightRequest(event)) {
+            eventFactory.setResponseBody(resourceBody as Buffer);
 
             return;
         }

--- a/src/proxyless/request-pipeline/index.ts
+++ b/src/proxyless/request-pipeline/index.ts
@@ -150,8 +150,14 @@ export default class ProxylessRequestPipeline {
                     responseCode:    event.responseStatusCode as number,
                     body:            (resourceInfo.body as Buffer).toString(),
                 },
-                this._isIframe(event.frameId),
+                {
+                    isIframe:          this._isIframe(event.frameId),
+                    url:               event.request.url,
+                    restoringStorages: this.restoringStorages,
+                },
                 this._client);
+
+            this.restoringStorages = null;
         }
     }
 

--- a/src/proxyless/request-pipeline/index.ts
+++ b/src/proxyless/request-pipeline/index.ts
@@ -27,7 +27,6 @@ import {
 
 import {
     IncomingMessageLike,
-    isRedirectStatusCode,
     SPECIAL_BLANK_PAGE,
     StoragesSnapshot,
 } from 'testcafe-hammerhead';
@@ -120,7 +119,7 @@ export default class ProxylessRequestPipeline {
     }
 
     private async _respondToOtherRequest (event: RequestPausedEvent): Promise<void> {
-        if (isRedirectStatusCode(event.responseStatusCode as number)) {
+        if (isRedirect(event)) {
             await safeContinueResponse(this._client, { requestId: event.requestId });
 
             return;

--- a/src/proxyless/request-pipeline/index.ts
+++ b/src/proxyless/request-pipeline/index.ts
@@ -20,7 +20,7 @@ import {
 import {
     IncomingMessageLike,
     isRedirectStatusCode,
-    SPECIAL_BLANK_PAGE
+    SPECIAL_BLANK_PAGE,
 } from 'testcafe-hammerhead';
 import ProxylessPipelineContext from '../request-hooks/pipeline-context';
 import { ProxylessSetupOptions } from '../../shared/types';

--- a/src/proxyless/request-pipeline/index.ts
+++ b/src/proxyless/request-pipeline/index.ts
@@ -38,7 +38,7 @@ export default class ProxylessRequestPipeline {
     private readonly _specialServiceRoutes: SpecialServiceRoutes;
     private _stopped: boolean;
     private _currentFrameTree: FrameTree | null;
-    private readonly _failedRequests: string[];
+    private readonly _failedRequestIds: string[];
 
     public constructor (browserId: string, client: ProtocolApi) {
         this._client                  = client;
@@ -48,7 +48,7 @@ export default class ProxylessRequestPipeline {
         this._options                 = DEFAULT_PROXYLESS_SETUP_OPTIONS;
         this._stopped                 = false;
         this._currentFrameTree        = null;
-        this._failedRequests          = [];
+        this._failedRequestIds        = [];
     }
 
     private _getSpecialServiceRoutes (browserId: string): SpecialServiceRoutes {
@@ -171,8 +171,8 @@ export default class ProxylessRequestPipeline {
                 await this._respondToOtherRequest(event);
             }
             catch (err) {
-                if (event.networkId && this._failedRequests.includes(event.networkId)) {
-                    remove(this._failedRequests, event.networkId);
+                if (event.networkId && this._failedRequestIds.includes(event.networkId)) {
+                    remove(this._failedRequestIds, event.networkId);
 
                     return;
                 }
@@ -235,7 +235,7 @@ export default class ProxylessRequestPipeline {
         this._client.Network.on('loadingFailed', async (event: LoadingFailedEvent) => {
             requestPipelineLogger('%l', event);
 
-            this._failedRequests.push(event.requestId);
+            this._failedRequestIds.push(event.requestId);
 
             if (event.requestId)
                 this.requestHookEventProvider.cleanUp(event.requestId);

--- a/src/proxyless/request-pipeline/index.ts
+++ b/src/proxyless/request-pipeline/index.ts
@@ -17,7 +17,11 @@ import {
     requestPipelineMockLogger,
     requestPipelineOtherRequestLogger,
 } from '../../utils/debug-loggers';
-import { IncomingMessageLike, SPECIAL_BLANK_PAGE } from 'testcafe-hammerhead';
+import {
+    IncomingMessageLike,
+    isRedirectStatusCode,
+    SPECIAL_BLANK_PAGE
+} from 'testcafe-hammerhead';
 import ProxylessPipelineContext from '../request-hooks/pipeline-context';
 import { ProxylessSetupOptions } from '../../shared/types';
 import DEFAULT_PROXYLESS_SETUP_OPTIONS from '../default-setup-options';
@@ -124,6 +128,12 @@ export default class ProxylessRequestPipeline {
             }
         }
         else {
+            if (isRedirectStatusCode(event.responseStatusCode as number)) {
+                await safeContinueResponse(this._client, { requestId: event.requestId });
+
+                return;
+            }
+
             const resourceInfo = await this._resourceInjector.getDocumentResourceInfo(event, this._client);
 
             if (resourceInfo.error) {

--- a/src/proxyless/utils/cdp.ts
+++ b/src/proxyless/utils/cdp.ts
@@ -28,6 +28,10 @@ export function isRequestPausedEvent (val: any): val is RequestPausedEvent {
     return val && val.frameId && typeof val.request === 'object';
 }
 
+export function isPreflightRequest (event: RequestPausedEvent): boolean {
+    return event.request.method === 'OPTIONS';
+}
+
 export function createRequestPausedEventForResponse (mockedResponse: IncomingMessageLike, requestEvent: RequestPausedEvent): RequestPausedEvent {
     return Object.assign({}, requestEvent, {
         responseStatusCode: mockedResponse.statusCode,

--- a/src/proxyless/utils/headers.ts
+++ b/src/proxyless/utils/headers.ts
@@ -20,7 +20,7 @@ export function convertToOutgoingHttpHeaders (headers: HeaderEntry[] | undefined
         return {};
 
     return headers.reduce((result: any, header) => {
-        result[header.name] = header.value;
+        result[header.name.toLowerCase()] = header.value;
 
         return result;
     }, {});

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -571,6 +571,7 @@ export default class TestRun extends AsyncEventEmitter {
         return Mustache.render(TEST_RUN_TEMPLATE, {
             testRunId:                          JSON.stringify(this.session.id),
             browserId:                          JSON.stringify(this.browserConnection.id),
+            activeWindowId:                     JSON.stringify(this.activeWindowId),
             browserHeartbeatRelativeUrl:        JSON.stringify(this.browserConnection.heartbeatRelativeUrl),
             browserStatusRelativeUrl:           JSON.stringify(this.browserConnection.statusRelativeUrl),
             browserStatusDoneRelativeUrl:       JSON.stringify(this.browserConnection.statusDoneRelativeUrl),

--- a/test/functional/fixtures/api/es-next/request-hooks/common/mock-routes.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/common/mock-routes.js
@@ -1,5 +1,6 @@
 module.exports = {
     main:    'http://one-dummy-url.com',
     get:     'http://one-dummy-url.com/get',
+    post:    'http://one-dummy-url.com/post',
     another: 'https://another-dummy-url.com',
 };

--- a/test/functional/fixtures/api/es-next/request-hooks/pages/request-logger/mocked-requests.html
+++ b/test/functional/fixtures/api/es-next/request-hooks/pages/request-logger/mocked-requests.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <button id="send-request">Send request</button>
+    <script>
+        document.getElementById('send-request').addEventListener('click', function () {
+            fetch('http://one-dummy-url.com/post', {
+                method: 'POST',
+                body:    JSON.stringify({ foo: 'bar' }),
+                headers: {
+                    'x-custom-header': 'test',
+                }
+            })
+            .then(res => res.json());
+        });
+    </script>
+</body>
+</html>

--- a/test/functional/fixtures/api/es-next/request-hooks/test.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/test.js
@@ -55,7 +55,7 @@ describe('Request Hooks', () => {
             return runTests('./testcafe-fixtures/request-logger/request-filter-rule-predicate.js', null, { only: 'chrome' });
         });
 
-        it('Log mocked requests', () => {
+        skipInExperimentalDebug('Log mocked requests', () => {
             return runTests('./testcafe-fixtures/request-logger/mocked-requests.js', null, { only: 'chrome' });
         });
     });

--- a/test/functional/fixtures/api/es-next/request-hooks/test.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/test.js
@@ -54,6 +54,10 @@ describe('Request Hooks', () => {
         it('Request filter rule predicate', () => {
             return runTests('./testcafe-fixtures/request-logger/request-filter-rule-predicate.js', null, { only: 'chrome' });
         });
+
+        it('Log mocked requests', () => {
+            return runTests('./testcafe-fixtures/request-logger/mocked-requests.js', null, { only: 'chrome' });
+        });
     });
 
     describe('API', () => {

--- a/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/request-logger/mocked-requests.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/request-logger/mocked-requests.js
@@ -3,7 +3,6 @@ import MOCK_ROUTES from '../../common/mock-routes';
 
 const logger = RequestLogger(MOCK_ROUTES.post, {
     logRequestHeaders:     true,
-    stringifyRequestBody:  true,
     logResponseHeaders:    true,
     logResponseBody:       true,
     stringifyResponseBody: true,

--- a/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/request-logger/mocked-requests.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/request-logger/mocked-requests.js
@@ -1,0 +1,41 @@
+import { RequestMock, RequestLogger } from 'testcafe';
+import MOCK_ROUTES from '../../common/mock-routes';
+
+const logger = RequestLogger(MOCK_ROUTES.post, {
+    logRequestHeaders:     true,
+    stringifyRequestBody:  true,
+    logResponseHeaders:    true,
+    logResponseBody:       true,
+    stringifyResponseBody: true,
+});
+
+const mock = RequestMock()
+    .onRequestTo(MOCK_ROUTES.post)
+    .respond((req, res) => {
+        res.headers['access-control-allow-origin']  = '*';
+
+        if (req.method === 'OPTIONS')
+            res.headers['access-control-allow-headers'] = 'x-custom-header';
+        else {
+            res.headers['x-custom-header'] = 'mocked';
+
+            res.setBody(JSON.stringify({ foo: 'mocked' }));
+        }
+    });
+
+fixture `Fixture`
+    .requestHooks(logger, mock)
+    .page `http://localhost:3000/fixtures/api/es-next/request-hooks/pages/request-logger/mocked-requests.html`;
+
+test('Log mocked requests', async t => {
+    await t
+        .click('#send-request')
+        .expect(logger.count(r => r.request.url === MOCK_ROUTES.post)).eql(2);
+
+    const req = logger.requests[1];
+
+    await t
+        .expect(req.request.headers['x-custom-header']).eql('test')
+        .expect(req.response.headers['x-custom-header']).eql('mocked')
+        .expect(req.response.body).eql('{"foo":"mocked"}');
+});

--- a/test/functional/fixtures/api/es-next/roles/test.js
+++ b/test/functional/fixtures/api/es-next/roles/test.js
@@ -35,7 +35,7 @@ const isRemoteTask = config.currentEnvironmentName === config.testingEnvironment
             });
     });
 
-    skipInProxyless('Should restore configuration after role initializer', function () {
+    it('Should restore configuration after role initializer', function () {
         return runTests('./testcafe-fixtures/configuration-test.js', 'Restore configuration', TEST_WITH_IFRAME_RUN_OPTIONS);
     });
 


### PR DESCRIPTION
Changes:
* support redirects
* support `t.getBrowserConsoleMessages`
* support preflight requests
* handle failed requests