### PR TITLE
Basic Http-auth in proxyless mode

### DIFF
--- a/gulp/constants/functional-test-globs.js
+++ b/gulp/constants/functional-test-globs.js
@@ -55,6 +55,7 @@ const PROXYLESS_TESTS_GLOB = [
     'test/functional/fixtures/api/es-next/generic-errors/test.js',
     'test/functional/fixtures/api/es-next/global-hooks/test.js',
     'test/functional/fixtures/api/es-next/hooks/test.js',
+    'test/functional/fixtures/api/es-next/auth/test.js',
     'test/functional/fixtures/regression/**/test.js',
     '!test/functional/fixtures/regression/gh-1138/test.js',
     '!test/functional/fixtures/regression/gh-1311/test.js',

--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -80,7 +80,7 @@ import {
 import { AssertionCommand } from '../../test-run/commands/assertion';
 import { getCallsiteId, getCallsiteStackFrameString } from '../../utils/callsite';
 import ReExecutablePromise from '../../utils/re-executable-promise';
-import sendRequest from '../../test-run/request/send';
+import { sendRequestThroughAPI as sendRequest } from '../../test-run/request/send';
 import { RequestRuntimeError } from '../../errors/runtime';
 import { RUNTIME_ERRORS } from '../../errors/types';
 import CustomActions from './custom-actions';

--- a/src/proxyless/request-pipeline/resendAuthRequest.ts
+++ b/src/proxyless/request-pipeline/resendAuthRequest.ts
@@ -1,0 +1,23 @@
+import Protocol from 'devtools-protocol';
+import Network = Protocol.Network;
+import { AuthCredentials } from '../../api/structure/interfaces';
+import { send } from '../../test-run/request/send';
+import { ResponseOptions } from '../../test-run/request/interfaces';
+import { RequestOptions } from 'testcafe-hammerhead';
+// @ts-ignore
+import { urlToHttpOptions } from 'node:url';
+
+export async function resendAuthRequest (request: Network.Request, credentials: AuthCredentials): Promise<ResponseOptions | string> {
+    const url = new URL(request.url);
+
+    const urlRequestOptions = urlToHttpOptions(url);
+
+    const requestOptions = new RequestOptions(Object.assign(urlRequestOptions, {
+        body:    request.postData || '',
+        auth:    `${credentials.username}:${credentials.password}`,
+        headers: request.headers,
+        method:  request.method,
+    }));
+
+    return send(requestOptions);
+}

--- a/src/proxyless/utils/cdp.ts
+++ b/src/proxyless/utils/cdp.ts
@@ -41,6 +41,10 @@ export function isRequest (event: RequestPausedEvent): boolean {
     return event.responseStatusCode === void 0;
 }
 
+export function isUnauthorized (statusCode: number): boolean {
+    return statusCode === 401;
+}
+
 export function isRequestPausedEvent (val: any): val is RequestPausedEvent {
     return val && val.frameId && typeof val.request === 'object';
 }

--- a/src/test-run/request/send.ts
+++ b/src/test-run/request/send.ts
@@ -1,6 +1,5 @@
 import TestRun from '../index';
-import { DestinationRequest, sameOriginCheck } from 'testcafe-hammerhead';
-import { IncomingMessage } from 'http';
+import { IncomingHttpHeaders, IncomingMessage } from 'http';
 import { ExternalRequestOptions, ResponseOptions } from './interfaces';
 import { createRequestOptions } from './create-request-options';
 import { processResponseData } from './process-response-data';
@@ -10,13 +9,18 @@ import { CallsiteRecord } from 'callsite-record';
 import { castArray } from 'lodash';
 import { RUNTIME_ERRORS } from '../../errors/types';
 
+import {
+    DestinationRequest,
+    sameOriginCheck,
+    RequestOptions,
+} from 'testcafe-hammerhead';
+
 type StrictIncomingMessage = IncomingMessage & { statusCode: number; statusMessage: string };
 
-async function send (testRun: TestRun, options: ExternalRequestOptions, callsite: CallsiteRecord | null): Promise<ResponseOptions> {
-    const currentPageUrl = new URL(await testRun.getCurrentUrl());
-    const requestOptions = await createRequestOptions(currentPageUrl, testRun, options, callsite);
-    const request        = new DestinationRequest(requestOptions);
-    const dataWaiter     = new Promise<StrictIncomingMessage | string>(resolve => {
+export async function send (requestOptions: RequestOptions, rawResponse?: boolean): Promise<ResponseOptions | string> {
+    const request = new DestinationRequest(requestOptions);
+
+    const dataWaiter = new Promise<StrictIncomingMessage | string>(resolve => {
         request.on('response', (res: StrictIncomingMessage) => resolve(res));
         request.on('error', (err: Error) => resolve(err.message));
         request.on('fatalError', (message: string) => resolve(message));
@@ -25,15 +29,9 @@ async function send (testRun: TestRun, options: ExternalRequestOptions, callsite
     const data = await dataWaiter;
 
     if (typeof data === 'string')
-        throw new RequestRuntimeError(callsite, RUNTIME_ERRORS.requestRuntimeError, data.replace(/<.*?>/g, ''));
+        return data;
 
-    const setCookie  = data.headers[HTTP_HEADERS.setCookie];
-    const sameOrigin = !currentPageUrl.host || sameOriginCheck(currentPageUrl.href, requestOptions.url);
-
-    if (setCookie && (sameOrigin || options.withCredentials) )
-        testRun.session.cookies.copySyncCookies(castArray(setCookie).join(';'), currentPageUrl.href);
-
-    const body = await processResponseData(data, options.rawResponse);
+    const body = await processResponseData(data, rawResponse);
 
     return {
         status:     data.statusCode,
@@ -43,4 +41,21 @@ async function send (testRun: TestRun, options: ExternalRequestOptions, callsite
     };
 }
 
-export default send;
+export async function sendRequestThroughAPI (testRun: TestRun, options: ExternalRequestOptions, callsite: CallsiteRecord | null): Promise<ResponseOptions> {
+    const currentPageUrl = new URL(await testRun.getCurrentUrl());
+
+    const requestOptions = await createRequestOptions(currentPageUrl, testRun, options, callsite);
+
+    const data = await send(requestOptions, options.rawResponse);
+
+    if (typeof data === 'string')
+        throw new RequestRuntimeError(callsite, RUNTIME_ERRORS.requestRuntimeError, data.replace(/<.*?>/g, ''));
+
+    const setCookie  = (data.headers as IncomingHttpHeaders)[HTTP_HEADERS.setCookie];
+    const sameOrigin = !currentPageUrl.host || sameOriginCheck(currentPageUrl.href, requestOptions.url);
+
+    if (setCookie && (sameOrigin || options.withCredentials) )
+        testRun.session.cookies.copySyncCookies(castArray(setCookie).join(';'), currentPageUrl.href);
+
+    return data;
+}

--- a/test/functional/fixtures/api/es-next/auth/test.js
+++ b/test/functional/fixtures/api/es-next/auth/test.js
@@ -1,4 +1,5 @@
-const os = require('os');
+const os                  = require('os');
+const { skipInProxyless } = require('../../../../utils/skip-in');
 
 const TRANSPARENT_PROXY_URL = os.hostname() + ':3005';
 
@@ -11,7 +12,7 @@ describe('Basic and NTLM authentications', function () {
         return runTests('./testcafe-fixtures/basic-auth-with-correct-credentials-test.js');
     });
 
-    it('Should authenticate on a "NTLM" server with correct credentials', function () {
+    skipInProxyless('Should authenticate on a "NTLM" server with correct credentials', function () {
         return runTests('./testcafe-fixtures/ntlm-auth-check-username-test.js');
     });
 
@@ -28,7 +29,7 @@ describe('Basic and NTLM authentications', function () {
             return runTests('./testcafe-fixtures/basic-auth-with-correct-credentials-test.js', null, { useProxy: TRANSPARENT_PROXY_URL });
         });
 
-        it('Should authenticate on a "NTLM" server with correct credentials', function () {
+        skipInProxyless('Should authenticate on a "NTLM" server with correct credentials', function () {
             return runTests('./testcafe-fixtures/ntlm-auth-check-username-test.js', null, { useProxy: TRANSPARENT_PROXY_URL });
         });
 


### PR DESCRIPTION
- only HTTP Basic auth
- Enter credentials only on failed request with 401 status (as in HH version)

**why?**
we cannot use [Fetch.authRequired](https://chromedevtools.github.io/devtools-protocol/tot/Fetch/#event-authRequired) event, since in this case Chrome will store credentials inside the user profile. We cannot reset credentials in this case without reopening browser.
Moreover, we cannot sent Authorization header on every request, since in this case other target websites can get access to the Authorization header + this leads to unexpected errors in browser (but I did not research these problems).

For making request, I use the method which was used in the Request API.
We handle the `requestPaused` event on the response stage. We check responseStatus. If responseStatus === 401, we are making the same request (but additionally we provide auth credentials) to the target website. Then we fulfill the original request with data from the additional request.