### PR TITLE
proxyless: implement 'keyPress' action

### DIFF
--- a/src/client/automation/playback/click/index.ts
+++ b/src/client/automation/playback/click/index.ts
@@ -5,7 +5,7 @@ import delay from '../../../core/utils/delay';
 // @ts-ignore
 import { utils, Promise } from '../../deps/hammerhead';
 import { createMouseClickStrategy, MouseClickStrategy } from './browser-click-strategy';
-import ProxylessEventSimulator from '../../../../proxyless/client/event-simulator';
+import ProxylessInput from '../../../../proxyless/client/input';
 import AxisValues from '../../../core/utils/values/axis-values';
 import { setCaretPosition } from '../../utils/utils';
 
@@ -31,14 +31,14 @@ export default class ClickAutomation extends VisibleElementAutomation {
 
     private _mousedown (eventArgs: MouseEventArgs): Promise<void> {
         if (this.canUseProxylessEventSimulator(eventArgs.element))
-            return (this.proxylessEventSimulator as ProxylessEventSimulator).mouseDown(eventArgs);
+            return (this.proxylessInput as ProxylessInput).mouseDown(eventArgs);
 
         return this.strategy.mousedown(eventArgs);
     }
 
     private _mouseup (element: HTMLElement, eventArgs: MouseEventArgs): Promise<MouseEventArgs> {
         if (this.canUseProxylessEventSimulator(eventArgs.element)) {
-            return (this.proxylessEventSimulator as ProxylessEventSimulator).mouseUp(eventArgs)
+            return (this.proxylessInput as ProxylessInput).mouseUp(eventArgs)
                 .then(result => {
                     const caretPos = (this.options as ClickOptions).caretPos;
 

--- a/src/client/automation/playback/press/get-key-info.ts
+++ b/src/client/automation/playback/press/get-key-info.ts
@@ -1,0 +1,50 @@
+import isLetterKey from '../../utils/is-letter';
+// @ts-ignore
+import { getSanitizedKey, KEY_MAPS } from '../../deps/testcafe-core';
+import getKeyIdentifier from '../../utils/get-key-identifier';
+import getKeyCode from '../../utils/get-key-code';
+
+export interface KeyInfo {
+    sanitizedKey: string;
+    isChar: boolean;
+    modifierKeyCode: string;
+    specialKeyCode: string;
+    isLetter: boolean;
+    isEnter: boolean;
+    keyIdentifierProperty: string;
+    keyProperty: string;
+    keyCode: string | null;
+}
+
+export default function (key: string, eventKeyProperty: string): KeyInfo {
+    const sanitizedKey    = getSanitizedKey(key);
+    const isChar          = key.length === 1 || key === 'space';
+    const isEnter         = key === 'enter';
+    const modifierKeyCode = KEY_MAPS.modifiers[sanitizedKey];
+    const specialKeyCode  = KEY_MAPS.specialKeys[sanitizedKey];
+
+    return {
+        sanitizedKey,
+        isChar,
+        modifierKeyCode,
+        specialKeyCode,
+        isEnter,
+        isLetter:              isLetterKey(key),
+        keyIdentifierProperty: getKeyIdentifier(eventKeyProperty),
+        keyProperty:           KEY_MAPS.keyProperty[eventKeyProperty] || eventKeyProperty,
+        keyCode:               getResultKeyCode(key, isChar, sanitizedKey, modifierKeyCode, specialKeyCode),
+    };
+}
+
+function getResultKeyCode (key: string, isChar: boolean, sanitizedKey: string, modifierKeyCode: string, specialKeyCode: string): string | null {
+    let keyCode = null;
+
+    if (isChar && key !== 'space')
+        keyCode = getKeyCode(sanitizedKey);
+    else if (modifierKeyCode)
+        keyCode = modifierKeyCode;
+    else if (specialKeyCode)
+        keyCode = specialKeyCode;
+
+    return keyCode;
+}

--- a/src/client/automation/playback/press/key-press-simulator.js
+++ b/src/client/automation/playback/press/key-press-simulator.js
@@ -1,21 +1,13 @@
 import hammerhead from '../../deps/hammerhead';
-import {
-    KEY_MAPS,
-    domUtils,
-    getSanitizedKey,
-} from '../../deps/testcafe-core';
-
+import { domUtils } from '../../deps/testcafe-core';
 import typeText from '../type/type-text';
 import {
     getChar,
     getDeepActiveElement,
     changeLetterCase,
 } from './utils';
-
-import getKeyCode from '../../utils/get-key-code';
-import getKeyIdentifier from '../../utils/get-key-identifier';
-import isLetterKey from '../../utils/is-letter';
 import getKeyProperties from '../../utils/get-key-properties';
+import getKeyInfo from './get-key-info';
 
 const browserUtils   = hammerhead.utils.browser;
 const extend         = hammerhead.utils.extend;
@@ -24,24 +16,12 @@ const eventSimulator = hammerhead.eventSandbox.eventSimulator;
 
 export default class KeyPressSimulator {
     constructor (key, eventKeyProperty) {
-        this.isLetter              = isLetterKey(key);
-        this.isChar                = key.length === 1 || key === 'space';
-        this.sanitizedKey          = getSanitizedKey(key);
-        this.modifierKeyCode       = KEY_MAPS.modifiers[this.sanitizedKey];
-        this.specialKeyCode        = KEY_MAPS.specialKeys[this.sanitizedKey];
-        this.keyCode               = null;
-        this.keyIdentifierProperty = getKeyIdentifier(eventKeyProperty);
+        const keyInfo = getKeyInfo(key, eventKeyProperty);
+
+        extend(this, keyInfo);
+
         this.topSameDomainDocument = domUtils.getTopSameDomainWindow(window).document;
-        this.keyProperty           = KEY_MAPS.keyProperty[eventKeyProperty] || eventKeyProperty;
-
-        if (this.isChar && key !== 'space')
-            this.keyCode = getKeyCode(this.sanitizedKey);
-        else if (this.modifierKeyCode)
-            this.keyCode = this.modifierKeyCode;
-        else if (this.specialKeyCode)
-            this.keyCode = this.specialKeyCode;
-
-        this.storedActiveElement = null;
+        this.storedActiveElement   = null;
     }
 
     static _isKeyActivatedInputElement (el) {

--- a/src/client/automation/visible-element-automation.ts
+++ b/src/client/automation/visible-element-automation.ts
@@ -27,7 +27,7 @@ import ScrollAutomation from '../core/scroll/index';
 import { Dictionary } from '../../configuration/interfaces';
 import ensureMouseEventAfterScroll from './utils/ensure-mouse-event-after-scroll';
 import WARNING_TYPES from '../../shared/warnings/types';
-import ProxylessEventSimulator from '../../proxyless/client/event-simulator';
+import ProxylessInput from '../../proxyless/client/input';
 
 
 const AVAILABLE_OFFSET_DEEP = 2;
@@ -98,7 +98,7 @@ export default class VisibleElementAutomation extends SharedEventEmitter {
     private readonly WARNING_EVENT: string;
     protected automationSettings: AutomationSettings;
     protected readonly options: OffsetOptions;
-    protected readonly proxylessEventSimulator: ProxylessEventSimulator | null;
+    protected readonly proxylessInput: ProxylessInput | null;
 
     protected constructor (element: HTMLElement, offsetOptions: OffsetOptions, win: Window, cursor: Cursor, dispatchProxylessEventFn?: Function, topLeftPoint?: AxisValues<number>) {
         super();
@@ -113,7 +113,7 @@ export default class VisibleElementAutomation extends SharedEventEmitter {
         this.window  = win;
         this.cursor  = cursor;
 
-        this.proxylessEventSimulator = dispatchProxylessEventFn ? new ProxylessEventSimulator(dispatchProxylessEventFn, topLeftPoint) : null;
+        this.proxylessInput = dispatchProxylessEventFn ? new ProxylessInput(dispatchProxylessEventFn, topLeftPoint) : null;
 
         // NOTE: only for legacy API
         this._ensureWindowAndCursorForLegacyTests(this);
@@ -125,7 +125,7 @@ export default class VisibleElementAutomation extends SharedEventEmitter {
     }
 
     protected canUseProxylessEventSimulator (element: HTMLElement | null): boolean {
-        return !!this.proxylessEventSimulator
+        return !!this.proxylessInput
             && !!element
             && domUtils.getTagName(element) !== 'select';
     }

--- a/src/client/core/utils/array.js
+++ b/src/client/core/utils/array.js
@@ -21,6 +21,7 @@ export const reverse = createNativeMethodWrapper('reverse');
 export const reduce  = createNativeMethodWrapper('reduce');
 export const concat  = createNativeMethodWrapper('concat');
 export const join    = createNativeMethodWrapper('join');
+export const every   = createNativeMethodWrapper('every');
 
 export function isArray (arg) {
     return nativeMethods.objectToString.call(arg) === '[object Array]';

--- a/src/client/driver/command-executors/action-executor/actions-initializer.ts
+++ b/src/client/driver/command-executors/action-executor/actions-initializer.ts
@@ -54,7 +54,7 @@ ActionExecutor.ACTIONS_HANDLERS[COMMAND_TYPE.dispatchEvent] = {
 };
 
 ActionExecutor.ACTIONS_HANDLERS[COMMAND_TYPE.pressKey] = {
-    create: command => new PressAutomation(parseKeySequence(command.keys).combinations, command.options),
+    create: (command, [], dispatchProxylessEventFn?: Function) => new PressAutomation(parseKeySequence(command.keys).combinations, command.options, dispatchProxylessEventFn), // eslint-disable-line no-empty-pattern
 
     ensureCmdArgs: command => {
         const parsedKeySequence = parseKeySequence(command.keys);

--- a/src/proxyless/client/input.ts
+++ b/src/proxyless/client/input.ts
@@ -3,13 +3,14 @@ import { EventType } from '../types';
 import { utils } from '../../client/core/deps/hammerhead';
 import { calculateKeyModifiersValue, calculateMouseButtonValue } from './utils';
 import AxisValues from '../../client/core/utils/values/axis-values';
+import { SimulatedKeyInfo } from './key-press/utils';
 
 const MOUSE_EVENT_OPTIONS = {
     clickCount: 1,
     button:     'left',
 };
 
-export default class ProxylessEventSimulator {
+export default class ProxylessInput {
 
     private readonly _dispatchEventFn: Function;
     private readonly _leftTopPoint: AxisValues<number>;
@@ -28,6 +29,16 @@ export default class ProxylessEventSimulator {
         }, MOUSE_EVENT_OPTIONS);
     }
 
+    private _getKeyDownEventText (options: SimulatedKeyInfo): any {
+        if (options.isEnter)
+            return '\r';
+
+        if (options.keyProperty.length === 1)
+            return options.keyProperty;
+
+        return '';
+    }
+
     public mouseDown (options: any): Promise<void> {
         const eventOptions = this._createMouseEventOptions('mousePressed', options);
 
@@ -38,5 +49,29 @@ export default class ProxylessEventSimulator {
         const eventOptions = this._createMouseEventOptions('mouseReleased', options);
 
         return this._dispatchEventFn(EventType.Mouse, eventOptions);
+    }
+
+    public keyDown (options: SimulatedKeyInfo): Promise<void> {
+        const text = this._getKeyDownEventText(options);
+
+        const eventOptions = {
+            type:                  text ? 'keyDown' : 'rawKeyDown',
+            modifiers:             options.modifiers,
+            windowsVirtualKeyCode: options.keyCode,
+            key:                   options.keyProperty,
+            text,
+        };
+
+        return this._dispatchEventFn(EventType.Keyboard, eventOptions);
+    }
+    public keyUp (options: SimulatedKeyInfo): Promise<void> {
+        const eventOptions = {
+            type:                  'keyUp',
+            modifiers:             options.modifiers,
+            key:                   options.keyProperty,
+            windowsVirtualKeyCode: options.keyCode,
+        };
+
+        return this._dispatchEventFn(EventType.Keyboard, eventOptions);
     }
 }

--- a/src/proxyless/client/key-press/utils.ts
+++ b/src/proxyless/client/key-press/utils.ts
@@ -1,0 +1,37 @@
+import getKeyInfo from '../../../client/automation/playback/press/get-key-info';
+// @ts-ignore
+import { utils } from '../../../client/core/deps/hammerhead';
+// @ts-ignore
+import { getKeyArray, arrayUtils } from '../../../client/automation/deps/testcafe-core';
+import { changeLetterCase, getActualKeysAndEventKeyProperties } from '../../../client/automation/playback/press/utils';
+import { getModifiersState } from '../utils';
+import getKeyCode from '../../../client/automation/utils/get-key-code';
+
+export interface SimulatedKeyInfo {
+    key: string;
+    keyCode: number;
+    keyProperty: string;
+    modifiers: number;
+    modifierKeyCode: number;
+    isLetter: boolean;
+    isChar: boolean;
+    isEnter: boolean;
+}
+
+export function getSimulatedKeyInfo (keyCombination: string): SimulatedKeyInfo[] {
+    const keysArray                          = getKeyArray(keyCombination);
+    const { actualKeys, eventKeyProperties } = getActualKeysAndEventKeyProperties(keysArray);
+
+    return arrayUtils.map(actualKeys, (key: string, index: number) => {
+        return utils.extend({ key }, getKeyInfo(key, eventKeyProperties[index]));
+    });
+}
+
+export function changeLetterCaseIfNecessary (keyInfo: SimulatedKeyInfo): void {
+    const modifiersState = getModifiersState(keyInfo.modifiers);
+
+    if (modifiersState.shift && keyInfo.isLetter) {
+        keyInfo.keyProperty = changeLetterCase(keyInfo.keyProperty);
+        keyInfo.keyCode     = getKeyCode(keyInfo.keyProperty);
+    }
+}

--- a/src/proxyless/client/utils.ts
+++ b/src/proxyless/client/utils.ts
@@ -1,9 +1,21 @@
 import { KeyModifiers, KeyModifierValues } from './types';
 import Protocol from 'devtools-protocol';
 import MouseButton = Protocol.Input.MouseButton;
+// @ts-ignore
+import { utils } from '../../client/core/deps/hammerhead';
 
-export function calculateKeyModifiersValue (modifiers: KeyModifiers): number {
+const EMPTY_MODIFIERS = {
+    ctrl:  false,
+    alt:   false,
+    shift: false,
+    meta:  false,
+};
+
+export function calculateKeyModifiersValue (modifiers?: KeyModifiers): number {
     let result = 0;
+
+    if (!modifiers)
+        return result;
 
     if (modifiers.ctrl)
         result |= KeyModifierValues.ctrl;
@@ -15,6 +27,29 @@ export function calculateKeyModifiersValue (modifiers: KeyModifiers): number {
         result |= KeyModifierValues.meta;
 
     return result;
+}
+
+export function getModifiersState (modifiersBit?: number): KeyModifiers {
+    const modifiers = utils.extend({}, EMPTY_MODIFIERS) as KeyModifiers;
+
+    if (!modifiersBit)
+        return modifiers;
+
+    if (modifiersBit & KeyModifierValues.ctrl)
+        modifiers.ctrl = true;
+    if (modifiersBit & KeyModifierValues.alt)
+        modifiers.alt = true;
+    if (modifiersBit & KeyModifierValues.shift)
+        modifiers.shift = true;
+    if (modifiersBit & KeyModifierValues.meta)
+        modifiers.meta = true;
+
+    return modifiers;
+}
+
+export function getModifiersBit (key: string): number {
+    // @ts-ignore
+    return KeyModifierValues[key] || 0;
 }
 
 export function calculateMouseButtonValue (options: any): MouseButton {

--- a/src/proxyless/types.ts
+++ b/src/proxyless/types.ts
@@ -34,6 +34,6 @@ export type SessionStorageInfo = Dictionary<Dictionary<string>> | null;
 
 export enum EventType {
     Mouse,
-    Key,
+    Keyboard,
     Touch,
 }

--- a/src/proxyless/utils/cdp.ts
+++ b/src/proxyless/utils/cdp.ts
@@ -27,7 +27,7 @@ export async function dispatchEvent (client: ProtocolApi, type: EventType, optio
         case EventType.Mouse:
             await client.Input.dispatchMouseEvent(options);
             break;
-        case EventType.Key:
+        case EventType.Keyboard:
             await client.Input.dispatchKeyEvent(options);
             break;
         case EventType.Touch:

--- a/test/client/fixtures/automation/key-press-simulation-test.js
+++ b/test/client/fixtures/automation/key-press-simulation-test.js
@@ -233,7 +233,7 @@ $(document).ready(function () {
         testKeysPress('option', expectedEvents);
     });
 
-    asyncTest('symbols with icorrect keycode', function () {
+    asyncTest('symbols with incorrect keycode', function () {
         const expectedEvents = [
             { type: 'keydown', keyCode: KEYCODES['shift'], shiftKey: true },
             { type: 'keydown', keyCode: KEYCODES['"'], shiftKey: true },

--- a/test/functional/fixtures/api/es-next/press-key/common/utils.js
+++ b/test/functional/fixtures/api/es-next/press-key/common/utils.js
@@ -1,0 +1,15 @@
+import { ClientFunction } from 'testcafe';
+
+const focusInput    = ClientFunction(() => document.getElementById('input').focus());
+const getInputValue = ClientFunction(() => document.getElementById('input').value);
+const getEventLog   = ClientFunction(() => document.getElementById('eventLog').textContent.trim());
+const setInputValue = ClientFunction(value => {
+    document.getElementById('input').value = value;
+});
+
+export {
+    focusInput,
+    getInputValue,
+    setInputValue,
+    getEventLog,
+};

--- a/test/functional/fixtures/api/es-next/press-key/pages/various-keys.html
+++ b/test/functional/fixtures/api/es-next/press-key/pages/various-keys.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <input id="input">
+    <div id="eventLog"></div>
+    <script>
+        const eventLog = document.getElementById('eventLog');
+        const input    = document.getElementById('input');
+
+        function logEvent (e) {
+            eventLog.textContent += e.type + ': ' + e.key + '; ';
+        }
+
+        ['keydown', 'keypress', 'keyup']
+            .forEach(eventName => input.addEventListener(eventName, logEvent));
+    </script>
+</body>
+</html>

--- a/test/functional/fixtures/api/es-next/press-key/test.js
+++ b/test/functional/fixtures/api/es-next/press-key/test.js
@@ -1,5 +1,4 @@
-const expect = require('chai').expect;
-
+const { expect } = require('chai');
 
 describe('[API] t.pressKey', function () {
     it('Should press keys', function () {
@@ -13,11 +12,49 @@ describe('[API] t.pressKey', function () {
         })
             .catch(function (errs) {
                 expect(errs[0]).to.contain('The "keys" argument is expected to be a non-empty string, but it was boolean.');
-                expect(errs[0]).to.contain('> 19 |    await t.pressKey(false);');
+                expect(errs[0]).to.contain('> 16 |    await t.pressKey(false);');
             });
     });
 
     it('Should raise event in different windows if focus was changed during action execution', function () {
         return runTests('./testcafe-fixtures/press-key-test.js', 'Press key in iframe', { only: 'chrome' });
+    });
+
+    describe('Press various keys', function () {
+        it('Should press literal symbol', function () {
+            return runTests('./testcafe-fixtures/press-various-keys-test.js', 'Press literal symbol', { only: 'chrome' });
+        });
+
+        it('Should press literal symbol uppercase', function () {
+            return runTests('./testcafe-fixtures/press-various-keys-test.js', 'Press literal symbol uppercase', { only: 'chrome' });
+        });
+
+        it('Should press two literal symbols', function () {
+            return runTests('./testcafe-fixtures/press-various-keys-test.js', 'Press two literal symbols', { only: 'chrome' });
+        });
+
+        it('Should press number key', function () {
+            return runTests('./testcafe-fixtures/press-various-keys-test.js', 'Press number key', { only: 'chrome' });
+        });
+
+        it('Should press special key', function () {
+            return runTests('./testcafe-fixtures/press-various-keys-test.js', 'Press special key', { only: 'chrome' });
+        });
+
+        it('Should press mapped modifier', function () {
+            return runTests('./testcafe-fixtures/press-various-keys-test.js', 'Press mapped modifier', { only: 'chrome' });
+        });
+
+        it('Shift+a', function () {
+            return runTests('./testcafe-fixtures/press-various-keys-test.js', 'Shift+a', { only: 'chrome' });
+        });
+
+        it('Shift+1', function () {
+            return runTests('./testcafe-fixtures/press-various-keys-test.js', 'Shift+1', { only: 'chrome' });
+        });
+
+        it('Ctrl+a, delete', function () {
+            return runTests('./testcafe-fixtures/press-various-keys-test.js', 'Ctrl+a, delete', { only: 'chrome' });
+        });
     });
 });

--- a/test/functional/fixtures/api/es-next/press-key/testcafe-fixtures/press-key-test.js
+++ b/test/functional/fixtures/api/es-next/press-key/testcafe-fixtures/press-key-test.js
@@ -1,13 +1,10 @@
 // NOTE: to preserve callsites, add new tests AFTER the existing ones
 import { ClientFunction } from 'testcafe';
 import { expect } from 'chai';
-
+import { focusInput, getInputValue } from '../common/utils.js';
 
 fixture `PressKey`
     .page `http://localhost:3000/fixtures/api/es-next/press-key/pages/index.html`;
-
-const focusInput    = ClientFunction(() => document.getElementById('input').focus());
-const getInputValue = ClientFunction(() => document.getElementById('input').value);
 
 test('Press keys', async t => {
     await focusInput();

--- a/test/functional/fixtures/api/es-next/press-key/testcafe-fixtures/press-various-keys-test.js
+++ b/test/functional/fixtures/api/es-next/press-key/testcafe-fixtures/press-various-keys-test.js
@@ -1,0 +1,90 @@
+import { t } from 'testcafe';
+import {
+    focusInput,
+    getInputValue,
+    getEventLog,
+    setInputValue,
+} from '../common/utils.js';
+
+fixture `Press various keys`
+    .page('http://localhost:3000/fixtures/api/es-next/press-key/pages/various-keys.html')
+    .beforeEach(async () => {
+        await focusInput();
+    });
+
+async function checkPressedKeyCombination ({ keyCombination, expectedInputValue, expectedEventLog }) {
+    await t
+        .pressKey(keyCombination)
+        .expect(getInputValue()).eql(expectedInputValue)
+        .expect(getEventLog()).eql(expectedEventLog);
+}
+test('Press literal symbol', async () => {
+    await checkPressedKeyCombination({
+        keyCombination:     'a',
+        expectedInputValue: 'a',
+        expectedEventLog:   'keydown: a; keypress: a; keyup: a;',
+    });
+});
+
+test('Press literal symbol uppercase', async () => {
+    await checkPressedKeyCombination({
+        keyCombination:     'A',
+        expectedInputValue: 'A',
+        expectedEventLog:   'keydown: A; keypress: A; keyup: A;',
+    });
+});
+
+test('Press two literal symbols', async () => {
+    await checkPressedKeyCombination({
+        keyCombination:     'a+b',
+        expectedInputValue: 'ab',
+        expectedEventLog:   'keydown: a; keypress: a; keydown: b; keypress: b; keyup: b; keyup: a;',
+    });
+});
+test('Press number key', async () => {
+    await checkPressedKeyCombination({
+        keyCombination:     '1',
+        expectedInputValue: '1',
+        expectedEventLog:   'keydown: 1; keypress: 1; keyup: 1;',
+    });
+});
+
+test('Press special key', async () => {
+    await checkPressedKeyCombination({
+        keyCombination:     'enter',
+        expectedInputValue: '',
+        expectedEventLog:   'keydown: Enter; keypress: Enter; keyup: Enter;',
+    });
+});
+
+test('Press mapped modifier', async () => {
+    await checkPressedKeyCombination({
+        keyCombination:     'alt',
+        expectedInputValue: '',
+        expectedEventLog:   'keydown: Alt; keyup: Alt;',
+    });
+});
+
+test('Shift+a', async () => {
+    await checkPressedKeyCombination({
+        keyCombination:     'shift+a',
+        expectedInputValue: 'A',
+        expectedEventLog:   'keydown: Shift; keydown: A; keypress: A; keyup: A; keyup: Shift;',
+    });
+});
+
+test('Shift+1', async () => {
+    await checkPressedKeyCombination({
+        keyCombination:     'shift+1',
+        expectedInputValue: '!',
+        expectedEventLog:   'keydown: Shift; keydown: !; keypress: !; keyup: !; keyup: Shift;',
+    });
+});
+
+test('Ctrl+a, delete', async () => {
+    await setInputValue('abc');
+
+    await t.pressKey('ctrl+a delete');
+
+    await t.expect(getInputValue()).eql('');
+});

--- a/test/functional/fixtures/multiple-windows/test.js
+++ b/test/functional/fixtures/multiple-windows/test.js
@@ -224,7 +224,7 @@ describe('Multiple windows', () => {
         it('Switch to window by predicate with error', () => {
             return runTests('testcafe-fixtures/api/api-test.js', 'Switch to window by predicate with error', { only: 'chrome', shouldFail: true })
                 .catch(errs => {
-                    expect(errs[0]).to.contain('An error occurred inside the "switchToWindow" argument function.  Error details: Cannot read property \'field\' of undefined');
+                    expect(errs[0]).to.contain('An error occurred inside the "switchToWindow" argument function.  Error details: Cannot read properties of undefined (reading \'field\')  [[user-agent]]');
                 });
         });
 


### PR DESCRIPTION
Changes:
* rename `ProxylessEventSimulator` -> `ProxylessInput`
* refactor the code related to getting pressed key information
* implement basic `keyPress` simulation using CDP API