### PR TITLE
run nativeAutomation by default: preparation 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .sass-cache
 .publish
 /___test-screenshots___
+___test-videos___
 /screenshots
 yarn.lock
 package-lock.json

--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -188,7 +188,7 @@ export default class TestController {
     _validateMultipleWindowCommand (apiMethodName) {
         const { disableMultipleWindows, activeWindowId } = this.testRun;
 
-        if (this.testRun.isNativeAutomation())
+        if (this.testRun.isNativeAutomation)
             throw new MultipleWindowsModeIsNotSupportedInNativeAutomationModeError(apiMethodName);
 
         if (disableMultipleWindows)

--- a/src/browser/connection/gateway/index.ts
+++ b/src/browser/connection/gateway/index.ts
@@ -28,7 +28,7 @@ export interface BrowserConnectionGatewayOptions {
 }
 
 const DEFAULT_BROWSER_CONNECTION_GATEWAY_OPTIONS = {
-    retryTestPages:   false,
+    retryTestPages: false,
 };
 
 export default class BrowserConnectionGateway extends EventEmitter {

--- a/src/browser/connection/gateway/index.ts
+++ b/src/browser/connection/gateway/index.ts
@@ -25,12 +25,10 @@ import { EventEmitter } from 'events';
 
 export interface BrowserConnectionGatewayOptions {
     retryTestPages: boolean;
-    nativeAutomation: boolean;
 }
 
 const DEFAULT_BROWSER_CONNECTION_GATEWAY_OPTIONS = {
     retryTestPages:   false,
-    nativeAutomation: false,
 };
 
 export default class BrowserConnectionGateway extends EventEmitter {
@@ -61,9 +59,7 @@ export default class BrowserConnectionGateway extends EventEmitter {
             const connection = this._connections[params.id];
 
             preventCaching(res);
-
-            if (this._options.nativeAutomation)
-                acceptCrossOrigin(res);
+            acceptCrossOrigin(res);
 
             if (connection)
                 handler(req, res, connection);
@@ -103,13 +99,10 @@ export default class BrowserConnectionGateway extends EventEmitter {
         proxy.GET(SERVICE_ROUTES.assets.index, { content: idlePageScript, contentType: 'application/x-javascript' });
         proxy.GET(SERVICE_ROUTES.assets.styles, { content: idlePageStyle, contentType: 'text/css' });
         proxy.GET(SERVICE_ROUTES.assets.logo, { content: idlePageLogo, contentType: 'image/svg+xml' });
-
-        if (this._options.nativeAutomation) {
-            proxy.GET(NATIVE_AUTOMATION_ERROR_ROUTE, (req: IncomingMessage, res: ServerResponse) => {
-                res.writeHead(200, { 'Content-Type': 'text/html' });
-                res.end(EMPTY_PAGE_MARKUP);
-            });
-        }
+        proxy.GET(NATIVE_AUTOMATION_ERROR_ROUTE, (req: IncomingMessage, res: ServerResponse) => {
+            res.writeHead(200, { 'Content-Type': 'text/html' });
+            res.end(EMPTY_PAGE_MARKUP);
+        });
     }
 
     // Helpers
@@ -338,10 +331,6 @@ export default class BrowserConnectionGateway extends EventEmitter {
         return this._connections;
     }
 
-    public get nativeAutomation (): boolean {
-        return this._options.nativeAutomation;
-    }
-
     public get status (): BrowserConnectionGatewayStatus {
         return this._status;
     }
@@ -365,8 +354,6 @@ export default class BrowserConnectionGateway extends EventEmitter {
     }
 
     public switchToNativeAutomation (): void {
-        this._options.nativeAutomation = true;
-
         this.proxy.switchToNativeAutomation();
     }
 }

--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -35,6 +35,7 @@ import { TestRun as LegacyTestRun } from 'testcafe-legacy-api';
 import { Proxy } from 'testcafe-hammerhead';
 import { NextTestRunInfo, OpenBrowserAdditionalOptions } from '../../shared/types';
 import { EventType } from '../../native-automation/types';
+import NativeAutomation from '../../native-automation';
 
 const getBrowserConnectionDebugScope = (id: string): string => `testcafe:browser:connection:${id}`;
 
@@ -643,5 +644,13 @@ export default class BrowserConnection extends EventEmitter {
         this._buildCommunicationUrls(this.browserConnectionGateway.proxy);
 
         process.nextTick(() => this._runBrowser());
+    }
+
+    public supportNativeAutomation (): boolean {
+        return this.provider.supportNativeAutomation();
+    }
+
+    public getNativeAutomation (): NativeAutomation {
+        return this.provider.getNativeAutomation(this.id);
     }
 }

--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -261,22 +261,15 @@ export default class BrowserConnection extends EventEmitter {
     }
 
     private _getAdditionalBrowserOptions (): OpenBrowserAdditionalOptions {
-        const options = {
+        return {
             disableMultipleWindows: this._options.disableMultipleWindows,
-        } as OpenBrowserAdditionalOptions;
-
-        if (this._options.nativeAutomation) {
-            options.nativeAutomation = {
-                serviceDomains: [
-                    this.browserConnectionGateway.proxy.server1Info.domain,
-                    this.browserConnectionGateway.proxy.server2Info.domain,
-                ],
-
-                developmentMode: this._options.developmentMode,
-            };
-        }
-
-        return options;
+            nativeAutomation:       this._options.nativeAutomation,
+            developmentMode:        this._options.developmentMode,
+            serviceDomains:         [
+                this.browserConnectionGateway.proxy.server1Info.domain,
+                this.browserConnectionGateway.proxy.server2Info.domain,
+            ],
+        };
     }
 
     private async _runBrowser (): Promise<void> {

--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -58,9 +58,9 @@ export default {
 
     async _setupNativeAutomation ({ browserId, browserClient, runtimeInfo, nativeAutomationOptions }) {
         const cdpClient = await browserClient.getActiveClient();
-        const nativeAutomation = new NativeAutomation(browserId, cdpClient);
+        const nativeAutomation = new NativeAutomation(browserId, cdpClient, nativeAutomationOptions);
 
-        await nativeAutomation.init(nativeAutomationOptions);
+        await nativeAutomation.start();
 
         runtimeInfo.nativeAutomation = nativeAutomation;
     },

--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -15,6 +15,7 @@ import NativeAutomation from '../../../../../native-automation';
 import { chromeBrowserProviderLogger } from '../../../../../utils/debug-loggers';
 import { EventType } from '../../../../../native-automation/types';
 import delay from '../../../../../utils/delay';
+import { toNativeAutomationSetupOptions } from '../../../../../native-automation/utils/convert';
 
 const MIN_AVAILABLE_DIMENSION = 50;
 
@@ -64,9 +65,9 @@ export default {
         runtimeInfo.nativeAutomation = nativeAutomation;
     },
 
-    async openBrowser (browserId, pageUrl, config, { disableMultipleWindows, nativeAutomation }) {
+    async openBrowser (browserId, pageUrl, config, additionalOptions) {
         const parsedPageUrl = parseUrl(pageUrl);
-        const runtimeInfo   = await this._createRunTimeInfo(parsedPageUrl.hostname, config, disableMultipleWindows);
+        const runtimeInfo   = await this._createRunTimeInfo(parsedPageUrl.hostname, config, additionalOptions.disableMultipleWindows);
 
         runtimeInfo.browserName = this._getBrowserName();
         runtimeInfo.browserId   = browserId;
@@ -88,7 +89,7 @@ export default {
         runtimeInfo.activeWindowId    = null;
         runtimeInfo.windowDescriptors = {};
 
-        if (!disableMultipleWindows)
+        if (!additionalOptions.disableMultipleWindows)
             runtimeInfo.activeWindowId = this.calculateWindowId();
 
         const browserClient = new BrowserClient(runtimeInfo);
@@ -101,8 +102,8 @@ export default {
 
         this._setUserAgentMetaInfoForEmulatingDevice(browserId, runtimeInfo.config);
 
-        if (nativeAutomation)
-            await this._setupNativeAutomation({ browserId, browserClient, runtimeInfo, nativeAutomationOptions: nativeAutomation });
+        if (additionalOptions.nativeAutomation)
+            await this._setupNativeAutomation({ browserId, browserClient, runtimeInfo, nativeAutomationOptions: toNativeAutomationSetupOptions(additionalOptions) });
 
         chromeBrowserProviderLogger('browser opened %s', browserId);
     },

--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -210,4 +210,10 @@ export default {
     supportNativeAutomation () {
         return true;
     },
+
+    getNativeAutomation (browserId) {
+        const runtimeInfo = this.openedBrowsers[browserId];
+
+        return runtimeInfo.nativeAutomation;
+    },
 };

--- a/src/browser/provider/index.ts
+++ b/src/browser/provider/index.ts
@@ -16,6 +16,7 @@ import { WindowDimentionsInfo } from '../interfaces';
 import getLocalOSInfo, { OSInfo } from 'get-os-info';
 import { OpenBrowserAdditionalOptions } from '../../shared/types';
 import { EventType } from '../../native-automation/types';
+import NativeAutomation from '../../native-automation';
 
 
 const DEBUG_LOGGER = debug('testcafe:browser:provider');
@@ -461,5 +462,9 @@ export default class BrowserProvider {
 
     public supportNativeAutomation (): boolean {
         return this.plugin.supportNativeAutomation();
+    }
+
+    public getNativeAutomation (browserId: string): NativeAutomation {
+        return this.plugin.getNativeAutomation(browserId);
     }
 }

--- a/src/browser/provider/index.ts
+++ b/src/browser/provider/index.ts
@@ -322,7 +322,7 @@ export default class BrowserProvider {
         return await this.plugin.getOSInfo(browserId);
     }
 
-    public async openBrowser (browserId: string, pageUrl: string, browserOption: unknown, additionalOptions: OpenBrowserAdditionalOptions = { disableMultipleWindows: false }): Promise<void> {
+    public async openBrowser (browserId: string, pageUrl: string, browserOption: unknown, additionalOptions: OpenBrowserAdditionalOptions): Promise<void> {
         await this.plugin.openBrowser(browserId, pageUrl, browserOption, additionalOptions);
 
         await this._ensureRetryTestPagesWarning(browserId);

--- a/src/browser/provider/plugin-host.js
+++ b/src/browser/provider/plugin-host.js
@@ -170,4 +170,8 @@ export default class BrowserProviderPluginHost {
     supportNativeAutomation () {
         return false;
     }
+
+    getNativeAutomation (/*browserId*/) {
+        return null;
+    }
 }

--- a/src/cli/remotes-wizard.ts
+++ b/src/cli/remotes-wizard.ts
@@ -10,6 +10,7 @@ import BrowserConnectionGateway from '../browser/connection/gateway';
 interface TestCafe {
     browserConnectionGateway: BrowserConnectionGateway;
     createBrowserConnection(): Promise<BrowserConnection>;
+    initializeBrowserConnectionGateway(): Promise<void>;
 }
 
 export default async function (testCafe: TestCafe, remoteCount: number, showQRCode: boolean): Promise<BrowserConnection[]> {
@@ -27,6 +28,8 @@ export default async function (testCafe: TestCafe, remoteCount: number, showQRCo
 
         if (showQRCode)
             log.write('You can either enter the URL or scan the QR-code.');
+
+        await testCafe.initializeBrowserConnectionGateway();
 
         const connectionUrl = testCafe.browserConnectionGateway.connectUrl;
 

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -169,8 +169,7 @@ export default class TestCafeConfiguration extends Configuration {
 
     public get browserConnectionGatewayOptions (): BrowserConnectionGatewayOptions {
         return {
-            retryTestPages:   this.getOption(OPTION_NAMES.retryTestPages),
-            nativeAutomation: this.getOption(OPTION_NAMES.nativeAutomation),
+            retryTestPages: this.getOption(OPTION_NAMES.retryTestPages),
         };
     }
 

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -38,7 +38,7 @@ import CustomizableCompilers from './customizable-compilers';
 import { DEPRECATED, getDeprecationMessage } from '../notifications/deprecated';
 import WarningLog from '../notifications/warning-log';
 import browserProviderPool from '../browser/provider/pool';
-import BrowserConnection, { BrowserInfo } from '../browser/connection';
+import BrowserConnection, { BrowserConnectionOptions, BrowserInfo } from '../browser/connection';
 import { CONFIGURATION_EXTENSIONS } from './formats';
 import { GeneralError } from '../errors/runtime';
 import { RUNTIME_ERRORS } from '../errors/types';
@@ -170,6 +170,14 @@ export default class TestCafeConfiguration extends Configuration {
     public get browserConnectionGatewayOptions (): BrowserConnectionGatewayOptions {
         return {
             retryTestPages: this.getOption(OPTION_NAMES.retryTestPages),
+        };
+    }
+
+    public get remoteBrowserConnectionOptions (): BrowserConnectionOptions {
+        return {
+            disableMultipleWindows: true,
+            nativeAutomation:       false,
+            developmentMode:        this.getOption(OPTION_NAMES.developmentMode),
         };
     }
 

--- a/src/custom-client-scripts/routing.ts
+++ b/src/custom-client-scripts/routing.ts
@@ -19,23 +19,21 @@ export function isLegacyTest (test: TestItem): test is LegacyTest {
     return !!(test as LegacyTest).isLegacy;
 }
 
-export function register (proxy: Proxy, tests: Test[], nativeAutomation: boolean): string[] {
+export function register (proxy: Proxy, test: Test, nativeAutomation: boolean): string[] {
     const routes: string[] = [];
 
-    tests.forEach(test => {
-        if (isLegacyTest(test))
-            return;
+    if (isLegacyTest(test))
+        return routes;
 
-        test.clientScripts.forEach((script: ClientScriptInit) => {
-            const route = getCustomClientScriptUrl(script as ClientScript);
+    test.clientScripts.forEach((script: ClientScriptInit) => {
+        const route = getCustomClientScriptUrl(script as ClientScript);
 
-            proxy.GET(route, {
-                content:     getCustomClientScriptCode(script as ClientScript, nativeAutomation),
-                contentType: CONTENT_TYPES.javascript,
-            });
-
-            routes.push(route);
+        proxy.GET(route, {
+            content:     getCustomClientScriptCode(script as ClientScript, nativeAutomation),
+            contentType: CONTENT_TYPES.javascript,
         });
+
+        routes.push(route);
     });
 
     return routes;

--- a/src/errors/runtime/templates.js
+++ b/src/errors/runtime/templates.js
@@ -144,5 +144,5 @@ export default {
     [RUNTIME_ERRORS.invalidCustomActionType]:                        `TestCafe cannot parse the "{actionName}" action, because the action definition is invalid. Format the definition in accordance with the custom actions guide: ${ DOCUMENTATION_LINKS.CUSTOM_ACTIONS }`,
     [RUNTIME_ERRORS.cannotImportESMInCommonsJS]:                     'Cannot import the {esModule} ECMAScript module from {targetFile}. Use a dynamic import() statement or enable the --esm CLI flag.',
     [RUNTIME_ERRORS.proxyInitializedMoreThanOnce]:                   'The proxy was initialized more than once.',
-    [RUNTIME_ERRORS.setNativeAutomationForUnsupportedBrowsers]:      'The following browser(s) do not support the Native Automation mode: {browsers}.',
+    [RUNTIME_ERRORS.setNativeAutomationForUnsupportedBrowsers]:      'The "{browser}" do not support the Native Automation mode. Remove the "native automation" option to continue.',
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,43 +1,14 @@
-import { GeneralError } from './errors/runtime';
-import { RUNTIME_ERRORS } from './errors/types';
 import embeddingUtils from './embedding-utils';
 import exportableLib from './api/exportable-lib';
 import TestCafeConfiguration from './configuration/testcafe-configuration';
 import OPTION_NAMES from './configuration/option-names';
 import ProcessTitle from './services/process-title';
 import userVariables from './api/user-variables';
+import { getValidHostname, getValidPort } from './configuration/utils';
 
 const lazyRequire   = require('import-lazy')(require);
 const TestCafe      = lazyRequire('./testcafe');
-const endpointUtils = lazyRequire('endpoint-utils');
 const setupExitHook = lazyRequire('async-exit-hook');
-
-// Validations
-async function getValidHostname (hostname) {
-    if (hostname) {
-        const valid = await endpointUtils.isMyHostname(hostname);
-
-        if (!valid)
-            throw new GeneralError(RUNTIME_ERRORS.invalidHostname, hostname);
-    }
-    else
-        hostname = endpointUtils.getIPAddress();
-
-    return hostname;
-}
-
-async function getValidPort (port) {
-    if (port) {
-        const isFree = await endpointUtils.isFreePort(port);
-
-        if (!isFree)
-            throw new GeneralError(RUNTIME_ERRORS.portIsNotFree, port);
-    }
-    else
-        port = await endpointUtils.getFreePort();
-
-    return port;
-}
 
 // API
 async function getConfiguration (args) {

--- a/src/native-automation/api-base.ts
+++ b/src/native-automation/api-base.ts
@@ -2,17 +2,20 @@ import { ProtocolApi } from 'chrome-remote-interface';
 import BrowserConnection from '../browser/connection';
 import TestRun from '../test-run';
 import { notImplementedError } from './errors';
+import { NativeAutomationInitOptions } from '../shared/types';
 
 export default class NativeAutomationApiBase {
     protected readonly _client: ProtocolApi;
     protected readonly _browserConnection: BrowserConnection;
+    protected readonly options: NativeAutomationInitOptions;
 
-    constructor (browserId: string, client: ProtocolApi) {
-        this._client = client;
+    constructor (browserId: string, client: ProtocolApi, options: NativeAutomationInitOptions) {
+        this._client            = client;
         this._browserConnection = BrowserConnection.getById(browserId) as BrowserConnection;
+        this.options            = options;
     }
 
-    public async init (): Promise<void> {
+    public async start (): Promise<void> {
         throw notImplementedError();
     }
 

--- a/src/native-automation/default-setup-options.ts
+++ b/src/native-automation/default-setup-options.ts
@@ -1,7 +1,0 @@
-const DEFAULT_NATIVE_AUTOMATION_SETUP_OPTIONS = {
-    serviceDomains:  [],
-    developmentMode: false,
-};
-
-export default DEFAULT_NATIVE_AUTOMATION_SETUP_OPTIONS;
-

--- a/src/native-automation/index.ts
+++ b/src/native-automation/index.ts
@@ -4,6 +4,7 @@ import addCustomDebugFormatters from './add-custom-debug-formatters';
 import { NativeAutomationInitOptions } from '../shared/types';
 import { nativeAutomationLogger } from '../utils/debug-loggers';
 import SessionStorage from './session-storage';
+import NativeAutomationApiBase from './api-base';
 
 export default class NativeAutomation {
     private readonly _client: ProtocolApi;
@@ -34,13 +35,8 @@ export default class NativeAutomation {
     }
 
     public async start (): Promise<void> {
-        const nativeAutomationSystems = [
-            this.requestPipeline,
-            this.sessionStorage,
-        ];
-
-        for (const api of nativeAutomationSystems)
-            await api.start();
+        for (const apiSystem of this.apiSystems)
+            await apiSystem.start();
 
         nativeAutomationLogger('nativeAutomation initialized');
     }
@@ -51,5 +47,12 @@ export default class NativeAutomation {
         await this.requestPipeline.dispose();
 
         nativeAutomationLogger('nativeAutomation disposed');
+    }
+
+    public get apiSystems (): NativeAutomationApiBase [] {
+        return [
+            this.requestPipeline,
+            this.sessionStorage,
+        ];
     }
 }

--- a/src/native-automation/request-pipeline/special-handlers.ts
+++ b/src/native-automation/request-pipeline/special-handlers.ts
@@ -8,7 +8,7 @@ import {
     requestPipelineLogger,
     requestPipelineServiceRequestLogger,
 } from '../../utils/debug-loggers';
-import { NativeAutomationSetupOptions } from '../../shared/types';
+import { NativeAutomationInitOptions } from '../../shared/types';
 import { isRequest } from '../utils/cdp';
 import { FAVICON_CONTENT_TYPE_HEADER } from './constants';
 import { StatusCodes } from 'http-status-codes';
@@ -32,7 +32,7 @@ const internalRequest = {
 } as RequestHandler;
 
 const serviceRequest = {
-    condition: (event: RequestPausedEvent, options: NativeAutomationSetupOptions, serviceRoutes: SpecialServiceRoutes): boolean => {
+    condition: (event: RequestPausedEvent, options: NativeAutomationInitOptions, serviceRoutes: SpecialServiceRoutes): boolean => {
         const url = event.request.url;
 
         // NOTE: the service 'Error page' should be proxied.
@@ -58,7 +58,7 @@ const defaultFaviconRequest = {
 
         return parsedUrl.pathname === DEFAULT_FAVICON_PATH;
     },
-    handler: async (event: RequestPausedEvent, client: ProtocolApi, options: NativeAutomationSetupOptions): Promise<void> => {
+    handler: async (event: RequestPausedEvent, client: ProtocolApi, options: NativeAutomationInitOptions): Promise<void> => {
         requestPipelineLogger('%r', event);
 
         if (isRequest(event))
@@ -86,7 +86,7 @@ const SPECIAL_REQUEST_HANDLERS = [
     defaultFaviconRequest,
 ];
 
-export default function getSpecialRequestHandler (event: RequestPausedEvent, options?: NativeAutomationSetupOptions, serviceRoutes?: SpecialServiceRoutes): any {
+export default function getSpecialRequestHandler (event: RequestPausedEvent, options?: NativeAutomationInitOptions, serviceRoutes?: SpecialServiceRoutes): any {
     const specialRequestHandler = SPECIAL_REQUEST_HANDLERS.find(h => h.condition(event, options, serviceRoutes));
 
     return specialRequestHandler ? specialRequestHandler.handler : null;

--- a/src/native-automation/session-storage/index.ts
+++ b/src/native-automation/session-storage/index.ts
@@ -5,14 +5,15 @@ import BindingCalledEvent = Protocol.Runtime.BindingCalledEvent;
 import AsyncEventEmitter from '../../utils/async-event-emitter';
 import Emittery from 'emittery';
 import MessageBus from '../../utils/message-bus';
+import { NativeAutomationInitOptions } from '../../shared/types';
 
 const NATIVE_AUTOMATION_STORAGE_BINDING = 'NATIVE_AUTOMATION_STORAGE_BINDING';
 
 export default class SessionStorage extends NativeAutomationApiBase {
     private _eventEmitter: AsyncEventEmitter;
 
-    constructor (browserId: string, client: ProtocolApi) {
-        super(browserId, client);
+    constructor (browserId: string, client: ProtocolApi, options: NativeAutomationInitOptions) {
+        super(browserId, client, options);
 
         this._eventEmitter = new AsyncEventEmitter();
 
@@ -34,7 +35,7 @@ export default class SessionStorage extends NativeAutomationApiBase {
         return this._eventEmitter.on(eventName, listener);
     }
 
-    public async init (): Promise<void> {
+    public async start (): Promise<void> {
         await this._client.Runtime.addBinding({ name: NATIVE_AUTOMATION_STORAGE_BINDING });
 
         await this._client.Runtime.on('bindingCalled', (event: BindingCalledEvent) => {

--- a/src/native-automation/session-storage/index.ts
+++ b/src/native-automation/session-storage/index.ts
@@ -6,6 +6,7 @@ import AsyncEventEmitter from '../../utils/async-event-emitter';
 import Emittery from 'emittery';
 import MessageBus from '../../utils/message-bus';
 import { NativeAutomationInitOptions } from '../../shared/types';
+import TestRun from '../../test-run';
 
 const NATIVE_AUTOMATION_STORAGE_BINDING = 'NATIVE_AUTOMATION_STORAGE_BINDING';
 
@@ -17,6 +18,17 @@ export default class SessionStorage extends NativeAutomationApiBase {
 
         this._eventEmitter = new AsyncEventEmitter();
 
+    }
+
+    private async _onTestRunDoneHandler (testRun: TestRun): Promise<void> {
+        await this._eventEmitter.emit('contextStorageTestRunDone', { testRunId: testRun.id });
+    }
+
+    private _addTestRunEventListeners (messageBus: MessageBus): void {
+        messageBus.on('test-run-done', this._onTestRunDoneHandler.bind(this));
+    }
+
+    private _addEventListeners (): void {
         if (this._browserConnection.messageBus)
             this._addTestRunEventListeners(this._browserConnection.messageBus);
 
@@ -25,17 +37,13 @@ export default class SessionStorage extends NativeAutomationApiBase {
         });
     }
 
-    private _addTestRunEventListeners (messageBus: MessageBus): void {
-        messageBus.on('test-run-done', testRun => {
-            this._eventEmitter.emit('contextStorageTestRunDone', { testRunId: testRun.id });
-        });
-    }
-
     public on (eventName: string, listener: (eventData?: any) => any): Emittery.UnsubscribeFn {
         return this._eventEmitter.on(eventName, listener);
     }
 
     public async start (): Promise<void> {
+        this._addEventListeners();
+
         await this._client.Runtime.addBinding({ name: NATIVE_AUTOMATION_STORAGE_BINDING });
 
         await this._client.Runtime.on('bindingCalled', (event: BindingCalledEvent) => {

--- a/src/native-automation/types.ts
+++ b/src/native-automation/types.ts
@@ -1,7 +1,7 @@
 import Protocol from 'devtools-protocol';
 import RequestPausedEvent = Protocol.Fetch.RequestPausedEvent;
 import { ProtocolApi } from 'chrome-remote-interface';
-import { NativeAutomationSetupOptions } from '../shared/types';
+import { NativeAutomationInitOptions } from '../shared/types';
 import { StoragesSnapshot } from 'testcafe-hammerhead';
 import { Dictionary } from '../configuration/interfaces';
 
@@ -18,8 +18,8 @@ export interface DocumentResourceInfo {
 }
 
 export interface RequestHandler {
-    condition: (event: RequestPausedEvent, options?: NativeAutomationSetupOptions, serviceRoutes?: SpecialServiceRoutes) => boolean;
-    handler: (event: RequestPausedEvent, client: ProtocolApi, options?: NativeAutomationSetupOptions) => Promise<void>;
+    condition: (event: RequestPausedEvent, options?: NativeAutomationInitOptions, serviceRoutes?: SpecialServiceRoutes) => boolean;
+    handler: (event: RequestPausedEvent, client: ProtocolApi, options?: NativeAutomationInitOptions) => Promise<void>;
 }
 
 export interface InjectableResourcesOptions {

--- a/src/native-automation/utils/convert.ts
+++ b/src/native-automation/utils/convert.ts
@@ -1,6 +1,6 @@
-import { NativeAutomationSetupOptions, OpenBrowserAdditionalOptions } from '../../shared/types';
+import { NativeAutomationInitOptions, OpenBrowserAdditionalOptions } from '../../shared/types';
 
-export function toNativeAutomationSetupOptions (options: OpenBrowserAdditionalOptions): NativeAutomationSetupOptions {
+export function toNativeAutomationSetupOptions (options: OpenBrowserAdditionalOptions): NativeAutomationInitOptions {
     return {
         serviceDomains:  options.serviceDomains,
         developmentMode: options.developmentMode,

--- a/src/native-automation/utils/convert.ts
+++ b/src/native-automation/utils/convert.ts
@@ -1,0 +1,8 @@
+import { NativeAutomationSetupOptions, OpenBrowserAdditionalOptions } from '../../shared/types';
+
+export function toNativeAutomationSetupOptions (options: OpenBrowserAdditionalOptions): NativeAutomationSetupOptions {
+    return {
+        serviceDomains:  options.serviceDomains,
+        developmentMode: options.developmentMode,
+    };
+}

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -193,7 +193,7 @@ export default class Bootstrapper {
     private _calculateIsNativeAutomation (remotes: BrowserConnection[]): void {
         // If there are remote connections, we should switch to legacy run mode.
         if (remotes.length)
-            this.configuration.mergeOptions({ nativeAutomation: true });
+            this.configuration.mergeOptions({ nativeAutomation: false });
 
         this.nativeAutomation = !!this.configuration.getOption(OPTION_NAMES.nativeAutomation);
     }

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -179,12 +179,11 @@ export default class Bootstrapper {
     }
 
     private async _setupProxy (): Promise<void> {
-        if (this.browserConnectionGateway.status === BrowserConnectionGatewayStatus.initialized)
-            return;
+        if (this.browserConnectionGateway.status === BrowserConnectionGatewayStatus.uninitialized) {
+            await this.configuration.calculateHostname({ nativeAutomation: this.nativeAutomation });
 
-        await this.configuration.calculateHostname({ nativeAutomation: this.nativeAutomation });
-
-        this.browserConnectionGateway.initialize(this.configuration.startOptions);
+            this.browserConnectionGateway.initialize(this.configuration.startOptions);
+        }
 
         if (this.nativeAutomation)
             this.browserConnectionGateway.switchToNativeAutomation();

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -245,7 +245,7 @@ export default class Runner extends EventEmitter {
         }
 
         this._messageBus.on('done', stopHandlingTestErrors);
-
+        this._messageBus.on('before-test-run-created-error', stopHandlingTestErrors);
         task.on('error', stopHandlingTestErrors);
 
         const onTaskCompleted = () => {

--- a/src/runner/index.js
+++ b/src/runner/index.js
@@ -98,7 +98,6 @@ export default class Runner extends EventEmitter {
 
     async _disposeTaskAndRelatedAssets (task, browserSet, reporters, testedApp, runnableConfigurationId) {
         task.abort();
-        task.unRegisterClientScriptRouting();
         task.clearListeners();
         this._messageBus.abort();
 
@@ -250,8 +249,6 @@ export default class Runner extends EventEmitter {
         task.on('error', stopHandlingTestErrors);
 
         const onTaskCompleted = () => {
-            task.unRegisterClientScriptRouting();
-
             completed = true;
         };
 

--- a/src/runner/task/index.ts
+++ b/src/runner/task/index.ts
@@ -5,7 +5,6 @@ import BrowserJob from '../browser-job';
 import Screenshots from '../../screenshots';
 import WarningLog from '../../notifications/warning-log';
 import FixtureHookController from '../fixture-hook-controller';
-import * as clientScriptsRouting from '../../custom-client-scripts/routing';
 import Videos from '../../video-recorder/videos';
 import TestRun from '../../test-run';
 import { Proxy } from 'testcafe-hammerhead';
@@ -35,7 +34,6 @@ export default class Task extends AsyncEventEmitter {
     public readonly screenshots: Screenshots;
     public readonly fixtureHookController: FixtureHookController;
     private readonly _pendingBrowserJobs: BrowserJob[];
-    private _clientScriptRoutes: string[] = [];
     public readonly testStructure: ReportedTestStructureItem[];
     public readonly videos?: Videos;
     private readonly _compilerService?: CompilerService;
@@ -80,8 +78,6 @@ export default class Task extends AsyncEventEmitter {
         this.fixtureHookController = new FixtureHookController(tests, browserConnectionGroups.length);
         this._pendingBrowserJobs   = this._createBrowserJobs(proxy, this.opts);
         this.testStructure         = this._prepareTestStructure(tests);
-
-        this.registerClientScriptRouting(!!this.opts.nativeAutomation);
 
         if (this.opts.videoPath) {
             const { videoPath, videoOptions, videoEncodingOptions } = this.opts;
@@ -173,14 +169,6 @@ export default class Task extends AsyncEventEmitter {
 
             return job;
         });
-    }
-
-    public registerClientScriptRouting (isNativeAutomation: boolean): void {
-        this._clientScriptRoutes = clientScriptsRouting.register(this._proxy, this.tests, isNativeAutomation);
-    }
-
-    public unRegisterClientScriptRouting (): void {
-        clientScriptsRouting.unRegister(this._proxy, this._clientScriptRoutes);
     }
 
     // API

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -96,7 +96,7 @@ export default class TestRunController extends AsyncEventEmitter {
             startRunExecutionTime,
         });
 
-        this.clientScriptRoutes = clientScriptsRouting.register(this._proxy, this.test, this.testRun.isNativeAutomation);
+        this.clientScriptRoutes = clientScriptsRouting.register(this._proxy, this.test, this._opts.nativeAutomation as boolean);
 
         await this.testRun.initialize();
 

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -21,6 +21,7 @@ import debug from 'debug';
 const DISCONNECT_THRESHOLD = 3;
 
 const debugLogger = debug('testcafe:runner:test-run-controller');
+
 export default class TestRunController extends AsyncEventEmitter {
     private readonly _quarantine: null | Quarantine;
     private _disconnectionCount: number;
@@ -186,6 +187,8 @@ export default class TestRunController extends AsyncEventEmitter {
         this.done = true;
 
         await this.emit('test-run-done');
+
+        debugLogger('done');
     }
 
     private async _emitTestRunStart (): Promise<void> {
@@ -237,6 +240,8 @@ export default class TestRunController extends AsyncEventEmitter {
     }
 
     public async start (connection: BrowserConnection, startRunExecutionTime?: Date): Promise<string | null> {
+        debugLogger('start');
+
         const testRun = await this._createTestRun(connection, startRunExecutionTime);
 
         const hookOk = await this._testRunHook.runTestRunBeforeHookIfNecessary(testRun)

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -95,6 +95,7 @@ export default class TestRunController extends AsyncEventEmitter {
             opts:              this._opts,
             compilerService:   this.compilerService,
             messageBus:        this._messageBus,
+            nativeAutomation:  this.isNativeAutomation,
             screenshotCapturer,
             startRunExecutionTime,
         });

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -100,7 +100,7 @@ export default class TestRunController extends AsyncEventEmitter {
             startRunExecutionTime,
         });
 
-        this.clientScriptRoutes = clientScriptsRouting.register(this._proxy, this.test, this._opts.nativeAutomation as boolean);
+        this.clientScriptRoutes = clientScriptsRouting.register(this._proxy, this.test, this.isNativeAutomation);
 
         await this.testRun.initialize();
 

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -250,6 +250,8 @@ export default class TestRunController extends AsyncEventEmitter {
         if (!this.isNativeAutomation || supportNativeAutomation)
             return;
 
+        await this._messageBus.emit('before-test-run-created-error');
+
         throw new GeneralError(RUNTIME_ERRORS.setNativeAutomationForUnsupportedBrowsers, connection.browserInfo.providerName);
     }
 

--- a/src/services/compiler/test-run-proxy.ts
+++ b/src/services/compiler/test-run-proxy.ts
@@ -46,7 +46,7 @@ class TestRunProxy extends AsyncEventEmitter {
     private readonly assertionCommands: Map<string, AssertionCommand>;
     private readonly switchToWindowByPredicateCommands: Map<string, SwitchToWindowByPredicateCommand>;
     private readonly asyncJsExpressionCallsites: Map<string, CallsiteRecord>;
-    private readonly _isNativeAutomation: boolean;
+    public readonly isNativeAutomation: boolean;
     public readonly browser: Browser;
     public readonly disableMultipleWindows: boolean;
     public activeWindowId: null | string;
@@ -70,7 +70,7 @@ class TestRunProxy extends AsyncEventEmitter {
         this.warningLog                        = new WarningLog(null, WarningLog.createAddWarningCallback(messageBus));
         this.disableMultipleWindows            = options.disableMultipleWindows as boolean;
         this.activeWindowId                    = activeWindowId;
-        this._isNativeAutomation               = isNativeAutomation;
+        this.isNativeAutomation                = isNativeAutomation;
 
         testRunTracker.addActiveTestRun(this);
 
@@ -219,10 +219,6 @@ class TestRunProxy extends AsyncEventEmitter {
         const command = this.switchToWindowByPredicateCommands.get(commandId) as SwitchToWindowByPredicateCommand;
 
         return command.checkWindow({ title, url });
-    }
-
-    public isNativeAutomation (): boolean {
-        return this._isNativeAutomation;
     }
 }
 

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -44,12 +44,12 @@ interface NextTestRunInfo {
     url: string;
 }
 
-interface NativeAutomationSetupOptions {
+interface NativeAutomationInitOptions {
     serviceDomains: string[];
     developmentMode: boolean;
 }
 
-interface OpenBrowserAdditionalOptions extends NativeAutomationSetupOptions {
+interface OpenBrowserAdditionalOptions extends NativeAutomationInitOptions {
     disableMultipleWindows: boolean;
     nativeAutomation: boolean;
 }

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -49,7 +49,7 @@ interface NativeAutomationSetupOptions {
     developmentMode: boolean;
 }
 
-interface OpenBrowserAdditionalOptions {
+interface OpenBrowserAdditionalOptions extends NativeAutomationSetupOptions {
     disableMultipleWindows: boolean;
-    nativeAutomation?: NativeAutomationSetupOptions;
+    nativeAutomation: boolean;
 }

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -398,9 +398,7 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     private get _nativeAutomation (): NativeAutomation {
-        const runtimeInfo = this.browserConnection.provider.plugin.openedBrowsers[this.browserConnection.id];
-
-        return runtimeInfo.nativeAutomation;
+        return this.browserConnection.getNativeAutomation();
     }
 
     private _getRoleProvider (): RoleProvider {

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -635,7 +635,7 @@ export default class TestRun extends AsyncEventEmitter {
             speed:                                                   this.speed,
             dialogHandler:                                           JSON.stringify(this.activeDialogHandler),
             canUseDefaultWindowActions:                              JSON.stringify(await this.browserConnection.canUseDefaultWindowActions()),
-            nativeAutomation:                                        JSON.stringify(this.isNativeAutomation),
+            nativeAutomation:                                        this.isNativeAutomation,
             domain:                                                  JSON.stringify(this.browserConnection.browserConnectionGateway.proxy.server1Info.domain),
         });
     }

--- a/src/test-run/request/create-request-options.ts
+++ b/src/test-run/request/create-request-options.ts
@@ -194,7 +194,7 @@ async function resolvePoxyUrlParts (testRun: TestRun, url: URL, withCredentials:
 }
 
 function resolveUrlParts (testRun: TestRun, url: URL, withCredentials: boolean): Promise<{ hostname: string; protocol: string; port: string; href: string; partAfterHost: string }> {
-    return testRun.isNativeAutomation() ? resolveNativeAutomationUrlParts(url) : resolvePoxyUrlParts(testRun, url, withCredentials);
+    return testRun.isNativeAutomation ? resolveNativeAutomationUrlParts(url) : resolvePoxyUrlParts(testRun, url, withCredentials);
 }
 
 export async function createRequestOptions (currentPageUrl: URL, testRun: TestRun, options: ExternalRequestOptions, callsite: CallsiteRecord | null): Promise<RequestOptions> {

--- a/src/test-run/session-controller.js
+++ b/src/test-run/session-controller.js
@@ -88,7 +88,7 @@ export default class SessionController extends Session {
                     disablePageCaching:   testRun.disablePageCaching,
                     allowMultipleWindows: TestRun.isMultipleWindowsAllowed(testRun),
                     requestTimeout:       testRun.requestTimeout,
-                    nativeAutomation:     testRun.opts.nativeAutomation,
+                    nativeAutomation:     testRun.isNativeAutomation,
                 };
 
                 if (options.allowMultipleWindows)

--- a/src/testcafe.js
+++ b/src/testcafe.js
@@ -98,7 +98,7 @@ export default class TestCafe {
 
         await this.initializeBrowserConnectionGateway();
 
-        const connection = new BrowserConnection(this.browserConnectionGateway, browserInfo, true);
+        const connection = new BrowserConnection(this.browserConnectionGateway, browserInfo, true, this.configuration.remoteBrowserConnectionOptions);
 
         connection.initialize();
 

--- a/src/testcafe.js
+++ b/src/testcafe.js
@@ -84,7 +84,7 @@ export default class TestCafe {
         return newRunner;
     }
 
-    async _initializeBrowserConnectionGateway () {
+    async initializeBrowserConnectionGateway () {
         await this.configuration.ensureHostname();
 
         if (this.browserConnectionGateway.status === BrowserConnectionGatewayStatus.uninitialized)
@@ -96,7 +96,7 @@ export default class TestCafe {
         // NOTE: 'remote' browser connection cannot be native automation.
         const browserInfo = await browserProviderPool.getBrowserInfo('remote');
 
-        await this._initializeBrowserConnectionGateway();
+        await this.initializeBrowserConnectionGateway();
 
         const connection = new BrowserConnection(this.browserConnectionGateway, browserInfo, true);
 

--- a/test/functional/fixtures/browser-provider/browser-reconnect/test.js
+++ b/test/functional/fixtures/browser-provider/browser-reconnect/test.js
@@ -6,6 +6,7 @@ const browserProviderPool = require('../../../../../lib/browser/provider/pool');
 const BrowserConnection   = require('../../../../../lib/browser/connection');
 const { createReporter }  = require('../../../utils/reporter');
 
+const setNativeAutomationForRemoteConnection = require('../../../utils/set-native-automation-for-remote-connection');
 
 let errors = null;
 
@@ -65,8 +66,12 @@ function run (pathToTest, filter, initializeConnection = initializeConnectionLow
             return connections;
         })
         .then(connection => {
-            return testCafe
-                .createRunner()
+            const runner = testCafe.createRunner();
+
+            if (config.nativeAutomation)
+                setNativeAutomationForRemoteConnection(runner);
+
+            return runner
                 .src(src)
                 .filter(testName => testName === filter)
                 .reporter(reporter)

--- a/test/functional/fixtures/native-automation/test.js
+++ b/test/functional/fixtures/native-automation/test.js
@@ -1,6 +1,5 @@
 const createTestCafe = require('../../../../lib');
 const path           = require('path');
-const { expect }     = require('chai');
 const config         = require('../../config.js');
 
 let testCafe = null;
@@ -41,21 +40,6 @@ if (thereAreAllRequiredBrowsers) {
 
         it('Enabled with the "nativeAutomation" option', function () {
             return runTest({ browsers: 'chrome', test: 'Enabled', nativeAutomation: true });
-        });
-
-        it('Should throw error on running with unsupported browser', function () {
-            let errorIsRaised = false;
-
-            return runTest({ browsers: ['chrome', 'firefox'], test: 'Disabled', nativeAutomation: true })
-                .catch(err => {
-                    errorIsRaised = true;
-
-                    expect(err.message).eql('The following browser(s) do not support the Native Automation mode: "firefox".');
-                })
-                .then(() => {
-                    if (!errorIsRaised)
-                        throw new Error('Promise rejection expected');
-                });
         });
     });
 }

--- a/test/functional/fixtures/regression/gh-2546/test.js
+++ b/test/functional/fixtures/regression/gh-2546/test.js
@@ -4,6 +4,7 @@ const { exec }           = require('child_process');
 const config             = require('../../../config');
 const unhandledRejection = require('./unhandled-rejection');
 const semver             = require('semver');
+const runInCLI           = require('../../../utils/run-in-cli');
 
 if (config.useLocalBrowsers) {
     describe('[Regression](GH-2546)', function () {
@@ -50,36 +51,27 @@ if (config.useLocalBrowsers) {
             });
         }
 
-        it('Should fail on uncaught exception when skipUncaughtErrors is false', function () {
-            const testcafePath = path.resolve('bin/testcafe');
-            const testFilePath = path.resolve('test/functional/fixtures/regression/gh-2546/testcafe-fixtures/uncaughtException.js');
-            const browsers     = '"chrome:headless --no-sandbox"';
-            const command      = `node ${testcafePath} ${browsers} ${testFilePath}`;
-
-            return new Promise(resolve => {
-                exec(command, (error, stdout) => {
-                    resolve({ error, stdout });
+        describe('CLI', () => {
+            it('Should fail on uncaught exception when skipUncaughtErrors is false', async function () {
+                const result = await runInCLI({
+                    testFile: 'test/functional/fixtures/regression/gh-2546/testcafe-fixtures/uncaughtException.js',
+                    browsers: '"chrome:headless --no-sandbox"',
+                    args: ['--disable-native-automation'],
                 });
-            }).then(value => {
-                expect(value.stdout).contains('Uncaught exception');
-                expect(value.stdout).contains('unhandled');
-                expect(value.error).is.not.null;
+
+                expect(result.stdout).contains('Uncaught exception');
+                expect(result.stdout).contains('unhandled');
+                expect(result.error).is.not.null;
             });
-        });
 
-        it('Should not fail on uncaught promise rejection when skipUncaughtErrors is true', function () {
-            const testcafePath = path.resolve('bin/testcafe');
-            const testFilePath = path.resolve('test/functional/fixtures/regression/gh-2546/testcafe-fixtures/uncaughtException.js');
-            const browsers     = '"chrome:headless --no-sandbox"';
-            const args         = '--skip-uncaught-errors';
-            const command      = `node ${testcafePath} ${browsers} ${testFilePath} ${args}`;
-
-            return new Promise(resolve => {
-                exec(command, (error, stdout) => {
-                    resolve({ error, stdout });
+            it('Should not fail on uncaught promise rejection when skipUncaughtErrors is true', async function () {
+                const result = await runInCLI({
+                    testFile: 'test/functional/fixtures/regression/gh-2546/testcafe-fixtures/uncaughtException.js',
+                    browsers: '"chrome:headless --no-sandbox"',
+                    args: ['--skip-uncaught-errors', '--disable-native-automation'],
                 });
-            }).then(value => {
-                expect(value.error).is.null;
+
+                expect(result.error).is.null;
             });
         });
 

--- a/test/functional/fixtures/regression/gh-2546/test.js
+++ b/test/functional/fixtures/regression/gh-2546/test.js
@@ -56,7 +56,7 @@ if (config.useLocalBrowsers) {
                 const result = await runInCLI({
                     testFile: 'test/functional/fixtures/regression/gh-2546/testcafe-fixtures/uncaughtException.js',
                     browsers: '"chrome:headless --no-sandbox"',
-                    args: ['--disable-native-automation'],
+                    args:     ['--disable-native-automation'],
                 });
 
                 expect(result.stdout).contains('Uncaught exception');
@@ -68,7 +68,7 @@ if (config.useLocalBrowsers) {
                 const result = await runInCLI({
                     testFile: 'test/functional/fixtures/regression/gh-2546/testcafe-fixtures/uncaughtException.js',
                     browsers: '"chrome:headless --no-sandbox"',
-                    args: ['--skip-uncaught-errors', '--disable-native-automation'],
+                    args:     ['--skip-uncaught-errors', '--disable-native-automation'],
                 });
 
                 expect(result.error).is.null;

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -191,7 +191,7 @@ before(function () {
                 mocha.timeout(0);
 
             if (USE_PROVIDER_POOL) {
-                return testCafe._initializeBrowserConnectionGateway()
+                return testCafe.initializeBrowserConnectionGateway()
                     .then(() => {
                         if (config.nativeAutomation)
                             testCafe.browserConnectionGateway.switchToNativeAutomation();

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -192,9 +192,8 @@ before(function () {
             if (isBrowserStack || !USE_PROVIDER_POOL)
                 mocha.timeout(0);
 
-            if (USE_PROVIDER_POOL) {
+            if (USE_PROVIDER_POOL)
                 return testCafe.initializeBrowserConnectionGateway();
-            }
 
             return openRemoteBrowsers();
         })

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -13,6 +13,8 @@ const getTestError               = require('./get-test-error.js');
 const { createSimpleTestStream } = require('./utils/stream');
 const BrowserConnectionStatus    = require('../../lib/browser/connection/status');
 
+const setNativeAutomationForRemoteConnection = require('./utils/set-native-automation-for-remote-connection');
+
 let testCafe     = null;
 let browsersInfo = null;
 
@@ -191,11 +193,7 @@ before(function () {
                 mocha.timeout(0);
 
             if (USE_PROVIDER_POOL) {
-                return testCafe.initializeBrowserConnectionGateway()
-                    .then(() => {
-                        if (config.nativeAutomation)
-                            testCafe.browserConnectionGateway.switchToNativeAutomation();
-                    });
+                return testCafe.initializeBrowserConnectionGateway();
             }
 
             return openRemoteBrowsers();
@@ -288,6 +286,9 @@ before(function () {
                     runner.reporter(customReporters);
                 else
                     runner.reporter('json', stream);
+
+                if (config.nativeAutomation)
+                    setNativeAutomationForRemoteConnection(runner);
 
                 return runner
                     .useProxy(proxy, proxyBypass)

--- a/test/functional/utils/run-in-cli.js
+++ b/test/functional/utils/run-in-cli.js
@@ -1,0 +1,14 @@
+const path     = require('path');
+const { exec } = require('child_process');
+
+module.exports = function runInCLI ({ testFile, browsers, args = [] }) {
+    const testcafePath = path.resolve('bin/testcafe');
+    const testFilePath = path.resolve(testFile);
+    const command      = `node ${testcafePath} ${browsers} ${testFilePath} ${args.join(' ')}`;
+
+    return new Promise(resolve => {
+        exec(command, (error, stdout) => {
+            resolve({ error, stdout });
+        });
+    });
+};

--- a/test/functional/utils/set-native-automation-for-remote-connection.js
+++ b/test/functional/utils/set-native-automation-for-remote-connection.js
@@ -1,0 +1,6 @@
+module.exports = function setNativeAutomationForRemoteConnection (runner) {
+    // Hack: it's necessary to run remote browsers in the native automation mode.
+    runner.bootstrapper._calculateIsNativeAutomation = function () {
+        this.nativeAutomation = true;
+    };
+};

--- a/test/server/api-test.js
+++ b/test/server/api-test.js
@@ -1799,18 +1799,27 @@ describe('API', function () {
     });
 
     describe('createTestCafe', () => {
-        it('Should accept configuration as an arguments array', async () => {
+        function getMockedCreateTestCafe () {
             const TestCafe = sinon.stub().returns({});
 
             const createTestCafe = proxyquire('../..', {
                 './testcafe':      TestCafe,
                 'async-exit-hook': () => {},
 
-                'endpoint-utils': {
-                    isMyHostname: sinon.stub().resolves(true),
-                    isFreePort:   sinon.stub().resolves(true),
+                './configuration/utils': {
+                    getValidHostname: val => val,
+                    getValidPort:     val => val,
                 },
             });
+
+            return {
+                TestCafe,
+                createTestCafe,
+            };
+        }
+
+        it('Should accept configuration as an arguments array', async () => {
+            const { createTestCafe, TestCafe } = getMockedCreateTestCafe();
 
             await createTestCafe('my-host', 1337, 1338, { test: 42 }, true, true);
 
@@ -1826,17 +1835,7 @@ describe('API', function () {
         });
 
         it('Should accept configuration as an object', async () => {
-            const TestCafe = sinon.stub().returns({});
-
-            const createTestCafe = proxyquire('../..', {
-                './testcafe':      TestCafe,
-                'async-exit-hook': () => {},
-
-                'endpoint-utils': {
-                    isMyHostname: sinon.stub().resolves(true),
-                    isFreePort:   sinon.stub().resolves(true),
-                },
-            });
+            const { createTestCafe, TestCafe } = getMockedCreateTestCafe();
 
             await createTestCafe({
                 hostname: 'my-host',

--- a/test/server/capturer-test.js
+++ b/test/server/capturer-test.js
@@ -83,6 +83,9 @@ function createTestRunControllerMock (screenshots, warningLog) {
         _proxy: {
             setMode: noop,
         },
+        _opts: {
+            nativeAutomation: false,
+        },
     };
 }
 

--- a/test/server/capturer-test.js
+++ b/test/server/capturer-test.js
@@ -10,11 +10,24 @@ const {
     writePng,
     deleteFile,
     readPng,
-}               = require('../../lib/utils/promisified-functions');
-const WarningLog                 = require('../../lib/notifications/warning-log');
+} = require('../../lib/utils/promisified-functions');
+
+const WarningLog = require('../../lib/notifications/warning-log');
 
 
 const filePath = resolve(process.cwd(), `temp${nanoid(7)}`, 'temp.png');
+
+const EMPTY_PROVIDER = {
+    takeScreenshot: () => noop,
+};
+
+const BROWSER_INFO = {
+    parsedUserAgent: {
+        os: {
+            name: 'os-name',
+        },
+    },
+};
 
 class CapturerMock extends Capturer {
     constructor (provider) {
@@ -47,16 +60,37 @@ class ScreenshotsMock extends Screenshots {
     }
 }
 
-const emptyProvider = {
-    takeScreenshot: () => {
-    },
-};
+function createScreenshotsMock () {
+    return new ScreenshotsMock({
+        enabled:     true,
+        path:        process.cwd(),
+        pathPattern: '',
+        fullPage:    false,
+    });
+}
+
+function createTestRunControllerMock (screenshots, warningLog) {
+    return {
+        _screenshots: screenshots,
+        test:         { fixture: {}, clientScripts: [] },
+        emit:         noop,
+        _warningLog:  warningLog,
+        _testRunCtor: function ({ browserConnection }) {
+            this.id                = 'test-run-id';
+            this.browserConnection = browserConnection;
+            this.initialize        = noop;
+        },
+        _proxy: {
+            setMode: noop,
+        },
+    };
+}
 
 describe('Capturer', () => {
     it('Taking screenshots does not create a directory if provider does not', async () => {
         let errCode = null;
 
-        const capturer = new CapturerMock(emptyProvider);
+        const capturer = new CapturerMock(EMPTY_PROVIDER);
 
         await capturer._takeScreenshot({ filePath });
 
@@ -71,34 +105,13 @@ describe('Capturer', () => {
     });
 
     it('Screenshot properties for reporter', async () => {
-        const screenshots = new ScreenshotsMock({
-            enabled:     true,
-            path:        process.cwd(),
-            pathPattern: '',
-            fullPage:    false,
-        });
-
-        const testRunControllerMock = {
-            _screenshots: screenshots,
-            test:         { fixture: {} },
-            emit:         noop,
-            _testRunCtor: function ({ browserConnection }) {
-                this.id                = 'test-run-id';
-                this.browserConnection = browserConnection;
-                this.initialize        = noop;
-            },
-        };
+        const screenshots           = createScreenshotsMock();
+        const testRunControllerMock = createTestRunControllerMock(screenshots);
 
         await TestRunController.prototype._createTestRun.call(testRunControllerMock, {
             id:          'browser-connection-id',
-            provider:    emptyProvider,
-            browserInfo: {
-                parsedUserAgent: {
-                    os: {
-                        name: 'os-name',
-                    },
-                },
-            },
+            provider:    EMPTY_PROVIDER,
+            browserInfo: BROWSER_INFO,
         });
 
         await screenshots.capturer._capture(false, {
@@ -119,15 +132,9 @@ describe('Capturer', () => {
     });
 
     it('Should not delete screenshot if unable to locate the page area', async () => {
-        const warningLog = new WarningLog();
-        const customPath = `${nanoid(7)}screenshot.png`;
-
-        const screenshots = new ScreenshotsMock({
-            enabled:     true,
-            path:        process.cwd(),
-            pathPattern: '',
-            fullPage:    false,
-        });
+        const warningLog  = new WarningLog();
+        const customPath  = `${nanoid(7)}screenshot.png`;
+        const screenshots = createScreenshotsMock();
 
         const providerMock = {
             takeScreenshot: async (_, path) => {
@@ -138,30 +145,14 @@ describe('Capturer', () => {
             },
         };
 
-        const testRunControllerMock = {
-            _screenshots: screenshots,
-            test:         { fixture: {} },
-            emit:         noop,
-            _warningLog:  warningLog,
-            _testRunCtor: function ({ browserConnection }) {
-                this.id                = 'test-run-id';
-                this.browserConnection = browserConnection;
-                this.initialize        = noop;
-            },
-        };
+        const testRunControllerMock = createTestRunControllerMock(screenshots, warningLog);
 
         await screenshots._onMessageBusStart();
 
         await TestRunController.prototype._createTestRun.call(testRunControllerMock, {
             id:          'browser-connection-id',
             provider:    providerMock,
-            browserInfo: {
-                parsedUserAgent: {
-                    os: {
-                        name: 'os-name',
-                    },
-                },
-            },
+            browserInfo: BROWSER_INFO,
         });
 
         await screenshots.capturer._capture(false, {

--- a/test/server/cli-remote-wizard-test.js
+++ b/test/server/cli-remote-wizard-test.js
@@ -3,6 +3,7 @@ const { expect }             = require('chai');
 const proxyquire             = require('proxyquire');
 const sinon                  = require('sinon');
 const { constructor: Chalk } = require('chalk');
+const { noop }               = require('lodash');
 
 
 describe('[CLI] Remote wizard', () => {
@@ -17,6 +18,8 @@ describe('[CLI] Remote wizard', () => {
             browserConnectionGateway: {
                 connectUrl: 'http://example.com',
             },
+
+            initializeBrowserConnectionGateway: noop,
 
             createBrowserConnection: () => {
                 const connection = new EventEmitter();

--- a/test/server/error-handle-test.js
+++ b/test/server/error-handle-test.js
@@ -16,8 +16,6 @@ class TaskMock extends AsyncEventEmitter {
 
         this.opts = {};
     }
-
-    unRegisterClientScriptRouting () {}
 }
 
 class RunnerMock extends Runner {

--- a/test/server/helpers/mocks.js
+++ b/test/server/helpers/mocks.js
@@ -30,6 +30,7 @@ class BrowserSetMock extends EventEmitter {
 const configurationMock = {
     getOption:         noop,
     calculateHostname: noop,
+    mergeOptions:      noop,
 
     startOptions: {
         hostname: 'localhost',

--- a/test/server/multiple-windows-test.js
+++ b/test/server/multiple-windows-test.js
@@ -46,7 +46,7 @@ describe('Multiple windows', () => {
         const testRun        = new TestRunMock();
         const testController = new TestController(testRun);
 
-        testRun.opts.nativeAutomation = true;
+        testRun.isNativeAutomation = true;
 
         try {
             await testController.openWindow('http://example.com');

--- a/test/server/test-run-controller-test.js
+++ b/test/server/test-run-controller-test.js
@@ -1,0 +1,38 @@
+const { expect }        = require('chai');
+const { noop }          = require('lodash');
+const TestRunController = require('../../lib/runner/test-run-controller');
+
+describe('TestRunController', () => {
+    it('Should raise an error on start in nativeAutomation mode with browser without its support', async () => {
+        const testMock = {
+            isNativeAutomation: true,
+        };
+
+        const browserConnectionMock = {
+            provider: {
+                supportNativeAutomation: () => false,
+            },
+            browserInfo: {
+                providerName: 'testBrowser',
+            },
+        };
+
+        const messageBusMock = {
+            emit: noop,
+        };
+
+        const testRunController = new TestRunController({
+            test:       testMock,
+            opts:       {},
+            messageBus: messageBusMock,
+        });
+
+        try {
+            await testRunController.start(browserConnectionMock);
+        }
+        catch (err) {
+            expect(err.message).to.equal('The "testBrowser" do not support the Native Automation mode. Use the "disable native automation" option to use the legacy run mode');
+        }
+
+    });
+});

--- a/test/server/test-run-controller-test.js
+++ b/test/server/test-run-controller-test.js
@@ -9,9 +9,8 @@ describe('TestRunController', () => {
         };
 
         const browserConnectionMock = {
-            provider: {
-                supportNativeAutomation: () => false,
-            },
+            supportNativeAutomation: () => false,
+
             browserInfo: {
                 providerName: 'testBrowser',
             },
@@ -23,16 +22,17 @@ describe('TestRunController', () => {
 
         const testRunController = new TestRunController({
             test:       testMock,
-            opts:       {},
             messageBus: messageBusMock,
+            opts:       {
+                nativeAutomation: true,
+            },
         });
 
         try {
             await testRunController.start(browserConnectionMock);
         }
         catch (err) {
-            expect(err.message).to.equal('The "testBrowser" do not support the Native Automation mode. Use the "disable native automation" option to use the legacy run mode');
+            expect(err.message).to.equal('The "testBrowser" do not support the Native Automation mode. Remove the "native automation" option to continue.');
         }
-
     });
 });


### PR DESCRIPTION
Changes:
* register/unregister custom client scripts on each test run
* remove the `nativeAutomation` option for the `BrowserConnectionGateway` class
* add the `BrowserConnection.supportNativeAutomation` and `BrowserConnection.getNativeAutomation` methods 
* rewrite an additional argument passing for the `provider.openBrowser` method
* calculate the `isNativeAutomation` before `testRun` creation
* small refactorings