### PR TITLE
proxyless handle native dialogs

### DIFF
--- a/gulp/constants/functional-test-globs.js
+++ b/gulp/constants/functional-test-globs.js
@@ -43,6 +43,8 @@ const PROXYLESS_TESTS_GLOB = [
     'test/functional/fixtures/api/es-next/roles/test.js',
     'test/functional/fixtures/request-pipeline/**/test.js',
     'test/functional/fixtures/hammerhead/worker/test.js',
+    'test/functional/fixtures/api/es-next/native-dialogs-handling/test.js',
+    'test/functional/fixtures/api/es-next/native-dialogs-handling/iframe/test.js',
 ];
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.23",
-    "testcafe-hammerhead": "https://github.com/AlexKamaev/issues/raw/master/testcafe-hammerhead-28.2.6.tgz",
+    "testcafe-hammerhead": "28.2.6",
     "testcafe-legacy-api": "5.1.6",
     "testcafe-reporter-dashboard": "^0.2.10",
     "testcafe-reporter-json": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.23",
-    "testcafe-hammerhead": "28.2.5",
+    "testcafe-hammerhead": "https://github.com/AlexKamaev/issues/raw/master/testcafe-hammerhead-28.2.6.tgz",
     "testcafe-legacy-api": "5.1.6",
     "testcafe-reporter-dashboard": "^0.2.10",
     "testcafe-reporter-json": "^2.1.0",

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -1873,13 +1873,15 @@ export default class Driver extends serviceUtils.EventEmitter {
     }
 
     _init () {
+        const { proxyless, dialogHandler, speed } = this.options;
+
         this.contextStorage       = new ContextStorage(window, this.testRunId, this.windowId);
-        this.nativeDialogsTracker = new NativeDialogTracker(this.contextStorage, this.options.dialogHandler);
+        this.nativeDialogsTracker = new NativeDialogTracker(this.contextStorage, { proxyless, dialogHandler });
         this.statusBar            = new StatusBar(this.runInfo.userAgent, this.runInfo.fixtureName, this.runInfo.testName, this.contextStorage);
 
         this.statusBar.on(this.statusBar.UNLOCK_PAGE_BTN_CLICK, disableRealEventsPreventing);
 
-        this.speed = this.options.speed;
+        this.speed = speed;
 
         this._initConsoleMessages();
         this._initParentWindowLink();

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -1875,7 +1875,12 @@ export default class Driver extends serviceUtils.EventEmitter {
     _init () {
         const { proxyless, dialogHandler, speed } = this.options;
 
-        this.contextStorage       = new ContextStorage(window, this.testRunId, this.windowId);
+        this.contextStorage = new ContextStorage(window, {
+            testRunId: this.testRunId,
+            windowId:  this.windowId,
+            proxyless,
+        });
+
         this.nativeDialogsTracker = new NativeDialogTracker(this.contextStorage, { proxyless, dialogHandler });
         this.statusBar            = new StatusBar(this.runInfo.userAgent, this.runInfo.fixtureName, this.runInfo.testName, this.contextStorage);
 

--- a/src/client/driver/iframe-driver.js
+++ b/src/client/driver/iframe-driver.js
@@ -120,7 +120,11 @@ export default class IframeDriver extends Driver {
 
     // API
     start () {
-        this.nativeDialogsTracker = new IframeNativeDialogTracker(this.options.dialogHandler);
+        this.nativeDialogsTracker = new IframeNativeDialogTracker({
+            dialogHandler: this.options.dialogHandler,
+            proxyless:     this.options.proxyless,
+        });
+
         this.statusBar            = new IframeStatusBar();
 
         const initializePromise   = this._init();

--- a/src/client/driver/iframe-driver.js
+++ b/src/client/driver/iframe-driver.js
@@ -102,7 +102,11 @@ export default class IframeDriver extends Driver {
     async _init () {
         const id = await this.parentDriverLink.establishConnection();
 
-        this.contextStorage = new ContextStorage(window, id, this.windowId);
+        this.contextStorage = new ContextStorage(window, {
+            testRunId: id,
+            windowId:  this.windowId,
+            proxyless: this.options.proxyless,
+        });
 
         if (this._failIfClientCodeExecutionIsInterrupted())
             return;

--- a/src/client/driver/native-dialog-tracker/iframe.js
+++ b/src/client/driver/native-dialog-tracker/iframe.js
@@ -6,8 +6,8 @@ const messageSandbox = hammerhead.eventSandbox.message;
 
 
 export default class IframeNativeDialogTracker extends NativeDialogTracker {
-    constructor (dialogHandler) {
-        super(null, dialogHandler);
+    constructor (options) {
+        super(null, options);
     }
 
     _defaultDialogHandler (type) {

--- a/src/client/driver/native-dialog-tracker/index.js
+++ b/src/client/driver/native-dialog-tracker/index.js
@@ -20,13 +20,7 @@ export default class NativeDialogTracker {
         this.dialogHandler  = dialogHandler;
         this.nativeHandlers = {};
 
-        if (proxyless) {
-            ['alert', 'confirm', 'prompt'].forEach(dialogType => {
-                this.nativeHandlers[dialogType] = window[dialogType];
-            });
-        }
-
-        this._init();
+        this._init(proxyless);
         this._initListening();
 
         if (this.dialogHandler)
@@ -84,7 +78,13 @@ export default class NativeDialogTracker {
         });
     }
 
-    _init () {
+    _init (proxyless) {
+        if (proxyless) {
+            ['alert', 'confirm', 'prompt'].forEach(dialogType => {
+                this.nativeHandlers[dialogType] = window[dialogType];
+            });
+        }
+
         hammerhead.on(hammerhead.EVENTS.beforeUnload, e => {
             if (e.prevented && !e.isFakeIEEvent) {
                 if (this.dialogHandler) {

--- a/src/client/driver/native-dialog-tracker/index.js
+++ b/src/client/driver/native-dialog-tracker/index.js
@@ -15,9 +15,16 @@ const GETTING_PAGE_URL_PROCESSED_SCRIPT = processScript('window.location.href');
 
 
 export default class NativeDialogTracker {
-    constructor (contextStorage, dialogHandler) {
+    constructor (contextStorage, { proxyless, dialogHandler } = {}) {
         this.contextStorage = contextStorage;
         this.dialogHandler  = dialogHandler;
+        this.nativeHandlers = {};
+
+        if (proxyless) {
+            ['alert', 'confirm', 'prompt'].forEach(dialogType => {
+                this.nativeHandlers[dialogType] = window[dialogType];
+            });
+        }
 
         this._init();
         this._initListening();
@@ -114,6 +121,11 @@ export default class NativeDialogTracker {
             catch (err) {
                 this._onHandlerError(type, err.message || String(err), url);
             }
+
+            // NOTE: need to call native handlers in proxyless
+            // mode to handle it on the cdp side
+            if (this.nativeHandlers[type])
+                this.nativeHandlers[type].call(window, text);
 
             return result;
         };

--- a/src/client/driver/storage.js
+++ b/src/client/driver/storage.js
@@ -3,15 +3,13 @@ import hammerhead from './deps/hammerhead';
 const JSON          = hammerhead.json;
 const nativeMethods = hammerhead.nativeMethods;
 
-const STORAGE_KEY_PREFIX = 'testcafe|driver|';
+const STORAGE_KEY_PREFIX    = 'testcafe|driver|';
+const PROXYLESS_STORAGE_KEY = '%proxylessContextStorage%';
 
-export default class Storage {
+class StorageStrategy {
     constructor (window, testRunId, windowId) {
         this.storage    = nativeMethods.winSessionStorageGetter.call(window);
         this.storageKey = this._createStorageKey(testRunId, windowId);
-        this.data       = {};
-
-        this._loadFromStorage();
     }
 
     _createStorageKey (testRunId, windowId) {
@@ -23,29 +21,74 @@ export default class Storage {
         return storageKey;
     }
 
-    _loadFromStorage () {
-        const savedData = nativeMethods.storageGetItem.call(this.storage, this.storageKey)
-            || window['%proxylessContextStorage%'];
+    loadFromStorage () {
+        let res = { };
+
+        const savedData = this._getData();
 
         if (savedData) {
-            this.data = JSON.parse(savedData);
+            res = JSON.parse(savedData);
 
-            window['%proxylessContextStorage%'] = null;
-
-            nativeMethods.storageRemoveItem.call(this.storage, this.storageKey);
+            this._deleteData();
         }
+
+        return res;
+    }
+
+    _getData () {
+        return nativeMethods.storageGetItem.call(this.storage, this.storageKey);
+    }
+
+    _deleteData () {
+        nativeMethods.storageRemoveItem.call(this.storage, this.storageKey);
+    }
+
+    save (data) {
+        nativeMethods.storageSetItem.call(this.storage, this.storageKey, JSON.stringify(data));
+    }
+
+    dispose () {
+        nativeMethods.storageRemoveItem.call(this.storage, this.storageKey);
+    }
+}
+
+class StorageStrategyProxyless extends StorageStrategy {
+    _getData () {
+        return super._getData() || window[PROXYLESS_STORAGE_KEY];
+    }
+
+    _deleteData () {
+        super._deleteData();
+
+        window[PROXYLESS_STORAGE_KEY] = null;
+    }
+
+    save (data) {
+        super.save(data);
+
+        if (window.PROXYLESS_STORAGE_BINDING)
+            window.PROXYLESS_STORAGE_BINDING(JSON.stringify(data));
+    }
+}
+
+export default class Storage {
+    constructor (window, { testRunId, windowId, proxyless }) {
+        this.strategy  = this._createStorageStrategy(proxyless, window, testRunId, windowId);
+        this.data      = this.strategy.loadFromStorage();
+    }
+
+    _createStorageStrategy (proxyless, window, testRunId, windowId) {
+        return proxyless ? new StorageStrategyProxyless(window, testRunId, windowId) : new StorageStrategy(window, testRunId, windowId);
     }
 
     save () {
-        nativeMethods.storageSetItem.call(this.storage, this.storageKey, JSON.stringify(this.data));
-
-        if (window.PROXYLESS_STORAGE_BINDING)
-            window.PROXYLESS_STORAGE_BINDING(JSON.stringify(this.data));
+        this.strategy.save(this.data);
     }
 
     setItem (prop, value) {
         this.data[prop] = value;
-        this.save();
+
+        this.save(this.data);
     }
 
     getItem (prop) {
@@ -53,6 +96,6 @@ export default class Storage {
     }
 
     dispose () {
-        nativeMethods.storageRemoveItem.call(this.storage, this.storageKey);
+        this.strategy.dispose();
     }
 }

--- a/src/client/driver/storage.js
+++ b/src/client/driver/storage.js
@@ -24,16 +24,23 @@ export default class Storage {
     }
 
     _loadFromStorage () {
-        const savedData = nativeMethods.storageGetItem.call(this.storage, this.storageKey);
+        const savedData = nativeMethods.storageGetItem.call(this.storage, this.storageKey)
+            || window['%proxylessContextStorage%'];
 
         if (savedData) {
             this.data = JSON.parse(savedData);
+
+            window['%proxylessContextStorage%'] = null;
+
             nativeMethods.storageRemoveItem.call(this.storage, this.storageKey);
         }
     }
 
     save () {
         nativeMethods.storageSetItem.call(this.storage, this.storageKey, JSON.stringify(this.data));
+
+        if (window.PROXYLESS_STORAGE_BINDING)
+            window.PROXYLESS_STORAGE_BINDING(JSON.stringify(this.data));
     }
 
     setItem (prop, value) {

--- a/src/client/test-run/iframe.js.mustache
+++ b/src/client/test-run/iframe.js.mustache
@@ -5,7 +5,8 @@
         pageLoadTimeout: {{{pageLoadTimeout}}},
         dialogHandler:   {{{dialogHandler}}},
         retryTestPages:  {{{retryTestPages}}},
-        speed:           {{{speed}}}
+        speed:           {{{speed}}},
+        proxyless:       {{{proxyless}}},
     });
 
     driver.start();

--- a/src/proxyless/api-base.ts
+++ b/src/proxyless/api-base.ts
@@ -11,6 +11,10 @@ export default class ProxylessApiBase {
         this._browserConnection = BrowserConnection.getById(browserId) as BrowserConnection;
     }
 
+    public async init (): Promise<void> {
+        throw new Error('Not implemented');
+    }
+
     protected get _testRun (): TestRun {
         return this._browserConnection.getCurrentTestRun() as TestRun;
     }

--- a/src/proxyless/native-dialogs/index.ts
+++ b/src/proxyless/native-dialogs/index.ts
@@ -1,0 +1,45 @@
+import { ProtocolApi } from 'chrome-remote-interface';
+import Protocol from 'devtools-protocol';
+import { Dictionary } from '../../configuration/interfaces';
+import ProxylessApiBase from '../api-base';
+
+export default class NativeDialogsAPI extends ProxylessApiBase {
+    private readonly _nativeDialogs: Dictionary<NativeDialogHistoryItem[]>;
+
+    constructor (browserId: string, client: ProtocolApi) {
+        super(browserId, client);
+
+        this._nativeDialogs = {};
+    }
+
+    public async init (): Promise<void> {
+        this._client.Page.on('javascriptDialogOpening', async ({ type, message, url }: Protocol.Page.JavascriptDialogOpeningEvent) => {
+            await this._client.Page.handleJavaScriptDialog({ accept: true });
+
+            this._nativeDialogs[this._testRun.id] = this._nativeDialogs[this._testRun.id] || [];
+
+            this._nativeDialogs[this._testRun.id].unshift({
+                text: message,
+                type,
+                url,
+            });
+        });
+    }
+
+    public async getNativeDialogHistory (): Promise<NativeDialogHistoryItem[]> {
+        const nativeDialogs = this._nativeDialogs[this._testRun.id] || [];
+
+        return nativeDialogs;
+    }
+
+    public async fixMissingBeforeUnloadHandling (): Promise<void> {
+        // NOTE: do fake mouse event to make cdp handle the `beforeunload` event.
+        // the `beforeunload` event is not handled without this click.
+        await this._client.Input.dispatchMouseEvent({
+            type:   'mousePressed',
+            button: 'left',
+            x:      -1,
+            y:      -1,
+        });
+    }
+}

--- a/src/proxyless/resource-injector.ts
+++ b/src/proxyless/resource-injector.ts
@@ -58,7 +58,13 @@ export default class ResourceInjector {
         return this._browserConnection.getCurrentTestRun();
     }
 
-    private async _prepareInjectableResources ({ isIframe, restoringStorages }: InjectableResourcesOptions): Promise<PageInjectableResources | null> {
+    private _getRestoreContextStorageScript (contextStorage?: string): string {
+        contextStorage = JSON.stringify(contextStorage || '');
+
+        return `window['%proxylessContextStorage%'] = ${contextStorage};`;
+    }
+
+    private async _prepareInjectableResources ({ isIframe, restoringStorages, contextStorage }: InjectableResourcesOptions): Promise<PageInjectableResources | null> {
         const proxy    = this._browserConnection.browserConnectionGateway.proxy;
         const windowId = this._browserConnection.activeWindowId;
 
@@ -83,7 +89,7 @@ export default class ResourceInjector {
                 ...HAMMERHEAD_INJECTABLE_SCRIPTS.map(hs => getAssetPath(hs, proxy.options.developmentMode)),
                 ...SCRIPTS.map(s => getAssetPath(s, proxy.options.developmentMode)),
             ],
-            embeddedScripts: [taskScript],
+            embeddedScripts: [this._getRestoreContextStorageScript(contextStorage), taskScript],
         };
 
         injectableResources.scripts     = injectableResources.scripts.map(script => proxy.resolveRelativeServiceUrl(script));

--- a/src/proxyless/resource-injector.ts
+++ b/src/proxyless/resource-injector.ts
@@ -61,7 +61,7 @@ export default class ResourceInjector {
     private _getRestoreContextStorageScript (contextStorage?: string): string {
         contextStorage = JSON.stringify(contextStorage || '');
 
-        return `window['%proxylessContextStorage%'] = ${contextStorage};`;
+        return `Object.defineProperty(window, '%proxylessContextStorage%', { configurable: true, value: ${contextStorage} });`;
     }
 
     private async _prepareInjectableResources ({ isIframe, restoringStorages, contextStorage }: InjectableResourcesOptions): Promise<PageInjectableResources | null> {

--- a/src/proxyless/session-storage/index.ts
+++ b/src/proxyless/session-storage/index.ts
@@ -1,0 +1,36 @@
+import { ProtocolApi } from 'chrome-remote-interface';
+import Protocol from 'devtools-protocol';
+import ProxylessApiBase from '../api-base';
+import BindingCalledEvent = Protocol.Runtime.BindingCalledEvent;
+import AsyncEventEmitter from '../../utils/async-event-emitter';
+import Emittery from 'emittery';
+
+const PROXYLESS_STORAGE_BINDING = 'PROXYLESS_STORAGE_BINDING';
+
+export default class SessionStorage extends ProxylessApiBase {
+    public sessionStorage: string;
+    private _eventEmitter: AsyncEventEmitter;
+
+    constructor (browserId: string, client: ProtocolApi) {
+        super(browserId, client);
+
+        this.sessionStorage = '';
+        this._eventEmitter = new AsyncEventEmitter();
+    }
+
+    public on (eventName: string, listener: (eventData?: any) => any): Emittery.UnsubscribeFn {
+        return this._eventEmitter.on(eventName, listener);
+    }
+
+    public async init (): Promise<void> {
+        await this._client.Runtime.addBinding({ name: PROXYLESS_STORAGE_BINDING });
+
+        await this._client.Runtime.on('bindingCalled', (event: BindingCalledEvent) => {
+            if (event.name === 'PROXYLESS_STORAGE_BINDING') {
+                this.sessionStorage = event.payload;
+
+                this._eventEmitter.emit('contextStorageModified', this.sessionStorage);
+            }
+        });
+    }
+}

--- a/src/proxyless/types.ts
+++ b/src/proxyless/types.ts
@@ -25,4 +25,5 @@ export interface InjectableResourcesOptions {
     isIframe: boolean;
     url?: string;
     restoringStorages?: StoragesSnapshot | null;
+    contextStorage?: string;
 }

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/test.js
@@ -14,7 +14,7 @@ describe('Native dialogs handling', function () {
         return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Null handler', { shouldFail: true })
             .catch(function (errs) {
                 errorInEachBrowserContains(errs, getNativeDialogNotHandledErrorText('alert', pageUrl), 0);
-                errorInEachBrowserContains(errs, '> 193 |        .click(\'#buttonAlert\');', 0);
+                errorInEachBrowserContains(errs, '> 199 |        .click(\'#buttonAlert\');', 0);
             });
     });
 
@@ -111,7 +111,7 @@ describe('Native dialogs handling', function () {
                 { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'AssertionError: expected 0 to equal 1', 0);
-                    errorInEachBrowserContains(errs, '> 163 |    expect(info.length).equals(1);', 0);
+                    errorInEachBrowserContains(errs, '> 169 |    expect(info.length).equals(1);', 0);
                 });
         });
 
@@ -129,7 +129,7 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Dialog handler has wrong type', { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'The native dialog handler is expected to be a function, ClientFunction or null, but it was number.', 0);
-                    errorInEachBrowserContains(errs, ' > 174 |    await t.setNativeDialogHandler(42);', 0);
+                    errorInEachBrowserContains(errs, ' > 180 |    await t.setNativeDialogHandler(42);', 0);
                 });
         });
 
@@ -137,7 +137,7 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Client function argument wrong type', { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'Cannot initialize a ClientFunction because ClientFunction is number, and not a function.', 0);
-                    errorInEachBrowserContains(errs, ' > 178 |    await t.setNativeDialogHandler(ClientFunction(42));', 0);
+                    errorInEachBrowserContains(errs, ' > 184 |    await t.setNativeDialogHandler(ClientFunction(42));', 0);
                 });
         });
 
@@ -145,7 +145,7 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Selector as dialogHandler', { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'The native dialog handler is expected to be a function, ClientFunction or null, but it was Selector.', 0);
-                    errorInEachBrowserContains(errs, '> 184 |    await t.setNativeDialogHandler(dialogHandler);', 0);
+                    errorInEachBrowserContains(errs, '> 190 |    await t.setNativeDialogHandler(dialogHandler);', 0);
                 });
         });
     });

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
@@ -104,7 +104,7 @@ test('Expected beforeUnload after an action', async t => {
 
     const info = await t.getNativeDialogHistory();
 
-    const { experimentalProxyless } = t.testRun.opts;
+    const experimentalProxyless = t.testRun.opts && t.testRun.opts.experimentalProxyless;
 
     if (experimentalProxyless)
         // NOTE: before unload handling through CDP does not support the type property

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
@@ -104,7 +104,13 @@ test('Expected beforeUnload after an action', async t => {
 
     const info = await t.getNativeDialogHistory();
 
-    expect(info).to.deep.equal([{ type: 'beforeunload', text: 'Before unload', url: pageUrl }]);
+    const { experimentalProxyless } = t.testRun.opts;
+
+    if (experimentalProxyless)
+        // NOTE: before unload handling through CDP does not support the type property
+        expect(info).to.deep.equal([{ type: 'beforeunload', text: '', url: pageUrl }]);
+    else
+        expect(info).to.deep.equal([{ type: 'beforeunload', text: 'Before unload', url: pageUrl }]);
 });
 
 test('Expected alert and prompt after redirect', async t => {


### PR DESCRIPTION
We solve two problems here:
1. The `beforeunload` dialog for some reason cannot be handled through CDP.
For some reason it starts working if we make some fake mouse action via CDP:
```JS
public async fixMissingBeforeUnloadHandling (): Promise<void> {
        // NOTE: do fake mouse event to make cdp handle the `beforeunload` event.
        // the `beforeunload` event is not handled without this click.
        await this._client.Input.dispatchMouseEvent({
            type:   'mousePressed',
                ...
        });
    }
```

2. Commands are still stored in the ContextStorage (which is sessionStorage actually). In proxy mode we use hammerhead and the sessionStorage is preserved between different domain page navigations. In the proxyless mode the sessionStorage is not preserved between different domain page navigations, so the `COMMAND_EXECUTING_FLAG` is not restored correctly. Thats why we have hangs on page navigations.
I use [CDP-bindings](https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#method-addBinding) to handle client code on the server side. Then, I store the `COMMAND_EXECUTING_FLAG` between page loads and restore this flag on before page load.
At this moment using bindings in temporary solution to complete the `native-dialogs` feature. However, it's still possible that we will still continue to using bindings approach.


The corresponding HH PR https://github.com/DevExpress/testcafe-hammerhead/pull/2833