### PR TITLE
fix: keyPress with space doesn't change the checkbox state(closes #6969)

### DIFF
--- a/src/client/automation/playback/press/key-press-simulator.js
+++ b/src/client/automation/playback/press/key-press-simulator.js
@@ -145,7 +145,7 @@ export default class KeyPressSimulator {
 
 
         // NOTE: in some browsers we should emulate click on active input element while pressing "space" key
-        const emulateClick = !browserUtils.isFirefox && !browserUtils.isSafari &&
+        const emulateClick = !browserUtils.isSafari &&
                            (!browserUtils.isChrome || browserUtils.version >= 53);
 
         if (emulateClick && raiseDefault && this.sanitizedKey === 'space' &&

--- a/test/functional/fixtures/regression/gh-6969/pages/index.html
+++ b/test/functional/fixtures/regression/gh-6969/pages/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<input id="checkbox" type="checkbox">
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-6969/test.js
+++ b/test/functional/fixtures/regression/gh-6969/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-6969)', () => {
+    it('Should change checkbox checked state when pressing space key', () => {
+        return runTests('./testcafe-fixtures/index.js', 'Should change checkbox checked state when pressing space key');
+    });
+});

--- a/test/functional/fixtures/regression/gh-6969/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-6969/testcafe-fixtures/index.js
@@ -1,0 +1,15 @@
+import { Selector } from 'testcafe';
+
+fixture`Getting Started`
+    .page`http://localhost:3000/fixtures/regression/gh-6969/pages/index.html`;
+
+test('Should change checkbox checked state when pressing space key', async t => {
+    const checkBox = Selector('#checkbox');
+
+    await t.click(checkBox)
+        .expect(checkBox.checked).ok()
+        .pressKey('space')
+        .expect(checkBox.checked).notOk()
+        .pressKey('space')
+        .expect(checkBox.checked).ok();
+});


### PR DESCRIPTION
## Purpose
#6969 

We emulate the click event in some browsers on space pressing. Previously we didn't emulate it in Firefox. Now, we need to emulate it for Firefox as well.   

## Approach
emulate click

## References
#6969 

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
