### PR TITLE
fix: firefox keypress event doesn't work with backspace, tab, etc, if preventDefault called

### DIFF
--- a/src/client/automation/playback/press/index.js
+++ b/src/client/automation/playback/press/index.js
@@ -18,7 +18,6 @@ import { getModifiersBit } from '../../../../native-automation/client/utils';
 import CDPEventDescriptor from '../../../../native-automation/client/event-descriptor';
 
 const Promise        = hammerhead.Promise;
-const browserUtils   = hammerhead.utils.browser;
 const messageSandbox = hammerhead.eventSandbox.message;
 const nativeMethods  = hammerhead.nativeMethods;
 
@@ -131,8 +130,9 @@ export default class PressAutomation {
         const currentShortcutHandler = this.shortcutHandlers[this.pressedKeyString];
         let keyPressPrevented      = false;
 
-        // NOTE: B254435
-        if (!currentShortcutHandler || browserUtils.isFirefox || keyPressSimulator.key === 'enter')
+        // NOTE: Old firefox prevented shortcut keys via preventDefault(B254435).
+        // Now this behavior the same as in other modern browsers
+        if (!currentShortcutHandler || keyPressSimulator.key === 'enter')
             keyPressPrevented = !keyPressSimulator.press(this.modifiersState);
 
         if ((!keyPressPrevented || this.isSelectElement) && currentShortcutHandler) {

--- a/test/client/fixtures/automation/key-press-simulation-test.js
+++ b/test/client/fixtures/automation/key-press-simulation-test.js
@@ -308,9 +308,6 @@ $(document).ready(function () {
             { type: 'keydown', keyCode: KEYCODES.end, ctrlKey: true },
         ];
 
-        if (browserUtils.isFirefox)
-            expectedEvents.push({ type: 'keypress', keyCode: KEYCODES.end, charCode: KEYCODES.end, ctrlKey: true });
-
         expectedEvents.push({ type: 'keyup', keyCode: KEYCODES.end, ctrlKey: true });
         expectedEvents.push({ type: 'keyup', keyCode: KEYCODES.ctrl });
 
@@ -371,7 +368,7 @@ $(document).ready(function () {
 
         runPressAutomation('ctrl+a', function () {
             runPressAutomation('delete', function () {
-                equal(input.value, browserUtils.isFirefox ? value : '');
+                equal(input.value, '');
 
                 start();
             });

--- a/test/client/fixtures/automation/press-shortcuts-test.js
+++ b/test/client/fixtures/automation/press-shortcuts-test.js
@@ -136,7 +136,7 @@ $(document).ready(function () {
         runPressAutomation('ctrl+a backspace', function () {
             equal(keydownCount, 3, 'keydown event raises twice');
             equal(keyupCount, 3, 'keyup event raises twice');
-            equal(keypressCount, browserUtils.isFirefox ? 2 : 0, 'keypress event raises twice');
+            equal(keypressCount, 0, 'keypress event is not raised');
             start();
         });
     });


### PR DESCRIPTION
## Purpose
Old Firefox prevented backspace, tab, etc. keys via preventDefault([B254435](https://supportcenter.devexpress.com/internal/ticket/details/B254435)). 
Now this behavior is the same as in other modern browsers. So we don't need to prevent such key pressing.

## Approach
Remove firefox check

## References
#4115 

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
