### PR TITLE
fix: skipJsErrors action without arguments doesn't skip errors(closes #7648)

### DIFF
--- a/src/test-run/commands/actions.js
+++ b/src/test-run/commands/actions.js
@@ -764,7 +764,7 @@ export class SkipJsErrorsCommand extends ActionCommandBase {
 
     getAssignableProperties () {
         return [
-            { name: 'options', type: skipJsErrorOptions, init: initSkipJsErrorsOptions, required: false },
+            { name: 'options', type: skipJsErrorOptions, init: initSkipJsErrorsOptions, required: false, defaultValue: true },
         ];
     }
 }

--- a/test/functional/fixtures/page-js-errors/testcafe-fixtures/test-controller.js
+++ b/test/functional/fixtures/page-js-errors/testcafe-fixtures/test-controller.js
@@ -36,7 +36,9 @@ test('Should skip JS errors with callback function returning Promise', async t =
 });
 
 test('Should skip JS errors without param', async t => {
-    await t.skipJsErrors();
+    await t
+        .skipJsErrors()
+        .click('button');
 });
 
 test('Should skip JS errors if some SkipJsErrorsCallbackOptions prop is string containing RegExp', async t => {


### PR DESCRIPTION
## Purpose
Calling skipJsErrors action without arguments should be equak .skipJsErrors(true), but actually it .skipJsErrors(false)

## Approach
Specify default value for action and fix test

## References
#7648

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
