### PR TITLE
add a separate headed browsers task for tests that cannot be run in headless mode

### DIFF
--- a/.github/workflows/test-client-desktop.yml
+++ b/.github/workflows/test-client-desktop.yml
@@ -4,18 +4,18 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        desciption: 'The test commit SHA or ref'
+        description: 'The test commit SHA or ref'
         required: true
         default: 'master'
       merged_sha:
-        description: 'The merge commit SHA' 
+        description: 'The merge commit SHA'
       deploy_run_id:
         description: 'The ID of a deployment workspace run with artifacts'
-jobs:  
+jobs:
   test:
     runs-on: ubuntu-latest
     environment: test-client
-    env: 
+    env:
       SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
       SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
     steps:
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{github.event.inputs.merged_sha || github.event.inputs.sha}}
-          
+
       - uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -42,9 +42,9 @@ jobs:
         with:
           script: |
             const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-            
+
             let artifacts = {};
-            
+
             for(let i = 0;i<36&&!artifacts.total_count;i++,await delay(5000)) {
               try {
                 ({ data: artifacts } = await github.actions.listWorkflowRunArtifacts({
@@ -57,14 +57,14 @@ jobs:
                 console.log(e);
               }
             }
-            
+
             const { data: artifact } = await github.request(artifacts.artifacts.find(artifact=> artifact.name === 'npm').archive_download_url);
             require('fs').writeFileSync(require('path').join(process.env.GITHUB_WORKSPACE, 'package.zip'), Buffer.from(artifact))
-        
+
       - run: |
           unzip package.zip
           tar --strip-components=1 -xzf testcafe-*.tgz
-          
+
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |

--- a/.github/workflows/test-client-mobile.yml
+++ b/.github/workflows/test-client-mobile.yml
@@ -4,18 +4,18 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        desciption: 'The test commit SHA or ref'
+        description: 'The test commit SHA or ref'
         required: true
         default: 'master'
       merged_sha:
-        description: 'The merge commit SHA' 
+        description: 'The merge commit SHA'
       deploy_run_id:
         description: 'The ID of a deployment workspace run with artifacts'
-jobs:  
+jobs:
   test:
     runs-on: ubuntu-latest
     environment: test-client
-    env: 
+    env:
       SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
       SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
     steps:
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{github.event.inputs.merged_sha || github.event.inputs.sha}}
-          
+
       - uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -42,9 +42,9 @@ jobs:
         with:
           script: |
             const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-            
+
             let artifacts = {};
-            
+
             for(let i = 0;i<36&&!artifacts.total_count;i++,await delay(5000)) {
               try {
                 ({ data: artifacts } = await github.actions.listWorkflowRunArtifacts({
@@ -57,14 +57,14 @@ jobs:
                 console.log(e);
               }
             }
-            
+
             const { data: artifact } = await github.request(artifacts.artifacts.find(artifact=> artifact.name === 'npm').archive_download_url);
             require('fs').writeFileSync(require('path').join(process.env.GITHUB_WORKSPACE, 'package.zip'), Buffer.from(artifact))
-        
+
       - run: |
           unzip package.zip
           tar --strip-components=1 -xzf testcafe-*.tgz
-          
+
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |

--- a/.github/workflows/test-functional-docker.yml
+++ b/.github/workflows/test-functional-docker.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        desciption: 'The test commit SHA or ref'
+        description: 'The test commit SHA or ref'
         required: true
         default: 'master'
       merged_sha:
-        description: 'The merge commit SHA' 
+        description: 'The merge commit SHA'
       deploy_run_id:
         description: 'The ID of a deployment workspace run with artifacts'
-jobs:  
+jobs:
   test:
     runs-on: ubuntu-latest
     environment: test-functional
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{github.event.inputs.merged_sha || github.event.inputs.sha}}
-          
+
       - uses: actions/setup-node@v2
         with:
           node-version: 14
@@ -39,9 +39,9 @@ jobs:
         with:
           script: |
             const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-            
+
             let artifacts = {};
-            
+
             for(let i = 0;i<36&&!artifacts.total_count;i++,await delay(5000)) {
               try {
                 ({ data: artifacts } = await github.actions.listWorkflowRunArtifacts({
@@ -54,14 +54,14 @@ jobs:
                 console.log(e);
               }
             }
-            
+
             const { data: artifact } = await github.request(artifacts.artifacts.find(artifact=> artifact.name === 'docker').archive_download_url);
             require('fs').writeFileSync(require('path').join(process.env.GITHUB_WORKSPACE, 'docker.zip'), Buffer.from(artifact))
-        
+
       - run: |
           unzip docker.zip
           docker load -i testcafe-*.tar
-          
+
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |

--- a/.github/workflows/test-functional-local-chrome.yml
+++ b/.github/workflows/test-functional-local-chrome.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        desciption: 'The test commit SHA or ref'
+        description: 'The test commit SHA or ref'
         required: true
         default: 'master'
       merged_sha:
-        description: 'The merge commit SHA' 
+        description: 'The merge commit SHA'
       deploy_run_id:
         description: 'The ID of a deployment workspace run with artifacts'
-jobs:  
+jobs:
   test:
     runs-on: ubuntu-latest
     environment: test-functional
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{github.event.inputs.merged_sha || github.event.inputs.sha}}
-          
+
       - uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -41,9 +41,9 @@ jobs:
         with:
           script: |
             const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-            
+
             let artifacts = {};
-            
+
             for(let i = 0;i<36&&!artifacts.total_count;i++,await delay(5000)) {
               try {
                 ({ data: artifacts } = await github.actions.listWorkflowRunArtifacts({
@@ -56,14 +56,14 @@ jobs:
                 console.log(e);
               }
             }
-            
+
             const { data: artifact } = await github.request(artifacts.artifacts.find(artifact=> artifact.name === 'npm').archive_download_url);
             require('fs').writeFileSync(require('path').join(process.env.GITHUB_WORKSPACE, 'package.zip'), Buffer.from(artifact))
-        
+
       - run: |
           unzip package.zip
           tar --strip-components=1 -xzf testcafe-*.tgz
-          
+
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |

--- a/.github/workflows/test-functional-local-esm.yml
+++ b/.github/workflows/test-functional-local-esm.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        desciption: 'The test commit SHA or ref'
+        description: 'The test commit SHA or ref'
         required: true
         default: 'master'
       merged_sha:
-        description: 'The merge commit SHA' 
+        description: 'The merge commit SHA'
       deploy_run_id:
         description: 'The ID of a deployment workspace run with artifacts'
-jobs:  
+jobs:
   test:
     runs-on: ubuntu-latest
     environment: test-functional
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{github.event.inputs.merged_sha || github.event.inputs.sha}}
-          
+
       - uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -41,9 +41,9 @@ jobs:
         with:
           script: |
             const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-            
+
             let artifacts = {};
-            
+
             for(let i = 0;i<36&&!artifacts.total_count;i++,await delay(5000)) {
               try {
                 ({ data: artifacts } = await github.actions.listWorkflowRunArtifacts({
@@ -56,14 +56,14 @@ jobs:
                 console.log(e);
               }
             }
-            
+
             const { data: artifact } = await github.request(artifacts.artifacts.find(artifact=> artifact.name === 'npm').archive_download_url);
             require('fs').writeFileSync(require('path').join(process.env.GITHUB_WORKSPACE, 'package.zip'), Buffer.from(artifact))
-        
+
       - run: |
           unzip package.zip
           tar --strip-components=1 -xzf testcafe-*.tgz
-          
+
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |

--- a/.github/workflows/test-functional-local-headed-browsers.yml
+++ b/.github/workflows/test-functional-local-headed-browsers.yml
@@ -1,10 +1,10 @@
-name: Test Functional (Multiple Windows)
+name: Test Functional (Headed Browsers)
 
 on:
   workflow_dispatch:
     inputs:
       sha:
-        desciption: 'The test commit SHA or ref'
+        description: 'The test commit SHA or ref'
         required: true
         default: 'master'
       merged_sha:
@@ -12,102 +12,7 @@ on:
       deploy_run_id:
         description: 'The ID of a deployment workspace run with artifacts'
 jobs:
-  test-multiple-windows:
-    runs-on: ubuntu-latest
-    environment: test-functional
-    env:
-      DISPLAY: ':99.0'
-      RETRY_FAILED_TESTS: true
-    steps:
-      - uses: actions/github-script@v3
-        with:
-          script: |
-            await github.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.inputs.sha,
-              context: context.workflow,
-              state: 'pending',
-              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            });
-
-      - run: |
-          sudo apt install fluxbox
-          Xvfb :99 -screen 0 1920x1080x24 &
-          sleep 3
-          fluxbox >/dev/null 2>&1 &
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{github.event.inputs.merged_sha || github.event.inputs.sha}}
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16
-
-      - uses: actions/github-script@v3
-        with:
-          script: |
-            const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-
-            let artifacts = {};
-
-            for(let i = 0;i<36&&!artifacts.total_count;i++,await delay(5000)) {
-              try {
-                ({ data: artifacts } = await github.actions.listWorkflowRunArtifacts({
-                repo: context.repo.repo,
-                owner: context.repo.owner,
-                run_id: context.payload.inputs.deploy_run_id
-              }));
-              }
-              catch (e) {
-                console.log(e);
-              }
-            }
-
-            const { data: artifact } = await github.request(artifacts.artifacts.find(artifact=> artifact.name === 'npm').archive_download_url);
-            require('fs').writeFileSync(require('path').join(process.env.GITHUB_WORKSPACE, 'package.zip'), Buffer.from(artifact))
-
-      - run: |
-          unzip package.zip
-          tar --strip-components=1 -xzf testcafe-*.tgz
-
-      - name: Get npm cache directory
-        id: npm-cache-dir
-        run: |
-          echo "::set-output name=dir::$(npm config get cache)"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - run: npm ci
-      - run: npx gulp test-functional-local-multiple-windows-run --steps-as-tasks
-        timeout-minutes: 60
-      - uses: actions/github-script@v3
-        with:
-          script: |
-            await github.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.inputs.sha,
-              context: context.workflow,
-              state: 'success',
-              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            });
-      - uses: actions/github-script@v3
-        if: failure() || cancelled()
-        with:
-          script: |
-            await github.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.inputs.sha,
-              context: context.workflow,
-              state: 'failure',
-              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
-            });
-  test-functional-local-chrome-firefox-headed:
+  test:
     runs-on: ubuntu-latest
     environment: test-functional
     env:

--- a/.github/workflows/test-functional-local-headed-browsers.yml
+++ b/.github/workflows/test-functional-local-headed-browsers.yml
@@ -8,11 +8,11 @@ on:
         required: true
         default: 'master'
       merged_sha:
-        description: 'The merge commit SHA' 
+        description: 'The merge commit SHA'
       deploy_run_id:
         description: 'The ID of a deployment workspace run with artifacts'
-jobs:  
-  test:
+jobs:
+  test-multiple-windows:
     runs-on: ubuntu-latest
     environment: test-functional
     env:
@@ -30,7 +30,7 @@ jobs:
               state: 'pending',
               target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             });
-            
+
       - run: |
           sudo apt install fluxbox
           Xvfb :99 -screen 0 1920x1080x24 &
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{github.event.inputs.merged_sha || github.event.inputs.sha}}
-          
+
       - uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -48,9 +48,9 @@ jobs:
         with:
           script: |
             const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-            
+
             let artifacts = {};
-            
+
             for(let i = 0;i<36&&!artifacts.total_count;i++,await delay(5000)) {
               try {
                 ({ data: artifacts } = await github.actions.listWorkflowRunArtifacts({
@@ -63,14 +63,14 @@ jobs:
                 console.log(e);
               }
             }
-            
+
             const { data: artifact } = await github.request(artifacts.artifacts.find(artifact=> artifact.name === 'npm').archive_download_url);
             require('fs').writeFileSync(require('path').join(process.env.GITHUB_WORKSPACE, 'package.zip'), Buffer.from(artifact))
-        
+
       - run: |
           unzip package.zip
           tar --strip-components=1 -xzf testcafe-*.tgz
-          
+
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |
@@ -83,6 +83,101 @@ jobs:
             ${{ runner.os }}-node-
       - run: npm ci
       - run: npx gulp test-functional-local-multiple-windows-run --steps-as-tasks
+        timeout-minutes: 60
+      - uses: actions/github-script@v3
+        with:
+          script: |
+            await github.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.inputs.sha,
+              context: context.workflow,
+              state: 'success',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
+      - uses: actions/github-script@v3
+        if: failure() || cancelled()
+        with:
+          script: |
+            await github.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.inputs.sha,
+              context: context.workflow,
+              state: 'failure',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
+  test-functional-local-chrome-firefox-headed:
+    runs-on: ubuntu-latest
+    environment: test-functional
+    env:
+      DISPLAY: ':99.0'
+      RETRY_FAILED_TESTS: true
+    steps:
+      - uses: actions/github-script@v3
+        with:
+          script: |
+            await github.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.inputs.sha,
+              context: context.workflow,
+              state: 'pending',
+              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
+
+      - run: |
+          sudo apt install fluxbox
+          Xvfb :99 -screen 0 1920x1080x24 &
+          sleep 3
+          fluxbox >/dev/null 2>&1 &
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.inputs.merged_sha || github.event.inputs.sha}}
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+
+      - uses: actions/github-script@v3
+        with:
+          script: |
+            const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+            let artifacts = {};
+
+            for(let i = 0;i<36&&!artifacts.total_count;i++,await delay(5000)) {
+              try {
+                ({ data: artifacts } = await github.actions.listWorkflowRunArtifacts({
+                repo: context.repo.repo,
+                owner: context.repo.owner,
+                run_id: context.payload.inputs.deploy_run_id
+              }));
+              }
+              catch (e) {
+                console.log(e);
+              }
+            }
+
+            const { data: artifact } = await github.request(artifacts.artifacts.find(artifact=> artifact.name === 'npm').archive_download_url);
+            require('fs').writeFileSync(require('path').join(process.env.GITHUB_WORKSPACE, 'package.zip'), Buffer.from(artifact))
+
+      - run: |
+          unzip package.zip
+          tar --strip-components=1 -xzf testcafe-*.tgz
+
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        run: |
+          echo "::set-output name=dir::$(npm config get cache)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npx gulp test-functional-local-chrome-firefox-headed-run --steps-as-tasks
         timeout-minutes: 60
       - uses: actions/github-script@v3
         with:

--- a/.github/workflows/test-functional-local-multiple-windows.yml
+++ b/.github/workflows/test-functional-local-multiple-windows.yml
@@ -1,4 +1,4 @@
-name: Test Functional (Local Firefox)
+name: Test Functional (Multiple Windows)
 
 on:
   workflow_dispatch:
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: test-functional
     env:
+      DISPLAY: ':99.0'
       RETRY_FAILED_TESTS: true
     steps:
       - uses: actions/github-script@v3
@@ -29,6 +30,12 @@ jobs:
               state: 'pending',
               target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             });
