### PR TITLE
proxyless: speed up 'pressKey' action

### DIFF
--- a/src/client/automation/playback/press/index.js
+++ b/src/client/automation/playback/press/index.js
@@ -15,7 +15,7 @@ import isIframeWindow from '../../../../utils/is-window-in-iframe';
 import ProxylessInput from '../../../../proxyless/client/input';
 import { changeLetterCaseIfNecessary, getSimulatedKeyInfo } from '../../../../proxyless/client/key-press/utils';
 import { getModifiersBit } from '../../../../proxyless/client/utils';
-import { EventType } from '../../../../proxyless/types';
+import CDPEventDescriptor from '../../../../proxyless/client/event-descriptor';
 
 const Promise        = hammerhead.Promise;
 const browserUtils   = hammerhead.utils.browser;
@@ -182,13 +182,10 @@ export default class PressAutomation {
 
                 changeLetterCaseIfNecessary(keyInfo);
 
-                eventSequence.push({
-                    type:    EventType.Keyboard,
-                    options: this.proxylessInput.createKeyDownOptions(keyInfo),
-                }, {
-                    type:    EventType.Delay,
-                    options: { delay: this.automationSettings.keyActionStepDelay },
-                });
+                eventSequence.push(
+                    CDPEventDescriptor.keyDown(keyInfo),
+                    CDPEventDescriptor.delay(this.automationSettings.keyActionStepDelay)
+                );
             }
 
             for (let i = simulatedKeyInfos.length - 1; i >= 0; i--) {
@@ -197,10 +194,7 @@ export default class PressAutomation {
                 modifiersBit     &= ~getModifiersBit(keyInfo.key);
                 keyInfo.modifiers = modifiersBit;
 
-                eventSequence.push({
-                    type:    EventType.Keyboard,
-                    options: this.proxylessInput.createKeyUpOptions(keyInfo),
-                });
+                eventSequence.push(CDPEventDescriptor.keyUp(keyInfo));
             }
         }
 

--- a/src/client/automation/playback/press/index.js
+++ b/src/client/automation/playback/press/index.js
@@ -15,6 +15,7 @@ import isIframeWindow from '../../../../utils/is-window-in-iframe';
 import ProxylessInput from '../../../../proxyless/client/input';
 import { changeLetterCaseIfNecessary, getSimulatedKeyInfo } from '../../../../proxyless/client/key-press/utils';
 import { getModifiersBit } from '../../../../proxyless/client/utils';
+import { EventType } from '../../../../proxyless/types';
 
 const Promise        = hammerhead.Promise;
 const browserUtils   = hammerhead.utils.browser;
@@ -148,34 +149,7 @@ export default class PressAutomation {
         return delay(this.automationSettings.keyActionStepDelay);
     }
 
-    _runCombinationViaCDP (keyCombination) {
-        const simulatedKeyInfos = getSimulatedKeyInfo(keyCombination);
-        let modifiersBit        = 0;
-
-        return promiseUtils.each(simulatedKeyInfos, keyInfo => {
-            modifiersBit     |= getModifiersBit(keyInfo.key);
-            keyInfo.modifiers = modifiersBit;
-
-            changeLetterCaseIfNecessary(keyInfo);
-
-            return this.proxylessInput.keyDown(keyInfo)
-                .then(() => {
-                    return delay(this.automationSettings.keyActionStepDelay);
-                });
-        })
-            .then(() => {
-                arrayUtils.reverse(simulatedKeyInfos);
-
-                return promiseUtils.each(simulatedKeyInfos, keyInfo => {
-                    modifiersBit     &= ~getModifiersBit(keyInfo.key);
-                    keyInfo.modifiers = modifiersBit;
-
-                    return this.proxylessInput.keyUp(keyInfo);
-                });
-            });
-    }
-
-    _runCombinationViaClientEventSimulation (keyCombination) {
+    _runCombination (keyCombination) {
         this.modifiersState   = { ctrl: false, alt: false, shift: false, meta: false };
         this.isSelectElement  = domUtils.isSelectElement(getDeepActiveElement(this.topSameDomainDocument));
         this.pressedKeyString = '';
@@ -195,11 +169,42 @@ export default class PressAutomation {
             });
     }
 
