### PR TITLE
fix docker server tests

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -27,7 +27,6 @@ const { exitDomains, enterDomains } = require('./gulp/helpers/domain');
 const getTimeout                    = require('./gulp/helpers/get-timeout');
 const promisifyStream               = require('./gulp/helpers/promisify-stream');
 const testFunctional                = require('./gulp/helpers/test-functional');
-const testClient                    = require('./gulp/helpers/test-client');
 const moduleExportsTransform        = require('./gulp/helpers/module-exports-transform');
 const createPackageFilesForTests    = require('./gulp/helpers/create-package-files-for-tests');
 
@@ -39,15 +38,6 @@ const {
     DEBUG_GLOB_2,
     HEADED_CHROME_FIREFOX_TESTS_GLOB,
 } = require('./gulp/constants/functional-test-globs');
-
-const {
-    CLIENT_TESTS_SETTINGS,
-    CLIENT_TESTS_LOCAL_SETTINGS,
-    CLIENT_TESTS_LEGACY_SETTINGS,
-    CLIENT_TESTS_SAUCELABS_SETTINGS,
-    CLIENT_TESTS_DESKTOP_BROWSERS,
-    CLIENT_TESTS_MOBILE_BROWSERS,
-} = require('./gulp/constants/client-test-settings');
 
 const readFile = promisify(fs.readFile);
 
