### PR TITLE
fix scroll position for cdp events

### DIFF
--- a/src/client/automation/move.ts
+++ b/src/client/automation/move.ts
@@ -217,7 +217,9 @@ export default class MoveAutomation {
             const events: any[] = [];
 
             await mouseMoveStep(mouseMoveOptions, nativeMethods.dateNow, async currPosition => {
-                events.push(this.proxylessInput?.createMouseMoveEvent(currPosition));
+                const moveEvent = await this.proxylessInput?.createMouseMoveEvent(currPosition);
+
+                events.push(moveEvent);
 
                 return nextTick();
             });

--- a/src/client/automation/playback/click/index.ts
+++ b/src/client/automation/playback/click/index.ts
@@ -6,7 +6,6 @@ import delay from '../../../core/utils/delay';
 import { utils, Promise } from '../../deps/hammerhead';
 import { createMouseClickStrategy, MouseClickStrategy } from './browser-click-strategy';
 import ProxylessInput from '../../../../proxyless/client/input';
-import AxisValues from '../../../core/utils/values/axis-values';
 import { setCaretPosition } from '../../utils/utils';
 import { DispatchEventFn } from '../../../../proxyless/client/types';
 
@@ -23,8 +22,8 @@ export default class ClickAutomation extends VisibleElementAutomation {
     private modifiers: Modifiers;
     public strategy: MouseClickStrategy;
 
-    protected constructor (element: HTMLElement, clickOptions: ClickOptions, win: Window, cursor: Cursor, dispatchProxylessEventFn?: DispatchEventFn, leftTopPoint?: AxisValues<number>) {
-        super(element, clickOptions, win, cursor, dispatchProxylessEventFn, leftTopPoint);
+    protected constructor (element: HTMLElement, clickOptions: ClickOptions, win: Window, cursor: Cursor, dispatchProxylessEventFn?: DispatchEventFn) {
+        super(element, clickOptions, win, cursor, dispatchProxylessEventFn);
 
         this.modifiers = clickOptions.modifiers;
         this.strategy  = createMouseClickStrategy(this.element, clickOptions.caretPos);

--- a/src/client/automation/playback/hover.js
+++ b/src/client/automation/playback/hover.js
@@ -3,8 +3,8 @@ import cursor from '../cursor';
 
 
 export default class HoverAutomation extends VisibleElementAutomation {
-    constructor (element, hoverOptions, dispatchProxylessEventFn, leftTopPoint) {
-        super(element, hoverOptions, window, cursor, dispatchProxylessEventFn, leftTopPoint);
+    constructor (element, hoverOptions, dispatchProxylessEventFn) {
+        super(element, hoverOptions, window, cursor, dispatchProxylessEventFn);
     }
 
     run (useStrictElementCheck) {

--- a/src/client/automation/types.d.ts
+++ b/src/client/automation/types.d.ts
@@ -1,10 +1,10 @@
 import { ActionCommandBase } from '../../test-run/commands/base';
 import EventEmitter from '../core/utils/event-emitter';
-import AxisValues, { AxisValuesData } from '../core/utils/values/axis-values';
+import { AxisValuesData } from '../core/utils/values/axis-values';
 import { DispatchEventFn } from '../../proxyless/client/types';
 
 export interface AutomationHandler {
-    create: (cmd: ActionCommandBase, elements: any[], dispatchProxylessEventFn?: DispatchEventFn, leftTopPoint?: AxisValues<number>) => Automation;
+    create: (cmd: ActionCommandBase, elements: any[], dispatchProxylessEventFn?: DispatchEventFn) => Automation;
     ensureElsProps?: (elements: any[]) => void;
     ensureCmdArgs?: (cmd: ActionCommandBase) => void;
     additionalSelectorProps?: string[];

--- a/src/client/automation/visible-element-automation.ts
+++ b/src/client/automation/visible-element-automation.ts
@@ -101,7 +101,7 @@ export default class VisibleElementAutomation extends SharedEventEmitter {
     protected readonly options: OffsetOptions;
     protected readonly proxylessInput: ProxylessInput | null;
 
-    protected constructor (element: HTMLElement, offsetOptions: OffsetOptions, win: Window, cursor: Cursor, dispatchProxylessEventFn?: DispatchEventFn, topLeftPoint?: AxisValues<number>) {
+    protected constructor (element: HTMLElement, offsetOptions: OffsetOptions, win: Window, cursor: Cursor, dispatchProxylessEventFn?: DispatchEventFn) {
         super();
 
         this.TARGET_ELEMENT_FOUND_EVENT = 'automation|target-element-found-event';

--- a/src/client/automation/visible-element-automation.ts
+++ b/src/client/automation/visible-element-automation.ts
@@ -114,7 +114,7 @@ export default class VisibleElementAutomation extends SharedEventEmitter {
         this.window  = win;
         this.cursor  = cursor;
 
-        this.proxylessInput = dispatchProxylessEventFn ? new ProxylessInput(dispatchProxylessEventFn, topLeftPoint) : null;
+        this.proxylessInput = dispatchProxylessEventFn ? new ProxylessInput(dispatchProxylessEventFn) : null;
 
         // NOTE: only for legacy API
         this._ensureWindowAndCursorForLegacyTests(this);

--- a/src/client/driver/command-executors/action-executor/actions-initializer.ts
+++ b/src/client/driver/command-executors/action-executor/actions-initializer.ts
@@ -39,7 +39,6 @@ import {
 import COMMAND_TYPE from '../../../../test-run/commands/type';
 import { ActionCommandBase } from '../../../../test-run/commands/base';
 import { Automation } from '../../../automation/types';
-import AxisValues from '../../../core/utils/values/axis-values';
 import { DispatchEventFn } from '../../../../proxyless/client/types';
 
 
@@ -66,11 +65,11 @@ ActionExecutor.ACTIONS_HANDLERS[COMMAND_TYPE.pressKey] = {
 };
 
 ActionExecutor.ACTIONS_HANDLERS[COMMAND_TYPE.click] = {
-    create: (command, elements, dispatchProxylessEventFn?: DispatchEventFn, leftTopPoint?: AxisValues<number>) => {
+    create: (command, elements, dispatchProxylessEventFn?: DispatchEventFn) => {
         if (/option|optgroup/.test(domUtils.getTagName(elements[0])))
             return new SelectChildClickAutomation(elements[0], command.options);
 
-        return new ClickAutomation(elements[0], command.options, window, cursor, dispatchProxylessEventFn, leftTopPoint);
+        return new ClickAutomation(elements[0], command.options, window, cursor, dispatchProxylessEventFn);
     },
 };
 
@@ -83,8 +82,8 @@ ActionExecutor.ACTIONS_HANDLERS[COMMAND_TYPE.doubleClick] = {
 };
 
 ActionExecutor.ACTIONS_HANDLERS[COMMAND_TYPE.hover] = {
-    create: (command, elements, dispatchProxylessEventFn?: DispatchEventFn, leftTopPoint?: AxisValues<number>) => {
-        return new HoverAutomation(elements[0], command.options, dispatchProxylessEventFn, leftTopPoint);
+    create: (command, elements, dispatchProxylessEventFn?: DispatchEventFn) => {
+        return new HoverAutomation(elements[0], command.options, dispatchProxylessEventFn);
     },
 };
 

--- a/src/client/driver/command-executors/action-executor/index.ts
+++ b/src/client/driver/command-executors/action-executor/index.ts
@@ -11,7 +11,6 @@ import { Automation, AutomationHandler } from '../../../automation/types';
 import { nativeMethods, Promise } from '../../deps/hammerhead';
 import { getOffsetOptions } from '../../../core/utils/offsets';
 import { TEST_RUN_ERRORS } from '../../../../errors/types';
-import AxisValues from '../../../core/utils/values/axis-values';
 import { DispatchEventFn } from '../../../../proxyless/client/types';
 
 const MAX_DELAY_AFTER_EXECUTION             = 2000;
@@ -22,7 +21,6 @@ interface ActionExecutorOptions {
     testSpeed: number;
     executeSelectorFn: ExecuteSelectorFn<HTMLElement>;
     dispatchProxylessEventFn: DispatchEventFn;
-    leftTopPoint: AxisValues<number>;
 }
 
 export default class ActionExecutor extends EventEmitter {
@@ -140,7 +138,7 @@ export default class ActionExecutor extends EventEmitter {
         if (!handler)
             throw new Error(`There is no handler for the "${this._command.type}" command.`);
 
-        return handler.create(this._command, this._elements, this._options.dispatchProxylessEventFn, this._options.leftTopPoint);
+        return handler.create(this._command, this._elements, this._options.dispatchProxylessEventFn);
     }
 
     private _runAction (strictElementCheck: boolean): Promise<void> {

--- a/src/client/driver/driver-link/iframe/child.js
+++ b/src/client/driver/driver-link/iframe/child.js
@@ -27,8 +27,6 @@ import {
 } from '../timeouts';
 
 import sendConfirmationMessage from '../send-confirmation-message';
-import { getBordersWidthFloat, getElementPaddingFloat } from '../../../core/utils/style';
-
 
 export default class ChildIframeDriverLink {
     constructor (driverWindow, driverId, dispatchProxylessEventUrls) {
@@ -92,20 +90,6 @@ export default class ChildIframeDriverLink {
             });
     }
 
-    _getLeftTopPoint (proxyless) {
-        if (!proxyless)
-            return null;
-
-        const rect     = this.driverIframe.getBoundingClientRect();
-        const borders  = getBordersWidthFloat(this.driverIframe);
-        const paddings = getElementPaddingFloat(this.driverIframe);
-
-        return {
-            x: rect.left + borders.left + paddings.left,
-            y: rect.top + borders.top + paddings.top,
-        };
-    }
-
     sendConfirmationMessage (requestMsgId) {
         sendConfirmationMessage({
             requestMsgId,
@@ -114,20 +98,13 @@ export default class ChildIframeDriverLink {
         });
     }
 
-    executeCommand (command, testSpeed, proxyless, leftTopPoint) {
+    executeCommand (command, testSpeed) {
         // NOTE:  We should check if the iframe is visible and exists before executing the next
         // command, because the iframe might be hidden or removed since the previous command.
         return this
             ._ensureIframe()
             .then(() => {
-                const currentLeftTopPoint = this._getLeftTopPoint(proxyless);
-
-                if (leftTopPoint) {
-                    currentLeftTopPoint.x += leftTopPoint.x;
-                    currentLeftTopPoint.y += leftTopPoint.y;
-                }
-
-                const msg = new ExecuteCommandMessage(command, testSpeed, currentLeftTopPoint);
+                const msg = new ExecuteCommandMessage(command, testSpeed);
 
                 return Promise.all([
                     sendMessageToDriver(msg, this.driverWindow, this.iframeAvailabilityTimeout, CurrentIframeIsNotLoadedError),

--- a/src/client/driver/driver-link/messages.js
+++ b/src/client/driver/driver-link/messages.js
@@ -84,12 +84,11 @@ export class CommandExecutedMessage extends InterDriverMessage {
 }
 
 export class ExecuteCommandMessage extends InterDriverMessage {
-    constructor (command, testSpeed, leftTopPoint) {
+    constructor (command, testSpeed) {
         super(TYPE.executeCommand);
 
-        this.command      = command;
-        this.testSpeed    = testSpeed;
-        this.leftTopPoint = leftTopPoint;
+        this.command   = command;
+        this.testSpeed = testSpeed;
     }
 }
 

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -941,7 +941,7 @@ export default class Driver extends serviceUtils.EventEmitter {
             .then(() => {
                 this.contextStorage.setItem(this.EXECUTING_IN_IFRAME_FLAG, true);
 
-                return this.activeChildIframeDriverLink.executeCommand(command, this.speed, this.options.proxyless, this.leftTopPoint);
+                return this.activeChildIframeDriverLink.executeCommand(command, this.speed, this.options.proxyless);
             })
             .then(status => this._onCommandExecutedInIframe(status))
             .catch(err => this._onCommandExecutedInIframe(new DriverStatus({
@@ -1194,7 +1194,6 @@ export default class Driver extends serviceUtils.EventEmitter {
             globalSelectorTimeout:    this.options.selectorTimeout,
             testSpeed:                this.speed,
             executeSelectorFn:        executeSelectorCb,
-            leftTopPoint:             this.leftTopPoint,
             dispatchProxylessEventFn: this.createDispatchProxylessEventFunctions(),
         });
 

--- a/src/client/driver/iframe-driver.js
+++ b/src/client/driver/iframe-driver.js
@@ -17,7 +17,6 @@ import {
     StopInternalFromFrameMessage,
     TYPE as MESSAGE_TYPE,
 } from './driver-link/messages';
-import AxisValues from '../core/utils/values/axis-values';
 
 const messageSandbox = eventSandbox.message;
 
@@ -29,8 +28,6 @@ export default class IframeDriver extends Driver {
         this.parentDriverLink          = new ParentIframeDriverLink(window.parent);
 
         this._initParentDriverListening();
-
-        this.leftTopPoint = new AxisValues(0, 0);
     }
 
     // Errors handling
@@ -70,8 +67,7 @@ export default class IframeDriver extends Driver {
                         this.lastParentDriverMessageId = msg.id;
 
                         this.readyPromise.then(() => {
-                            this.speed        = msg.testSpeed;
-                            this.leftTopPoint = msg.leftTopPoint;
+                            this.speed = msg.testSpeed;
 
                             this.parentDriverLink.sendConfirmationMessage(msg.id);
                             this._onCommand(msg.command);

--- a/src/proxyless/client/input.ts
+++ b/src/proxyless/client/input.ts
@@ -1,26 +1,23 @@
 import { EventType } from '../types';
-import AxisValues, { AxisValuesData } from '../../client/core/utils/values/axis-values';
+import { AxisValuesData } from '../../client/core/utils/values/axis-values';
 import { SimulatedKeyInfo } from './key-press/utils';
 import { DispatchEventFn } from './types';
 import CDPEventDescriptor from './event-descriptor';
 
 export default class ProxylessInput {
-
     private readonly _dispatchEventFn: DispatchEventFn;
-    private readonly _leftTopPoint: AxisValues<number>;
-    constructor (dispatchEventFn: DispatchEventFn, leftTopPoint?: AxisValues<number>) {
+    constructor (dispatchEventFn: DispatchEventFn) {
         this._dispatchEventFn = dispatchEventFn;
-        this._leftTopPoint    = leftTopPoint || new AxisValues<number>(0, 0);
     }
 
-    public mouseDown (options: any): Promise<void> {
-        const eventOptions = CDPEventDescriptor.createMouseEventOptions('mousePressed', options, this._leftTopPoint);
+    public async mouseDown (options: any): Promise<void> {
+        const eventOptions = await CDPEventDescriptor.createMouseEventOptions('mousePressed', options);
 
         return this._dispatchEventFn.single(EventType.Mouse, eventOptions);
     }
 
-    public mouseUp (options: any): Promise<void> {
-        const eventOptions = CDPEventDescriptor.createMouseEventOptions('mouseReleased', options, this._leftTopPoint);
+    public async mouseUp (options: any): Promise<void> {
+        const eventOptions = await CDPEventDescriptor.createMouseEventOptions('mouseReleased', options);
 
         return this._dispatchEventFn.single(EventType.Mouse, eventOptions);
     }
@@ -40,15 +37,14 @@ export default class ProxylessInput {
         return this._dispatchEventFn.sequence(eventSequence);
     }
 
-    public createMouseMoveEvent (currPosition: AxisValuesData<number>): any {
-        const options = CDPEventDescriptor.createMouseEventOptions('mouseMoved', {
+    public async createMouseMoveEvent (currPosition: AxisValuesData<number>): Promise<any> {
+        const options = await CDPEventDescriptor.createMouseEventOptions('mouseMoved', {
             options: {
                 clientX: currPosition.x,
                 clientY: currPosition.y,
                 button:  'none',
             },
-            // @ts-ignore
-        }, this._leftTopPoint);
+        });
 
         return {
             type: EventType.Mouse,

--- a/test/functional/fixtures/regression/gh-7557/pages/frame.html
+++ b/test/functional/fixtures/regression/gh-7557/pages/frame.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title></title>
+    <style>
+        button {
+            margin-top: 600px;
+            margin-left: 300px;
+        }
+
+        iframe {
+            margin-top: 5000px;
+            margin-left: 5000px;
+        }
+    </style>
+</head>
+<body>
+
+    <button>click me in child</button>
+    <iframe src="http://localhost:3001/fixtures/regression/gh-7557/pages/nested-frame.html"></iframe>
+
+    <script>
+        document.querySelector('button').addEventListener('click', function (e) {
+            e.target.style.backgroundColor = 'blue';
+
+            window.clickedInChild = true;
+        });
+    </script>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-7557/pages/index.html
+++ b/test/functional/fixtures/regression/gh-7557/pages/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title></title>
+    <style>
+        iframe {
+            margin-top: 5000px;
+            margin-left: 5000px;
+            width: 800px;
+            height: 500px;
+        }
+
+        button {
+            margin-left: 5000px;
+        }
+    </style>
+</head>
+<body>
+    <iframe src="http://localhost:3001/fixtures/regression/gh-7557/pages/frame.html"></iframe>
+    <button>click me in parent</button>
+
+    <script>
+        document.querySelector('button').addEventListener('click', function (e) {
+            e.target.style.backgroundColor = 'red';
+
+            window.clickedInParent = true;
+        });
+    </script>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-7557/pages/nested-frame.html
+++ b/test/functional/fixtures/regression/gh-7557/pages/nested-frame.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title></title>
+    <style>
+        button {
+            margin-top: 600px;
+            margin-left: 300px;
+        }
+    </style>
+</head>
+<body>
+    <button>click me in child</button>
+
+    <script>
+        document.querySelector('button').addEventListener('click', function (e) {
+            e.target.style.backgroundColor = 'green';
+
+            window.clickedInNestedChild = true;
+        });
+    </script>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-7557/test.js
+++ b/test/functional/fixtures/regression/gh-7557/test.js
@@ -1,0 +1,9 @@
+const { onlyInProxyless } = require('../../../utils/skip-in');
+
+describe('[Regression](GH-7557)', function () {
+    onlyInProxyless('Should consider document scroll in CDP clicking', function () {
+        return runTests('./testcafe-fixtures/index.js', null, { only: 'chrome' });
+    });
+});
+
+

--- a/test/functional/fixtures/regression/gh-7557/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-7557/testcafe-fixtures/index.js
@@ -1,0 +1,24 @@
+fixture `Should consider document scroll in CDP clicking`
+    .page `http://localhost:3000/fixtures/regression/gh-7557/pages/index.html`;
+
+test('Should consider document scroll in CDP clicking', async t => {
+    await t.click('button');
+
+    const isClickedInParent = await t.eval(() => window.clickedInParent);
+
+    await t.expect(isClickedInParent).eql(true);
+
+    await t.switchToIframe('iframe');
+    await t.click('button');
+
+    const isClickedInChild = await t.eval(() => window.clickedInChild);
+
+    await t.expect(isClickedInChild).eql(true);
+
+    await t.switchToIframe('iframe');
+    await t.click('button');
+
+    const isClickedInNestedChild = await t.eval(() => window.clickedInNestedChild);
+
+    await t.expect(isClickedInNestedChild).eql(true);
+});


### PR DESCRIPTION
calculate leftTopPoint on demand before making request to the cdp route
remove leftTopPoint passing from all other places

this PR fixes the #7557 issue only partially because, there is another problem with fixed header + iframes + proxyless, which is specific to the DevExtreme website