### PR TITLE
proxyless: use it by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.23",
-    "testcafe-hammerhead": "29.0.0",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/10963730/testcafe-hammerhead-30.0.0.zip",
     "testcafe-legacy-api": "5.1.6",
     "testcafe-reporter-dashboard": "^0.2.10",
     "testcafe-reporter-json": "^2.1.0",

--- a/src/browser/connection/gateway/index.ts
+++ b/src/browser/connection/gateway/index.ts
@@ -356,8 +356,15 @@ export default class BrowserConnectionGateway extends EventEmitter {
         return this._connections;
     }
 
+<<<<<<< HEAD
     public get proxyless (): boolean {
         return this._options.proxyless;
+=======
+    public switchToProxyless (): void {
+        this._proxyless = true;
+
+        this.proxy.switchToProxyless();
+>>>>>>> 3b874ffff... fix proxyless calculation
     }
 
     public get status (): BrowserConnectionGatewayStatus {

--- a/src/browser/connection/gateway/status.ts
+++ b/src/browser/connection/gateway/status.ts
@@ -1,0 +1,6 @@
+enum BrowserConnectionGatewayStatus {
+    uninitialized,
+    initialized,
+}
+
+export default BrowserConnectionGatewayStatus;

--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -291,6 +291,7 @@ export default class BrowserConnection extends EventEmitter {
     private _getAdditionalBrowserOptions (): OpenBrowserAdditionalOptions {
         const options = {
             disableMultipleWindows: this._options.disableMultipleWindows,
+            proxyless:              this._options.proxyless,
         } as OpenBrowserAdditionalOptions;
 
         if (this._options.proxyless) {

--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -24,8 +24,8 @@ import BrowserProvider from '../provider';
 import { OSInfo } from 'get-os-info';
 import SERVICE_ROUTES from './service-routes';
 import {
-    BROWSER_RESTART_TIMEOUT,
     BROWSER_CLOSE_TIMEOUT,
+    BROWSER_RESTART_TIMEOUT,
     HEARTBEAT_TIMEOUT,
     LOCAL_BROWSER_INIT_TIMEOUT,
     REMOTE_BROWSER_INIT_TIMEOUT,
@@ -87,9 +87,15 @@ export interface BrowserInfo {
 }
 
 export interface BrowserConnectionOptions {
+<<<<<<< HEAD
     disableMultipleWindows: boolean;
     developmentMode: boolean;
     proxyless: boolean;
+=======
+    disableMultipleWindows?: boolean;
+    developmentMode: boolean;
+    proxyless?: boolean;
+>>>>>>> 1442cb0cf... run in the proxyless mode by default
 }
 
 const DEFAULT_BROWSER_CONNECTION_OPTIONS = {
@@ -98,6 +104,10 @@ const DEFAULT_BROWSER_CONNECTION_OPTIONS = {
     proxyless:              false,
 };
 
+<<<<<<< HEAD
+=======
+
+>>>>>>> 1442cb0cf... run in the proxyless mode by default
 export default class BrowserConnection extends EventEmitter {
     public permanent: boolean;
     public previousActiveWindowId: string | null;
@@ -148,7 +158,11 @@ export default class BrowserConnection extends EventEmitter {
         gateway: BrowserConnectionGateway,
         browserInfo: BrowserInfo,
         permanent: boolean,
+<<<<<<< HEAD
         options: Partial<BrowserConnectionOptions> = {},
+=======
+        options: BrowserConnectionOptions,
+>>>>>>> 1442cb0cf... run in the proxyless mode by default
         messageBus?: MessageBus) {
         super();
 
@@ -183,7 +197,6 @@ export default class BrowserConnection extends EventEmitter {
         this.pendingTestRunInfo     = null;
         this._options               = this._calculateResultOptions(options);
 
-        this._buildCommunicationUrls(gateway.proxy);
         this._setEventHandlers();
 
         BrowserConnectionTracker.add(this);
@@ -191,9 +204,10 @@ export default class BrowserConnection extends EventEmitter {
         this.previousActiveWindowId = null;
 
         this.browserConnectionGateway.startServingConnection(this);
+    }
 
-        // NOTE: Give a caller time to assign event listeners
-        process.nextTick(() => this._runBrowser());
+    private _calculateResultOptions (options: BrowserConnectionOptions): BrowserConnectionOptions {
+        return Object.assign({}, DEFAULT_BROWSER_CONNECTION_OPTIONS, options);
     }
 
     private _calculateResultOptions (options: Partial<BrowserConnectionOptions>): BrowserConnectionOptions {
@@ -221,6 +235,12 @@ export default class BrowserConnection extends EventEmitter {
         this.statusUrl           = proxy.resolveRelativeServiceUrl(this.statusRelativeUrl);
         this.statusDoneUrl       = proxy.resolveRelativeServiceUrl(this.statusDoneRelativeUrl);
         this.openFileProtocolUrl = proxy.resolveRelativeServiceUrl(this.openFileProtocolRelativeUrl);
+    }
+
+    public initialize (): void {
+        this._buildCommunicationUrls(this.browserConnectionGateway.proxy);
+
+        this._runBrowser();
     }
 
     public initMessageBus (): void {

--- a/src/cli/argument-parser/index.ts
+++ b/src/cli/argument-parser/index.ts
@@ -44,8 +44,8 @@ const REMOTE_ALIAS_RE = /^remote(?::(\d*))?$/;
 const DESCRIPTION = dedent(`
 
     To select a browser, specify an alias ("ie", "chrome", etc.) or the path to the browser executable. You can select more than one browser.
-    
-    Use the "all" alias to run tests against all available browsers.   
+
+    Use the "all" alias to run tests against all available browsers.
     Use the "remote" alias to run tests on remote devices, like smartphones or tablets. Specify the number of remote browsers after the semicolon ("remote:3").
     If you use a browser provider plugin, specify both the name of the plugin and the name of the browser. Separate the two with a semicolon ("saucelabs:chrome@51").
 
@@ -86,7 +86,7 @@ interface CommandLineOptions {
     videoEncodingOptions?: string | Dictionary<number | string | boolean>;
     compilerOptions?: string | Dictionary<number | string | boolean>;
     configFile?: string;
-    proxyless?: boolean;
+    disableProxyless?: boolean;
     v8Flags?: string[];
     dashboardOptions?: string | Dictionary<string | boolean | number>;
     baseUrl?: string;
@@ -167,7 +167,7 @@ export default class CLIArgumentParser {
             .option('--test-meta <key=value[,key2=value2,...]>', 'filter tests by metadata')
             .option('--fixture-meta <key=value[,key2=value2,...]>', 'filter fixtures by metadata')
             .option('--debug-on-fail', 'pause tests on failure')
-            .option('--experimental-proxyless', 'enable proxyless mode: https://testcafe.io/documentation/404237/guides/experimental-capabilities/proxyless-mode')
+            .option('--disable-proxyless', 'disable proxyless mode')
             .option('--app-init-delay <ms>', 'specify your application`s initialization time')
             .option('--selector-timeout <ms>', 'specify the maximum Selector resolution time')
             .option('--assertion-timeout <ms>', 'specify the maximum Assertion resolution time')

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -85,7 +85,6 @@ async function runTests (argParser) {
         cache,
         disableHttp2,
         v8Flags,
-        experimentalProxyless,
         disableCrossDomain,
         experimentalEsm,
     } = opts;
@@ -104,7 +103,6 @@ async function runTests (argParser) {
         configFile,
         disableHttp2,
         v8Flags,
-        experimentalProxyless,
         disableCrossDomain,
         experimentalEsm,
     });

--- a/src/configuration/option-names.ts
+++ b/src/configuration/option-names.ts
@@ -44,7 +44,7 @@ enum OptionNames {
     debugLogger = 'debugLogger',
     disableMultipleWindows = 'disableMultipleWindows',
     disableHttp2 = 'disableHttp2',
-    experimentalProxyless = 'experimentalProxyless',
+    disableProxyless = 'disableProxyless',
     experimentalDebug = 'experimentalDebug',
     compilerOptions = 'compilerOptions',
     pageRequestTimeout = 'pageRequestTimeout',

--- a/src/configuration/run-option-names.ts
+++ b/src/configuration/run-option-names.ts
@@ -21,6 +21,6 @@ export default [
     OPTION_NAMES.pageRequestTimeout,
     OPTION_NAMES.ajaxRequestTimeout,
     OPTION_NAMES.retryTestPages,
-    OPTION_NAMES.experimentalProxyless,
+    OPTION_NAMES.disableProxyless,
     OPTION_NAMES.baseUrl,
 ];

--- a/src/configuration/utils.ts
+++ b/src/configuration/utils.ts
@@ -1,0 +1,29 @@
+import { GeneralError } from '../errors/runtime';
+import { RUNTIME_ERRORS } from '../errors/types';
+import endpointUtils from 'endpoint-utils';
+
+export async function getValidHostname (hostname: string): Promise<string> {
+    if (hostname) {
+        const valid = await endpointUtils.isMyHostname(hostname);
+
+        if (!valid)
+            throw new GeneralError(RUNTIME_ERRORS.invalidHostname, hostname);
+    }
+    else
+        hostname = endpointUtils.getIPAddress();
+
+    return hostname;
+}
+
+export async function getValidPort (port: number): Promise<number> {
+    if (port) {
+        const isFree = await endpointUtils.isFreePort(port);
+
+        if (!isFree)
+            throw new GeneralError(RUNTIME_ERRORS.portIsNotFree, port);
+    }
+    else
+        port = await endpointUtils.getFreePort();
+
+    return port;
+}

--- a/src/proxyless/request-pipeline/index.ts
+++ b/src/proxyless/request-pipeline/index.ts
@@ -9,7 +9,7 @@ import FrameTree = Protocol.Page.FrameTree;
 import FulfillRequestRequest = Protocol.Fetch.FulfillRequestRequest;
 import RequestPattern = Protocol.Fetch.RequestPattern;
 import ProxylessRequestHookEventProvider from '../request-hooks/event-provider';
-import ResourceInjector from '../resource-injector';
+import ResourceInjector, { ResourceInjectorOptions } from '../resource-injector';
 import { convertToHeaderEntries } from '../utils/headers';
 
 import {
@@ -73,7 +73,7 @@ export default class ProxylessRequestPipeline extends ProxylessApiBase {
         this._contextInfo             = new ProxylessRequestContextInfo(this._testRunBridge);
         this._specialServiceRoutes    = this._getSpecialServiceRoutes();
         this.requestHookEventProvider = new ProxylessRequestHookEventProvider();
-        this._resourceInjector        = new ResourceInjector(this._testRunBridge, this._specialServiceRoutes);
+        this._resourceInjector        = new ResourceInjector(this._testRunBridge);
         this._options                 = DEFAULT_PROXYLESS_SETUP_OPTIONS;
         this._stopped                 = false;
         this._currentFrameTree        = null;
@@ -312,8 +312,17 @@ export default class ProxylessRequestPipeline extends ProxylessApiBase {
         return this._currentFrameTree.frame.id !== frameId;
     }
 
+    private _createResourceInjectorOptions (): ResourceInjectorOptions {
+        return {
+            specialServiceRoutes: this._specialServiceRoutes,
+            developmentMode:      this._options.developmentMode,
+        };
+    }
+
     public async init (options?: ProxylessSetupOptions): Promise<void> {
         this._options = options as ProxylessSetupOptions;
+
+        this._resourceInjector.setOptions(this._createResourceInjectorOptions());
 
         // NOTE: We are forced to handle all requests and responses at once
         // because CDP API does not allow specifying request filtering behavior for different handlers.

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -38,6 +38,7 @@ import assertRequestHookType from '../api/request-hooks/assert-type';
 import userVariables from '../api/user-variables';
 import OPTION_NAMES from '../configuration/option-names';
 import TestCafeConfiguration from '../configuration/testcafe-configuration';
+import BrowserConnectionGatewayStatus from '../browser/connection/gateway/status';
 
 const DEBUG_SCOPE = 'testcafe:bootstrapper';
 
@@ -190,22 +191,19 @@ export default class Bootstrapper {
     }
 
     private async _setupProxyless (automatedBrowserInfo: BrowserInfo[], remoteBrowserConnections: BrowserConnection[]): Promise<void> {
-        if (remoteBrowserConnections.length) {
-            this.proxyless = false;
-
+        if (this.browserConnectionGateway.status === BrowserConnectionGatewayStatus.initialized)
             return;
-        }
 
-        this.proxyless = this._calculateIsProxyless(automatedBrowserInfo);
+        this.proxyless = remoteBrowserConnections.length
+            ? false
+            : this._calculateIsProxyless(automatedBrowserInfo);
 
         await this.configuration.calculateHostname({ proxyless: this.proxyless });
 
         this.browserConnectionGateway.initialize(this.configuration.startOptions);
 
-        if (this.proxyless) {
+        if (this.proxyless)
             this.browserConnectionGateway.switchToProxyless();
-            this.browserConnectionGateway.proxy.switchToProxyless();
-        }
     }
 
     private async _getBrowserConnections (browserInfo: BrowserInfoSource[]): Promise<BrowserSet> {

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -229,7 +229,10 @@ export default class Runner extends EventEmitter {
     }
 
     _runTask ({ reporters, browserSet, tests, testedApp, options, runnableConfigurationId }) {
-        const task              = this._createTask(tests, browserSet.browserConnectionGroups, this.proxy, options, this.warningLog);
+        const task = this._createTask(tests, browserSet.browserConnectionGroups, this.proxy, options, this.warningLog);
+
+        task.registerClientScriptRouting(this.bootstrapper.proxyless);
+
         const completionPromise = this._getTaskResult(task, browserSet, reporters, testedApp, runnableConfigurationId);
         let completed           = false;
 

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -62,6 +62,7 @@ export default class Task extends AsyncEventEmitter {
         this.warningLog              = new WarningLog(null, WarningLog.createAddWarningCallback(messageBus));
         this._compilerService        = compilerService;
         this._messageBus             = messageBus;
+        this._clientScriptRoutes     = [];
 
         this.warningLog.copyFrom(runnerWarningLog);
 

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -375,7 +375,7 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     public isProxyless (): boolean {
-        return !!this.opts.experimentalProxyless;
+        return this.browserConnection.browserConnectionGateway.proxyless;
     }
 
     private _getRequestHookEventProvider (): RequestHookEventProvider {

--- a/test/functional/config.js
+++ b/test/functional/config.js
@@ -213,16 +213,16 @@ module.exports = {
         return process.env.DEV_MODE === 'true';
     },
 
-    get proxyless () {
-        return process.env.PROXYLESS === 'true';
-    },
-
     get retryTestPages () {
         return this.currentEnvironment.retryTestPages;
     },
 
     get experimentalDebug () {
         return !!process.env.EXPERIMENTAL_DEBUG;
+    },
+
+    get proxyless () {
+        return process.env.PROXYLESS === 'true';
     },
 
     testingEnvironmentNames,

--- a/test/functional/fixtures/live/test.js
+++ b/test/functional/fixtures/live/test.js
@@ -48,7 +48,7 @@ class RunnerMock extends LiveModeRunner {
 }
 
 function createTestCafeInstance (opts = {}) {
-    return createTestCafe({ experimentalProxyless: config.proxyless, ...opts })
+    return createTestCafe({ ...opts })
         .then(tc => {
             cafe = tc;
         });

--- a/test/functional/fixtures/page-js-errors/test.js
+++ b/test/functional/fixtures/page-js-errors/test.js
@@ -9,10 +9,10 @@ const {
 } = require('./constants');
 
 const { createReporter } = require('../../utils/reporter');
-const experimentalDebug  = !!process.env.EXPERIMENTAL_DEBUG;
-const proxyless          = !!process.env.PROXYLESS;
+const config             = require('../../config');
 
-const CALLBACK_FUNC_ERROR = proxyless ? 'Error in the skipJsError callback function' : 'An error occurred in skipJsErrors handler code:';
+
+const CALLBACK_FUNC_ERROR = config.proxyless ? 'Error in the skipJsError callback function' : 'An error occurred in skipJsErrors handler code:';
 
 describe('Test should fail after js-error on the page', () => {
     it('if an error is raised before test done', () => {
@@ -87,7 +87,7 @@ const expectFailAttempt = (errors, expectedMessage) => {
 };
 
 // TODO: fix tests for Debug task
-(experimentalDebug ? describe.skip : describe)('Customize SkipJSErrors (GH-2775)', () => {
+(config.experimentalDebug ? describe.skip : describe)('Customize SkipJSErrors (GH-2775)', () => {
     describe('TestController method', () => {
         it('Should skip JS errors without param', async () => {
             return runTests('./testcafe-fixtures/test-controller.js', 'Should skip JS errors without param');

--- a/test/functional/fixtures/proxy/test.js
+++ b/test/functional/fixtures/proxy/test.js
@@ -1,4 +1,5 @@
 const os                  = require('os');
+const http                = require('http');
 const { expect }          = require('chai');
 const { skipInProxyless } = require('../../utils/skip-in');
 
@@ -41,8 +42,6 @@ describe('Using proxy-bypass', function () {
     });
 
     skipInProxyless('Should open page without proxy but get resource with proxy', function () {
-        const http = require('http');
-
         const server = http.createServer(function (req, res) {
             res.write('document.getElementById(\'result\').innerHTML = \'proxy\'');
             res.end();

--- a/test/functional/fixtures/proxyless/pages/index.html
+++ b/test/functional/fixtures/proxyless/pages/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <h1>Simple page</h1>
+    <a id="link" href="https://example.com">Link</a>
+</body>
+</html>

--- a/test/functional/fixtures/proxyless/test.js
+++ b/test/functional/fixtures/proxyless/test.js
@@ -1,0 +1,38 @@
+const createTestCafe = require('../../../../lib');
+const path           = require('path');
+
+async function runTest ({ browsers, test, disableProxyless }) {
+    const testCafe = await createTestCafe('127.0.0.1', 1335, 1336);
+    const runner   = testCafe.createRunner();
+    const source   = path.join(__dirname, './testcafe-fixtures/index.js');
+
+    const failedCount = await runner.browsers(browsers)
+        .src(source)
+        .filter(testName => {
+            return testName ? test === testName : true;
+        })
+        .run({ disableProxyless });
+
+    await testCafe.close();
+
+    if (failedCount)
+        throw new Error('Error has occurred');
+}
+
+describe('Proxyless', function () {
+    it('Enabled by-default', function () {
+        return runTest({ browsers: 'chrome', test: 'Enabled' });
+    });
+
+    it('Disabled with the "disableProxyless" option', function () {
+        return runTest({ browsers: 'chrome', test: 'Disabled', disableProxyless: true });
+    });
+
+    it('Disabled on run with Chrome and Firefox browsers', function () {
+        return runTest({ browsers: ['chrome', 'firefox'], test: 'Disabled' });
+    });
+
+    it('Disabled on Firefox browser with the "disableProxyless" option', function () {
+        return runTest({ browsers: 'firefox', test: 'Disabled', disableProxyless: true });
+    });
+});

--- a/test/functional/fixtures/proxyless/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/proxyless/testcafe-fixtures/index.js
@@ -1,0 +1,23 @@
+import { ClientFunction } from 'testcafe';
+
+const getParsedUrl = ClientFunction(() => {
+    const link       = document.getElementById('link');
+    const hammerhead = window['%hammerhead%'];
+    const urlUtils   = hammerhead.utils.url;
+    const url        = hammerhead.nativeMethods.anchorHrefGetter.call(link);
+
+    return urlUtils.parseProxyUrl(url);
+});
+
+fixture `Fixture`
+    .page('http://localhost:3000/fixtures/proxyless/pages/index.html');
+
+test('Enabled', async t => {
+    await t.expect(getParsedUrl()).eql(null);
+});
+
+test('Disabled', async t => {
+    const parsedUrl = await getParsedUrl();
+
+    await t.expect(parsedUrl.proxy).eql({ hostname: '127.0.0.1', port: '1335' });
+});

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -56,6 +56,7 @@ function getBrowserInfo (settings) {
 
             return browserProviderPool
                 .getBrowserInfo(settings.browserName)
+<<<<<<< HEAD
                 .then(browserInfo => {
                     const options = {
                         disableMultipleWindows: false,
@@ -65,6 +66,9 @@ function getBrowserInfo (settings) {
 
                     return new BrowserConnection(testCafe.browserConnectionGateway, browserInfo, true, options);
                 });
+=======
+                .then(browserInfo => new BrowserConnection(testCafe.browserConnectionGateway, browserInfo, true, { developmentMode: config.devMode }));
+>>>>>>> e005d0698... small fixes
         })
         .then(connection => {
             return {

--- a/test/server/api-test.js
+++ b/test/server/api-test.js
@@ -1847,10 +1847,9 @@ describe('API', function () {
                     test: 42,
                 },
 
-                developmentMode:       true,
-                retryTestPages:        true,
-                disableHttp2:          true,
-                experimentalProxyless: true,
+                developmentMode: true,
+                retryTestPages:  true,
+                disableHttp2:    true,
             });
 
             const configuration = TestCafe.firstCall.args[0];
@@ -1862,7 +1861,6 @@ describe('API', function () {
             expect(configuration.getOption(OPTION_NAMES.developmentMode)).be.true;
             expect(configuration.getOption(OPTION_NAMES.retryTestPages)).be.true;
             expect(configuration.getOption(OPTION_NAMES.disableHttp2)).be.true;
-            expect(configuration.getOption(OPTION_NAMES.experimentalProxyless)).be.true;
         });
     });
 });

--- a/test/server/bootstrapper-test.js
+++ b/test/server/bootstrapper-test.js
@@ -23,6 +23,8 @@ describe('Bootstrapper', () => {
             bootstrapper.browserInitTimeout           = 100;
             bootstrapper.TESTS_COMPILATION_UPPERBOUND = 0;
 
+            bootstrapper._calculateIsProxyless = () => true;
+
             bootstrapper.browsers = [ new BrowserConnection(browserConnectionGatewayMock, { provider: createBrowserProviderMock({ local: false }) }) ];
         });
 

--- a/test/server/browser-connection-test.js
+++ b/test/server/browser-connection-test.js
@@ -1,11 +1,13 @@
-const { expect }              = require('chai');
-const { promisify }           = require('util');
-const request                 = require('request');
-const { noop }                = require('lodash');
-const createTestCafe          = require('../../lib/');
-const COMMAND                 = require('../../lib/browser/connection/command');
-const browserProviderPool     = require('../../lib/browser/provider/pool');
-const BrowserConnectionStatus = require('../../lib/browser/connection/status');
+const { expect }                    = require('chai');
+const { promisify }                 = require('util');
+const request                       = require('request');
+const { noop }                      = require('lodash');
+const createTestCafe                = require('../../lib/');
+const COMMAND                       = require('../../lib/browser/connection/command');
+const browserProviderPool           = require('../../lib/browser/provider/pool');
+const BrowserConnectionStatus       = require('../../lib/browser/connection/status');
+const { createBrowserProviderMock } = require('./helpers/mocks');
+const { HOSTNAME, PORT1, PORT2 }    = require('./helpers/constants');
 
 const { createBrowserProviderMock } = require('./helpers/mocks');
 
@@ -21,7 +23,7 @@ describe('Browser connection', function () {
     before(function () {
         this.timeout(20000);
 
-        return createTestCafe('127.0.0.1', 1335, 1336)
+        return createTestCafe(HOSTNAME, PORT1, PORT2)
             .then(function (tc) {
                 testCafe = tc;
 

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -753,7 +753,7 @@ describe('CLI argument parser', function () {
     });
 
     it('Should parse command line arguments', function () {
-        return parse('-r list -S -q -e message=/testMessage/i,stack=testStack,pageUrl=testPageUrl --hostname myhost --base-url localhost:3000 --proxy localhost:1234 --proxy-bypass localhost:5678 --qr-code --app run-app --speed 0.5 --debug-on-fail --disable-page-reloads --retry-test-pages --dev --sf --disable-page-caching --disable-http2 --experimental-proxyless --disable-cross-domain ie test/server/data/file-list/file-1.js')
+        return parse('-r list -S -q -e message=/testMessage/i,stack=testStack,pageUrl=testPageUrl --hostname myhost --base-url localhost:3000 --proxy localhost:1234 --proxy-bypass localhost:5678 --qr-code --app run-app --speed 0.5 --debug-on-fail --disable-page-reloads --retry-test-pages --dev --sf --disable-page-caching --disable-http2 --disable-proxyless --disable-cross-domain ie test/server/data/file-list/file-1.js')
             .then(parser => {
                 expect(parser.opts.browsers).eql(['ie']);
                 expect(parser.opts.src).eql(['test/server/data/file-list/file-1.js']);
@@ -780,7 +780,7 @@ describe('CLI argument parser', function () {
                 expect(parser.opts.retryTestPages).to.be.ok;
                 expect(parser.opts.disableHttp2).to.be.ok;
                 expect(parser.opts.disableCrossDomain).to.be.ok;
-                expect(parser.opts.experimentalProxyless).to.be.ok;
+                expect(parser.opts.disableProxyless).to.be.ok;
                 expect(parser.opts.baseUrl).eql('localhost:3000');
             });
     });
@@ -856,7 +856,7 @@ describe('CLI argument parser', function () {
             { long: '--ajax-request-timeout' },
             { long: '--cache' },
             { long: '--disable-http2' },
-            { long: '--experimental-proxyless' },
+            { long: '--disable-proxyless' },
             { long: '--base-url' },
             { long: '--disable-cross-domain' },
             { long: '--experimental-esm' },

--- a/test/server/create-testcafe-test.js
+++ b/test/server/create-testcafe-test.js
@@ -29,6 +29,7 @@ describe('TestCafe factory function', function () {
     afterEach(function () {
         if (server) {
             server.close();
+
             server = null;
         }
 
@@ -94,6 +95,9 @@ describe('TestCafe factory function', function () {
     it("Should raise error if specified hostname doesn't resolve to the current machine", function () {
         return getTestCafe('example.org')
             .then(function () {
+                return testCafe.createBrowserConnection();
+            })
+            .then(function () {
                 throw new Error('Promise rejection expected');
             })
             .catch(function (err) {
@@ -114,6 +118,9 @@ describe('TestCafe factory function', function () {
         };
 
         return getTestCafe('localhost', 1338, 1339, sslOptions)
+            .then(() => {
+                return testCafe.createBrowserConnection();
+            })
             .then(() => {
                 expect(testCafe.proxy.server1.key).eql(sslOptions.key);
                 expect(testCafe.proxy.server1.cert).eql(sslOptions.cert);

--- a/test/server/error-handle-test.js
+++ b/test/server/error-handle-test.js
@@ -18,6 +18,8 @@ class TaskMock extends AsyncEventEmitter {
     }
 
     unRegisterClientScriptRouting () {}
+
+    registerClientScriptRouting () {}
 }
 
 class RunnerMock extends Runner {

--- a/test/server/helpers/base-test-run-mock.js
+++ b/test/server/helpers/base-test-run-mock.js
@@ -39,6 +39,10 @@ class BaseTestRunMock extends TestRun {
     get id () {
         return 'id';
     }
+
+    isProxyless () {
+        return false;
+    }
 }
 
 module.exports = BaseTestRunMock;

--- a/test/server/helpers/constants.js
+++ b/test/server/helpers/constants.js
@@ -1,0 +1,9 @@
+const HOSTNAME = 'localhost';
+const PORT1    = 1335;
+const PORT2    = 1336;
+
+module.exports = {
+    HOSTNAME,
+    PORT1,
+    PORT2,
+};

--- a/test/server/helpers/mocks.js
+++ b/test/server/helpers/mocks.js
@@ -10,7 +10,51 @@ const browserConnectionGatewayMock = {
 
     proxy: {
         resolveRelativeServiceUrl: noop,
+        switchToProxyless:         noop,
+        start:                     noop,
     },
+
+    switchToProxyless: noop,
+};
+
+class BrowserSetMock extends EventEmitter {
+    constructor () {
+        super();
+
+        this.browserConnectionGroups = [];
+    }
+
+    async dispose () {}
+}
+
+const configurationMock = {
+    getOption:         noop,
+    calculateHostname: noop,
+
+    startOptions: {
+        hostname: 'localhost',
+        port1:    1337,
+        port2:    1338,
+    },
+};
+
+function createBrowserProviderMock ({ local, headless } = { local: false, headless: false }) {
+    return {
+        openBrowser:       async () => {},
+        closeBrowser:      async () => {},
+        isLocalBrowser:    () => local,
+        isHeadlessBrowser: () => headless,
+    };
+}
+
+const compilerServiceMock = {
+    init:     noop,
+    getTests: async () => {
+        await delay(1500);
+
+        return [ new Test({ currentFixture: void 0 }) ];
+    },
+    setUserVariables: noop,
 };
 
 class BrowserSetMock extends EventEmitter {

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -30,6 +30,7 @@ const {
     configurationMock,
     createBrowserProviderMock,
 } = require('./helpers/mocks');
+
 const createConfigFile = (configPath, options) => {
     options = options || {};
     fs.writeFileSync(configPath, JSON.stringify(options));


### PR DESCRIPTION
Proxyless mode turn on by-default for Chromium browser.
Add an additional option `disable-proxyless` to manually turn off the proxyless mode.
The API design is similar to the [disable-multiple-windows](https://testcafe.io/documentation/402655/reference/testcafe-api/runner/run?search#disablemultiplewindows) option. 

Changes:
* [breaking changes] the `proxyless` option is removed, the `disable-proxyless` option is added
* start proxy on the bootstrapping stage (early, the proxy started in the `createTestCafe` stage)
* remote BrowserConnection cannot be proxyless. Add a separate proxy initialization for the `TestCafe.createBrowserConnection` method
* rewrote TestCafe's assets initialization
* added `BrowserProvider.supportProxyless` method
* rewrote server tests according the changed browser connection initialization behavior
* create separate option for the `BrowserConnection`, `BrowserConnectionGateway` classes.
* create typed `configuration.getOption` method
