### PR TITLE
fix: TestCafe Studio recorder stops working after a request hook is added

### DIFF
--- a/src/test-run/commands/utils.js
+++ b/src/test-run/commands/utils.js
@@ -86,5 +86,7 @@ export function isExecutableOnClientCommand (command) {
            command.type !== TYPE.useRole &&
            command.type !== TYPE.assertion &&
            command.type !== TYPE.executeExpression &&
-           command.type !== TYPE.executeAsyncExpression;
+           command.type !== TYPE.executeAsyncExpression &&
+           command.type !== TYPE.addRequestHooks &&
+           command.type !== TYPE.removeRequestHooks;
 }

--- a/test/server/helpers/base-test-run-mock.js
+++ b/test/server/helpers/base-test-run-mock.js
@@ -22,7 +22,9 @@ const TestRun = proxyquire('../../../lib/test-run/index', {
 class BaseTestRunMock extends TestRun {
     constructor (init = {}) {
         init = Object.assign({
-            test:               {},
+            test: {
+                requestHooks: [],
+            },
             browserConnection:  {},
             screenshotCapturer: {},
             globalWarningLog:   {},
@@ -35,6 +37,10 @@ class BaseTestRunMock extends TestRun {
     _addInjectables () {}
 
     _initRequestHooks () {}
+
+    _initRequestHook () {}
+
+    _disposeRequestHook () {}
 
     get id () {
         return 'id';

--- a/test/server/test-run-driver-task-queue-test.js
+++ b/test/server/test-run-driver-task-queue-test.js
@@ -25,7 +25,7 @@ class TestRunMock extends BaseTestRunMock {
     }
 }
 
-class MockRequestHook extends RequestHook {
+class EmptyRequestHook extends RequestHook {
     onRequest () {}
 
     onResponse () {}
@@ -123,7 +123,7 @@ describe('Driver task queue', () => {
     });
 
     it('Should return real queue length after hooks commands are added', async () => {
-        const hook = new MockRequestHook();
+        const hook = new EmptyRequestHook();
 
         const commandExecutionPromises = [
             testRunMock.executeCommand(new AddRequestHooksCommand({ hooks: [ hook ] })),


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
The t.addRequestHooks action crashes the TestCafe Studio recorder.

## Approach
Specify that the addRequestHooks command should be executed only on the server side. This will make the recorder work.

## References
https://github.com/DevExpress/testcafe-studio/issues/4350

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
