### PR TITLE
fix: vulnerabilities in Jekyll dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,0 @@
-source 'https://rubygems.org' do
-  gem 'jekyll', '~>3.8'
-  gem 'htmlentities', '~>4.3'
-  gem 'sanitize', '~>5.0'
-  gem 'redcarpet', '~>3.5'
-  gem 'jekyll-sitemap', '~>1.3'
-  gem 'jekyll-redirect-from', git: 'https://github.com/VasilyStrelyaev/jekyll-redirect-from'
-end 


### PR DESCRIPTION
<img width="1148" alt="image" src="https://user-images.githubusercontent.com/3633477/221114696-8d057e22-9e63-47d7-af8d-82ff9e66e0ac.png">
@AlexKamaev If I understand correctly, we don't need Jekyll anymore.
So I removed Gemfile to not deal with vulnerabilities in the redundant dependencies.