@@ -304,24 +294,42 @@ gulp.step('test-server-bootstrap', gulp.series('prepare-tests', 'test-server-run
 gulp.task('test-server', gulp.parallel('check-licenses', 'test-server-bootstrap'));
 
 gulp.step('test-client-run', () => {
+    const testClient                = require('./gulp/helpers/test-client');
+    const { CLIENT_TESTS_SETTINGS } = require('./gulp/constants/client-test-settings');
+
     return testClient('test/client/fixtures/**/*-test.js', CLIENT_TESTS_SETTINGS);
 });
 
 gulp.task('test-client', gulp.series('prepare-tests', 'test-client-run'));
 
 gulp.step('test-client-local-run', () => {
+    const testClient                      = require('./gulp/helpers/test-client');
+    const { CLIENT_TESTS_LOCAL_SETTINGS } = require('./gulp/constants/client-test-settings');
+
     return testClient('test/client/fixtures/**/*-test.js', CLIENT_TESTS_LOCAL_SETTINGS, {}, true);
 });
 
 gulp.task('test-client-local', gulp.series('prepare-tests', 'test-client-local-run'));
 
 gulp.step('test-client-legacy-run', () => {
+    const testClient                       = require('./gulp/helpers/test-client');
+    const { CLIENT_TESTS_LEGACY_SETTINGS } = require('./gulp/constants/client-test-settings');
+
     return testClient('test/client/legacy-fixtures/**/*-test.js', CLIENT_TESTS_LEGACY_SETTINGS);
 });
 
 gulp.task('test-client-legacy', gulp.series('prepare-tests', 'test-client-legacy-run'));
 
 gulp.step('test-client-travis-run', () => {
+    const testClient = require('./gulp/helpers/test-client');
+
+    const {
+        CLIENT_TESTS_SETTINGS,
+        CLIENT_TESTS_SAUCELABS_SETTINGS,
+        CLIENT_TESTS_DESKTOP_BROWSERS,
+    } = require('./gulp/constants/client-test-settings');
+
+
     const saucelabsSettings = CLIENT_TESTS_SAUCELABS_SETTINGS;
 
     saucelabsSettings.browsers = CLIENT_TESTS_DESKTOP_BROWSERS;
@@ -332,6 +340,15 @@ gulp.step('test-client-travis-run', () => {
 gulp.task('test-client-travis', gulp.series('prepare-tests', 'test-client-travis-run'));
 
 gulp.step('test-client-travis-mobile-run', () => {
+    const testClient = require('./gulp/helpers/test-client');
+
+    const {
+        CLIENT_TESTS_SETTINGS,
+        CLIENT_TESTS_SAUCELABS_SETTINGS,
+        CLIENT_TESTS_MOBILE_BROWSERS,
+    } = require('./gulp/constants/client-test-settings');
+
+
     const saucelabsSettings = CLIENT_TESTS_SAUCELABS_SETTINGS;
 
     saucelabsSettings.browsers = CLIENT_TESTS_MOBILE_BROWSERS;
@@ -342,6 +359,14 @@ gulp.step('test-client-travis-mobile-run', () => {
 gulp.task('test-client-travis-mobile', gulp.series('prepare-tests', 'test-client-travis-mobile-run'));
 
 gulp.step('test-client-legacy-travis-run', () => {
+    const testClient = require('./gulp/helpers/test-client');
+
+    const {
+        CLIENT_TESTS_LEGACY_SETTINGS,
+        CLIENT_TESTS_SAUCELABS_SETTINGS,
+        CLIENT_TESTS_DESKTOP_BROWSERS,
+    } = require('./gulp/constants/client-test-settings');
+
     const saucelabsSettings = CLIENT_TESTS_SAUCELABS_SETTINGS;
 
     saucelabsSettings.browsers = CLIENT_TESTS_DESKTOP_BROWSERS;
@@ -352,6 +377,14 @@ gulp.step('test-client-legacy-travis-run', () => {
 gulp.task('test-client-legacy-travis', gulp.series('prepare-tests', 'test-client-legacy-travis-run'));
 
 gulp.step('test-client-legacy-travis-mobile-run', () => {
+    const testClient = require('./gulp/helpers/test-client');
+
+    const {
+        CLIENT_TESTS_LEGACY_SETTINGS,
+        CLIENT_TESTS_SAUCELABS_SETTINGS,
+        CLIENT_TESTS_MOBILE_BROWSERS,
+    } = require('./gulp/constants/client-test-settings');
+
     const saucelabsSettings = CLIENT_TESTS_SAUCELABS_SETTINGS;
 
     saucelabsSettings.browsers = CLIENT_TESTS_MOBILE_BROWSERS;

--- a/test/docker/Dockerfile
+++ b/test/docker/Dockerfile
@@ -2,7 +2,10 @@ ARG tag
 FROM testcafe/testcafe:$tag
 
 USER root
-COPY . /usr/lib/node_modules/testcafe
-RUN cd /usr/lib/node_modules/testcafe && npm install --only=dev && \
-    node node_modules/gulp/bin/gulp.js --steps-as-tasks --gulpfile Gulpfile.js test-server-run
-USER user
+WORKDIR /usr/local/lib/node_modules/testcafe
+COPY ./ ./
+# NOTE: testcafe-browser-provider-browserstack -> sharp module failed to install on the Alpine Linux 18.x
+# https://github.com/lovell/sharp/issues/3641
+RUN node -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("./package.json", "utf-8")); delete pkg.devDependencies["testcafe-browser-provider-browserstack"]; fs.writeFileSync("./package.json", JSON.stringify(pkg), "utf-8");'
+RUN npm install
+RUN npx gulp --steps-as-tasks --gulpfile Gulpfile.js test-server-run

--- a/test/server/live-test.js
+++ b/test/server/live-test.js
@@ -20,7 +20,7 @@ const testFileWithSkippedTestPath              = path.resolve('test/server/data/
 const externalModulePath         = path.resolve('test/server/data/test-suites/live/module.js');
 const externalCommonJsModulePath = path.resolve('test/server/data/test-suites/live/commonjs-module.js');
 
-const DOCKER_TESTCAFE_FOLDER_REGEXP = /^\/usr\/lib\/node_modules\/testcafe/;
+const DOCKER_TESTCAFE_FOLDER_REGEXP = /^\/usr\/local\/lib\/node_modules\/testcafe/;
 
 
 class FileWatcherMock extends FileWatcher {


### PR DESCRIPTION
Changes:
* rewrite `Gulpfile.js` and `test/docker/Dockerfile` files to avoid the https://github.com/lovell/sharp/issues/3641 issue.
* fix server tests on docker.