### PR TITLE
fix: use calculated osInfo in userAgent

### DIFF
--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -4,8 +4,6 @@ import { EventEmitter } from 'events';
 import Mustache from 'mustache';
 import { pull as remove } from 'lodash';
 import {
-    calculatePrettyUserAgent,
-    extractMetaInfo,
     ParsedUserAgent,
     parseUserAgent,
 } from '../../utils/parse-user-agent';
@@ -21,7 +19,6 @@ import BrowserConnectionGateway from './gateway';
 import BrowserJob from '../../runner/browser-job';
 import WarningLog from '../../notifications/warning-log';
 import BrowserProvider from '../provider';
-import { OSInfo } from 'get-os-info';
 import SERVICE_ROUTES from './service-routes';
 import {
     BROWSER_RESTART_TIMEOUT,

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -461,7 +461,7 @@ export default class Reporter {
         const startTime              = task.startTime;
         const browserConnectionsInfo = ([] as BrowserConnection[])
             .concat(...task.browserConnectionGroups)
-            .map(connection => connection.connectionInfo);
+            .map(connection => connection.userAgent);
         const first                  = this.taskInfo.testQueue[0];
 
         const taskProperties = {

--- a/src/utils/get-browser.ts
+++ b/src/utils/get-browser.ts
@@ -9,11 +9,9 @@ interface Browser extends ParsedUserAgent {
 
 export default function getBrowser (browserConnection: BrowserConnection): Browser {
     const { browserInfo: { parsedUserAgent, alias } } = browserConnection;
-    const prettyUserAgent                             = browserConnection.connectionInfo;
 
     return assign({}, parsedUserAgent, {
         alias,
-        prettyUserAgent,
         headless: browserConnection.isHeadlessBrowser(),
     });
 }

--- a/src/utils/get-browser.ts
+++ b/src/utils/get-browser.ts
@@ -9,6 +9,11 @@ interface Browser extends ParsedUserAgent {
 
 export default function getBrowser (browserConnection: BrowserConnection): Browser {
     const { browserInfo: { parsedUserAgent, alias } } = browserConnection;
+    const prettyUserAgent                             = browserConnection.connectionInfo;
 
-    return assign({}, parsedUserAgent, { alias, headless: browserConnection.isHeadlessBrowser() });
+    return assign({}, parsedUserAgent, {
+        alias,
+        prettyUserAgent,
+        headless: browserConnection.isHeadlessBrowser(),
+    });
 }

--- a/src/utils/parse-user-agent.ts
+++ b/src/utils/parse-user-agent.ts
@@ -5,7 +5,6 @@ const DEFAULT_NAME            = 'Other';
 const DEFAULT_VERSION         = '0.0';
 const DEFAULT_PLATFORM_TYPE   = DEFAULT_NAME.toLowerCase();
 const EMPTY_PARSED_USER_AGENT = Bowser.parse(' ');
-const META_INFO_REGEX = /\([^(|^)]*\)/;
 
 interface ParsedComponent {
     name: string;
@@ -55,15 +54,6 @@ function calculateEngine (engineDetails: Bowser.Parser.EngineDetails): ParsedCom
 
 export function calculatePrettyUserAgent (browser: ParsedComponent, os: ParsedComponent): string {
     return `${browser.name} ${browser.version} / ${os.name} ${os.version}`;
-}
-
-export function extractMetaInfo (prettyUserAgent: string): string {
-    const parenthesisExpressions = prettyUserAgent.match(META_INFO_REGEX);
-
-    if (!parenthesisExpressions || !parenthesisExpressions.length)
-        return '';
-
-    return parenthesisExpressions[parenthesisExpressions.length - 1].replace(/[()]/g, '');
 }
 
 export function parseUserAgent (userAgent = '', osInfo?: OSInfo): ParsedUserAgent {

--- a/src/utils/parse-user-agent.ts
+++ b/src/utils/parse-user-agent.ts
@@ -1,4 +1,5 @@
 import Bowser from 'bowser';
+import { OSInfo } from 'get-os-info';
 
 const DEFAULT_NAME            = 'Other';
 const DEFAULT_VERSION         = '0.0';
@@ -65,10 +66,10 @@ export function extractMetaInfo (prettyUserAgent: string): string {
     return parenthesisExpressions[parenthesisExpressions.length - 1].replace(/[()]/g, '');
 }
 
-export function parseUserAgent (userAgent = ''): ParsedUserAgent {
+export function parseUserAgent (userAgent = '', osInfo?: OSInfo): ParsedUserAgent {
     const parsedUserAgent = userAgent ? Bowser.parse(userAgent) : EMPTY_PARSED_USER_AGENT;
     const browser         = calculateBrowser(parsedUserAgent.browser);
-    const os              = calculateOs(parsedUserAgent.os);
+    const os              = osInfo || calculateOs(parsedUserAgent.os);
     const engine          = calculateEngine(parsedUserAgent.engine);
     const prettyUserAgent = calculatePrettyUserAgent(browser, os);
 

--- a/test/functional/fixtures/api/es-next/browser-info/testcafe-fixtures/browser-info-test.js
+++ b/test/functional/fixtures/api/es-next/browser-info/testcafe-fixtures/browser-info-test.js
@@ -1,13 +1,15 @@
 import { ClientFunction } from 'testcafe';
 import { parseUserAgent } from '../../../../../../../lib/utils/parse-user-agent.js';
 import config from '../../../../../config.js';
+import getOSInfo from 'get-os-info';
 
 fixture `Browser information in headless Chrome`;
 
 test.page `http://localhost:3000/fixtures/api/es-next/browser-info/pages/index.html`
 ('t.browser', async t => {
     const userAgent       = ClientFunction(() => window.navigator.userAgent);
-    const parsedUserAgent = parseUserAgent(await userAgent());
+    const osInfo          = await getOSInfo();
+    const parsedUserAgent = parseUserAgent(await userAgent(), osInfo);
     const currentBrowser  = config.currentEnvironment.browsers.find(browser => browser.userAgent === 'headlesschrome');
     const expected        = Object.assign({}, parsedUserAgent, {
         alias:    currentBrowser.browserName,

--- a/test/functional/fixtures/api/es-next/browser-info/testcafe-fixtures/browser-info-test.js
+++ b/test/functional/fixtures/api/es-next/browser-info/testcafe-fixtures/browser-info-test.js
@@ -1,7 +1,7 @@
 import { ClientFunction } from 'testcafe';
 import { parseUserAgent } from '../../../../../../../lib/utils/parse-user-agent.js';
 import config from '../../../../../config.js';
-import getOSInfo from 'get-os-info';
+import { getOSInfo } from 'get-os-info';
 
 fixture `Browser information in headless Chrome`;
 

--- a/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-screenshot.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-screenshot.js
@@ -6,6 +6,7 @@ import sanitizeFilename from 'sanitize-filename';
 import { readPngFile } from '../../../../../../../lib/utils/promisified-functions.js';
 import config from '../../../../../config.js';
 import { join } from 'path';
+import getOSInfo from 'get-os-info';
 
 
 // NOTE: to preserve callsites, add new tests AFTER the existing ones
@@ -61,7 +62,8 @@ test('Take screenshots with same path', async t => {
 
 test('Take screenshots for reporter', async t => {
     const ua            = await getUserAgent();
-    const safeUserAgent = sanitizeFilename(parseUserAgent(ua).prettyUserAgent).replace(/\s+/g, '_');
+    const osInfo        = await getOSInfo();
+    const safeUserAgent = sanitizeFilename(parseUserAgent(ua, osInfo).prettyUserAgent).replace(/\s+/g, '_');
 
     quarantineScope[safeUserAgent] = quarantineScope[safeUserAgent] || {};
 

--- a/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-screenshot.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-screenshot.js
@@ -6,7 +6,7 @@ import sanitizeFilename from 'sanitize-filename';
 import { readPngFile } from '../../../../../../../lib/utils/promisified-functions.js';
 import config from '../../../../../config.js';
 import { join } from 'path';
-import getOSInfo from 'get-os-info';
+import { getOSInfo } from 'get-os-info';
 
 // NOTE: to preserve callsites, add new tests AFTER the existing ones
 fixture `Take a screenshot`

--- a/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-screenshot.js
+++ b/test/functional/fixtures/api/es-next/take-screenshot/testcafe-fixtures/take-screenshot.js
@@ -8,7 +8,6 @@ import config from '../../../../../config.js';
 import { join } from 'path';
 import getOSInfo from 'get-os-info';
 
-
 // NOTE: to preserve callsites, add new tests AFTER the existing ones
 fixture `Take a screenshot`
     .page `../pages/index.html`;

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -10,33 +10,40 @@ const delay                           = require('../../lib/utils/delay');
 const { ReporterPluginError }         = require('../../lib/errors/runtime');
 const WarningLog                      = require('../../lib/notifications/warning-log');
 const util                            = require('util');
+const getBrowser                      = require('../../lib/utils/get-browser');
 
 
-describe('Reporter', () => {
+describe.only('Reporter', () => {
     const screenshotDir = '/screenshots/1445437598847';
 
     const browserMocks = [
         {
-            alias:     'Chrome',
-            userAgent: 'Chrome',
-            headless:  false,
+            alias:           'Chrome',
+            userAgent:       'Chrome',
+            parsedUserAgent: {},
+            headless:        false,
         },
         {
-            alias:     'Firefox',
-            userAgent: 'Firefox',
-            headless:  false,
+            alias:           'Firefox',
+            userAgent:       'Firefox',
+            parsedUserAgent: {},
+            headless:        false,
         },
     ];
 
     const browserConnectionMocks = [
         {
+            browserInfo:    browserMocks[0],
             userAgent:      'Chrome',
-            connectionInfo: 'Chrome',
+            connectionInfo: 'Chrome Ubuntu',
+            isHeadlessBrowser: () => false,
 
         },
         {
+            browserInfo:    browserMocks[1],
             userAgent:      'Firefox',
-            connectionInfo: 'Firefox',
+            connectionInfo: 'Firefox Ubuntu',
+            isHeadlessBrowser: () => false,
         },
     ];
 
@@ -67,12 +74,12 @@ describe('Reporter', () => {
 
     const testMocks = [
         {
-            id:          'idf1t1',
-            name:        'fixture1test1',
-            pageUrl:     'urlf1t1',
-            fixture:     fixtureMocks[0],
-            skip:        false,
-            screenshots: [{
+            id:            'idf1t1',
+            name:          'fixture1test1',
+            pageUrl:       'urlf1t1',
+            fixture:       fixtureMocks[0],
+            skip:          false,
+            screenshots:   [{
                 testRunId:         'idf1t1-1',
                 screenshotPath:    'screenshot1.png',
                 thumbnailPath:     'thumbnail1.png',
@@ -86,12 +93,12 @@ describe('Reporter', () => {
             },
         },
         {
-            id:          'idf1t2',
-            name:        'fixture1test2',
-            pageUrl:     'urlf1t2',
-            fixture:     fixtureMocks[0],
-            skip:        false,
-            screenshots: [{
+            id:            'idf1t2',
+            name:          'fixture1test2',
+            pageUrl:       'urlf1t2',
+            fixture:       fixtureMocks[0],
+            skip:          false,
+            screenshots:   [{
                 testRunId:         'idf1t2-1',
                 screenshotPath:    'screenshot1.png',
                 thumbnailPath:     'thumbnail1.png',
@@ -195,7 +202,7 @@ describe('Reporter', () => {
                     { testRunId: 'secondRunId', errors: [] },
                 ],
             },
-            browser: browserMocks[0],
+            browser:           getBrowser(browserConnectionMocks[0]),
         },
 
         //fixture1test2
@@ -205,7 +212,7 @@ describe('Reporter', () => {
             unstable:          false,
             browserConnection: browserConnectionMocks[0],
             warningLog:        { messages: [] },
-            browser:           browserMocks[0],
+            browser:           getBrowser(browserConnectionMocks[0]),
 
             errs: [
                 { text: 'err1' },
@@ -221,7 +228,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           browserMocks[0],
+            browser:           getBrowser(browserConnectionMocks[0]),
         },
 
         //fixture2test1
@@ -232,7 +239,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           browserMocks[0],
+            browser:           getBrowser(browserConnectionMocks[0]),
         },
 
         //fixture2test2
@@ -243,7 +250,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           browserMocks[0],
+            browser:           getBrowser(browserConnectionMocks[0]),
         },
 
         //fixture3test1
@@ -254,7 +261,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           browserMocks[0],
+            browser:           getBrowser(browserConnectionMocks[0]),
         },
 
         //fixture3test2
@@ -265,7 +272,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           browserMocks[0],
+            browser:           getBrowser(browserConnectionMocks[0]),
         },
 
         //fixture3test3
@@ -276,7 +283,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: ['warning2'] },
-            browser:           browserMocks[0],
+            browser:           getBrowser(browserConnectionMocks[0]),
         },
     ];
 
@@ -295,7 +302,7 @@ describe('Reporter', () => {
                     { testRunId: 'secondRunId', errors: [] },
                 ],
             },
-            browser: browserMocks[1],
+            browser:           getBrowser(browserConnectionMocks[1]),
         },
 
         // 'fixture1test2
@@ -306,7 +313,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [{ text: 'err1' }],
             warningLog:        { messages: [] },
-            browser:           browserMocks[1],
+            browser:           getBrowser(browserConnectionMocks[1]),
         },
 
         //fixture1test3
@@ -317,7 +324,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           browserMocks[1],
+            browser:           getBrowser(browserConnectionMocks[1]),
         },
 
         //fixture2test1
@@ -328,7 +335,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           browserMocks[1],
+            browser:           getBrowser(browserConnectionMocks[1]),
         },
 
         //fixture2test2
@@ -339,7 +346,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           browserMocks[1],
+            browser:           getBrowser(browserConnectionMocks[1]),
         },
 
         //fixture3test1
@@ -350,7 +357,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [{ text: 'err1' }],
             warningLog:        { messages: ['warning1'] },
-            browser:           browserMocks[1],
+            browser:           getBrowser(browserConnectionMocks[1]),
         },
 
         //fixture3test2
@@ -361,7 +368,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           browserMocks[1],
+            browser:           getBrowser(browserConnectionMocks[1]),
         },
 
         //fixture3test3
@@ -372,7 +379,7 @@ describe('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [],
             warningLog:        { messages: ['warning2', 'warning3'] },
-            browser:           browserMocks[1],
+            browser:           getBrowser(browserConnectionMocks[1]),
         },
     ];
 
@@ -383,7 +390,8 @@ describe('Reporter', () => {
     });
 
     class ScreenshotsMock {
-        constructor () {}
+        constructor () {
+        }
 
         getScreenshotsInfo (testMock) {
             return testMock.screenshots;
@@ -528,7 +536,9 @@ describe('Reporter', () => {
 
                 reportFixtureStart: function () {
                     return delay(1000)
-                        .then(() => log.push({ method: 'reportFixtureStart', args: Array.prototype.slice.call(arguments) }));
+                        .then(() => log.push({
+                            method: 'reportFixtureStart', args: Array.prototype.slice.call(arguments),
+                        }));
                 },
 
                 reportTestStart: function (...args) {
@@ -549,7 +559,7 @@ describe('Reporter', () => {
 
                     // NOTE: replace durationMs
                     args[1].durationMs = 74000;
-                    args[1].browsers = sortBy(args[1].browsers, ['alias']);
+                    args[1].browsers   = sortBy(args[1].browsers, ['alias']);
 
                     return delay(1000)
                         .then(() => log.push({ method: 'reportTestDone', args: args }));
@@ -573,8 +583,8 @@ describe('Reporter', () => {
                 args:   [
                     new Date('1970-01-01T00:00:00.000Z'),
                     [
-                        'Chrome',
-                        'Firefox',
+                        'Chrome Ubuntu',
+                        'Firefox Ubuntu',
                     ],
                     7,
                     [
@@ -703,8 +713,8 @@ describe('Reporter', () => {
                             'f1t1',
                             'f1t1ff',
                         ],
-                        startTime: new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:   false,
+                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:    false,
                     },
                 ],
             },
@@ -715,12 +725,12 @@ describe('Reporter', () => {
                 args:   [
                     'fixture1test1',
                     {
-                        errs:       [],
-                        warnings:   [],
-                        durationMs: 74000,
-                        unstable:   true,
-                        skipped:    false,
-                        quarantine: {
+                        errs:           [],
+                        warnings:       [],
+                        durationMs:     74000,
+                        unstable:       true,
+                        skipped:        false,
+                        quarantine:     {
                             1:             { passed: false },
                             2:             { passed: true },
                             'firstRunId':  { passed: false, errors: ['1', '2'] },
@@ -735,9 +745,9 @@ describe('Reporter', () => {
                             takenOnFail:       false,
                             quarantineAttempt: 2,
                         }],
-                        videos:   [],
-                        testId:   'idf1t1',
-                        browsers: [
+                        videos:         [],
+                        testId:         'idf1t1',
+                        browsers:       [
                             {
                                 alias:                        'Chrome',
                                 userAgent:                    'Chrome',
@@ -747,6 +757,7 @@ describe('Reporter', () => {
                                     'firstRunId',
                                     'secondRunId',
                                 ],
+                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:                        'Firefox',
@@ -757,9 +768,10 @@ describe('Reporter', () => {
                                     'firstRunId',
                                     'secondRunId',
                                 ],
+                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture: {
+                        fixture:        {
                             id:   'fid1',
                             name: 'fixture1',
                             path: './file1.js',
@@ -788,8 +800,8 @@ describe('Reporter', () => {
                             'f1t2',
                             'f1t2ff',
                         ],
-                        startTime: new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:   false,
+                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:    false,
                     },
                 ],
             },
@@ -836,23 +848,25 @@ describe('Reporter', () => {
                             takenOnFail:       true,
                             quarantineAttempt: null,
                         }],
-                        videos:   [],
-                        testId:   'idf1t2',
-                        browsers: [
+                        videos:         [],
+                        testId:         'idf1t2',
+                        browsers:       [
                             {
                                 alias:     'Chrome',
                                 userAgent: 'Chrome',
                                 headless:  false,
                                 testRunId: 'f1t2',
+                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:     'Firefox',
                                 userAgent: 'Firefox',
                                 headless:  false,
                                 testRunId: 'f1t2ff',
+                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture: {
+                        fixture:        {
                             id:   'fid1',
                             name: 'fixture1',
                             path: './file1.js',
@@ -881,8 +895,8 @@ describe('Reporter', () => {
                             'f1t3',
                             'f1t3ff',
                         ],
-                        startTime: new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:   false,
+                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:    false,
                     },
                 ],
             },
@@ -909,15 +923,17 @@ describe('Reporter', () => {
                                 userAgent: 'Chrome',
                                 headless:  false,
                                 testRunId: 'f1t3',
+                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:     'Firefox',
                                 userAgent: 'Firefox',
                                 headless:  false,
                                 testRunId: 'f1t3ff',
+                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture: {
+                        fixture:        {
                             id:   'fid1',
                             name: 'fixture1',
                             path: './file1.js',
@@ -956,8 +972,8 @@ describe('Reporter', () => {
                             'f2t1',
                             'f2t1ff',
                         ],
-                        startTime: new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:   false,
+                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:    false,
                     },
                 ],
             },
@@ -984,15 +1000,17 @@ describe('Reporter', () => {
                                 userAgent: 'Chrome',
                                 headless:  false,
                                 testRunId: 'f2t1',
+                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:     'Firefox',
                                 userAgent: 'Firefox',
                                 headless:  false,
                                 testRunId: 'f2t1ff',
+                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture: {
+                        fixture:        {
                             id:   'fid2',
                             name: 'fixture2',
                             path: './file1.js',
@@ -1021,8 +1039,8 @@ describe('Reporter', () => {
                             'f2t2',
                             'f2t2ff',
                         ],
-                        startTime: new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:   false,
+                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:    false,
                     },
                 ],
             },
@@ -1049,15 +1067,17 @@ describe('Reporter', () => {
                                 userAgent: 'Chrome',
                                 headless:  false,
                                 testRunId: 'f2t2',
+                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:     'Firefox',
                                 userAgent: 'Firefox',
                                 headless:  false,
                                 testRunId: 'f2t2ff',
+                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture: {
+                        fixture:        {
                             id:   'fid2',
                             name: 'fixture2',
                             path: './file1.js',
@@ -1094,8 +1114,8 @@ describe('Reporter', () => {
                             'f3t1',
                             'f3t1ff',
                         ],
-                        startTime: new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:   false,
+                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:    false,
                     },
                 ],
             },
@@ -1128,15 +1148,17 @@ describe('Reporter', () => {
                                 userAgent: 'Chrome',
                                 headless:  false,
                                 testRunId: 'f3t1',
+                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:     'Firefox',
                                 userAgent: 'Firefox',
                                 headless:  false,
                                 testRunId: 'f3t1ff',
+                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture: {
+                        fixture:        {
                             id:   'fid3',
                             name: 'fixture3',
                             path: './file2.js',
@@ -1163,8 +1185,8 @@ describe('Reporter', () => {
                             'f3t2',
                             'f3t2ff',
                         ],
-                        startTime: new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:   true,
+                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:    true,
                     },
                 ],
             },
@@ -1191,15 +1213,17 @@ describe('Reporter', () => {
                                 userAgent: 'Chrome',
                                 headless:  false,
                                 testRunId: 'f3t2',
+                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:     'Firefox',
                                 userAgent: 'Firefox',
                                 headless:  false,
                                 testRunId: 'f3t2ff',
+                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture: {
+                        fixture:        {
                             id:   'fid3',
                             name: 'fixture3',
                             path: './file2.js',
@@ -1226,8 +1250,8 @@ describe('Reporter', () => {
                             'f3t3',
                             'f3t3ff',
                         ],
-                        startTime: new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:   false,
+                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:    false,
                     },
                 ],
             },
@@ -1254,15 +1278,17 @@ describe('Reporter', () => {
                                 userAgent: 'Chrome',
                                 headless:  false,
                                 testRunId: 'f3t3',
+                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:     'Firefox',
                                 userAgent: 'Firefox',
                                 headless:  false,
                                 testRunId: 'f3t3ff',
+                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture: {
+                        fixture:        {
                             id:   'fid3',
                             name: 'fixture3',
                             path: './file2.js',
@@ -1371,7 +1397,7 @@ describe('Reporter', () => {
                     [
                         { testRunId: 'f1t2-id1', videoPath: 'f1t2-path1' },
                         { testRunId: 'f1t2-id2', videoPath: 'f1t2-path2' },
-                    ]]
+                    ]],
                 );
             });
     });

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -10,40 +10,30 @@ const delay                           = require('../../lib/utils/delay');
 const { ReporterPluginError }         = require('../../lib/errors/runtime');
 const WarningLog                      = require('../../lib/notifications/warning-log');
 const util                            = require('util');
-const getBrowser                      = require('../../lib/utils/get-browser');
 
 
-describe.only('Reporter', () => {
+describe('Reporter', () => {
     const screenshotDir = '/screenshots/1445437598847';
 
     const browserMocks = [
         {
-            alias:           'Chrome',
-            userAgent:       'Chrome',
-            parsedUserAgent: {},
-            headless:        false,
+            alias:     'Chrome',
+            userAgent: 'Chrome',
+            headless:  false,
         },
         {
-            alias:           'Firefox',
-            userAgent:       'Firefox',
-            parsedUserAgent: {},
-            headless:        false,
+            alias:     'Firefox',
+            userAgent: 'Firefox',
+            headless:  false,
         },
     ];
 
     const browserConnectionMocks = [
         {
-            browserInfo:    browserMocks[0],
             userAgent:      'Chrome',
-            connectionInfo: 'Chrome Ubuntu',
-            isHeadlessBrowser: () => false,
-
         },
         {
-            browserInfo:    browserMocks[1],
             userAgent:      'Firefox',
-            connectionInfo: 'Firefox Ubuntu',
-            isHeadlessBrowser: () => false,
         },
     ];
 
@@ -74,12 +64,12 @@ describe.only('Reporter', () => {
 
     const testMocks = [
         {
-            id:            'idf1t1',
-            name:          'fixture1test1',
-            pageUrl:       'urlf1t1',
-            fixture:       fixtureMocks[0],
-            skip:          false,
-            screenshots:   [{
+            id:          'idf1t1',
+            name:        'fixture1test1',
+            pageUrl:     'urlf1t1',
+            fixture:     fixtureMocks[0],
+            skip:        false,
+            screenshots: [{
                 testRunId:         'idf1t1-1',
                 screenshotPath:    'screenshot1.png',
                 thumbnailPath:     'thumbnail1.png',
@@ -93,12 +83,12 @@ describe.only('Reporter', () => {
             },
         },
         {
-            id:            'idf1t2',
-            name:          'fixture1test2',
-            pageUrl:       'urlf1t2',
-            fixture:       fixtureMocks[0],
-            skip:          false,
-            screenshots:   [{
+            id:          'idf1t2',
+            name:        'fixture1test2',
+            pageUrl:     'urlf1t2',
+            fixture:     fixtureMocks[0],
+            skip:        false,
+            screenshots: [{
                 testRunId:         'idf1t2-1',
                 screenshotPath:    'screenshot1.png',
                 thumbnailPath:     'thumbnail1.png',
@@ -202,7 +192,7 @@ describe.only('Reporter', () => {
                     { testRunId: 'secondRunId', errors: [] },
                 ],
             },
-            browser:           getBrowser(browserConnectionMocks[0]),
+            browser: browserMocks[0],
         },
 
         //fixture1test2
@@ -212,7 +202,7 @@ describe.only('Reporter', () => {
             unstable:          false,
             browserConnection: browserConnectionMocks[0],
             warningLog:        { messages: [] },
-            browser:           getBrowser(browserConnectionMocks[0]),
+            browser:           browserMocks[0],
 
             errs: [
                 { text: 'err1' },
@@ -228,7 +218,7 @@ describe.only('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           getBrowser(browserConnectionMocks[0]),
+            browser:           browserMocks[0],
         },
 
         //fixture2test1
@@ -239,7 +229,7 @@ describe.only('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           getBrowser(browserConnectionMocks[0]),
+            browser:           browserMocks[0],
         },
 
         //fixture2test2
@@ -250,7 +240,7 @@ describe.only('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           getBrowser(browserConnectionMocks[0]),
+            browser:           browserMocks[0],
         },
 
         //fixture3test1
@@ -261,7 +251,7 @@ describe.only('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           getBrowser(browserConnectionMocks[0]),
+            browser:           browserMocks[0],
         },
 
         //fixture3test2
@@ -272,7 +262,7 @@ describe.only('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           getBrowser(browserConnectionMocks[0]),
+            browser:           browserMocks[0],
         },
 
         //fixture3test3
@@ -283,7 +273,7 @@ describe.only('Reporter', () => {
             browserConnection: browserConnectionMocks[0],
             errs:              [],
             warningLog:        { messages: ['warning2'] },
-            browser:           getBrowser(browserConnectionMocks[0]),
+            browser:           browserMocks[0],
         },
     ];
 
@@ -302,7 +292,7 @@ describe.only('Reporter', () => {
                     { testRunId: 'secondRunId', errors: [] },
                 ],
             },
-            browser:           getBrowser(browserConnectionMocks[1]),
+            browser: browserMocks[1],
         },
 
         // 'fixture1test2
@@ -313,7 +303,7 @@ describe.only('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [{ text: 'err1' }],
             warningLog:        { messages: [] },
-            browser:           getBrowser(browserConnectionMocks[1]),
+            browser:           browserMocks[1],
         },
 
         //fixture1test3
@@ -324,7 +314,7 @@ describe.only('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           getBrowser(browserConnectionMocks[1]),
+            browser:           browserMocks[1],
         },
 
         //fixture2test1
@@ -335,7 +325,7 @@ describe.only('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           getBrowser(browserConnectionMocks[1]),
+            browser:           browserMocks[1],
         },
 
         //fixture2test2
@@ -346,7 +336,7 @@ describe.only('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           getBrowser(browserConnectionMocks[1]),
+            browser:           browserMocks[1],
         },
 
         //fixture3test1
@@ -357,7 +347,7 @@ describe.only('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [{ text: 'err1' }],
             warningLog:        { messages: ['warning1'] },
-            browser:           getBrowser(browserConnectionMocks[1]),
+            browser:           browserMocks[1],
         },
 
         //fixture3test2
@@ -368,7 +358,7 @@ describe.only('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [],
             warningLog:        { messages: [] },
-            browser:           getBrowser(browserConnectionMocks[1]),
+            browser:           browserMocks[1],
         },
 
         //fixture3test3
@@ -379,7 +369,7 @@ describe.only('Reporter', () => {
             browserConnection: browserConnectionMocks[1],
             errs:              [],
             warningLog:        { messages: ['warning2', 'warning3'] },
-            browser:           getBrowser(browserConnectionMocks[1]),
+            browser:           browserMocks[1],
         },
     ];
 
@@ -390,8 +380,7 @@ describe.only('Reporter', () => {
     });
 
     class ScreenshotsMock {
-        constructor () {
-        }
+        constructor () {}
 
         getScreenshotsInfo (testMock) {
             return testMock.screenshots;
@@ -536,9 +525,7 @@ describe.only('Reporter', () => {
 
                 reportFixtureStart: function () {
                     return delay(1000)
-                        .then(() => log.push({
-                            method: 'reportFixtureStart', args: Array.prototype.slice.call(arguments),
-                        }));
+                        .then(() => log.push({ method: 'reportFixtureStart', args: Array.prototype.slice.call(arguments) }));
                 },
 
                 reportTestStart: function (...args) {
@@ -559,7 +546,7 @@ describe.only('Reporter', () => {
 
                     // NOTE: replace durationMs
                     args[1].durationMs = 74000;
-                    args[1].browsers   = sortBy(args[1].browsers, ['alias']);
+                    args[1].browsers = sortBy(args[1].browsers, ['alias']);
 
                     return delay(1000)
                         .then(() => log.push({ method: 'reportTestDone', args: args }));
@@ -583,8 +570,8 @@ describe.only('Reporter', () => {
                 args:   [
                     new Date('1970-01-01T00:00:00.000Z'),
                     [
-                        'Chrome Ubuntu',
-                        'Firefox Ubuntu',
+                        'Chrome',
+                        'Firefox',
                     ],
                     7,
                     [
@@ -713,8 +700,8 @@ describe.only('Reporter', () => {
                             'f1t1',
                             'f1t1ff',
                         ],
-                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:    false,
+                        startTime: new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:   false,
                     },
                 ],
             },
@@ -725,12 +712,12 @@ describe.only('Reporter', () => {
                 args:   [
                     'fixture1test1',
                     {
-                        errs:           [],
-                        warnings:       [],
-                        durationMs:     74000,
-                        unstable:       true,
-                        skipped:        false,
-                        quarantine:     {
+                        errs:       [],
+                        warnings:   [],
+                        durationMs: 74000,
+                        unstable:   true,
+                        skipped:    false,
+                        quarantine: {
                             1:             { passed: false },
                             2:             { passed: true },
                             'firstRunId':  { passed: false, errors: ['1', '2'] },
@@ -745,9 +732,9 @@ describe.only('Reporter', () => {
                             takenOnFail:       false,
                             quarantineAttempt: 2,
                         }],
-                        videos:         [],
-                        testId:         'idf1t1',
-                        browsers:       [
+                        videos:   [],
+                        testId:   'idf1t1',
+                        browsers: [
                             {
                                 alias:                        'Chrome',
                                 userAgent:                    'Chrome',
@@ -757,7 +744,6 @@ describe.only('Reporter', () => {
                                     'firstRunId',
                                     'secondRunId',
                                 ],
-                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:                        'Firefox',
@@ -768,10 +754,9 @@ describe.only('Reporter', () => {
                                     'firstRunId',
                                     'secondRunId',
                                 ],
-                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture:        {
+                        fixture: {
                             id:   'fid1',
                             name: 'fixture1',
                             path: './file1.js',
@@ -800,8 +785,8 @@ describe.only('Reporter', () => {
                             'f1t2',
                             'f1t2ff',
                         ],
-                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:    false,
+                        startTime: new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:   false,
                     },
                 ],
             },
@@ -848,25 +833,23 @@ describe.only('Reporter', () => {
                             takenOnFail:       true,
                             quarantineAttempt: null,
                         }],
-                        videos:         [],
-                        testId:         'idf1t2',
-                        browsers:       [
+                        videos:   [],
+                        testId:   'idf1t2',
+                        browsers: [
                             {
                                 alias:     'Chrome',
                                 userAgent: 'Chrome',
                                 headless:  false,
                                 testRunId: 'f1t2',
-                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:     'Firefox',
                                 userAgent: 'Firefox',
                                 headless:  false,
                                 testRunId: 'f1t2ff',
-                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture:        {
+                        fixture: {
                             id:   'fid1',
                             name: 'fixture1',
                             path: './file1.js',
@@ -895,8 +878,8 @@ describe.only('Reporter', () => {
                             'f1t3',
                             'f1t3ff',
                         ],
-                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:    false,
+                        startTime: new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:   false,
                     },
                 ],
             },
@@ -923,17 +906,15 @@ describe.only('Reporter', () => {
                                 userAgent: 'Chrome',
                                 headless:  false,
                                 testRunId: 'f1t3',
-                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:     'Firefox',
                                 userAgent: 'Firefox',
                                 headless:  false,
                                 testRunId: 'f1t3ff',
-                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture:        {
+                        fixture: {
                             id:   'fid1',
                             name: 'fixture1',
                             path: './file1.js',
@@ -972,8 +953,8 @@ describe.only('Reporter', () => {
                             'f2t1',
                             'f2t1ff',
                         ],
-                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:    false,
+                        startTime: new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:   false,
                     },
                 ],
             },
@@ -1000,17 +981,15 @@ describe.only('Reporter', () => {
                                 userAgent: 'Chrome',
                                 headless:  false,
                                 testRunId: 'f2t1',
-                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:     'Firefox',
                                 userAgent: 'Firefox',
                                 headless:  false,
                                 testRunId: 'f2t1ff',
-                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture:        {
+                        fixture: {
                             id:   'fid2',
                             name: 'fixture2',
                             path: './file1.js',
@@ -1039,8 +1018,8 @@ describe.only('Reporter', () => {
                             'f2t2',
                             'f2t2ff',
                         ],
-                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:    false,
+                        startTime: new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:   false,
                     },
                 ],
             },
@@ -1067,17 +1046,15 @@ describe.only('Reporter', () => {
                                 userAgent: 'Chrome',
                                 headless:  false,
                                 testRunId: 'f2t2',
-                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:     'Firefox',
                                 userAgent: 'Firefox',
                                 headless:  false,
                                 testRunId: 'f2t2ff',
-                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture:        {
+                        fixture: {
                             id:   'fid2',
                             name: 'fixture2',
                             path: './file1.js',
@@ -1114,8 +1091,8 @@ describe.only('Reporter', () => {
                             'f3t1',
                             'f3t1ff',
                         ],
-                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:    false,
+                        startTime: new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:   false,
                     },
                 ],
             },
@@ -1148,17 +1125,15 @@ describe.only('Reporter', () => {
                                 userAgent: 'Chrome',
                                 headless:  false,
                                 testRunId: 'f3t1',
-                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:     'Firefox',
                                 userAgent: 'Firefox',
                                 headless:  false,
                                 testRunId: 'f3t1ff',
-                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture:        {
+                        fixture: {
                             id:   'fid3',
                             name: 'fixture3',
                             path: './file2.js',
@@ -1185,8 +1160,8 @@ describe.only('Reporter', () => {
                             'f3t2',
                             'f3t2ff',
                         ],
-                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:    true,
+                        startTime: new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:   true,
                     },
                 ],
             },
@@ -1213,17 +1188,15 @@ describe.only('Reporter', () => {
                                 userAgent: 'Chrome',
                                 headless:  false,
                                 testRunId: 'f3t2',
-                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:     'Firefox',
                                 userAgent: 'Firefox',
                                 headless:  false,
                                 testRunId: 'f3t2ff',
-                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture:        {
+                        fixture: {
                             id:   'fid3',
                             name: 'fixture3',
                             path: './file2.js',
@@ -1250,8 +1223,8 @@ describe.only('Reporter', () => {
                             'f3t3',
                             'f3t3ff',
                         ],
-                        startTime:  new Date('1970-01-01T00:00:00.000Z'),
-                        skipped:    false,
+                        startTime: new Date('1970-01-01T00:00:00.000Z'),
+                        skipped:   false,
                     },
                 ],
             },
@@ -1278,17 +1251,15 @@ describe.only('Reporter', () => {
                                 userAgent: 'Chrome',
                                 headless:  false,
                                 testRunId: 'f3t3',
-                                prettyUserAgent: "Chrome Ubuntu",
                             },
                             {
                                 alias:     'Firefox',
                                 userAgent: 'Firefox',
                                 headless:  false,
                                 testRunId: 'f3t3ff',
-                                prettyUserAgent: "Firefox Ubuntu",
                             },
                         ],
-                        fixture:        {
+                        fixture: {
                             id:   'fid3',
                             name: 'fixture3',
                             path: './file2.js',
@@ -1397,7 +1368,7 @@ describe.only('Reporter', () => {
                     [
                         { testRunId: 'f1t2-id1', videoPath: 'f1t2-path1' },
                         { testRunId: 'f1t2-id2', videoPath: 'f1t2-path2' },
-                    ]],
+                    ]]
                 );
             });
     });

--- a/test/server/reporter-test.js
+++ b/test/server/reporter-test.js
@@ -30,10 +30,10 @@ describe('Reporter', () => {
 
     const browserConnectionMocks = [
         {
-            userAgent:      'Chrome',
+            userAgent: 'Chrome',
         },
         {
-            userAgent:      'Firefox',
+            userAgent: 'Firefox',
         },
     ];
 


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
https://github.com/DevExpress/testcafe-private/issues/147

Both the browserConnection.connectionInfo and browserConnection.userAgent are prettyUserAgent string. The only difference is in osInfo. In the case of userAgent it is calculated from the browser and usually it is incorrect. 

## Approach
Calculate osInfo in userAgent using the provider getOSInfo method. 

## References
https://github.com/DevExpress/testcafe-private/issues/147

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
