### PR TITLE
fix 'Incorrect browser alias is displayed while running Edge in headless mode' (close #7647)

### DIFF
--- a/src/utils/parse-user-agent.ts
+++ b/src/utils/parse-user-agent.ts
@@ -6,6 +6,11 @@ const DEFAULT_VERSION         = '0.0';
 const DEFAULT_PLATFORM_TYPE   = DEFAULT_NAME.toLowerCase();
 const EMPTY_PARSED_USER_AGENT = Bowser.parse(' ');
 
+const HEADLESS_EDGE = {
+    regExp:      /HeadlessEdg/i,
+    browserName: 'Microsoft Edge',
+};
+
 interface ParsedComponent {
     name: string;
     version: string;
@@ -52,12 +57,27 @@ function calculateEngine (engineDetails: Bowser.Parser.EngineDetails): ParsedCom
     };
 }
 
+function calculateParsedUserAgent (userAgent: string): Bowser.Parser.ParsedResult {
+    if (!userAgent)
+        return EMPTY_PARSED_USER_AGENT;
+
+    // The 'bowser' module incorrectly determine the headless edge browser.
+    // Since this module is abandoned, we are forced to fix it in our side.
+    const isHeadlessEdge  = HEADLESS_EDGE.regExp.test(userAgent);
+    const parsedUserAgent = Bowser.parse(userAgent);
+
+    if (isHeadlessEdge)
+        parsedUserAgent.browser.name = HEADLESS_EDGE.browserName;
+
+    return parsedUserAgent;
+}
+
 export function calculatePrettyUserAgent (browser: ParsedComponent, os: ParsedComponent): string {
     return `${browser.name} ${browser.version} / ${os.name} ${os.version}`;
 }
 
 export function parseUserAgent (userAgent = '', osInfo?: OSInfo): ParsedUserAgent {
-    const parsedUserAgent = userAgent ? Bowser.parse(userAgent) : EMPTY_PARSED_USER_AGENT;
+    const parsedUserAgent = calculateParsedUserAgent(userAgent);
     const browser         = calculateBrowser(parsedUserAgent.browser);
     const os              = osInfo || calculateOs(parsedUserAgent.os);
     const engine          = calculateEngine(parsedUserAgent.engine);

--- a/src/utils/parse-user-agent.ts
+++ b/src/utils/parse-user-agent.ts
@@ -62,7 +62,7 @@ function calculateParsedUserAgent (userAgent: string): Bowser.Parser.ParsedResul
         return EMPTY_PARSED_USER_AGENT;
 
     // The 'bowser' module incorrectly determine the headless edge browser.
-    // Since this module is abandoned, we are forced to fix it in our side.
+    // Since this module is abandoned, we are forced to fix it on our side.
     const isHeadlessEdge  = HEADLESS_EDGE.regExp.test(userAgent);
     const parsedUserAgent = Bowser.parse(userAgent);
 

--- a/test/server/util-test.js
+++ b/test/server/util-test.js
@@ -133,6 +133,18 @@ describe('Utils', () => {
                     userAgent:       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.130 Electron/7.1.7 Safari/537.36',
                 },
             },
+            {
+                sourceUA: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/113.0.1774.42 Safari/537.36 HeadlessEdg/113.0.1774.42',
+                expected: {
+                    'engine':          { 'name': 'Blink', 'version': '0.0' },
+                    'name':            'Microsoft Edge',
+                    'os':              { 'name': 'Windows', 'version': '10' },
+                    'platform':        'desktop',
+                    'prettyUserAgent': 'Microsoft Edge 113.0.1774.42 / Windows 10',
+                    'userAgent':       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/113.0.1774.42 Safari/537.36 HeadlessEdg/113.0.1774.42',
+                    'version':         '113.0.1774.42',
+                },
+            },
         ];
 
         testCases.forEach(testCase => {


### PR DESCRIPTION
Closes #7647