### PR TITLE
fix: adjust typing of `SkipJsErrorsCallback`

### DIFF
--- a/src/configuration/interfaces.ts
+++ b/src/configuration/interfaces.ts
@@ -18,7 +18,7 @@ export interface SkipJsErrorsOptionsObject {
     pageUrl?: string | RegExp;
 }
 
-export type SkipJsErrorsCallback = (opts?: { message: string; stack: string; pageUrl: string }) => boolean;
+export type SkipJsErrorsCallback = (opts?: { message?: string; stack: string; pageUrl: string }) => boolean;
 
 export interface SkipJsErrorsCallbackWithOptionsObject {
     fn: SkipJsErrorsCallback;

--- a/ts-defs-src/test-api/skip-js-errors-options.d.ts
+++ b/ts-defs-src/test-api/skip-js-errors-options.d.ts
@@ -1,7 +1,7 @@
 // SkipJsErrors API
 //----------------------------------------------------------------------------------------------------------------------
 
-type SkipJsErrorsCallback = (opts?: {message: string; stack: string; pageUrl: string }) => boolean;
+type SkipJsErrorsCallback = (opts?: {message?: string; stack: string; pageUrl: string }) => boolean;
 
 interface SkipJsErrorsCallbackWithOptionsObject {
     fn: SkipJsErrorsCallback;


### PR DESCRIPTION
When a non-`Error` exception is thrown in the client, the object received by the `skipJsErrors` callback will not contain the `message` field. Adjust the typings to reflect this.

Closes issue #7627