+
+      - run: |
+          sudo apt install fluxbox
+          Xvfb :99 -screen 0 1920x1080x24 &
+          sleep 3
+          fluxbox >/dev/null 2>&1 &
       - uses: actions/checkout@v2
         with:
           ref: ${{github.event.inputs.merged_sha || github.event.inputs.sha}}
@@ -75,7 +82,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
       - run: npm ci
-      - run: npx gulp test-functional-local-headless-firefox-run --steps-as-tasks
+      - run: npx gulp test-functional-local-multiple-windows-run --steps-as-tasks
         timeout-minutes: 60
       - uses: actions/github-script@v3
         with:

--- a/.github/workflows/test-functional-local-proxyless.yml
+++ b/.github/workflows/test-functional-local-proxyless.yml
@@ -4,7 +4,7 @@ on:
     workflow_dispatch:
         inputs:
             sha:
-                desciption: 'The test commit SHA or ref'
+                description: 'The test commit SHA or ref'
                 required: true
                 default: 'master'
             merged_sha:

--- a/.github/workflows/test-functional-remote-macos.yml
+++ b/.github/workflows/test-functional-remote-macos.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        desciption: 'The test commit SHA or ref'
+        description: 'The test commit SHA or ref'
         required: true
         default: 'master'
       merged_sha:
