### PR TITLE
fix: Native Automation - Support modifier keys for the hover action (closes #7676)

### DIFF
--- a/src/client/automation/move.ts
+++ b/src/client/automation/move.ts
@@ -217,7 +217,7 @@ export default class MoveAutomation {
             const events: any[] = [];
 
             await mouseMoveStep(mouseMoveOptions, nativeMethods.dateNow, async currPosition => {
-                const moveEvent = await this.nativeAutomationInput?.createMouseMoveEvent(currPosition);
+                const moveEvent = await this.nativeAutomationInput?.createMouseMoveEvent(currPosition, this.modifiers);
 
                 events.push(moveEvent);
 

--- a/src/native-automation/client/input.ts
+++ b/src/native-automation/client/input.ts
@@ -3,6 +3,7 @@ import { AxisValuesData } from '../../client/core/utils/values/axis-values';
 import { SimulatedKeyInfo } from './key-press/utils';
 import { DispatchEventFn } from './types';
 import CDPEventDescriptor from './event-descriptor';
+import { Modifiers } from '../../test-run/commands/options';
 
 export default class NativeAutomationInput {
     private readonly _dispatchEventFn: DispatchEventFn;
@@ -41,12 +42,13 @@ export default class NativeAutomationInput {
         return this._dispatchEventFn.single(EventType.InsertText, { text });
     }
 
-    public async createMouseMoveEvent (currPosition: AxisValuesData<number>): Promise<any> {
+    public async createMouseMoveEvent (currPosition: AxisValuesData<number>, modifiers: Modifiers): Promise<any> {
         const options = await CDPEventDescriptor.createMouseEventOptions('mouseMoved', {
             options: {
                 clientX: currPosition.x,
                 clientY: currPosition.y,
                 button:  'none',
+                ...modifiers,
             },
         });
 

--- a/test/functional/fixtures/api/es-next/hover/pages/index.html
+++ b/test/functional/fixtures/api/es-next/hover/pages/index.html
@@ -63,7 +63,18 @@
     const content2    = document.getElementById('content2');
 
     function eventHandler (e) {
-        window.eventLog.push(e.type + ':' + e.target.id + ':' + e.currentTarget.id);
+        let modifiers = '';
+
+        if (e.altKey)
+            modifiers += ':alt';
+        if (e.ctrlKey)
+            modifiers += ':ctrl';
+        if (e.metaKey)
+            modifiers += ':meta';
+        if (e.shiftKey)
+            modifiers += ':shift';
+
+        window.eventLog.push(e.type + ':' + e.target.id + ':' + e.currentTarget.id + modifiers);
     }
 
     function listenElementEvents (element) {

--- a/test/functional/fixtures/api/es-next/hover/testcafe-fixtures/hover-test.js
+++ b/test/functional/fixtures/api/es-next/hover/testcafe-fixtures/hover-test.js
@@ -6,7 +6,7 @@ fixture `Hover`
 test('Hover over elements', async t => {
     await t
         .hover('#point')
-        .hover('#container', { offsetX: 150, offsetY: 50 })
+        .hover('#container', { offsetX: 150, offsetY: 50, modifiers: { alt: true, ctrl: true, meta: true, shift: true } })
         .hover('#content1')
         .hover('#content1', { offsetY: 55 })
         .hover('#content2')
@@ -15,8 +15,8 @@ test('Hover over elements', async t => {
 
     const eventsLog   = (await t.eval(() => window.eventLog)).join(',');
     const expectedLog = [
-        'mouseover:container:container',
-        'mouseenter:container:container',
+        'mouseover:container:container:alt:ctrl:meta:shift',
+        'mouseenter:container:container:alt:ctrl:meta:shift',
         'mouseout:container:container',
         'mouseover:content1:content1',
         'mouseover:content1:child1',


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
The CDP 'mouseMoved' event does not have the "modifiers" option.

## Approach
Add the 'modifiers' property to the 'mouseMoved' event.

## References
https://github.com/DevExpress/testcafe/issues/7676

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
