### PR TITLE
fix: job reporting tests in proxyless

### DIFF
--- a/gulp/constants/functional-test-globs.js
+++ b/gulp/constants/functional-test-globs.js
@@ -30,7 +30,6 @@ const DEBUG_GLOB_2 = [
 const PROXYLESS_TESTS_GLOB = [
     ...TESTS_GLOB,
     '!test/functional/fixtures/ui/test.js',
-    '!test/functional/fixtures/browser-provider/job-reporting/test.js',
     '!test/functional/fixtures/driver/script-execution-barrier/test.js',
     '!test/functional/fixtures/run-options/request-timeout/test.js',
     '!test/functional/fixtures/run-options/disable-page-caching/test.js',

--- a/test/functional/fixtures/browser-provider/job-reporting/test.js
+++ b/test/functional/fixtures/browser-provider/job-reporting/test.js
@@ -18,7 +18,7 @@ if (config.useLocalBrowsers && !config.hasBrowser('ie')) {
             state:     {},
             idNameMap: {},
 
-            openBrowser (browserId, pageUrl, browserConfig) {
+            openBrowser (browserId, pageUrl, browserConfig, additionalOptions) {
                 const self       = this;
                 const providerId = typeof browserConfig ===
                                    'string' ? browserConfig : browserConfig.userArgs.replace(/\W*/, '');
@@ -37,7 +37,7 @@ if (config.useLocalBrowsers && !config.hasBrowser('ie')) {
                     userArgs: `--no-sandbox ${browserConfig.userArgs}`,
                     headless: true,
                 },
-                { disableMultipleWindows: false });
+                { ...additionalOptions, disableMultipleWindows: false });
             },
 
             closeBrowser (browserId) {


### PR DESCRIPTION
## Purpose
Job Reporting tests do not work in proxyless
## Approach
Pass proxyless settings to the browserProvider mock

## Pre-Merge TODO
- [ ] Make sure that existing tests do not fail