@@ -44,9 +44,9 @@ jobs:
         with:
           script: |
             const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-            
+
             let artifacts = {};
-            
+
             for(let i = 0;i<36&&!artifacts.total_count;i++,await delay(5000)) {
               try {
                 ({ data: artifacts } = await github.actions.listWorkflowRunArtifacts({
@@ -59,7 +59,7 @@ jobs:
                 console.log(e);
               }
             }
-            
+
             const { data: artifact } = await github.request(artifacts.artifacts.find(artifact=> artifact.name === 'npm').archive_download_url);
             require('fs').writeFileSync(require('path').join(process.env.GITHUB_WORKSPACE, 'package.zip'), Buffer.from(artifact))
 

--- a/.github/workflows/test-functional-remote-mobile.yml
+++ b/.github/workflows/test-functional-remote-mobile.yml
@@ -4,18 +4,18 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        desciption: 'The test commit SHA or ref'
+        description: 'The test commit SHA or ref'
         required: true
         default: 'master'
       merged_sha:
-        description: 'The merge commit SHA' 
+        description: 'The merge commit SHA'
       deploy_run_id:
         description: 'The ID of a deployment workspace run with artifacts'
-jobs:  
+jobs:
   test:
     runs-on: browserstack
     environment: test-functional
-    env: 
+    env:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
       USE_PUBLIC_HOSTNAME: true
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{github.event.inputs.merged_sha || github.event.inputs.sha}}
-          
+
       - uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -44,9 +44,9 @@ jobs:
         with:
           script: |
             const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-            
+
             let artifacts = {};
-            
+
             for(let i = 0;i<36&&!artifacts.total_count;i++,await delay(5000)) {
               try {
                 ({ data: artifacts } = await github.actions.listWorkflowRunArtifacts({
@@ -59,14 +59,14 @@ jobs:
                 console.log(e);
               }
             }
-            
+
             const { data: artifact } = await github.request(artifacts.artifacts.find(artifact=> artifact.name === 'npm').archive_download_url);
             require('fs').writeFileSync(require('path').join(process.env.GITHUB_WORKSPACE, 'package.zip'), Buffer.from(artifact))
-        
+
       - run: |
           unzip package.zip
           tar --strip-components=1 -xzf testcafe-*.tgz
-          
+
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |

--- a/.github/workflows/test-server-docker.yml
+++ b/.github/workflows/test-server-docker.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        desciption: 'The test commit SHA or ref'
+        description: 'The test commit SHA or ref'
         required: true
         default: 'master'
       merged_sha:
-        description: 'The merge commit SHA' 
+        description: 'The merge commit SHA'
       deploy_run_id:
         description: 'The ID of a deployment workspace run with artifacts'
-jobs:  
+jobs:
   test:
     runs-on: ubuntu-latest
     environment: test-server
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{github.event.inputs.merged_sha || github.event.inputs.sha}}
-          
+
       - uses: actions/setup-node@v2
         with:
           node-version: 14
@@ -39,9 +39,9 @@ jobs:
         with:
           script: |
             const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-            
+
             let artifacts = {};
-            
+
             for(let i = 0;i<36&&!artifacts.total_count;i++,await delay(5000)) {
               try {
                 ({ data: artifacts } = await github.actions.listWorkflowRunArtifacts({
@@ -54,14 +54,14 @@ jobs:
                 console.log(e);
               }
             }
-            
+
             const { data: artifact } = await github.request(artifacts.artifacts.find(artifact=> artifact.name === 'docker').archive_download_url);
             require('fs').writeFileSync(require('path').join(process.env.GITHUB_WORKSPACE, 'docker.zip'), Buffer.from(artifact))
-        
+
       - run: |
           unzip docker.zip
           docker load -i testcafe-*.tar
-          
+
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |

--- a/.github/workflows/test-server-lts.yml
+++ b/.github/workflows/test-server-lts.yml
@@ -4,14 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        desciption: 'The test commit SHA or ref'
+        description: 'The test commit SHA or ref'
         required: true
         default: 'master'
       merged_sha:
-        description: 'The merge commit SHA' 
+        description: 'The merge commit SHA'
       deploy_run_id:
         description: 'The ID of a deployment workspace run with artifacts'
-jobs:  
+jobs:
   test:
     runs-on: ubuntu-latest
     environment: test-server
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{github.event.inputs.merged_sha || github.event.inputs.sha}}
-          
+
       - uses: actions/setup-node@v2
         with:
           node-version: 18
@@ -39,9 +39,9 @@ jobs:
         with:
           script: |
             const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
-            
+
             let artifacts = {};
-            
+
             for(let i = 0;i<36&&!artifacts.total_count;i++,await delay(5000)) {
               try {
                 ({ data: artifacts } = await github.actions.listWorkflowRunArtifacts({
@@ -54,14 +54,14 @@ jobs:
                 console.log(e);
               }
             }
-            
+
             const { data: artifact } = await github.request(artifacts.artifacts.find(artifact=> artifact.name === 'npm').archive_download_url);
             require('fs').writeFileSync(require('path').join(process.env.GITHUB_WORKSPACE, 'package.zip'), Buffer.from(artifact))
-        
+
       - run: |
           unzip package.zip
           tar --strip-components=1 -xzf testcafe-*.tgz
-          
+
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -38,6 +38,7 @@ const {
     DEBUG_GLOB_1,
     DEBUG_GLOB_2,
     PROXYLESS_TESTS_GLOB,
+    HEADED_CHROME_FIREFOX_TESTS_GLOB,
 } = require('./gulp/constants/functional-test-globs');
 
 const {
@@ -426,6 +427,12 @@ gulp.step('test-functional-local-multiple-windows-run', () => {
 });
 
 gulp.task('test-functional-local-multiple-windows', gulp.series('prepare-tests', 'test-functional-local-multiple-windows-run'));
+
+gulp.step('test-functional-local-chrome-firefox-headed-run', () => {
+    return testFunctional(HEADED_CHROME_FIREFOX_TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localBrowsersChromeFirefox);
+});
+
+gulp.task('test-functional-local-chrome-firefox-headed', gulp.series('prepare-tests', 'test-functional-local-chrome-firefox-headed-run'));
 
 gulp.step('test-functional-local-debug-run-1', () => {
     return testFunctional(DEBUG_GLOB_1, functionalTestConfig.testingEnvironmentNames.localHeadlessChrome, { experimentalDebug: true });

--- a/gulp/constants/functional-test-globs.js
+++ b/gulp/constants/functional-test-globs.js
@@ -1,4 +1,5 @@
 const MULTIPLE_WINDOWS_TESTS_GLOB = 'test/functional/fixtures/multiple-windows/test.js';
+const HEADED_CHROME_FIREFOX_TESTS_GLOB = ['test/functional/fixtures/multiple-windows/test.js'];
 const COMPILER_SERVICE_TESTS_GLOB = 'test/functional/fixtures/compiler-service/test.js';
 const LEGACY_TESTS_GLOB           = 'test/functional/legacy-fixtures/**/test.js';
 const BASIC_TESTS_GLOB            = 'test/functional/fixtures/**/test.js';
@@ -53,4 +54,5 @@ module.exports = {
     DEBUG_GLOB_2,
     SCREENSHOT_TESTS_GLOB,
     PROXYLESS_TESTS_GLOB,
+    HEADED_CHROME_FIREFOX_TESTS_GLOB,
 };

--- a/gulp/constants/functional-test-globs.js
+++ b/gulp/constants/functional-test-globs.js
@@ -1,4 +1,5 @@
 const MULTIPLE_WINDOWS_TESTS_GLOB = 'test/functional/fixtures/multiple-windows/test.js';
+// NOTE: This source is specified temporary. I will change it to live mode test suit in the next PR.
 const HEADED_CHROME_FIREFOX_TESTS_GLOB = ['test/functional/fixtures/multiple-windows/test.js'];
 const COMPILER_SERVICE_TESTS_GLOB = 'test/functional/fixtures/compiler-service/test.js';
 const LEGACY_TESTS_GLOB           = 'test/functional/legacy-fixtures/**/test.js';


### PR DESCRIPTION
## Purpose
We have only one task that runs tests in headed mode(multiple-windows). We need an additional task that can be used for tests that need to run in headed mode.
 
## Approach
Add the additional task "headed-browsers" 

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
