### PR TITLE
fix: raise reporter reportTaskDone event if browser has been disconnected

### DIFF
--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -205,6 +205,8 @@ export default class Reporter {
         messageBus.on('test-action-done', async e => await this._onTaskTestActionDone(e));
 
         messageBus.once('done', async () => await this._onceTaskDoneHandler());
+
+        messageBus.once('unhandled-rejection', async () => await this._onceTaskDoneHandler());
     }
 
     public async dispose (): Promise<unknown> {

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -200,6 +200,8 @@ export default class Runner extends EventEmitter {
             await Promise.race(promises);
         }
         catch (err) {
+            await this._messageBus.emit('unhandled-rejection');
+            await Promise.all(reporters.map(reporter => reporter.taskInfo.pendingTaskDonePromise));
             await this._disposeTaskAndRelatedAssets(task, browserSet, reporters, testedApp, runnableConfigurationId);
 
             throw err;

--- a/test/functional/fixtures/browser-provider/browser-reconnect/run-log-error-on-disconnect-test.js
+++ b/test/functional/fixtures/browser-provider/browser-reconnect/run-log-error-on-disconnect-test.js
@@ -1,7 +1,15 @@
-const path           = require('path');
-const createTestCafe = require('../../../../../lib');
+const path               = require('path');
+const createTestCafe     = require('../../../../../lib');
+const { createReporter } = require('../../../utils/reporter');
 
-let testcafe = null;
+let testcafe               = null;
+const shouldAttachReporter = !!process.env.CUSTOM_REPORTER;
+
+const reporter = createReporter({
+    reportTaskDone: () => {
+        process.stdout.write('reportTaskDone');
+    },
+});
 
 createTestCafe()
     .then(function (tc) {
@@ -14,6 +22,7 @@ createTestCafe()
             .filter(function (testName) {
                 return testName === 'Should log error on browser disconnect';
             })
+            .reporter(shouldAttachReporter ? reporter : [])
             .run();
     })
     .catch(function () {

--- a/test/functional/fixtures/browser-provider/browser-reconnect/test.js
+++ b/test/functional/fixtures/browser-provider/browser-reconnect/test.js
@@ -90,6 +90,29 @@ if (config.useLocalBrowsers) {
                 });
         });
 
+        it('Should raise reporter reportTaskDone event on browser disconnect', function () {
+
+            let reporterLog = '';
+
+            return new Promise(resolve => {
+                const proc = spawn(`node ${path.join(__dirname, 'run-log-error-on-disconnect-test.js')}`, {
+                    shell: true,
+                    env:   {
+                        ...process.env, CUSTOM_REPORTER: true,
+                    },
+                });
+
+                proc.stdout.on('data', data => {
+                    reporterLog += data.toString('utf-8');
+                });
+
+                proc.on('close', resolve);
+            })
+                .then(() => {
+                    expect(reporterLog).eql('reportTaskDone');
+                });
+        });
+
         it('Should fail on 3 disconnects in one browser', function () {
             return run('./testcafe-fixtures/index-test.js', 'Should fail on 3 disconnects in one browser')
                 .then(() => {

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -498,7 +498,7 @@ describe('Reporter', () => {
 
         createReporter(messageBus);
 
-        expect(messageBus.listenerCount()).eql(7);
+        expect(messageBus.listenerCount()).eql(8);
         expect(messageBus.listenerCount('warning-add')).eql(1);
         expect(messageBus.listenerCount('start')).eql(1);
         expect(messageBus.listenerCount('test-run-start')).eql(1);
@@ -506,6 +506,7 @@ describe('Reporter', () => {
         expect(messageBus.listenerCount('test-action-start')).eql(1);
         expect(messageBus.listenerCount('test-action-done')).eql(1);
         expect(messageBus.listenerCount('done')).eql(1);
+        expect(messageBus.listenerCount('unhandled-rejection')).eql(1);
     });
 
     it('Should analyze task progress and call appropriate plugin methods', function () {


### PR DESCRIPTION
## Purpose
Currently, reportTaskDone event is not raised if the browser has been disconnected. As a result, the reporters that do not write data on the fly, but create structures (html, xml, etc.) and write them to a file at the very end - do not create reports.

## Approach
Raise reportTaskDone event if an error occurred that is not handled on the testrun level. 

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
