### PR TITLE
fix(Selector Inspector): selectors parsing in experimental debug mode

### DIFF
--- a/src/api/test-controller/execution-context.js
+++ b/src/api/test-controller/execution-context.js
@@ -44,7 +44,9 @@ function createRequire (filename) {
 
 function createSelectorDefinition (testRun) {
     return (fn, options = {}) => {
-        const { skipVisibilityCheck, collectionMode } = testRun.controller.getExecutionContext()[OPTIONS_KEY];
+        const { skipVisibilityCheck, collectionMode } = testRun.controller ?
+            testRun.controller.getExecutionContext()[OPTIONS_KEY] :
+            createExecutionContext(testRun)[OPTIONS_KEY];
 
         if (skipVisibilityCheck)
             options.visibilityCheck = false;

--- a/src/test-run/execute-js-expression/index.js
+++ b/src/test-run/execute-js-expression/index.js
@@ -8,7 +8,11 @@ import {
 } from '../../errors/runtime';
 
 import { UncaughtErrorInCustomScript, UncaughtTestCafeErrorInCustomScript } from '../../errors/test-run';
-import { setContextOptions, DEFAULT_CONTEXT_OPTIONS } from '../../api/test-controller/execution-context';
+import {
+    setContextOptions,
+    DEFAULT_CONTEXT_OPTIONS,
+    createExecutionContext,
+} from '../../api/test-controller/execution-context';
 
 import {
     ERROR_LINE_COLUMN_REGEXP,
@@ -78,7 +82,10 @@ function isRuntimeError (err) {
 }
 
 export function executeJsExpression (expression, testRun, options) {
-    const context      = getExecutionContext(testRun.controller, options);
+    const context = testRun.controller ?
+        getExecutionContext(testRun.controller, options) :
+        createExecutionContext(testRun);
+
     const errorOptions = createErrorFormattingOptions();
 
     return runInContext(expression, context, errorOptions);

--- a/test/functional/fixtures/ui/test.js
+++ b/test/functional/fixtures/ui/test.js
@@ -34,7 +34,9 @@ describe('TestCafe UI', () => {
 
         runTestCafeTest('should fill the selectors list with the generated selectors');
 
-        runTestCafeTest('should indicate the correct number of elements matching the selector');
+        runTestCafeTest('should indicate the correct number of elements matching the css selector');
+
+        runTestCafeTest('should indicate the correct number of elements matching the TestCafe selector');
 
         runTestCafeTest('should indicate if the selector is invalid on input');
 

--- a/test/functional/fixtures/ui/test.js
+++ b/test/functional/fixtures/ui/test.js
@@ -22,6 +22,9 @@ describe('TestCafe UI', () => {
     describe('Selector Inspector', () => {
         function runTestCafeTest (testName) {
             it (testName, function () {
+                if (config.experimentalDebug)
+                    this.skip();
+
                 return runTests('./testcafe-fixtures/selector-inspector-test.js', testName, { skip: ['ie', 'android', 'ipad', 'iphone'] });
             });
         }

--- a/test/functional/fixtures/ui/test.js
+++ b/test/functional/fixtures/ui/test.js
@@ -22,9 +22,6 @@ describe('TestCafe UI', () => {
     describe('Selector Inspector', () => {
         function runTestCafeTest (testName) {
             it (testName, function () {
-                if (config.experimentalDebug)
-                    this.skip();
-
                 return runTests('./testcafe-fixtures/selector-inspector-test.js', testName, { skip: ['ie', 'android', 'ipad', 'iphone'] });
             });
         }

--- a/test/functional/fixtures/ui/testcafe-fixtures/selector-inspector-test.js
+++ b/test/functional/fixtures/ui/testcafe-fixtures/selector-inspector-test.js
@@ -93,11 +93,28 @@ test('should fill the selectors list with the generated selectors', async t => {
     await t.debug();
 });
 
-test('should indicate the correct number of elements matching the selector', async t => {
+test('should indicate the correct number of elements matching the css selector', async t => {
     await ClientFunction(() => {
         const { typeSelector, getMatchIndicatorInnerText, resumeTest } = window;
 
         typeSelector('div')
+            .then(() => {
+                return getMatchIndicatorInnerText();
+            })
+            .then(text => {
+                if (text === 'Found: 4')
+                    resumeTest();
+            });
+    })();
+
+    await t.debug();
+});
+
+test('should indicate the correct number of elements matching the TestCafe selector', async t => {
+    await ClientFunction(() => {
+        const { typeSelector, getMatchIndicatorInnerText, resumeTest } = window;
+
+        typeSelector("Selector('div')")
             .then(() => {
                 return getMatchIndicatorInnerText();
             })


### PR DESCRIPTION
In experimental debug mode, the TestRun instance has a `controller` field of `null`. Because of this, it was impossible to get the context in which the selector is executed.

## Steps to reproduce
1. Run Selector Inspector in experimental debug mode.
2. Enter selector in css format - the match indicator should show the correct number of elements.
3. Enter selector in TestCafe format - the match indicator should show the correct number of elements.

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
