### PR TITLE
fix server test after the `device-specs` module update

### DIFF
--- a/test/server/chrome-provider-config-test.js
+++ b/test/server/chrome-provider-config-test.js
@@ -5,7 +5,7 @@ const getChromeConfig = require('../../lib/browser/provider/built-in/dedicated/c
 
 describe('Chrome provider config parser', function () {
     it('Should parse options and arguments', function () {
-        const config = getChromeConfig('/chrome/path/with\\::headless:emulation:device=iPhone 4;cdpPort=9222 --arg1 --arg2');
+        const config = getChromeConfig('/chrome/path/with\\::headless:emulation:device=Apple iPhone 4;cdpPort=9222 --arg1 --arg2');
 
         expect(config.path).to.equal('/chrome/path/with:');
         expect(config.userProfile).to.be.false;


### PR DESCRIPTION
The problem is in the bad searching device mechanism in the `findDevice` method:
```JS
function findDevice (deviceName) {
    const simpleName = simplifyDeviceName(deviceName);

    return emulatedDevices.filter(device => simplifyDeviceName(device.title).indexOf(simpleName) >= 0)[0];
}
```
The PR does not fix the problem, just fixes the test.

**This is not critical problem and should not affect users.**