### PR TITLE
fix navigate to `about:blank/file://` page in the CDP mode

### DIFF
--- a/gulp/constants/functional-test-globs.js
+++ b/gulp/constants/functional-test-globs.js
@@ -36,7 +36,6 @@ const PROXYLESS_TESTS_GLOB = [
     '!test/functional/fixtures/run-options/request-timeout/test.js',
     '!test/functional/fixtures/run-options/disable-page-caching/test.js',
     '!test/functional/fixtures/live/test.js',
-    '!test/functional/fixtures/api/es-next/navigate-to-and-test-page/test.js',
     '!test/functional/fixtures/api/es-next/request/test.js',
     '!test/functional/fixtures/regression/gh-1311/test.js',
     '!test/functional/fixtures/regression/gh-1388/test.js',

--- a/src/client/browser/index.js
+++ b/src/client/browser/index.js
@@ -104,11 +104,15 @@ export function stopInitScriptExecution () {
     allowInitScriptExecution = false;
 }
 
+export function redirectUsingCdp (command, createXHR, openFileProtocolUrl) {
+    sendXHR(openFileProtocolUrl, createXHR, { method: 'POST', data: JSON.stringify({ url: command.url }) }); //eslint-disable-line no-restricted-globals
+}
+
 export function redirect (command, createXHR, openFileProtocolUrl) {
     stopInitScriptExecution();
 
     if (isFileProtocol(command.url))
-        sendXHR(openFileProtocolUrl, createXHR, { method: 'POST', data: JSON.stringify({ url: command.url }) }); //eslint-disable-line no-restricted-globals
+        redirectUsingCdp(command, createXHR, openFileProtocolUrl);
     else
         document.location = command.url;
 }

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -117,6 +117,7 @@ import createErrorCtorCallback, {
 } from '../../shared/errors/selector-error-ctor-callback';
 import './command-executors/action-executor/actions-initializer';
 import { shouldSkipJsError } from './process-skip-js-errors';
+import isFileProtocol from '../../shared/utils/is-file-protocol';
 
 
 const settings       = hammerhead.settings;
@@ -1242,12 +1243,16 @@ export default class Driver extends serviceUtils.EventEmitter {
     _onNavigateToCommand (command) {
         this.contextStorage.setItem(this.COMMAND_EXECUTING_FLAG, true);
 
-        executeNavigateToCommand(command)
-            .then(driverStatus => {
-                this.contextStorage.setItem(this.COMMAND_EXECUTING_FLAG, false);
+        if (this.options.proxyless && isFileProtocol(command.url))
+            browser.redirectUsingCdp(command, hammerhead.createNativeXHR, this.communicationUrls.openFileProtocolUrl);
+        else {
+            executeNavigateToCommand(command)
+                .then(driverStatus => {
+                    this.contextStorage.setItem(this.COMMAND_EXECUTING_FLAG, false);
 
-                return this._onReady(driverStatus);
-            });
+                    return this._onReady(driverStatus);
+                });
+        }
     }
 
     _onGetProxyUrlCommand (command) {

--- a/src/proxyless/request-pipeline/index.ts
+++ b/src/proxyless/request-pipeline/index.ts
@@ -312,7 +312,7 @@ export default class ProxylessRequestPipeline extends ProxylessApiBase {
 
             const userScripts = await this._getUserScripts(event);
 
-            await this._resourceInjector.processAboutBlankPage(event, userScripts, this._client);
+            await this._resourceInjector.processAboutBlankPage(event, userScripts, this.contextStorage, this._client);
 
             this._contextInfo.dispose(getRequestId(event));
         });

--- a/src/proxyless/resource-injector.ts
+++ b/src/proxyless/resource-injector.ts
@@ -181,10 +181,10 @@ export default class ResourceInjector {
         }
     }
 
-    public async processAboutBlankPage (event: FrameNavigatedEvent, userScripts: string[], client: ProtocolApi): Promise<void> {
+    public async processAboutBlankPage (event: FrameNavigatedEvent, userScripts: string[], contextStorage: SessionStorageInfo | null, client: ProtocolApi): Promise<void> {
         resourceInjectorLogger('Handle page as about:blank. Origin url: %s', event.frame.url);
 
-        const injectableResources = await this._prepareInjectableResources({ isIframe: false, userScripts }) as PageInjectableResources;
+        const injectableResources = await this._prepareInjectableResources({ isIframe: false, userScripts, contextStorage }) as PageInjectableResources;
         const html                = injectResources(EMPTY_PAGE_MARKUP, injectableResources);
 
         await client.Page.setDocumentContent({

--- a/src/shared/utils/is-file-protocol.ts
+++ b/src/shared/utils/is-file-protocol.ts
@@ -1,4 +1,4 @@
-const FILE_PROTOCOL = 'file:///';
+const FILE_PROTOCOL = 'file://';
 
 function isFileProtocol (url = ''): boolean {
     return url.indexOf(FILE_PROTOCOL) === 0;


### PR DESCRIPTION
1. Make the `isFileProtocol` condition less strong, since it's very common to write file URI with just two slashes like `file://blabla` instead of `file:///blabla`.
2. Add contextStorage restoring to the blank page to complete executing function (COMMAND_EXECUTING_FLAG)
3. Use CDP redirect in the navigateTo command in case of the proxyless mode and file protocol usage.