### PR TITLE
fix: quarantine and skipJsErrors CLI option value cannot be set to false(closes #7077)

### DIFF
--- a/src/cli/argument-parser/index.ts
+++ b/src/cli/argument-parser/index.ts
@@ -38,6 +38,7 @@ import { parsePortNumber, parseList } from './parse-utils';
 import COMMAND_NAMES from './command-names';
 import { SendReportState } from '../../dashboard/interfaces';
 import { SKIP_JS_ERRORS_OPTIONS_OBJECT_OPTION_NAMES } from '../../configuration/skip-js-errors-option-names';
+import convertToBestFitType from '../../utils/convert-to-best-fit-type';
 
 const REMOTE_ALIAS_RE = /^remote(?::(\d*))?$/;
 
@@ -344,7 +345,7 @@ export default class CLIArgumentParser {
     }
 
     private async _parseQuarantineOptions (): Promise<void> {
-        if (this.opts.quarantineMode)
+        if (this.opts.quarantineMode !== void 0)
             this.opts.quarantineMode = await getQuarantineOptions('--quarantine-mode', this.opts.quarantineMode);
     }
 
@@ -454,8 +455,10 @@ export default class CLIArgumentParser {
             el => optionNames.some(opt => el.startsWith(opt)));
 
         if (optionIndex > -1) {
-            const isNotLastOption       = optionIndex < argv.length - 1;
-            const shouldMoveOptionToEnd = isNotLastOption &&
+            const isNotLastOption        = optionIndex < argv.length - 1;
+            const isBooleanValueProvided = typeof convertToBestFitType(argv[optionIndex + 1]) === 'boolean';
+            const shouldMoveOptionToEnd  = isNotLastOption &&
+                !isBooleanValueProvided &&
                 !subOptionsNames.some(opt => argv[optionIndex + 1].startsWith(opt));
 
             if (shouldMoveOptionToEnd)

--- a/src/cli/argument-parser/index.ts
+++ b/src/cli/argument-parser/index.ts
@@ -350,7 +350,7 @@ export default class CLIArgumentParser {
     }
 
     private async _parseSkipJsErrorsOptions (): Promise<void> {
-        if (this.opts.skipJsErrors)
+        if (this.opts.skipJsErrors !== void 0)
             this.opts.skipJsErrors = await getSkipJsErrorsOptions('--skip-js-errors', this.opts.skipJsErrors);
     }
 

--- a/src/cli/argument-parser/index.ts
+++ b/src/cli/argument-parser/index.ts
@@ -38,7 +38,7 @@ import { parsePortNumber, parseList } from './parse-utils';
 import COMMAND_NAMES from './command-names';
 import { SendReportState } from '../../dashboard/interfaces';
 import { SKIP_JS_ERRORS_OPTIONS_OBJECT_OPTION_NAMES } from '../../configuration/skip-js-errors-option-names';
-import convertToBestFitType from '../../utils/convert-to-best-fit-type';
+import shouldMoveOptionToEnd from '../utils/should-move-option-to-end';
 
 const REMOTE_ALIAS_RE = /^remote(?::(\d*))?$/;
 
@@ -454,17 +454,8 @@ export default class CLIArgumentParser {
         const optionIndex = argv.findIndex(
             el => optionNames.some(opt => el.startsWith(opt)));
 
-        if (optionIndex > -1) {
-            const isNotLastOption        = optionIndex < argv.length - 1;
-            const possibleValue          = argv[optionIndex + 1];
-            const isBooleanValueProvided = typeof convertToBestFitType(possibleValue) === 'boolean';
-            const shouldMoveOptionToEnd  = isNotLastOption &&
-                !isBooleanValueProvided &&
-                !subOptionsNames.some(opt => possibleValue.startsWith(opt));
-
-            if (shouldMoveOptionToEnd)
-                argv.push(argv.splice(optionIndex, 1)[0]);
-        }
+        if (optionIndex > -1 && shouldMoveOptionToEnd(argv, optionIndex, subOptionsNames))
+            argv.push(argv.splice(optionIndex, 1)[0]);
     }
 
     public async parse (argv: string[]): Promise<void> {

--- a/src/cli/argument-parser/index.ts
+++ b/src/cli/argument-parser/index.ts
@@ -456,10 +456,11 @@ export default class CLIArgumentParser {
 
         if (optionIndex > -1) {
             const isNotLastOption        = optionIndex < argv.length - 1;
-            const isBooleanValueProvided = typeof convertToBestFitType(argv[optionIndex + 1]) === 'boolean';
+            const possibleValue          = argv[optionIndex + 1];
+            const isBooleanValueProvided = typeof convertToBestFitType(possibleValue) === 'boolean';
             const shouldMoveOptionToEnd  = isNotLastOption &&
                 !isBooleanValueProvided &&
-                !subOptionsNames.some(opt => argv[optionIndex + 1].startsWith(opt));
+                !subOptionsNames.some(opt => possibleValue.startsWith(opt));
 
             if (shouldMoveOptionToEnd)
                 argv.push(argv.splice(optionIndex, 1)[0]);

--- a/src/cli/utils/should-move-option-to-end.ts
+++ b/src/cli/utils/should-move-option-to-end.ts
@@ -1,0 +1,11 @@
+import convertToBestFitType from '../../utils/convert-to-best-fit-type';
+
+export default function shouldMoveOptionToEnd (argv: string[], optionIndex: number, subOptionsNames: string[]): boolean {
+    const isNotLastOption        = optionIndex < argv.length - 1;
+    const possibleValue          = argv[optionIndex + 1];
+    const isBooleanValueProvided = typeof convertToBestFitType(possibleValue) === 'boolean';
+
+    return isNotLastOption &&
+        !isBooleanValueProvided &&
+        !subOptionsNames.some(opt => possibleValue.startsWith(opt));
+}

--- a/src/utils/get-options/boolean-or-object-option.ts
+++ b/src/utils/get-options/boolean-or-object-option.ts
@@ -1,0 +1,19 @@
+import baseGetOptions from './base';
+import convertToBestFitType from '../convert-to-best-fit-type';
+import { Dictionary, GetOptionConfiguration } from '../../configuration/interfaces';
+
+type BooleanOrObjectOption<T> = boolean | Dictionary<T>
+type ValidationFunction<T> = (opts: Dictionary<T>) => void | Promise<void>;
+
+export async function getBooleanOrObjectOption<T> (optionName: string, options: boolean | string | Dictionary<any>, optionsConfig: GetOptionConfiguration, validator: ValidationFunction<T>): Promise<BooleanOrObjectOption<T>> {
+    options = convertToBestFitType(options);
+
+    if (typeof options === 'boolean')
+        return options;
+
+    const parsedOptions = await baseGetOptions(options as string, optionsConfig);
+
+    await validator(parsedOptions);
+
+    return parsedOptions;
+}

--- a/src/utils/get-options/quarantine.ts
+++ b/src/utils/get-options/quarantine.ts
@@ -4,6 +4,7 @@ import { RUNTIME_ERRORS } from '../../errors/types';
 import { GeneralError } from '../../errors/runtime';
 import { Dictionary } from '../../configuration/interfaces';
 import TestRunErrorFormattableAdapter from '../../errors/test-run/formattable-adapter';
+import convertToBestFitType from '../convert-to-best-fit-type';
 
 const DEFAULT_ATTEMPT_LIMIT = 5;
 const DEFAULT_THRESHOLD     = 3;
@@ -34,8 +35,10 @@ export function validateQuarantineOptions (options: Dictionary<string | number>)
 }
 
 export async function getQuarantineOptions (optionName: string, options: string | boolean | Dictionary<string | number>): Promise<Dictionary<number> | boolean> {
+    options = convertToBestFitType(options);
+
     if (typeof options === 'boolean')
-        return true;
+        return options;
 
     const parsedOptions = await baseGetOptions(options, {
         skipOptionValueTypeConversion: true,

--- a/src/utils/get-options/skip-js-errors.ts
+++ b/src/utils/get-options/skip-js-errors.ts
@@ -18,16 +18,16 @@ export function validateSkipJsErrorsOptionValue (options: boolean | Dictionary<u
     return void 0;
 }
 
-export async function getSkipJsErrorsOptions (optionName: string, options: string | boolean | Dictionary<string | RegExp>): Promise<Dictionary<RegExp | string> | boolean> {
-    const onOptionParsed = async (key: string, value: string | RegExp): Promise<string | RegExp> => {
+export async function getSkipJsErrorsOptions (optionName: string, options: string | boolean | Dictionary<string | RegExp>): Promise<Dictionary<string> | boolean> {
+    const onOptionParsed = async (key: string, value: string): Promise<string> => {
         if (!key || !value)
             throw new GeneralError(RUNTIME_ERRORS.optionValueIsNotValidKeyValue, optionName);
 
         return value;
     };
-    const validator = (opts: Dictionary<RegExp | string>): void => validateSkipJsErrorsOptionsObject(opts, GeneralError);
+    const validator = (opts: Dictionary<string>): void => validateSkipJsErrorsOptionsObject(opts, GeneralError);
 
-    return await getBooleanOrObjectOption<RegExp | string>(optionName, options, {
+    return await getBooleanOrObjectOption<string>(optionName, options, {
         onOptionParsed,
         skipOptionValueTypeConversion: true,
     }, validator);

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -1,11 +1,14 @@
-const { expect }        = require('chai');
-const path              = require('path');
-const fs                = require('fs');
-const tmp               = require('tmp');
-const { find }          = require('lodash');
-const CliArgumentParser = require('../../lib/cli/argument-parser');
-const { nanoid }        = require('nanoid');
-const runOptionNames    = require('../../lib/configuration/run-option-names');
+const { expect }                  = require('chai');
+const path                        = require('path');
+const fs                          = require('fs');
+const tmp                         = require('tmp');
+const { find }                    = require('lodash');
+const CliArgumentParser           = require('../../lib/cli/argument-parser');
+const { nanoid }                  = require('nanoid');
+const runOptionNames              = require('../../lib/configuration/run-option-names');
+const shouldMoveOptionToEnd       =  require('../../lib/cli/utils/should-move-option-to-end');
+const QUARANTINE_OPTION_NAMES     = require('../../lib/configuration/quarantine-option-names');
+const { SKIP_JS_ERRORS_OPTIONS_OBJECT_OPTION_NAMES } = require('../../lib/configuration/skip-js-errors-option-names');
 
 describe('CLI argument parser', function () {
     this.timeout(10000);
@@ -688,6 +691,22 @@ describe('CLI argument parser', function () {
         }
 
         await checkCliArgs('chrome -q false test.js -e false');
+    });
+
+    it('Should move booleanOrObject option to the end in no value provided', async () => {
+        const quarantineOptions   = Object.values(QUARANTINE_OPTION_NAMES);
+        const skipJsErrorsOptions = Object.values(SKIP_JS_ERRORS_OPTIONS_OBJECT_OPTION_NAMES);
+
+        function checkOption (args, optionName, subOptions) {
+            const optionIndex = args.indexOf(optionName);
+
+            return shouldMoveOptionToEnd(args, optionIndex, subOptions);
+        }
+
+        expect(checkOption(['-q', 'attemptLimit=5', 'chrome'], '-q', quarantineOptions)).eql(false);
+        expect(checkOption(['-e', 'message=test', 'chrome'], '-e', skipJsErrorsOptions)).eql(false);
+        expect(checkOption(['-q', 'chrome', 'test.js'], '-q', quarantineOptions)).eql(true);
+        expect(checkOption(['-e', 'chrome', 'test.js'], '-e', skipJsErrorsOptions)).eql(true);
     });
 
     describe('Quarantine Option', function () {

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -679,6 +679,17 @@ describe('CLI argument parser', function () {
             });
     });
 
+    it('Should parse bool false value for booleanOrObject options', async () => {
+        async function checkCliArgs (argsString) {
+            const parser = await parse(argsString);
+
+            expect(parser.opts.quarantineMode).equal(false);
+            expect(parser.opts.skipJsErrors).equal(false);
+        }
+
+        await checkCliArgs('chrome -q false test.js -e false');
+    });
+
     describe('Quarantine Option', function () {
         it('Should parse quarantine arguments', async () => {
             async function checkCliArgs (argsString) {
@@ -691,16 +702,6 @@ describe('CLI argument parser', function () {
 
             await checkCliArgs('-q attemptLimit=5,successThreshold=1');
             await checkCliArgs('--quarantine-mode attemptLimit=5,successThreshold=1');
-        });
-
-        it('Should parse bool false quarantine argument', async () => {
-            async function checkCliArgs (argsString) {
-                const parser = await parse(argsString);
-
-                expect(parser.opts.quarantineMode).equal(false);
-            }
-
-            await checkCliArgs('-q false chrome');
         });
 
         it('Should pass if only "successThreshold" is provided', async () => {

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -693,6 +693,16 @@ describe('CLI argument parser', function () {
             await checkCliArgs('--quarantine-mode attemptLimit=5,successThreshold=1');
         });
 
+        it('Should parse bool false quarantine argument', async () => {
+            async function checkCliArgs (argsString) {
+                const parser = await parse(argsString);
+
+                expect(parser.opts.quarantineMode).equal(false);
+            }
+
+            await checkCliArgs('-q false chrome');
+        });
+
         it('Should pass if only "successThreshold" is provided', async () => {
             async function checkCliArgs (argsString) {
                 const parser = await parse(argsString);


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
You cannot set the quarantine or skipJsErrors value to false via CLI. This should be allowed in order to have an ability to override the config file value

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
