### PR TITLE
fix: calculate the status bar reactively (closes #7384)

### DIFF
--- a/src/client/ui/status-bar/index.js
+++ b/src/client/ui/status-bar/index.js
@@ -85,6 +85,7 @@ export default class StatusBar extends serviceUtils.EventEmitter {
         this.showingTimeout    = null;
 
         this.windowHeight = document.documentElement ? styleUtils.getHeight(window) : window.innerHeight;
+        this.maxHeight    = 0;
 
         this.state = {
             created:          false,
@@ -100,6 +101,12 @@ export default class StatusBar extends serviceUtils.EventEmitter {
 
         this._createBeforeReady();
         this._initChildListening();
+    }
+
+    get visibleHeight () {
+        this.maxHeight = Math.max(this.maxHeight, styleUtils.getHeight(this.statusBar));
+
+        return this.maxHeight;
     }
 
     _createButton (text, className) {
@@ -300,13 +307,11 @@ export default class StatusBar extends serviceUtils.EventEmitter {
             this.windowHeight = window.innerHeight;
         });
 
-        const statusBarHeight = styleUtils.getHeight(this.statusBar);
-
         listeners.addFirstInternalEventBeforeListener(window, ['mousemove', 'mouseout', 'touchmove'], e => {
             if (e.type === 'mouseout' && !e.relatedTarget)
                 this._fadeIn(e);
             else if (e.type === 'mousemove' || e.type === 'touchmove') {
-                if (e.clientY > this.windowHeight - statusBarHeight)
+                if (e.clientY > this.windowHeight - this.visibleHeight)
                     this._fadeOut(e);
                 else if (this.state.hidden)
                     this._fadeIn(e);

--- a/test/functional/fixtures/ui/pages/hiding.html
+++ b/test/functional/fixtures/ui/pages/hiding.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head></head>
+    <body style="display: none;">
+        Test
+        <script>
+            setTimeout(() => {
+                document.body.style.display = 'initial';
+            }, 500);
+        </script>
+    </body>
+</html>

--- a/test/functional/fixtures/ui/test.js
+++ b/test/functional/fixtures/ui/test.js
@@ -1,3 +1,6 @@
+const config = require('../../config');
+
+
 describe('TestCafe UI', () => {
     it('Should display correct status', () => {
         return runTests('./testcafe-fixtures/status-bar-test.js', 'Show status prefix', { assertionTimeout: 3000 });
@@ -5,5 +8,13 @@ describe('TestCafe UI', () => {
 
     it('Hide elements when resizing the window', () => {
         return runTests('./testcafe-fixtures/status-bar-test.js', 'Hide elements when resizing the window', { skip: ['android', 'ipad', 'iphone', 'edge', 'safari'] });
+    });
+
+    it('Should hide the status bar even if document was hidden during initialization (GH-7384)', function () {
+        // NOTE: the test needs direct access to the CDP client through the test controller
+        if (config.experimentalDebug)
+            this.skip();
+
+        return runTests('./testcafe-fixtures/status-bar-test.js', 'Hide status bar after mouse move', { only: ['chrome'] });
     });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
When the document body is hidden (with `display: none`) during the page initialization, the status bar cannot correctly calculate its height. Later this calculated height is used to determine if the bar should hide or not when the mouse is moving. When the height is not calculated correctly, the bar will never hide.

## Approach
The status bar height is recalculated on each mouse move.

## References
Closes #7384.

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
