### PR TITLE
fix(Selector Inspector): selector is parsed correctly in life mode

### DIFF
--- a/src/live/test-runner.js
+++ b/src/live/test-runner.js
@@ -43,7 +43,7 @@ class LiveModeRunner extends Runner {
                 this.testRunController.setExpectedTestCount(expectedTestCount);
             })
             .then(() => {
-                this.runnerTaskPromise = super.run(this.opts);
+                this.runnerTaskPromise = this._prepareAndRunTask(this.opts);
 
                 return this.runnerTaskPromise;
             })
@@ -86,6 +86,8 @@ class LiveModeRunner extends Runner {
     }
 
     run (options) {
+        this._resetBeforeRun();
+
         this.configurationCache = null;
 
         if (this._running)

--- a/test/functional/fixtures/live/test.js
+++ b/test/functional/fixtures/live/test.js
@@ -242,6 +242,17 @@ if (config.useLocalBrowsers && !config.useHeadlessBrowsers) {
                     return cafe.close();
                 });
         });
+
+        it('Selector Inspector should indicate the correct number of elements matching the selector in live mode', async () => {
+            const testCafe = await createTestCafe();
+            const runner   = createLiveModeRunner(testCafe, '/testcafe-fixtures/selector-inspector.js');
+
+            helper.emitter.once('tests-completed', () => runner.exit());
+
+            await runner.run();
+
+            return testCafe.close();
+        });
     });
 }
 else if (testingEnvironmentName === 'local-headless-chrome' && !config.experimentalESM) {

--- a/test/functional/fixtures/live/testcafe-fixtures/selector-inspector.js
+++ b/test/functional/fixtures/live/testcafe-fixtures/selector-inspector.js
@@ -1,0 +1,27 @@
+import { ClientFunction } from 'testcafe';
+
+import helper from '../test-helper.js';
+
+fixture `Selector Inspector`
+    .clientScripts `../../ui/utils/selector-inspector.js`
+    .page `../pages/index.html`
+    .after(() => {
+        helper.emitter.emit('tests-completed');
+    });
+
+test('should indicate the correct number of elements matching the selector', async t => {
+    await ClientFunction(() => {
+        const { typeSelector, getMatchIndicatorInnerText, resumeTest } = window;
+
+        typeSelector('button')
+            .then(() => {
+                return getMatchIndicatorInnerText();
+            })
+            .then(text => {
+                if (text === 'Found: 2')
+                    resumeTest();
+            });
+    })();
+
+    await t.debug();
+});


### PR DESCRIPTION
## Purpose
The Selector Inspector could not evaluate the selector in live mode because the request handler on the server could not get the TestRun instance.
The reason was that the LiveModeTestRunner was calling `this._messageBus.clearListeners()` too late, and this resulted in the removal of the handler by which the BrowserConnection instance received the actual TestRun.

## Steps to reproduce
1. Run Selector Inspector in live mode.
2. Enter the selector in the appropriate input - the match indicator should show the correct number of elements.

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
