### PR TITLE
proxyless: support client scripts

### DIFF
--- a/gulp/constants/functional-test-globs.js
+++ b/gulp/constants/functional-test-globs.js
@@ -71,6 +71,7 @@ const PROXYLESS_TESTS_GLOB = [
     '!test/functional/fixtures/regression/gh-5886/test.js',
     '!test/functional/fixtures/regression/gh-664/test.js',
     '!test/functional/fixtures/regression/hammerhead/gh-2350/test.js',
+    'test/functional/fixtures/api/es-next/custom-client-scripts/test.js',
 ];
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.23",
-    "testcafe-hammerhead": "28.3.1",
+    "testcafe-hammerhead": "28.4.0",
     "testcafe-legacy-api": "5.1.6",
     "testcafe-reporter-dashboard": "^0.2.10",
     "testcafe-reporter-json": "^2.1.0",

--- a/src/custom-client-scripts/get-code.ts
+++ b/src/custom-client-scripts/get-code.ts
@@ -2,9 +2,11 @@ import { processScript } from 'testcafe-hammerhead';
 import INTERNAL_PROPERTIES from '../client/driver/internal-properties';
 import ClientScript from './client-script';
 
-export default function getCustomClientScriptCode (script: ClientScript): string {
+export default function getCustomClientScriptCode (script: ClientScript, proxyless: boolean): string {
+    const scriptCode = proxyless ? script.content : processScript(script.content);
+
     return `try {
-        ${processScript(script.content)}
+        ${scriptCode}
     }
     catch (e) {
        window['${INTERNAL_PROPERTIES.testCafeDriverInstance}'].onCustomClientScriptError(e, '${script.module || ''}');

--- a/src/custom-client-scripts/routing.ts
+++ b/src/custom-client-scripts/routing.ts
@@ -19,7 +19,7 @@ export function isLegacyTest (test: TestItem): test is LegacyTest {
     return !!(test as LegacyTest).isLegacy;
 }
 
-export function register (proxy: Proxy, tests: Test[]): string[] {
+export function register (proxy: Proxy, tests: Test[], proxyless: boolean): string[] {
     const routes: string[] = [];
 
     tests.forEach(test => {
@@ -30,7 +30,7 @@ export function register (proxy: Proxy, tests: Test[]): string[] {
             const route = getCustomClientScriptUrl(script as ClientScript);
 
             proxy.GET(route, {
-                content:     getCustomClientScriptCode(script as ClientScript),
+                content:     getCustomClientScriptCode(script as ClientScript, proxyless),
                 contentType: CONTENT_TYPES.javascript,
             });
 

--- a/src/proxyless/request-hooks/event-factory/frame-navigated-event-based.ts
+++ b/src/proxyless/request-hooks/event-factory/frame-navigated-event-based.ts
@@ -1,0 +1,53 @@
+import {
+    BaseRequestHookEventFactory,
+    ConfigureResponseEvent,
+    ModifyResponseFunctions,
+    RequestFilterRule,
+    RequestInfo,
+    RequestOptions,
+    ResponseInfo,
+} from 'testcafe-hammerhead';
+import Protocol from 'devtools-protocol';
+import FrameNavigatedEvent = Protocol.Page.FrameNavigatedEvent;
+import { getRequestId } from '../../utils/cdp';
+
+export default class FrameNavigatedEventBasedEventFactory extends BaseRequestHookEventFactory {
+    private readonly _event: FrameNavigatedEvent;
+    private readonly _sessionId: string;
+    public constructor (event: FrameNavigatedEvent, sessionId: string) {
+        super();
+
+        this._event     = event;
+        this._sessionId = sessionId;
+    }
+
+    public createRequestInfo (): RequestInfo {
+        // NOTE: We can't get some request information from the FrameNavigated event.
+        // So, we initialize the RequestInfo object with empty or default values.
+        return new RequestInfo({
+            requestId: getRequestId(this._event),
+            sessionId: this._sessionId,
+            userAgent: '',
+            url:       this._event.frame.url,
+            method:    '',
+            headers:   {},
+            body:      Buffer.alloc(0),
+            isAjax:    false,
+        });
+    }
+
+    public createConfigureResponseEvent (rule: RequestFilterRule): ConfigureResponseEvent {
+        // NOTE: Used as a stub
+        return new ConfigureResponseEvent(rule, {} as ModifyResponseFunctions);
+    }
+
+    public createRequestOptions (): RequestOptions {
+        // NOTE: Used as a stub
+        return {} as RequestOptions;
+    }
+
+    public createResponseInfo (): ResponseInfo {
+        // NOTE: Used as a stub
+        return {} as ResponseInfo;
+    }
+}

--- a/src/proxyless/request-hooks/event-factory/request-paused-event-based.ts
+++ b/src/proxyless/request-hooks/event-factory/request-paused-event-based.ts
@@ -13,12 +13,12 @@ import Protocol from 'devtools-protocol';
 import RequestPausedEvent = Protocol.Fetch.RequestPausedEvent;
 import Request = Protocol.Network.Request;
 import HeaderEntry = Protocol.Fetch.HeaderEntry;
-import { fromBase64String } from '../utils/string';
+import { fromBase64String } from '../../utils/string';
 import { StatusCodes } from 'http-status-codes';
-import { convertToOutgoingHttpHeaders, lowerCaseHeaderNames } from '../utils/headers';
+import { convertToOutgoingHttpHeaders, lowerCaseHeaderNames } from '../../utils/headers';
 
 
-export default class ProxylessEventFactory extends BaseRequestHookEventFactory {
+export default class RequestPausedEventBasedEventFactory extends BaseRequestHookEventFactory {
     private _event: RequestPausedEvent;
     private _responseBody: Buffer;
     private readonly _sessionId: string;
@@ -85,8 +85,8 @@ export default class ProxylessEventFactory extends BaseRequestHookEventFactory {
             url:       request.url,
             method:    request.method.toLowerCase(),
             headers:   lowerCaseHeaderNames(request.headers),
-            body:      ProxylessEventFactory._getRequestData(request),
-            isAjax:    ProxylessEventFactory._getIsAjaxRequest(this._event),
+            body:      RequestPausedEventBasedEventFactory._getRequestData(request),
+            isAjax:    RequestPausedEventBasedEventFactory._getIsAjaxRequest(this._event),
         });
     }
 
@@ -102,8 +102,8 @@ export default class ProxylessEventFactory extends BaseRequestHookEventFactory {
             port:     parsedUrl.port,
             path:     parsedUrl.pathname,
             headers:  this._event.request.headers,
-            body:     ProxylessEventFactory._getRequestData(this._event.request),
-            isAjax:   ProxylessEventFactory._getIsAjaxRequest(this._event),
+            body:     RequestPausedEventBasedEventFactory._getRequestData(this._event.request),
+            isAjax:   RequestPausedEventBasedEventFactory._getIsAjaxRequest(this._event),
         };
 
         if (parsedUrl.username)

--- a/src/proxyless/request-pipeline/context-info.ts
+++ b/src/proxyless/request-pipeline/context-info.ts
@@ -1,0 +1,76 @@
+import { Dictionary } from '../../configuration/interfaces';
+import ProxylessPipelineContext from '../request-hooks/pipeline-context';
+import RequestPausedEventBasedEventFactory from '../request-hooks/event-factory/request-paused-event-based';
+import Protocol from 'devtools-protocol';
+import RequestPausedEvent = Protocol.Fetch.RequestPausedEvent;
+import FrameNavigatedEvent = Protocol.Page.FrameNavigatedEvent;
+import TestRunBridge from './test-run-bridge';
+import { getRequestId, isRequestPausedEvent } from '../utils/cdp';
+import { BaseRequestHookEventFactory } from 'testcafe-hammerhead';
+import FrameNavigatedEventBasedEventFactory from '../request-hooks/event-factory/frame-navigated-event-based';
+
+export interface ContextData {
+    pipelineContext: ProxylessPipelineContext;
+    eventFactory: BaseRequestHookEventFactory;
+}
+
+export default class ProxylessRequestContextInfo {
+    private readonly _pipelineContexts: Dictionary<ProxylessPipelineContext>;
+    private readonly _eventFactories: Dictionary<BaseRequestHookEventFactory>;
+    private readonly _testRunBridge: TestRunBridge;
+
+    public constructor (testRunBridge: TestRunBridge) {
+        this._pipelineContexts = {};
+        this._eventFactories   = {};
+        this._testRunBridge    = testRunBridge;
+    }
+
+    private _createPipelineContext (requestId: string): ProxylessPipelineContext {
+        const pipelineContext = new ProxylessPipelineContext(requestId);
+
+        this._pipelineContexts[requestId] = pipelineContext;
+
+        return pipelineContext;
+    }
+
+    private _createEventFactory (event: RequestPausedEvent | FrameNavigatedEvent): BaseRequestHookEventFactory {
+        const sessionId    = this._testRunBridge.getSessionId();
+        const requestId    = getRequestId(event);
+        const eventFactory = isRequestPausedEvent(event) ? new RequestPausedEventBasedEventFactory(event, sessionId) : new FrameNavigatedEventBasedEventFactory(event, sessionId);
+
+        this._eventFactories[requestId] = eventFactory;
+
+        return eventFactory;
+    }
+
+    private _getEventFactory (requestId: string): BaseRequestHookEventFactory {
+        return this._eventFactories[requestId];
+    }
+
+    public init (event: RequestPausedEvent | FrameNavigatedEvent): void {
+        const requestId       = getRequestId(event);
+        const pipelineContext = this._createPipelineContext(requestId);
+        const eventFactory    = this._createEventFactory(event);
+
+        pipelineContext.setRequestOptions(eventFactory);
+    }
+    public dispose (requestId?: string): void {
+        if (!requestId)
+            return;
+
+        delete this._pipelineContexts[requestId];
+        delete this._eventFactories[requestId];
+    }
+
+    public getPipelineContext (requestId: string): ProxylessPipelineContext {
+        return this._pipelineContexts[requestId];
+    }
+
+    public getContextData (event: RequestPausedEvent | FrameNavigatedEvent): ContextData {
+        const requestId       = getRequestId(event);
+        const pipelineContext = this.getPipelineContext(requestId);
+        const eventFactory    = this._getEventFactory(requestId);
+
+        return { pipelineContext, eventFactory };
+    }
+}

--- a/src/proxyless/request-pipeline/test-run-bridge.ts
+++ b/src/proxyless/request-pipeline/test-run-bridge.ts
@@ -1,0 +1,50 @@
+import TestRun from '../../test-run';
+import BrowserConnection from '../../browser/connection';
+import { UserScript } from 'testcafe-hammerhead';
+import { InjectableResourcesOptions } from '../types';
+
+export default class TestRunBridge {
+    private readonly _browserId: string;
+    public constructor (browserId: string) {
+        this._browserId = browserId;
+    }
+
+    public getBrowserConnection (): BrowserConnection {
+        return BrowserConnection.getById(this._browserId) as BrowserConnection;
+    }
+
+    public getCurrentTestRun (): TestRun {
+        const browserConnection = this.getBrowserConnection();
+
+        return browserConnection.getCurrentTestRun();
+    }
+
+    public getSessionId (): string {
+        return this.getCurrentTestRun()?.id || '';
+    }
+
+    public getUserScripts (): UserScript[] {
+        const currentTestRun = this.getCurrentTestRun();
+
+        if (!currentTestRun)
+            return [];
+
+        return currentTestRun.injectable.userScripts;
+    }
+
+    public async getTaskScript ({ isIframe }: InjectableResourcesOptions): Promise<string> {
+        const browserConnection = this.getBrowserConnection();
+        const proxy             = browserConnection.browserConnectionGateway.proxy;
+        const windowId          = browserConnection.activeWindowId;
+
+        // @ts-ignore
+        return await this.getCurrentTestRun().session.getTaskScript({
+            referer:     '',
+            cookieUrl:   '',
+            withPayload: true,
+            serverInfo:  proxy.server1Info,
+            windowId,
+            isIframe,
+        });
+    }
+}

--- a/src/proxyless/types.ts
+++ b/src/proxyless/types.ts
@@ -27,6 +27,7 @@ export interface InjectableResourcesOptions {
     url?: string;
     restoringStorages?: StoragesSnapshot | null;
     contextStorage?: SessionStorageInfo;
+    userScripts?: string[];
 }
 
 export type SessionStorageInfo = Dictionary<Dictionary<string>> | null;

--- a/src/proxyless/utils/cdp.ts
+++ b/src/proxyless/utils/cdp.ts
@@ -2,6 +2,7 @@ import { ProtocolApi } from 'chrome-remote-interface';
 import { StatusCodes } from 'http-status-codes';
 import Protocol from 'devtools-protocol';
 import RequestPausedEvent = Protocol.Fetch.RequestPausedEvent;
+import FrameNavigatedEvent = Protocol.Page.FrameNavigatedEvent;
 import { IncomingMessageLike } from 'testcafe-hammerhead';
 import { convertToHeaderEntries } from './headers';
 import { EventType } from '../types';
@@ -58,4 +59,11 @@ export function createRequestPausedEventForResponse (mockedResponse: IncomingMes
         responseStatusCode: mockedResponse.statusCode,
         responseHeaders:    convertToHeaderEntries(mockedResponse.headers),
     });
+}
+
+export function getRequestId (event: RequestPausedEvent | FrameNavigatedEvent): string {
+    if (isRequestPausedEvent(event))
+        return event.networkId as string;
+
+    return event.frame.loaderId;
 }

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -79,7 +79,7 @@ export default class Task extends AsyncEventEmitter {
 
         this.fixtureHookController = new FixtureHookController(tests, browserConnectionGroups.length);
         this._pendingBrowserJobs   = this._createBrowserJobs(proxy, this.opts);
-        this._clientScriptRoutes   = clientScriptsRouting.register(proxy, tests);
+        this._clientScriptRoutes   = clientScriptsRouting.register(proxy, tests, !!this.opts.experimentalProxyless);
         this.testStructure         = this._prepareTestStructure(tests);
 
         if (this.opts.videoPath) {

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -247,7 +247,7 @@ export default class TestRun extends AsyncEventEmitter {
     public readonly session: SessionController;
     public consoleMessages: BrowserConsoleMessages;
     private pendingRequest: PendingRequest | null;
-    private pendingPageError: PageLoadError | Error | null;
+    public pendingPageError: PageLoadError | Error | null;
     public controller: TestController | null;
     public ctx: object;
     public fixtureCtx: object | null;


### PR DESCRIPTION
Changes:
* create request pipeline context for each request
* add two event factories for `RequestPausedEvent` and `FrameNavigatedEvent` events
* move all `TestRun` related code to the `TestRunBridge` class.