### PR TITLE
skip request timeout tests in proxyless until native timeout support is implemented

### DIFF
--- a/gulp/constants/functional-test-globs.js
+++ b/gulp/constants/functional-test-globs.js
@@ -30,7 +30,6 @@ const DEBUG_GLOB_2 = [
 
 const PROXYLESS_TESTS_GLOB = [
     ...TESTS_GLOB,
-    '!test/functional/fixtures/run-options/request-timeout/test.js',
     '!test/functional/fixtures/run-options/disable-page-caching/test.js',
     '!test/functional/fixtures/regression/gh-1311/test.js',
     '!test/functional/fixtures/hammerhead/gh-2622/test.js',

--- a/test/functional/fixtures/run-options/request-timeout/test.js
+++ b/test/functional/fixtures/run-options/request-timeout/test.js
@@ -1,6 +1,9 @@
-const { expect } = require('chai');
+const { expect }          = require('chai');
+const { skipDescribeInProxyless } = require('../../../utils/skip-in');
 
-describe('Request timeout', () => {
+// NOTE: CDP doesn't support request timeouts out of the box.
+// We have decided not to implement such functionality until it is supported in CDP.
+skipDescribeInProxyless('Request timeout', () => {
     describe('Test level', () => {
         it('Page request timeout', () => {
             return runTests('testcafe-fixtures/test-level.js', 'page request timeout', { only: 'chrome', shouldFail: true })


### PR DESCRIPTION
## Purpose
We have {pageRequestTimeout, ajaxRequestTimeout} props on different levels. CDP doesn't support request timeouts out of the box. 

## Approach
skipInProxyless
We decided not to manually implement such functionality until it is supported in the CDP, in order not to complicate the code and not create potential bugs.

## Pre-Merge TODO
- [ ] Make sure that existing tests do not fail
