### PR TITLE
fix: Native automation - Do not generate a char for hotkey combinations (closes #7680)

### DIFF
--- a/src/native-automation/client/event-descriptor.ts
+++ b/src/native-automation/client/event-descriptor.ts
@@ -2,12 +2,14 @@ import { EventType } from '../types';
 import { SimulatedKeyInfo } from './key-press/utils';
 import { KeyModifierValues } from './types';
 // @ts-ignore
-import { utils, eventSandbox, nativeMethods } from '../../client/core/deps/hammerhead';
+import hammerhead from '../../client/core/deps/hammerhead';
 import { calculateKeyModifiersValue, calculateMouseButtonValue } from './utils';
 import { AxisValuesData } from '../../client/core/utils/values/axis-values';
 import sendRequestToFrame from '../../client/core/utils/send-request-to-frame';
 import { findIframeByWindow } from '../../client/core/utils/dom';
 import { getBordersWidthFloat, getElementPaddingFloat } from '../../client/core/utils/style';
+
+const { utils, eventSandbox, nativeMethods } = hammerhead;
 
 const messageSandbox = eventSandbox.message;
 
@@ -76,7 +78,7 @@ export default class CDPEventDescriptor {
         if (options.isNewLine)
             return '\r';
 
-        if (options.keyProperty.length === 1 && CDPEventDescriptor._isNonCharKeyModifier(options.modifiers))
+        if (options.keyProperty.length === 1 && !CDPEventDescriptor._isNonCharKeyModifier(options.modifiers))
             return options.keyProperty;
 
         return '';

--- a/src/native-automation/client/event-descriptor.ts
+++ b/src/native-automation/client/event-descriptor.ts
@@ -1,5 +1,6 @@
 import { EventType } from '../types';
 import { SimulatedKeyInfo } from './key-press/utils';
+import { KeyModifierValues } from './types';
 // @ts-ignore
 import { utils, eventSandbox } from '../../client/core/deps/hammerhead';
 import { calculateKeyModifiersValue, calculateMouseButtonValue } from './utils';
@@ -69,7 +70,7 @@ export default class CDPEventDescriptor {
         if (options.isNewLine)
             return '\r';
 
-        if (options.keyProperty.length === 1)
+        if (options.keyProperty.length === 1 && ![KeyModifierValues.ctrl, KeyModifierValues.alt, KeyModifierValues.meta].includes(options.modifiers))
             return options.keyProperty;
 
         return '';

--- a/src/native-automation/client/event-descriptor.ts
+++ b/src/native-automation/client/event-descriptor.ts
@@ -2,7 +2,7 @@ import { EventType } from '../types';
 import { SimulatedKeyInfo } from './key-press/utils';
 import { KeyModifierValues } from './types';
 // @ts-ignore
-import { utils, eventSandbox } from '../../client/core/deps/hammerhead';
+import { utils, eventSandbox, nativeMethods } from '../../client/core/deps/hammerhead';
 import { calculateKeyModifiersValue, calculateMouseButtonValue } from './utils';
 import { AxisValuesData } from '../../client/core/utils/values/axis-values';
 import sendRequestToFrame from '../../client/core/utils/send-request-to-frame';
@@ -66,11 +66,17 @@ async function calculateIFrameTopLeftPoint (): Promise<AxisValuesData<number>> {
 }
 
 export default class CDPEventDescriptor {
+    private static _isNonCharKeyModifier (modifiers: number): boolean {
+        const nonCharModifiers = [KeyModifierValues.ctrl, KeyModifierValues.alt, KeyModifierValues.meta];
+
+        return nativeMethods.arrayIndexOf.call(nonCharModifiers, modifiers) > -1;
+    }
+
     private static _getKeyDownEventText (options: SimulatedKeyInfo): any {
         if (options.isNewLine)
             return '\r';
 
-        if (options.keyProperty.length === 1 && ![KeyModifierValues.ctrl, KeyModifierValues.alt, KeyModifierValues.meta].includes(options.modifiers))
+        if (options.keyProperty.length === 1 && CDPEventDescriptor._isNonCharKeyModifier(options.modifiers))
             return options.keyProperty;
 
         return '';

--- a/test/functional/fixtures/api/es-next/press-key/test.js
+++ b/test/functional/fixtures/api/es-next/press-key/test.js
@@ -56,5 +56,13 @@ describe('[API] t.pressKey', function () {
         it('Ctrl+a, delete', function () {
             return runTests('./testcafe-fixtures/press-various-keys-test.js', 'Ctrl+a, delete', { only: 'chrome' });
         });
+
+        it('Ctrl+s', function () {
+            return runTests('./testcafe-fixtures/press-various-keys-test.js', 'Ctrl+s', { only: 'chrome' });
+        });
+
+        it('Alt+s', function () {
+            return runTests('./testcafe-fixtures/press-various-keys-test.js', 'Alt+s', { only: 'chrome' });
+        });
     });
 });

--- a/test/functional/fixtures/api/es-next/press-key/test.js
+++ b/test/functional/fixtures/api/es-next/press-key/test.js
@@ -1,5 +1,7 @@
 const { expect } = require('chai');
 
+const { onlyInNativeAutomation } = require('../../../../utils/skip-in');
+
 describe('[API] t.pressKey', function () {
     it('Should press keys', function () {
         return runTests('./testcafe-fixtures/press-key-test.js', 'Press keys', { only: 'chrome' });
@@ -57,11 +59,11 @@ describe('[API] t.pressKey', function () {
             return runTests('./testcafe-fixtures/press-various-keys-test.js', 'Ctrl+a, delete', { only: 'chrome' });
         });
 
-        it('Ctrl+s', function () {
+        onlyInNativeAutomation('Ctrl+s', function () {
             return runTests('./testcafe-fixtures/press-various-keys-test.js', 'Ctrl+s', { only: 'chrome' });
         });
 
-        it('Alt+s', function () {
+        onlyInNativeAutomation('Alt+s', function () {
             return runTests('./testcafe-fixtures/press-various-keys-test.js', 'Alt+s', { only: 'chrome' });
         });
     });

--- a/test/functional/fixtures/api/es-next/press-key/testcafe-fixtures/press-various-keys-test.js
+++ b/test/functional/fixtures/api/es-next/press-key/testcafe-fixtures/press-various-keys-test.js
@@ -88,3 +88,19 @@ test('Ctrl+a, delete', async () => {
 
     await t.expect(getInputValue()).eql('');
 });
+
+test('Ctrl+s', async () => {
+    await checkPressedKeyCombination({
+        keyCombination:     'ctrl+s',
+        expectedInputValue: '',
+        expectedEventLog:   'keydown: Control; keydown: s; keyup: s; keyup: Control;',
+    });
+});
+
+test('Alt+s', async () => {
+    await checkPressedKeyCombination({
+        keyCombination:     'alt+s',
+        expectedInputValue: '',
+        expectedEventLog:   'keydown: Alt; keydown: s; keyup: s; keyup: Alt;',
+    });
+});


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
For example, the `await t.pressKey('Ctrl+s')` action produces the 's' char in the input field. This behavior is incorrect.

## Approach
Do not produce a char when a modified Ctrl or Alt is enabled.

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
