### PR TITLE
fix: request action returns bad request if request method is specified in lowercase in native automation(closes #7609)

### DIFF
--- a/src/test-run/request/create-request-options.ts
+++ b/src/test-run/request/create-request-options.ts
@@ -93,10 +93,9 @@ function changeHeaderNamesToLowercase (headers: OutgoingHttpHeaders): OutgoingHt
 }
 
 async function prepareHeaders (options: ExternalRequestOptions, currentPageUrl: URL, url: URL, body: Buffer, testRun: TestRun, withCredentials: boolean): Promise<OutgoingHttpHeaders> {
-    const { host, origin } = url;
+    const { host, origin }                      = url;
     const { method, proxy, auth, headers = {} } = options;
-
-    const preparedHeaders: OutgoingHttpHeaders = Object.assign({}, DEFAULT_ACCEPT, changeHeaderNamesToLowercase(headers));
+    const preparedHeaders: OutgoingHttpHeaders  = Object.assign({}, DEFAULT_ACCEPT, changeHeaderNamesToLowercase(headers));
 
     preparedHeaders[HTTP_HEADERS.host]          = host;
     preparedHeaders[HTTP_HEADERS.origin]        = origin;

--- a/test/functional/fixtures/api/es-next/request/test.js
+++ b/test/functional/fixtures/api/es-next/request/test.js
@@ -141,6 +141,14 @@ describe('Request', () => {
             return runTests('testcafe-fixtures/request-test.js', 'Should execute a request with relative url');
         });
 
+        it('Should execute a GET HTTPS request with method in lowercase', function () {
+            return runTests('testcafe-fixtures/request-test.js', 'Should execute a GET HTTPS request with method in lowercase');
+        });
+
+        it('Should set a content type for POST request', function () {
+            return runTests('testcafe-fixtures/request-test.js', 'Should set a content type for POST request');
+        });
+
         if (config.useLocalBrowsers) {
             it('Should rise request runtime error', function () {
                 return runTests('testcafe-fixtures/request-test.js', 'Should rise request runtime error', { shouldFail: true })

--- a/test/functional/fixtures/api/es-next/request/testcafe-fixtures/request-test.js
+++ b/test/functional/fixtures/api/es-next/request/testcafe-fixtures/request-test.js
@@ -387,3 +387,36 @@ test('Should execute a GET HTTPS request', async (t) => {
             position: 'CTO',
         });
 });
+
+
+test('Should execute a GET HTTPS request with method in lowercase', async (t) => {
+    const {
+        status,
+        statusText,
+        headers,
+        body,
+    } = await t.request(HTTPS_API_URL, {
+        method: 'get',
+    });
+
+    await t
+        .expect(status).eql(200)
+        .expect(statusText).eql('OK')
+        .expect(headers).contains({ 'content-type': 'application/json; charset=utf-8' })
+        .expect(body).eql({
+            name:     'John Hearts',
+            position: 'CTO',
+        });
+});
+
+test('Should set a content type for POST request', async (t) => {
+    const options = {
+        method: 'POST',
+    };
+
+    const data = await t.request(`${API_URL}/request-info`, options);
+
+    await t.expect(data.body.headers['content-type']).eql('application/x-www-form-urlencoded');
+});
+
+

--- a/test/functional/site/api.js
+++ b/test/functional/site/api.js
@@ -90,6 +90,12 @@ router.post('/data', (req, res) => {
     res.send(responses.handlePostResult(req.body));
 });
 
+router.post('/request-info', (req, res) => {
+    res.send({
+        headers: req.headers,
+    });
+});
+
 router.delete('/data/:dataId', (req, res) => {
     res.send(responses.handleDeleteResult(req.params));
 });


### PR DESCRIPTION
## Purpose
Request action returns bad request if request method is specified in lowercase. The issue is only in native automation mode, because the request is not fully handled by hammerhead.  

## Approach
Use uppercase
## References
#7609

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
