### PR TITLE
skip disablePageCaching tests in proxyless until multiple windows support

### DIFF
--- a/gulp/constants/functional-test-globs.js
+++ b/gulp/constants/functional-test-globs.js
@@ -30,7 +30,6 @@ const DEBUG_GLOB_2 = [
 
 const PROXYLESS_TESTS_GLOB = [
     ...TESTS_GLOB,
-    '!test/functional/fixtures/run-options/disable-page-caching/test.js',
     '!test/functional/fixtures/regression/gh-1311/test.js',
     '!test/functional/fixtures/hammerhead/gh-2622/test.js',
     '!test/functional/fixtures/regression/gh-2861/test.js',

--- a/test/functional/fixtures/run-options/disable-page-caching/test.js
+++ b/test/functional/fixtures/run-options/disable-page-caching/test.js
@@ -1,4 +1,9 @@
-describe('Disable page caching', () => {
+const { skipDescribeInProxyless } = require('../../../utils/skip-in');
+
+// NOTE: This test suit tests localStorage synchronisation between windows. We didn't support multiple windows in CDP yet.
+// We need to turn on these tests and implement cache-control response header in proxyless once multiple windows are supported.
+
+skipDescribeInProxyless('Disable page caching', () => {
     it('Test run', () => {
         return runTests('testcafe-fixtures/test-run.js', null, { disablePageCaching: true, disableMultipleWindows: true });
     });


### PR DESCRIPTION
## Purpose

This test suit tests localStorage synchronisation between windows. We didn't support multiple windows in CDP yet.
We need to turn on these tests and implement cache-control response header in proxyless once multiple windows are supported.
To implement this see the following:
https://github.com/DevExpress/testcafe-hammerhead/blob/master/src/request-pipeline/context/index.ts#L474
https://github.com/DevExpress/testcafe-hammerhead/blob/master/src/request-pipeline/header-transforms/index.ts#L98

## Approach
skipInProxyless

## Pre-Merge TODO
- [ ] Make sure that existing tests do not fail
