### PR TITLE
fix: fixed click on SVG inside `shadowRoot`

### DIFF
--- a/src/client/core/utils/position.ts
+++ b/src/client/core/utils/position.ts
@@ -255,7 +255,7 @@ function getDisplayNoneParent (el: Node): HTMLElement {
 }
 
 function hiddenUsingStyles (el: HTMLElement): boolean {
-    return elHasVisibilityHidden(el) || elHasVisibilityCollapse(el) || elHasDisplayNone(el);
+    return !domUtils.isShadowElement(el) && (elHasVisibilityHidden(el) || elHasVisibilityCollapse(el) || elHasDisplayNone(el));
 }
 
 function hiddenByRectangle (el: HTMLElement): boolean {

--- a/test/functional/fixtures/regression/gh-7454/pages/index.html
+++ b/test/functional/fixtures/regression/gh-7454/pages/index.html
@@ -1,0 +1,16 @@
+<html>
+<body>
+    <script>
+        const shadowDOMContainer = document.createElement('div');
+        const shadow             = shadowDOMContainer.attachShadow({ mode: 'open' });
+
+        shadow.innerHTML = `<div>
+                  <svg xmlns="http://www.w3.org/2000/svg">
+                      <rect fill="#000" stroke="red" width="220" height="86"/>
+                  </svg>
+          </div>`;
+
+        document.body.appendChild(shadowDOMContainer);
+    </script>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-7454/test.js
+++ b/test/functional/fixtures/regression/gh-7454/test.js
@@ -1,5 +1,5 @@
 describe('[Regression](GH-7387)', () => {
     it('Should click on SVG inside shadowRoot', async () => {
-        return runTests('./testcafe-fixtures/index.js');
+        return runTests('./testcafe-fixtures/index.js', '', { skip: ['ie'] });
     });
 });

--- a/test/functional/fixtures/regression/gh-7454/test.js
+++ b/test/functional/fixtures/regression/gh-7454/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-7387)', () => {
+    it('Should click on SVG inside shadowRoot', async () => {
+        return runTests('./testcafe-fixtures/index.js');
+    });
+});

--- a/test/functional/fixtures/regression/gh-7454/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-7454/testcafe-fixtures/index.js
@@ -1,0 +1,9 @@
+import { Selector } from 'testcafe';
+
+fixture('Fixture').page('../pages/index.html');
+
+test('Test', async t => {
+    const rectElement = Selector('div').shadowRoot().find('rect');
+
+    await t.click(rectElement);
+});


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->
[closed #7454]

## Purpose
Fix the possibility to click on SVG element inside `shadowRoot`. Skip visibility check for `shadowRoot`.

## Approach
1. Add test
2. Update HH
3. Skip visibility check for shadowRoot

## References
https://github.com/DevExpress/testcafe-hammerhead/pull/2837
https://github.com/DevExpress/testcafe/issues/7454

## Pre-Merge TODO
- [X] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
