### PR TITLE
FIPS compliance (#5864)

### DIFF
--- a/src/custom-client-scripts/client-script.ts
+++ b/src/custom-client-scripts/client-script.ts
@@ -111,7 +111,7 @@ export default class ClientScript {
     }
 
     private _calculateHash (): void {
-        this.hash = createHash('md5').update(this.content).digest();
+        this.hash = createHash('sha256').update(this.content).digest();
     }
 
     private _contentToString (): string {


### PR DESCRIPTION
FIPS doesn't allow for MD5, so replace it with SHA256.

<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Replaces MD5 usage with SHA256, in order to be FIPS/StateRAMP-compliant.

## Approach
See the Purpose section.

## References
https://github.com/DevExpress/testcafe/issues/5864

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