-    _runCombination (keyCombination) {
-        if (this.proxylessInput)
-            return this._runCombinationViaCDP(keyCombination);
+    _calculateCDPEventSequence () {
+        const eventSequence = [];
 
-        return this._runCombinationViaClientEventSimulation(keyCombination);
+        for (const keyCombination of this.keyCombinations) {
+            const simulatedKeyInfos = getSimulatedKeyInfo(keyCombination);
+            let modifiersBit        = 0;
+
+            for (const keyInfo of simulatedKeyInfos) {
+                modifiersBit     |= getModifiersBit(keyInfo.key);
+                keyInfo.modifiers = modifiersBit;
+
+                changeLetterCaseIfNecessary(keyInfo);
+
+                eventSequence.push({
+                    type:    EventType.Keyboard,
+                    options: this.proxylessInput.createKeyDownOptions(keyInfo),
+                }, {
+                    type:    EventType.Delay,
+                    options: { delay: this.automationSettings.keyActionStepDelay },
+                });
+            }
+
+            for (let i = simulatedKeyInfos.length - 1; i >= 0; i--) {
+                const keyInfo = simulatedKeyInfos[i];
+
+                modifiersBit     &= ~getModifiersBit(keyInfo.key);
+                keyInfo.modifiers = modifiersBit;
+
+                eventSequence.push({
+                    type:    EventType.Keyboard,
+                    options: this.proxylessInput.createKeyUpOptions(keyInfo),
+                });
+            }
+        }
+
+        return eventSequence;
     }
 
     run () {
@@ -214,6 +219,12 @@ export default class PressAutomation {
             };
 
             return sendRequestToFrame(msg, PRESS_RESPONSE_CMD, nativeMethods.contentWindowGetter.call(activeElement));
+        }
+
+        if (this.proxylessInput) {
+            const eventSequence = this._calculateCDPEventSequence();
+
+            return this.proxylessInput.executeEventSequence(eventSequence);
         }
 
         return promiseUtils.each(this.keyCombinations, combination => {

--- a/src/client/automation/playback/type/index.js
+++ b/src/client/automation/playback/type/index.js
@@ -11,7 +11,7 @@ import getKeyProperties from '../../utils/get-key-properties';
 import cursor from '../../cursor';
 import ProxylessInput from '../../../../proxyless/client/input';
 import getKeyInfo from '../press/get-key-info';
-import { EventType } from '../../../../proxyless/types';
+import CDPEventDescriptor from '../../../../proxyless/client/event-descriptor';
 
 const Promise               = hammerhead.Promise;
 const extend                = hammerhead.utils.extend;
@@ -201,16 +201,11 @@ export default class TypeAutomation {
             const keyInfo          = getKeyInfo(currentKey);
             const simulatedKeyInfo = extend({ key: currentKey }, keyInfo);
 
-            eventSequence.push({
-                type:    EventType.Keyboard,
-                options: this.proxylessInput.createKeyDownOptions(simulatedKeyInfo),
-            }, {
-                type:    EventType.Keyboard,
-                options: this.proxylessInput.createKeyUpOptions(simulatedKeyInfo),
-            }, {
-                type:    EventType.Delay,
-                options: { delay: this.automationSettings.keyActionStepDelay },
-            });
+            eventSequence.push(
+                CDPEventDescriptor.keyDown(simulatedKeyInfo),
+                CDPEventDescriptor.keyUp(simulatedKeyInfo),
+                CDPEventDescriptor.delay(this.automationSettings.keyActionStepDelay)
+            );
         }
 
         return eventSequence;

--- a/src/proxyless/client/event-descriptor.ts
+++ b/src/proxyless/client/event-descriptor.ts
@@ -1,0 +1,75 @@
+import { EventType } from '../types';
+import { SimulatedKeyInfo } from './key-press/utils';
+// @ts-ignore
+import { utils } from '../../client/core/deps/hammerhead';
+import { calculateKeyModifiersValue, calculateMouseButtonValue } from './utils';
+import AxisValues from '../../client/core/utils/values/axis-values';
+
+const MOUSE_EVENT_OPTIONS = {
+    clickCount: 1,
+    button:     'left',
+};
+
+export default class CDPEventDescriptor {
+    private static _getKeyDownEventText (options: SimulatedKeyInfo): any {
+        if (options.isNewLine)
+            return '\r';
+
+        if (options.keyProperty.length === 1)
+            return options.keyProperty;
+
+        return '';
+    }
+
+    public static createKeyDownOptions (options: SimulatedKeyInfo): any {
+        const text = CDPEventDescriptor._getKeyDownEventText(options);
+
+        return {
+            type:                  text ? 'keyDown' : 'rawKeyDown',
+            modifiers:             options.modifiers || 0,
+            windowsVirtualKeyCode: options.keyCode,
+            key:                   options.keyProperty,
+            text,
+        };
+    }
+
+    public static createKeyUpOptions (options: SimulatedKeyInfo): any {
+        return {
+            type:                  'keyUp',
+            modifiers:             options.modifiers || 0,
+            key:                   options.keyProperty,
+            windowsVirtualKeyCode: options.keyCode,
+        };
+    }
+
+    public static createMouseEventOptions (type: string, options: any, leftTopPoint: AxisValues<number>): any {
+        return utils.extend({
+            x:         options.options.clientX + leftTopPoint.x,
+            y:         options.options.clientY + leftTopPoint.y,
+            modifiers: calculateKeyModifiersValue(options.options),
+            button:    calculateMouseButtonValue(options.options),
+            type,
+        }, MOUSE_EVENT_OPTIONS);
+    }
+
+    public static delay (delay: number): any {
+        return {
+            type:    EventType.Delay,
+            options: { delay },
+        };
+    }
+
+    public static keyDown (keyInfo: SimulatedKeyInfo): any {
+        return {
+            type:    EventType.Keyboard,
+            options: CDPEventDescriptor.createKeyDownOptions(keyInfo),
+        };
+    }
+
+    public static keyUp (keyInfo: SimulatedKeyInfo): any {
+        return {
+            type:    EventType.Keyboard,
+            options: CDPEventDescriptor.createKeyUpOptions(keyInfo),
+        };
+    }
+}

--- a/src/proxyless/client/input.ts
+++ b/src/proxyless/client/input.ts
@@ -1,15 +1,8 @@
 import { EventType } from '../types';
-// @ts-ignore
-import { utils } from '../../client/core/deps/hammerhead';
-import { calculateKeyModifiersValue, calculateMouseButtonValue } from './utils';
 import AxisValues from '../../client/core/utils/values/axis-values';
 import { SimulatedKeyInfo } from './key-press/utils';
 import { DispatchEventFn } from './types';
-
-const MOUSE_EVENT_OPTIONS = {
-    clickCount: 1,
-    button:     'left',
-};
+import CDPEventDescriptor from './event-descriptor';
 
 export default class ProxylessInput {
 
@@ -20,66 +13,25 @@ export default class ProxylessInput {
         this._leftTopPoint    = leftTopPoint || new AxisValues<number>(0, 0);
     }
 
-    private _createMouseEventOptions (type: string, options: any): any {
-        return utils.extend({
-            x:         options.options.clientX + this._leftTopPoint.x,
-            y:         options.options.clientY + this._leftTopPoint.y,
-            modifiers: calculateKeyModifiersValue(options.options),
-            button:    calculateMouseButtonValue(options.options),
-            type,
-        }, MOUSE_EVENT_OPTIONS);
-    }
-
-    private _getKeyDownEventText (options: SimulatedKeyInfo): any {
-        if (options.isNewLine)
-            return '\r';
-
-        if (options.keyProperty.length === 1)
-            return options.keyProperty;
-
-        return '';
-    }
-
     public mouseDown (options: any): Promise<void> {
-        const eventOptions = this._createMouseEventOptions('mousePressed', options);
+        const eventOptions = CDPEventDescriptor.createMouseEventOptions('mousePressed', options, this._leftTopPoint);
 
         return this._dispatchEventFn.single(EventType.Mouse, eventOptions);
     }
 
     public mouseUp (options: any): Promise<void> {
-        const eventOptions = this._createMouseEventOptions('mouseReleased', options);
+        const eventOptions = CDPEventDescriptor.createMouseEventOptions('mouseReleased', options, this._leftTopPoint);
 
         return this._dispatchEventFn.single(EventType.Mouse, eventOptions);
     }
 
-    public createKeyDownOptions (options: SimulatedKeyInfo): any {
-        const text = this._getKeyDownEventText(options);
-
-        return {
-            type:                  text ? 'keyDown' : 'rawKeyDown',
-            modifiers:             options.modifiers || 0,
-            windowsVirtualKeyCode: options.keyCode,
-            key:                   options.keyProperty,
-            text,
-        };
-    }
-
-    public createKeyUpOptions (options: SimulatedKeyInfo): any {
-        return {
-            type:                  'keyUp',
-            modifiers:             options.modifiers || 0,
-            key:                   options.keyProperty,
-            windowsVirtualKeyCode: options.keyCode,
-        };
-    }
-
     public keyDown (options: SimulatedKeyInfo): Promise<void> {
-        const eventOptions = this.createKeyDownOptions(options);
+        const eventOptions = CDPEventDescriptor.createKeyDownOptions(options);
 
         return this._dispatchEventFn.single(EventType.Keyboard, eventOptions);
     }
     public keyUp (options: SimulatedKeyInfo): Promise<void> {
-        const eventOptions = this.createKeyUpOptions(options);
+        const eventOptions = CDPEventDescriptor.createKeyUpOptions(options);
 
         return this._dispatchEventFn.single(EventType.Keyboard, eventOptions);
     }


### PR DESCRIPTION
*Run a simple test 50 times.*

```js
import { ClientFunction } from 'testcafe';

fixture `TypeText speed up test suite`
    .page('https://devexpress.github.io/testcafe/example/');

const prepareInput = ClientFunction(() => {
    const input = document.getElementById('developer-name');

    input.value = 'Peter Parker';
    input.focus();
});

for (let i = 0; i < 50; i++) {
    test('test', async t => {
        await prepareInput();

        await t.pressKey('ctrl+a delete p e t e r p a r k e r');
    });
}
```

*Execution time (from fastest):*
* improved proxyless mode (this PR) - 41s.
* regular mode - 1m 01s. 
* current proxyless mode (master) - (1m 03s).