### PR TITLE
Configuration: proxyless + hostname

### DIFF
--- a/src/utils/is-localhost.ts
+++ b/src/utils/is-localhost.ts
@@ -1,9 +1,5 @@
-const LOCALHOST_NAMES = [
-    'localhost',
-    '127.0.0.1',
-    '[::1]',
-];
+import { LOCALHOST_NAMES } from './localhost-names';
 
 export default function (hostname: string): boolean {
-    return LOCALHOST_NAMES.includes(hostname);
+    return Object.values(LOCALHOST_NAMES).includes(hostname);
 }

--- a/src/utils/localhost-names.ts
+++ b/src/utils/localhost-names.ts
@@ -1,0 +1,5 @@
+export const LOCALHOST_NAMES = {
+    LOCALHOST: 'localhost',
+    IPv4:      '127.0.0.1',
+    IPv6:      '[::1]',
+};

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -431,6 +431,37 @@ describe('TestCafeConfiguration', function () {
                         expect(testCafeConfiguration.getOption('hostname')).eql('123.456.789');
                     });
             });
+
+            describe('Proxyless and hostname configuration', () => {
+                let configuration;
+
+                beforeEach(async () => {
+                    configuration = new TestCafeConfiguration();
+
+                    await del(configuration.defaultPaths);
+                });
+
+                it('Proxyless is enabled/hostname is unset', async () => {
+                    return configuration.init({ experimentalProxyless: true })
+                        .then(() => {
+                            expect(configuration.getOption('hostname')).eql('localhost');
+                        });
+                });
+
+                it('Proxyless is enabled/hostname is set', async () => {
+                    return configuration.init({ hostname: '123.456.789', experimentalProxyless: true })
+                        .then(() => {
+                            expect(configuration.getOption('hostname')).eql('123.456.789');
+                        });
+                });
+
+                it('Proxyless is disabled/hostname is unset', async () => {
+                    return configuration.init({ experimentalProxyless: false })
+                        .then(() => {
+                            expect(configuration.getOption('hostname')).eql(void 0);
+                        });
+                });
+            });
         });
 
         describe('Should copy value from "tsConfigPath" to compiler options', () => {


### PR DESCRIPTION
Set hostname to 'locahost' if experminetalProxyless mode is enabled to prevent block-mixed-content error.