### PR TITLE
test: Fix for electron or studio tests with native automation mode

### DIFF
--- a/src/browser/provider/built-in/dedicated/chrome/cdp-client/index.ts
+++ b/src/browser/provider/built-in/dedicated/chrome/cdp-client/index.ts
@@ -24,6 +24,8 @@ import ScreencastFrameEvent = Protocol.Page.ScreencastFrameEvent;
 const DEBUG_SCOPE = (id: string): string => `testcafe:browser:provider:built-in:chrome:browser-client:${id}`;
 const DOWNLOADS_DIR = path.join(os.homedir(), 'Downloads');
 
+const DEVTOOLS_REGEX = /^devtools:\/\/devtools/;
+
 const debugLog = debug('testcafe:browser:provider:built-in:dedicated:chrome');
 
 class ProtocolApiInfo {
@@ -76,7 +78,7 @@ export class BrowserClient {
     private async _getTabs (): Promise<remoteChrome.TargetInfo[]> {
         const tabs = await remoteChrome.List({ port: this._runtimeInfo.cdpPort });
 
-        return tabs.filter(t => t.type === 'page');
+        return tabs.filter(t => t.type === 'page' && !DEVTOOLS_REGEX.test(t.url));
     }
 
     private async _getActiveTab (): Promise<remoteChrome.TargetInfo> {
@@ -85,7 +87,7 @@ export class BrowserClient {
         if (this._runtimeInfo.activeWindowId)
             tabs = tabs.filter(t => t.title.includes(this._runtimeInfo.activeWindowId));
 
-        return tabs.filter(t => !t.url.includes('devtools'))[0];
+        return tabs[0];
     }
 
     private _checkDropOfPerformance (method: CheckedCDPMethod, elapsedTime: [number, number]): void {

--- a/src/browser/provider/built-in/dedicated/chrome/cdp-client/index.ts
+++ b/src/browser/provider/built-in/dedicated/chrome/cdp-client/index.ts
@@ -85,7 +85,7 @@ export class BrowserClient {
         if (this._runtimeInfo.activeWindowId)
             tabs = tabs.filter(t => t.title.includes(this._runtimeInfo.activeWindowId));
 
-        return tabs[0];
+        return tabs.filter(t => !t.url.includes('devtools'))[0];
     }
 
     private _checkDropOfPerformance (method: CheckedCDPMethod, elapsedTime: [number, number]): void {

--- a/src/browser/provider/built-in/dedicated/chrome/cdp-client/index.ts
+++ b/src/browser/provider/built-in/dedicated/chrome/cdp-client/index.ts
@@ -24,7 +24,7 @@ import ScreencastFrameEvent = Protocol.Page.ScreencastFrameEvent;
 const DEBUG_SCOPE = (id: string): string => `testcafe:browser:provider:built-in:chrome:browser-client:${id}`;
 const DOWNLOADS_DIR = path.join(os.homedir(), 'Downloads');
 
-const DEVTOOLS_REGEX = /^devtools:\/\/devtools/;
+const DEVTOOLS_TAB_URL_REGEX = /^devtools:\/\/devtools/;
 
 const debugLog = debug('testcafe:browser:provider:built-in:dedicated:chrome');
 
@@ -78,7 +78,7 @@ export class BrowserClient {
     private async _getTabs (): Promise<remoteChrome.TargetInfo[]> {
         const tabs = await remoteChrome.List({ port: this._runtimeInfo.cdpPort });
 
-        return tabs.filter(t => t.type === 'page' && !DEVTOOLS_REGEX.test(t.url));
+        return tabs.filter(t => t.type === 'page' && !DEVTOOLS_TAB_URL_REGEX.test(t.url));
     }
 
     private async _getActiveTab (): Promise<remoteChrome.TargetInfo> {

--- a/src/browser/provider/built-in/dedicated/chrome/index.js
+++ b/src/browser/provider/built-in/dedicated/chrome/index.js
@@ -65,6 +65,13 @@ export default {
         runtimeInfo.nativeAutomation = nativeAutomation;
     },
 
+    async _startChrome (runtimeInfo, pageUrl) {
+        if (runtimeInfo.isContainerized)
+            await startLocalChromeOnDocker(pageUrl, runtimeInfo);
+        else
+            await startLocalChrome(pageUrl, runtimeInfo);
+    },
+
     async openBrowser (browserId, pageUrl, config, additionalOptions) {
         const parsedPageUrl = parseUrl(pageUrl);
         const runtimeInfo   = await this._createRunTimeInfo(parsedPageUrl.hostname, config, additionalOptions.disableMultipleWindows);
@@ -78,11 +85,7 @@ export default {
         };
 
         //NOTE: A not-working tab is opened when the browser start in the docker so we should create a new tab.
-        if (runtimeInfo.isContainerized)
-            await startLocalChromeOnDocker(pageUrl, runtimeInfo);
-        else
-            await startLocalChrome(pageUrl, runtimeInfo);
-
+        await this._startChrome(runtimeInfo, pageUrl);
         await this.waitForConnectionReady(browserId);
 
         runtimeInfo.viewportSize      = await this.runInitScript(browserId, GET_WINDOW_DIMENSIONS_INFO_SCRIPT);


### PR DESCRIPTION
## Purpose
Fix a case when browser or electron window is opened with DevTools. Make it possible to inherit Chrome browser provider.

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
