### PR TITLE
add types for TestController.customActions property

### DIFF
--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -31,7 +31,5 @@ interface GlobalHooks {
     request?: typeof RequestHook[] | typeof RequestHook;
 }
 
-type CustomActions = { [name: string]: () => void }
-
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type OptionValue = undefined | null | string | boolean | number | string[] | Function | { [key: string]: any } | ScreenshotOptionValue | QuarantineOptionValue | CompilerOptions | GlobalHooks | SkipJsErrorsOptionValue | CustomActions;

--- a/ts-defs-src/test-api/test-controller.d.ts
+++ b/ts-defs-src/test-api/test-controller.d.ts
@@ -97,6 +97,10 @@ interface WindowFilterData {
     url: URL;
 }
 
+interface CustomActions {
+    [key: string]: (...args: any[]) => TestControllerPromise
+}
+
 type ScrollPosition = 'top' | 'right' | 'bottom' | 'left' | 'topRight' | 'topLeft' | 'bottomRight' | 'bottomLeft' | 'center';
 
 interface TestController {
@@ -112,6 +116,10 @@ interface TestController {
      * Returns an object that contains browser information.
      */
     readonly browser: Browser;
+    /**
+     * Returns an object that contains registered custom actions.
+     */
+    readonly customActions: CustomActions;
     /**
      * Dispatches an event over a specified webpage element.
      *


### PR DESCRIPTION
## Purpose
TestController.customActions property doesn't have types definitions. 

## References
https://github.com/DevExpress/testcafe/pull/7393

## Pre-Merge TODO
- [ ] Make sure that existing tests do not fail
