### PR TITLE
native automation: run by default (#7677)

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "callsite-record": "^4.0.0",
     "chai": "4.3.4",
     "chalk": "^2.3.0",
-    "chrome-remote-interface": "^0.32.1",
+    "chrome-remote-interface": "^0.32.2",
     "coffeescript": "^2.3.1",
     "commander": "^8.3.0",
     "debug": "^4.3.1",

--- a/src/browser/connection/gateway/index.ts
+++ b/src/browser/connection/gateway/index.ts
@@ -97,6 +97,7 @@ export default class BrowserConnectionGateway extends EventEmitter {
         proxy.GET(SERVICE_ROUTES.assets.index, { content: idlePageScript, contentType: 'application/x-javascript' });
         proxy.GET(SERVICE_ROUTES.assets.styles, { content: idlePageStyle, contentType: 'text/css' });
         proxy.GET(SERVICE_ROUTES.assets.logo, { content: idlePageLogo, contentType: 'image/svg+xml' });
+
         proxy.GET(NATIVE_AUTOMATION_ERROR_ROUTE, (req: IncomingMessage, res: ServerResponse) => {
             res.writeHead(200, { 'Content-Type': 'text/html' });
             res.end(EMPTY_PAGE_MARKUP);
@@ -350,10 +351,6 @@ export default class BrowserConnectionGateway extends EventEmitter {
         this._status    = BrowserConnectionGatewayStatus.initialized;
 
         this.emit('initialized');
-    }
-
-    public switchToNativeAutomation (): void {
-        this.proxy.switchToNativeAutomation();
     }
 }
 

--- a/src/cli/argument-parser/index.ts
+++ b/src/cli/argument-parser/index.ts
@@ -164,7 +164,7 @@ export default class CLIArgumentParser {
             .option('--test-meta <key=value[,key2=value2,...]>', 'filter tests by metadata')
             .option('--fixture-meta <key=value[,key2=value2,...]>', 'filter fixtures by metadata')
             .option('--debug-on-fail', 'pause tests on failure')
-            .option('--native-automation', 'enable native automation')
+            .option('--disable-native-automation', 'disable native automation')
             .option('--app-init-delay <ms>', 'specify your application`s initialization time')
             .option('--selector-timeout <ms>', 'specify the maximum Selector resolution time')
             .option('--assertion-timeout <ms>', 'specify the maximum Assertion resolution time')

--- a/src/cli/remotes-wizard.ts
+++ b/src/cli/remotes-wizard.ts
@@ -6,11 +6,13 @@ import dedent from 'dedent';
 
 import BrowserConnection from '../browser/connection';
 import BrowserConnectionGateway from '../browser/connection/gateway';
+import TestCafeConfiguration from '../configuration/testcafe-configuration';
 
 interface TestCafe {
     browserConnectionGateway: BrowserConnectionGateway;
     createBrowserConnection(): Promise<BrowserConnection>;
     initializeBrowserConnectionGateway(): Promise<void>;
+    configuration: TestCafeConfiguration;
 }
 
 export default async function (testCafe: TestCafe, remoteCount: number, showQRCode: boolean): Promise<BrowserConnection[]> {
@@ -28,6 +30,9 @@ export default async function (testCafe: TestCafe, remoteCount: number, showQRCo
 
         if (showQRCode)
             log.write('You can either enter the URL or scan the QR-code.');
+
+        // NOTE: 'remote' browser connection cannot be in the 'native automation' mode.
+        testCafe.configuration.mergeOptions({ disableNativeAutomation: true });
 
         await testCafe.initializeBrowserConnectionGateway();
 

--- a/src/configuration/default-values.ts
+++ b/src/configuration/default-values.ts
@@ -15,13 +15,13 @@ export const DEFAULT_CONCURRENCY_VALUE = 1;
 
 export const DEFAULT_SOURCE_DIRECTORIES = ['tests', 'test'];
 
-export const DEFAULT_DEVELOPMENT_MODE      = false;
-export const DEFAULT_RETRY_TEST_PAGES      = false;
-export const DEFAULT_DISABLE_HTTP2         = false;
-export const DEFAULT_NATIVE_AUTOMATION     = false;
-export const DEFAULT_SCREENSHOT_THUMBNAILS = true;
-export const DEFAULT_FILTER_FN             = null;
-export const DEFAULT_DISABLE_CROSS_DOMAIN  = false;
+export const DEFAULT_DEVELOPMENT_MODE          = false;
+export const DEFAULT_RETRY_TEST_PAGES          = false;
+export const DEFAULT_DISABLE_HTTP2             = false;
+export const DEFAULT_DISABLE_NATIVE_AUTOMATION = false;
+export const DEFAULT_SCREENSHOT_THUMBNAILS     = true;
+export const DEFAULT_FILTER_FN                 = null;
+export const DEFAULT_DISABLE_CROSS_DOMAIN     = false;
 
 export const DEFAULT_TYPESCRIPT_COMPILER_OPTIONS: Dictionary<boolean | number> = {
     experimentalDecorators:  true,

--- a/src/configuration/option-names.ts
+++ b/src/configuration/option-names.ts
@@ -44,7 +44,7 @@ enum OptionNames {
     debugLogger = 'debugLogger',
     disableMultipleWindows = 'disableMultipleWindows',
     disableHttp2 = 'disableHttp2',
-    nativeAutomation = 'nativeAutomation',
+    disableNativeAutomation = 'disableNativeAutomation',
     compilerOptions = 'compilerOptions',
     pageRequestTimeout = 'pageRequestTimeout',
     ajaxRequestTimeout = 'ajaxRequestTimeout',

--- a/src/configuration/run-option-names.ts
+++ b/src/configuration/run-option-names.ts
@@ -21,6 +21,6 @@ export default [
     OPTION_NAMES.pageRequestTimeout,
     OPTION_NAMES.ajaxRequestTimeout,
     OPTION_NAMES.retryTestPages,
-    OPTION_NAMES.nativeAutomation,
+    OPTION_NAMES.disableNativeAutomation,
     OPTION_NAMES.baseUrl,
 ];

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -16,7 +16,7 @@ import {
     DEFAULT_DISABLE_CROSS_DOMAIN,
     DEFAULT_DISABLE_HTTP2,
     DEFAULT_FILTER_FN,
-    DEFAULT_NATIVE_AUTOMATION,
+    DEFAULT_DISABLE_NATIVE_AUTOMATION,
     DEFAULT_RETRY_TEST_PAGES,
     DEFAULT_SCREENSHOT_THUMBNAILS,
     DEFAULT_SOURCE_DIRECTORIES,
@@ -67,7 +67,7 @@ const OPTION_INIT_FLAG_NAMES = [
     OPTION_NAMES.retryTestPages,
     OPTION_NAMES.cache,
     OPTION_NAMES.disableHttp2,
-    OPTION_NAMES.nativeAutomation,
+    OPTION_NAMES.disableNativeAutomation,
     OPTION_NAMES.disableCrossDomain,
 ];
 
@@ -162,7 +162,7 @@ export default class TestCafeConfiguration extends Configuration {
             cache:              this.getOption(OPTION_NAMES.cache),
             disableHttp2:       this.getOption(OPTION_NAMES.disableHttp2),
             disableCrossDomain: this.getOption(OPTION_NAMES.disableCrossDomain),
-            nativeAutomation:   this.getOption(OPTION_NAMES.nativeAutomation),
+            nativeAutomation:   !this.getOption(OPTION_NAMES.disableNativeAutomation),
         };
     }
 
@@ -278,7 +278,7 @@ export default class TestCafeConfiguration extends Configuration {
         this._ensureOptionWithValue(OPTION_NAMES.developmentMode, DEFAULT_DEVELOPMENT_MODE, OptionSource.Configuration);
         this._ensureOptionWithValue(OPTION_NAMES.retryTestPages, DEFAULT_RETRY_TEST_PAGES, OptionSource.Configuration);
         this._ensureOptionWithValue(OPTION_NAMES.disableHttp2, DEFAULT_DISABLE_HTTP2, OptionSource.Configuration);
-        this._ensureOptionWithValue(OPTION_NAMES.nativeAutomation, DEFAULT_NATIVE_AUTOMATION, OptionSource.Configuration);
+        this._ensureOptionWithValue(OPTION_NAMES.disableNativeAutomation, DEFAULT_DISABLE_NATIVE_AUTOMATION, OptionSource.Configuration);
         this._ensureOptionWithValue(OPTION_NAMES.disableCrossDomain, DEFAULT_DISABLE_CROSS_DOMAIN, OptionSource.Configuration);
 
         this._ensureScreenshotOptions();

--- a/src/errors/runtime/templates.js
+++ b/src/errors/runtime/templates.js
@@ -143,5 +143,5 @@ export default {
     [RUNTIME_ERRORS.invalidCustomActionsOptionType]:                 `The value of the customActions option does not belong to type Object. Refer to the following article for custom action setup instructions: ${ DOCUMENTATION_LINKS.CUSTOM_ACTIONS }`,
     [RUNTIME_ERRORS.invalidCustomActionType]:                        `TestCafe cannot parse the "{actionName}" action, because the action definition is invalid. Format the definition in accordance with the custom actions guide: ${ DOCUMENTATION_LINKS.CUSTOM_ACTIONS }`,
     [RUNTIME_ERRORS.cannotImportESMInCommonsJS]:                     'Cannot import the {esModule} ECMAScript module from {targetFile}. Use a dynamic import() statement or enable the --esm CLI flag.',
-    [RUNTIME_ERRORS.setNativeAutomationForUnsupportedBrowsers]:      'The "{browser}" do not support the Native Automation mode. Remove the "native automation" option to continue.',
+    [RUNTIME_ERRORS.setNativeAutomationForUnsupportedBrowsers]:      'The "{browser}" do not support the Native Automation mode. Use the "disable native automation" option to continue.',
 };

--- a/src/errors/test-run/templates.js
+++ b/src/errors/test-run/templates.js
@@ -407,7 +407,7 @@ export default {
     `,
 
     [TEST_RUN_ERRORS.multipleWindowsModeIsNotSupportedInNativeAutomationError]: () => `
-        The Native Automation mode does not support the use of multiple browser windows. Remove the "native automation" option to continue.
+        The Native Automation mode does not support the use of multiple browser windows. Use the "disable native automation" option to continue.
     `,
 
     [TEST_RUN_ERRORS.cannotCloseWindowWithoutParent]: () => `

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import exportableLib from './api/exportable-lib';
 import TestCafeConfiguration from './configuration/testcafe-configuration';
 import OPTION_NAMES from './configuration/option-names';
 import userVariables from './api/user-variables';
-import { getValidHostname, getValidPort } from './configuration/utils';
+import { getValidPort } from './configuration/utils';
 
 const lazyRequire   = require('import-lazy')(require);
 const TestCafe      = lazyRequire('./testcafe');
@@ -45,8 +45,7 @@ async function getConfiguration (args) {
 async function createTestCafe (...args) {
     const configuration = await getConfiguration(args);
 
-    const [hostname, port1, port2] = await Promise.all([
-        getValidHostname(configuration.getOption(OPTION_NAMES.hostname)),
+    const [port1, port2] = await Promise.all([
         getValidPort(configuration.getOption(OPTION_NAMES.port1)),
         getValidPort(configuration.getOption(OPTION_NAMES.port2)),
     ]);
@@ -56,7 +55,7 @@ async function createTestCafe (...args) {
     if (userVariablesOption)
         userVariables.value = userVariablesOption;
 
-    configuration.mergeOptions({ hostname, port1, port2 });
+    configuration.mergeOptions({ port1, port2 });
 
     const testcafe = new TestCafe(configuration);
 

--- a/src/native-automation/index.ts
+++ b/src/native-automation/index.ts
@@ -40,12 +40,14 @@ export default class NativeAutomation {
     }
 
     public async start (): Promise<void> {
+        nativeAutomationLogger('starting');
+
         for (const apiSystem of this.apiSystems)
             await apiSystem.start();
 
         this._addEventListeners();
 
-        nativeAutomationLogger('nativeAutomation initialized');
+        nativeAutomationLogger('started');
     }
 
     public async dispose (): Promise<void> {

--- a/src/runner/bootstrapper.ts
+++ b/src/runner/bootstrapper.ts
@@ -92,7 +92,6 @@ export default class Bootstrapper {
     public tsConfigPath?: string;
     public clientScripts: ClientScriptInit[];
     public disableMultipleWindows: boolean;
-    public nativeAutomation: boolean;
     public compilerOptions?: CompilerOptions;
     public browserInitTimeout?: number;
     public hooks?: GlobalHooks;
@@ -115,7 +114,6 @@ export default class Bootstrapper {
         this.tsConfigPath             = void 0;
         this.clientScripts            = [];
         this.disableMultipleWindows   = false;
-        this.nativeAutomation         = false;
         this.compilerOptions          = void 0;
         this.debugLogger              = debug(DEBUG_SCOPE);
         this.warningLog               = new WarningLog(null, WarningLog.createAddWarningCallback(messageBus));
@@ -154,7 +152,7 @@ export default class Bootstrapper {
             const options = {
                 disableMultipleWindows: this.disableMultipleWindows,
                 developmentMode:        this.configuration.getOption(OPTION_NAMES.developmentMode) as boolean,
-                nativeAutomation:       this.nativeAutomation,
+                nativeAutomation:       !this.configuration.getOption(OPTION_NAMES.disableNativeAutomation),
             };
 
             const connection = new BrowserConnection(this.browserConnectionGateway, { ...browser }, false, options, this.messageBus);
@@ -174,22 +172,23 @@ export default class Bootstrapper {
     }
 
     private async _setupProxy (): Promise<void> {
-        if (this.browserConnectionGateway.status === BrowserConnectionGatewayStatus.uninitialized) {
-            await this.configuration.calculateHostname({ nativeAutomation: this.nativeAutomation });
+        if (this.browserConnectionGateway.status === BrowserConnectionGatewayStatus.initialized)
+            return;
 
-            this.browserConnectionGateway.initialize(this.configuration.startOptions);
-        }
+        await this.configuration.calculateHostname({ nativeAutomation: !this.configuration.getOption(OPTION_NAMES.disableNativeAutomation) });
 
-        if (this.nativeAutomation)
-            this.browserConnectionGateway.switchToNativeAutomation();
+        this.browserConnectionGateway.initialize(this.configuration.startOptions);
     }
 
-    private _calculateIsNativeAutomation (remotes: BrowserConnection[]): void {
-        // If there are remote connections, we should switch to legacy run mode.
-        if (remotes.length)
-            this.configuration.mergeOptions({ nativeAutomation: false });
+    private _hasNotSupportedBrowserInNativeAutomation (browserInfos: BrowserInfo[]): boolean {
+        return browserInfos.some(browserInfo => {
+            return !browserInfo.provider.supportNativeAutomation();
+        });
+    }
 
-        this.nativeAutomation = !!this.configuration.getOption(OPTION_NAMES.nativeAutomation);
+    private _disableNativeAutomationIfNecessary (remotes: BrowserConnection[], automated: BrowserInfo[]): void {
+        if (remotes.length || this._hasNotSupportedBrowserInNativeAutomation(automated))
+            this.configuration.mergeOptions({ disableNativeAutomation: true });
     }
 
     private async _getBrowserConnections (browserInfo: BrowserInfoSource[]): Promise<BrowserSet> {
@@ -198,7 +197,7 @@ export default class Bootstrapper {
         if (remotes && remotes.length % this.concurrency)
             throw new GeneralError(RUNTIME_ERRORS.cannotDivideRemotesCountByConcurrency);
 
-        this._calculateIsNativeAutomation(remotes);
+        this._disableNativeAutomationIfNecessary(remotes, automated);
 
         await this._setupProxy();
 

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -15,13 +15,11 @@ import { Quarantine } from '../utils/get-options/quarantine';
 import MessageBus from '../utils/message-bus';
 import TestRunHookController from './test-run-hook-controller';
 import * as clientScriptsRouting from '../custom-client-scripts/routing';
-import debug from 'debug';
 import { RUNTIME_ERRORS } from '../errors/types';
 import { GeneralError } from '../errors/runtime';
+import { testRunControllerLogger } from '../utils/debug-loggers';
 
 const DISCONNECT_THRESHOLD = 3;
-
-const debugLogger = debug('testcafe:runner:test-run-controller');
 
 export default class TestRunController extends AsyncEventEmitter {
     private readonly _quarantine: null | Quarantine;
@@ -187,7 +185,7 @@ export default class TestRunController extends AsyncEventEmitter {
 
         await this.emit('test-run-done');
 
-        debugLogger('done');
+        testRunControllerLogger('done');
     }
 
     private async _emitTestRunStart (): Promise<void> {
@@ -239,7 +237,7 @@ export default class TestRunController extends AsyncEventEmitter {
     }
 
     private async _handleNativeAutomationMode (connection: BrowserConnection): Promise<void> {
-        this.isNativeAutomation = !!this._opts.nativeAutomation;
+        this.isNativeAutomation = !this._opts.disableNativeAutomation;
 
         const supportNativeAutomation = connection.supportNativeAutomation();
 
@@ -252,7 +250,7 @@ export default class TestRunController extends AsyncEventEmitter {
     }
 
     public async start (connection: BrowserConnection, startRunExecutionTime?: Date): Promise<string | null> {
-        debugLogger('start');
+        testRunControllerLogger('start');
 
         await this._handleNativeAutomationMode(connection);
 

--- a/src/testcafe.js
+++ b/src/testcafe.js
@@ -85,8 +85,10 @@ export default class TestCafe {
 
     // API
     async createBrowserConnection () {
-        // NOTE: 'remote' browser connection cannot be native automation.
         const browserInfo = await browserProviderPool.getBrowserInfo('remote');
+
+        // NOTE: 'remote' browser connection cannot be in the 'native automation' mode.
+        this.configuration.mergeOptions({ disableNativeAutomation: true });
 
         await this.initializeBrowserConnectionGateway();
 

--- a/src/utils/debug-loggers.ts
+++ b/src/utils/debug-loggers.ts
@@ -17,6 +17,10 @@ const browserLogger               = testcafeLogger.extend('browser');
 const browserProviderLogger       = browserLogger.extend('provider');
 const chromeBrowserProviderLogger = browserProviderLogger.extend('chrome');
 
+const runnerLogger = testcafeLogger.extend('runner');
+
+const testRunControllerLogger = runnerLogger.extend('test-run-controller');
+
 export {
     nativeAutomationLogger,
     requestPipelineLogger,
@@ -28,4 +32,5 @@ export {
     requestPipelineServiceRequestLogger,
     requestPipelineOtherRequestLogger,
     requestPipelineContextLogger,
+    testRunControllerLogger,
 };

--- a/test/functional/fixtures/api/es-next/global-hooks/test.js
+++ b/test/functional/fixtures/api/es-next/global-hooks/test.js
@@ -20,7 +20,7 @@ const runTestsLocal = (testName) => {
         .filter(test => {
             return testName ? test === testName : true;
         })
-        .run({ nativeAutomation: config.nativeAutomation })
+        .run({ disableNativeAutomation: !config.nativeAutomation })
         .then(failedCount => {
             const taskReport = JSON.parse(stream.data);
             const testReport = taskReport.fixtures.length === 1 ?

--- a/test/functional/fixtures/browser-provider/browser-reconnect/run-log-error-on-disconnect-test.js
+++ b/test/functional/fixtures/browser-provider/browser-reconnect/run-log-error-on-disconnect-test.js
@@ -24,7 +24,7 @@ createTestCafe()
                 return testName === 'Should log error on browser disconnect';
             })
             .reporter(shouldAttachReporter ? reporter : [])
-            .run({ nativeAutomation: config.nativeAutomation });
+            .run({ disableNativeAutomation: !config.nativeAutomation });
     })
     .catch(function () {
         return testcafe.close();

--- a/test/functional/fixtures/browser-provider/browser-reconnect/test.js
+++ b/test/functional/fixtures/browser-provider/browser-reconnect/test.js
@@ -76,7 +76,7 @@ function run (pathToTest, filter, initializeConnection = initializeConnectionLow
                 .filter(testName => testName === filter)
                 .reporter(reporter)
                 .browsers(connection)
-                .run({ nativeAutomation: config.nativeAutomation });
+                .run({ disableNativeAutomation: !config.nativeAutomation });
         });
 }
 

--- a/test/functional/fixtures/browser-provider/chrome-emulation/test.js
+++ b/test/functional/fixtures/browser-provider/chrome-emulation/test.js
@@ -20,7 +20,7 @@ if (config.useLocalBrowsers && config.hasBrowser('chrome')) {
                     .filter(fixtureName => fixtureName === 'Check presence of touch event handlers')
                     .reporter('minimal', createNullStream())
                     .browsers(browserAlias)
-                    .run({ nativeAutomation: config.nativeAutomation });
+                    .run({ disableNativeAutomation: !config.nativeAutomation });
 
                 expect(failedCount).eql(0);
             }
@@ -50,7 +50,7 @@ if (config.useLocalBrowsers && config.hasBrowser('chrome')) {
                 .src(path.join(__dirname, './testcafe-fixtures/index-test.js'))
                 .reporter(reporter)
                 .browsers('chrome:headless:emulation:device=iphone X --no-sandbox')
-                .run({ nativeAutomation: config.nativeAutomation });
+                .run({ disableNativeAutomation: !config.nativeAutomation });
 
             expect(prettyUserAgents.length).eql(1);
             expect(prettyUserAgents[0]).endsWith('(Emulating iPhone X)');

--- a/test/functional/fixtures/browser-provider/custom-profile/test.js
+++ b/test/functional/fixtures/browser-provider/custom-profile/test.js
@@ -15,7 +15,7 @@ if (config.useLocalBrowsers && !config.useHeadlessBrowsers && !config.hasBrowser
                 .src(path.join(__dirname, './testcafe-fixtures/index-test.js'))
                 .reporter('minimal', createNullStream())
                 .browsers('chrome:userProfile', 'firefox:userProfile')
-                .run({ nativeAutomation: config.nativeAutomation })
+                .run({ disableNativeAutomation: !config.nativeAutomation })
                 .then(failedCount => {
                     expect(failedCount).eql(0);
                 });
@@ -30,7 +30,7 @@ if (config.useLocalBrowsers && !config.useHeadlessBrowsers && !config.hasBrowser
                         .src(path.join(__dirname, './testcafe-fixtures/index-test.js'))
                         .reporter('minimal', createNullStream())
                         .browsers(`chrome --user-data-dir=${chromeProfile.name}`, `firefox -profile ${firefoxProfile.name}`)
-                        .run({ nativeAutomation: config.nativeAutomation });
+                        .run({ disableNativeAutomation: !config.nativeAutomation });
                 })
                 .then(failedCount => {
                     expect(failedCount).eql(0);

--- a/test/functional/fixtures/browser-provider/job-reporting/test.js
+++ b/test/functional/fixtures/browser-provider/job-reporting/test.js
@@ -78,7 +78,7 @@ if (config.useLocalBrowsers && !config.hasBrowser('ie')) {
                     end:   noop,
                 })
                 .browsers(browsers)
-                .run({ nativeAutomation: config.nativeAutomation });
+                .run({ disableNativeAutomation: !config.nativeAutomation });
         }
 
         before(function () {

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -42,7 +42,7 @@ if (config.useLocalBrowsers) {
                 })
                 .browsers(browsers)
                 .concurrency(concurrency)
-                .run({ nativeAutomation: config.nativeAutomation });
+                .run({ disableNativeAutomation: !config.nativeAutomation });
         }
 
         function createConnections (count) {

--- a/test/functional/fixtures/live/test.js
+++ b/test/functional/fixtures/live/test.js
@@ -94,7 +94,7 @@ if (config.useLocalBrowsers) {
                         }, 1000);
                     });
 
-                    return runner.run({ nativeAutomation: config.nativeAutomation });
+                    return runner.run({ disableNativeAutomation: !config.nativeAutomation });
                 })
                 .then(() => {
                     expect(helper.counter).eql(config.browsers.length * helper.testCount * runCount);
@@ -115,8 +115,8 @@ if (config.useLocalBrowsers) {
                     });
 
                     return runner.run({
-                        quarantineMode:   true,
-                        nativeAutomation: config.nativeAutomation,
+                        quarantineMode:          true,
+                        disableNativeAutomation: !config.nativeAutomation,
                     });
                 })
                 .then(() => {
@@ -143,7 +143,7 @@ if (config.useLocalBrowsers) {
                         }, 1000);
                     });
 
-                    return runner.run({ nativeAutomation: config.nativeAutomation });
+                    return runner.run({ disableNativeAutomation: !config.nativeAutomation });
                 })
                 .then(() => {
                     return cafe.close();
@@ -172,7 +172,7 @@ if (config.useLocalBrowsers) {
                                 return runner
                                     .browsers(config.browsers.map(browserInfo => browserInfo.browserName))
                                     .src(path.join(__dirname, '/testcafe-fixtures/test-2.js'))
-                                    .run({ nativeAutomation: config.nativeAutomation })
+                                    .run({ disableNativeAutomation: !config.nativeAutomation })
                                     .then(() => {
                                         return cafe.close();
                                     })
@@ -183,7 +183,7 @@ if (config.useLocalBrowsers) {
                     }, 10000);
 
                     return runner
-                        .run({ nativeAutomation: config.nativeAutomation });
+                        .run({ disableNativeAutomation: !config.nativeAutomation });
                 });
 
             return promise;
@@ -232,7 +232,7 @@ if (config.useLocalBrowsers) {
             });
 
             return runner
-                .run({ nativeAutomation: config.nativeAutomation })
+                .run({ disableNativeAutomation: !config.nativeAutomation })
                 .then(() => {
                     return cafe.close();
                 });
@@ -250,7 +250,7 @@ if (config.useLocalBrowsers) {
                 }, 1000);
             });
 
-            await runner.run({ nativeAutomation: config.nativeAutomation });
+            await runner.run({ disableNativeAutomation: !config.nativeAutomation });
 
             return cafe.close();
         });

--- a/test/functional/fixtures/multiple-windows/test.js
+++ b/test/functional/fixtures/multiple-windows/test.js
@@ -49,7 +49,7 @@ describe('Multiple windows', () => {
         });
     });
 
-    describe('Cookie synchonization', () => {
+    describe('Cookie synchronization', () => {
         it('cross-domain', () => {
             return runTests('testcafe-fixtures/cookie-synchronization/cross-domain.js', null, { only: 'chrome' });
         });
@@ -81,7 +81,7 @@ describe('Multiple windows', () => {
                 return testCafeInstance.createRunner()
                     .browsers(`chrome:headless`)
                     .src(fullTestPath)
-                    .run();
+                    .run({ disableNativeAutomation: true });
             })
             .then(() => {
                 return testCafeInstance.close();
@@ -352,7 +352,7 @@ describe('Multiple windows', () => {
                         .createRunner()
                         .src(path.join(__dirname, './testcafe-fixtures/features/emulation.js'))
                         .browsers('chrome:emulation:device=iphone X')
-                        .run();
+                        .run({ disableNativeAutomation: true });
                 })
                 .then(failedCount => {
                     expect(failedCount).eql(0);
@@ -374,7 +374,7 @@ describe('Multiple windows', () => {
                         .src(path.join(__dirname, './testcafe-fixtures/api/api-test.js'))
                         .filter(testName => testName === 'Resize multiple windows')
                         .browsers(browser)
-                        .run();
+                        .run({ disableNativeAutomation: true });
                 })
                 .then(failedCount => {
                     expect(failedCount).eql(0);

--- a/test/functional/fixtures/regression/gh-2546/test.js
+++ b/test/functional/fixtures/regression/gh-2546/test.js
@@ -1,6 +1,4 @@
-const path               = require('path');
 const { expect }         = require('chai');
-const { exec }           = require('child_process');
 const config             = require('../../../config');
 const unhandledRejection = require('./unhandled-rejection');
 const semver             = require('semver');
@@ -73,22 +71,17 @@ if (config.useLocalBrowsers) {
 
                 expect(result.error).is.null;
             });
-        });
 
-        it('Should handle errors in the exception handler', () => {
-            const testcafePath = path.resolve('bin/testcafe');
-            const testFilePath = path.resolve('test/functional/fixtures/regression/gh-2546/testcafe-fixtures/uncaughtExceptionInHandler.js');
-            const browsers     = '"chrome:headless --no-sandbox"';
-            const command      = `node ${testcafePath} ${browsers} ${testFilePath}`;
-
-            return new Promise(resolve => {
-                exec(command, (error, stdout) => {
-                    resolve({ error, stdout });
+            it('Should handle errors in the exception handler', async () => {
+                const result = await runInCLI({
+                    testFile: 'test/functional/fixtures/regression/gh-2546/testcafe-fixtures/uncaughtExceptionInHandler.js',
+                    browsers: '"chrome:headless --no-sandbox"',
+                    args:     ['--disable-native-automation'],
                 });
-            }).then(value => {
-                expect(value.stdout).contains('Exception in the code');
-                expect(value.stdout).contains('Exception in the handler');
-                expect(value.error).is.not.null;
+
+                expect(result.stdout).contains('Exception in the code');
+                expect(result.stdout).contains('Exception in the handler');
+                expect(result.error).is.not.null;
             });
         });
     });

--- a/test/functional/fixtures/regression/gh-3049/test.js
+++ b/test/functional/fixtures/regression/gh-3049/test.js
@@ -19,7 +19,7 @@ if (isLocalChrome) {
                     return testCafe.createRunner()
                         .browsers(`chrome${headless} --window-size=1,1`)
                         .src(path.join(__dirname, './testcafe-fixtures/index.js'))
-                        .run({ nativeAutomation: config.nativeAutomation });
+                        .run({ disableNativeAutomation: !config.nativeAutomation });
                 })
                 .then(failed => {
                     failedCount = failed;

--- a/test/functional/fixtures/regression/gh-3456/test.js
+++ b/test/functional/fixtures/regression/gh-3456/test.js
@@ -27,7 +27,7 @@ if (config.useLocalBrowsers) {
                         .src(fixturePath)
                         .browsers(browsers)
                         .screenshots(SCREENSHOTS_PATH)
-                        .run({ nativeAutomation: config.nativeAutomation });
+                        .run({ disableNativeAutomation: !config.nativeAutomation });
                 })
                 .then(failedCount => {
                     expect(failedCount).eql(0);

--- a/test/functional/fixtures/regression/gh-3929/test.js
+++ b/test/functional/fixtures/regression/gh-3929/test.js
@@ -17,7 +17,7 @@ if (config.useLocalBrowsers && !config.useHeadlessBrowsers) {
                     return testCafe.createRunner()
                         .browsers(`chrome`)
                         .src(path.join(__dirname, './testcafe-fixtures/index.js'))
-                        .run({ nativeAutomation: config.nativeAutomation });
+                        .run({ disableNativeAutomation: !config.nativeAutomation });
                 })
                 .then(failed => {
                     failedCount = failed;

--- a/test/functional/fixtures/regression/gh-4675/test.js
+++ b/test/functional/fixtures/regression/gh-4675/test.js
@@ -29,7 +29,7 @@ if (config.useLocalBrowsers && !config.useHeadlessBrowsers) {
                         .browsers(`chrome`)
                         .src(path.join(__dirname, './testcafe-fixtures/index.js'))
                         .reporter([customReporter('custom1'), customReporter('custom2')])
-                        .run({ nativeAutomation: config.nativeAutomation });
+                        .run({ disableNativeAutomation: !config.nativeAutomation });
                 })
                 .catch(err => {
                     error = err;

--- a/test/functional/fixtures/regression/gh-4787/test.js
+++ b/test/functional/fixtures/regression/gh-4787/test.js
@@ -53,7 +53,7 @@ if (config.useLocalBrowsers && !config.useHeadlessBrowsers) {
                         .src(path.join(__dirname, './testcafe-fixtures/index.js'))
                         .browsers(['chrome', 'firefox'])
                         .reporter(reporter)
-                        .run({ nativeAutomation: config.nativeAutomation });
+                        .run({ disableNativeAutomation: !config.nativeAutomation });
                 })
                 .then(() => {
                     return cafe.close();

--- a/test/functional/fixtures/regression/gh-5239/test.js
+++ b/test/functional/fixtures/regression/gh-5239/test.js
@@ -51,7 +51,7 @@ async function run ({ src, browsers, retryTestPages, reporter }) {
     if (reporter)
         runner.reporter(reporter);
 
-    await runner.run({ nativeAutomation: config.nativeAutomation });
+    await runner.run({ disableNativeAutomation: !config.nativeAutomation });
 
     await testcafe.close();
 }

--- a/test/functional/fixtures/regression/gh-5549/test.js
+++ b/test/functional/fixtures/regression/gh-5549/test.js
@@ -18,7 +18,7 @@ if (config.useLocalBrowsers) {
                         .createRunner()
                         .browsers('chrome:headless')
                         .src(path.join(__dirname, './testcafe-fixtures/index.js'))
-                        .run({ nativeAutomation: config.nativeAutomation });
+                        .run({ disableNativeAutomation: !config.nativeAutomation });
                 })
                 .then(failed => {
                     failedCount = failed;

--- a/test/functional/fixtures/regression/gh-7599/test.js
+++ b/test/functional/fixtures/regression/gh-7599/test.js
@@ -6,14 +6,14 @@ describe('Multiple windows in the Native Automation mode', function () {
     onlyInNativeAutomation('Should fail in the Native Automation mode if window opened using the link click', function () {
         return runTests('./testcafe-fixtures/index.js', 'Should fail on link[target="blank"] click', { shouldFail: true })
             .catch(errs => {
-                expect(errs[0]).contains('The Native Automation mode does not support the use of multiple browser windows. Remove the "native automation" option to continue');
+                expect(errs[0]).contains('The Native Automation mode does not support the use of multiple browser windows. Use the "disable native automation" option to continue');
             });
     });
 
     onlyInNativeAutomation('Should fail in the Native Automation mode', function () {
         return runTests('./testcafe-fixtures/index.js', 'Should fail on Multiple Window API call in the Native Automation mode', { shouldFail: true })
             .catch(errs => {
-                expect(errs[0]).contains('The Native Automation mode does not support the use of multiple browser windows. Remove the "native automation" option to continue');
+                expect(errs[0]).contains('The Native Automation mode does not support the use of multiple browser windows. Use the "disable native automation" option to continue');
             });
     });
 });

--- a/test/functional/fixtures/regression/hammerhead/gh-863/test.js
+++ b/test/functional/fixtures/regression/hammerhead/gh-863/test.js
@@ -79,7 +79,7 @@ async function run ({ src, browser }) {
     await testcafe.createRunner()
         .src(path.join(__dirname, src))
         .browsers(browser)
-        .run({ nativeAutomation: config.nativeAutomation });
+        .run({ disableNativeAutomation: !config.nativeAutomation });
 
     await testcafe.close();
 }

--- a/test/functional/fixtures/runner/test.js
+++ b/test/functional/fixtures/runner/test.js
@@ -8,7 +8,7 @@ function run (browsers, testFile) {
         .createRunner()
         .src(path.join(__dirname, testFile))
         .browsers(browsers)
-        .run({ nativeAutomation: config.nativeAutomation });
+        .run({ disableNativeAutomation: !config.nativeAutomation });
 }
 
 describe('Runner', () => {

--- a/test/functional/fixtures/video-recording/skip/ffmpeg-test.js
+++ b/test/functional/fixtures/video-recording/skip/ffmpeg-test.js
@@ -28,7 +28,7 @@ if (config.useLocalBrowsers) {
                         .src('test/functional/fixtures/video-recording/skip/fixture.test.js')
                         .browsers('chrome')
                         .video('reports')
-                        .run({ nativeAutomation: config.nativeAutomation });
+                        .run({ disableNativeAutomation: !config.nativeAutomation });
                 })
                 .then(async () => {
                     testcafe.close();

--- a/test/functional/setup.js
+++ b/test/functional/setup.js
@@ -191,8 +191,13 @@ before(function () {
             if (isBrowserStack || !USE_PROVIDER_POOL)
                 mocha.timeout(0);
 
-            if (USE_PROVIDER_POOL)
+            if (USE_PROVIDER_POOL) {
+                testCafe.configuration.mergeOptions({
+                    disableNativeAutomation: !config.nativeAutomation,
+                });
+
                 return testCafe.initializeBrowserConnectionGateway();
+            }
 
             return openRemoteBrowsers();
         })

--- a/test/functional/utils/run-tests-with-config.js
+++ b/test/functional/utils/run-tests-with-config.js
@@ -8,7 +8,7 @@ module.exports = async (testName, configPath) => {
 
     const cafe        = await createTestCafe({ configFile: path.resolve(configPath) });
     const runner      = cafe.createRunner();
-    const failedCount = await runner.run({ nativeAutomation: config.nativeAutomation });
+    const failedCount = await runner.run({ disableNativeAutomation: !config.nativeAutomation });
 
     await cafe.close();
 

--- a/test/functional/utils/set-native-automation-for-remote-connection.js
+++ b/test/functional/utils/set-native-automation-for-remote-connection.js
@@ -1,6 +1,6 @@
+const { noop } = require('lodash');
+
 module.exports = function setNativeAutomationForRemoteConnection (runner) {
     // Hack: it's necessary to run remote browsers in the native automation mode.
-    runner.bootstrapper._calculateIsNativeAutomation = function () {
-        this.nativeAutomation = true;
-    };
+    runner.bootstrapper._disableNativeAutomationIfNecessary = noop;
 };

--- a/test/server/api-test.js
+++ b/test/server/api-test.js
@@ -1846,10 +1846,9 @@ describe('API', function () {
                     test: 42,
                 },
 
-                developmentMode:  true,
-                retryTestPages:   true,
-                disableHttp2:     true,
-                nativeAutomation: true,
+                developmentMode: true,
+                retryTestPages:  true,
+                disableHttp2:    true,
             });
 
             const configuration = TestCafe.firstCall.args[0];
@@ -1861,7 +1860,6 @@ describe('API', function () {
             expect(configuration.getOption(OPTION_NAMES.developmentMode)).be.true;
             expect(configuration.getOption(OPTION_NAMES.retryTestPages)).be.true;
             expect(configuration.getOption(OPTION_NAMES.disableHttp2)).be.true;
-            expect(configuration.getOption(OPTION_NAMES.nativeAutomation)).be.true;
         });
     });
 });

--- a/test/server/bootstrapper-test.js
+++ b/test/server/bootstrapper-test.js
@@ -116,5 +116,45 @@ describe('Bootstrapper', () => {
                                         'The test.globalAfter hook (string) is not of expected type (function).');
             }
         });
+
+        it("Should disable native automation mode if it's necessary", async () => {
+            let remoteBrowserConnections    = [];
+            let automatedBrowserConnections = [];
+
+            const chromeBrowserInfoMock = {
+                provider: {
+                    supportNativeAutomation: () => true,
+                },
+            };
+
+            const firefoxBrowserInfoMock = {
+                provider: {
+                    supportNativeAutomation: () => false,
+                },
+            };
+
+            bootstrapper.configuration.clear();
+            bootstrapper._disableNativeAutomationIfNecessary(remoteBrowserConnections, automatedBrowserConnections);
+            expect(bootstrapper.configuration._mergedOptions).to.be.undefined;
+
+            remoteBrowserConnections = [{}];
+
+            bootstrapper._disableNativeAutomationIfNecessary(remoteBrowserConnections, automatedBrowserConnections);
+            expect(bootstrapper.configuration._mergedOptions).eql({ disableNativeAutomation: true });
+            bootstrapper.configuration.clear();
+
+            remoteBrowserConnections    = [];
+            automatedBrowserConnections = [chromeBrowserInfoMock];
+
+            bootstrapper._disableNativeAutomationIfNecessary(remoteBrowserConnections, automatedBrowserConnections);
+            expect(bootstrapper.configuration._mergedOptions).to.be.undefined;
+            bootstrapper.configuration.clear();
+
+            automatedBrowserConnections = [chromeBrowserInfoMock, firefoxBrowserInfoMock];
+
+            bootstrapper._disableNativeAutomationIfNecessary(remoteBrowserConnections, automatedBrowserConnections);
+            expect(bootstrapper.configuration._mergedOptions).eql({ disableNativeAutomation: true });
+            bootstrapper.configuration.clear();
+        });
     });
 });

--- a/test/server/cli-argument-parser-test.js
+++ b/test/server/cli-argument-parser-test.js
@@ -783,7 +783,7 @@ describe('CLI argument parser', function () {
     });
 
     it('Should parse command line arguments', function () {
-        return parse('-r list -S -q -e message=/testMessage/i,stack=testStack,pageUrl=testPageUrl --hostname myhost --base-url localhost:3000 --proxy localhost:1234 --proxy-bypass localhost:5678 --qr-code --app run-app --speed 0.5 --debug-on-fail --disable-page-reloads --retry-test-pages --dev --sf --disable-page-caching --disable-http2 --native-automation --disable-cross-domain ie test/server/data/file-list/file-1.js')
+        return parse('-r list -S -q -e message=/testMessage/i,stack=testStack,pageUrl=testPageUrl --hostname myhost --base-url localhost:3000 --proxy localhost:1234 --proxy-bypass localhost:5678 --qr-code --app run-app --speed 0.5 --debug-on-fail --disable-page-reloads --retry-test-pages --dev --sf --disable-page-caching --disable-http2 --disable-native-automation --disable-cross-domain ie test/server/data/file-list/file-1.js')
             .then(parser => {
                 expect(parser.opts.browsers).eql(['ie']);
                 expect(parser.opts.src).eql(['test/server/data/file-list/file-1.js']);
@@ -810,7 +810,7 @@ describe('CLI argument parser', function () {
                 expect(parser.opts.retryTestPages).to.be.ok;
                 expect(parser.opts.disableHttp2).to.be.ok;
                 expect(parser.opts.disableCrossDomain).to.be.ok;
-                expect(parser.opts.nativeAutomation).to.be.ok;
+                expect(parser.opts.disableNativeAutomation).to.be.ok;
                 expect(parser.opts.baseUrl).eql('localhost:3000');
             });
     });
@@ -885,7 +885,7 @@ describe('CLI argument parser', function () {
             { long: '--ajax-request-timeout' },
             { long: '--cache' },
             { long: '--disable-http2' },
-            { long: '--native-automation' },
+            { long: '--disable-native-automation' },
             { long: '--base-url' },
             { long: '--disable-cross-domain' },
             { long: '--esm' },

--- a/test/server/cli-remote-wizard-test.js
+++ b/test/server/cli-remote-wizard-test.js
@@ -4,6 +4,7 @@ const proxyquire             = require('proxyquire');
 const sinon                  = require('sinon');
 const { constructor: Chalk } = require('chalk');
 const { noop }               = require('lodash');
+const { configurationMock }  = require('./helpers/mocks');
 
 
 describe('[CLI] Remote wizard', () => {
@@ -20,6 +21,8 @@ describe('[CLI] Remote wizard', () => {
             },
 
             initializeBrowserConnectionGateway: noop,
+
+            configuration: configurationMock,
 
             createBrowserConnection: () => {
                 const connection = new EventEmitter();

--- a/test/server/configuration-test.js
+++ b/test/server/configuration-test.js
@@ -99,19 +99,18 @@ describe('TestCafeConfiguration', function () {
 
         describe('Init', () => {
             describe('Exists', () => {
-                it('Config is not well-formed', () => {
+                it('Config is not well-formed', async () => {
                     const filePath = testCafeConfiguration.defaultPaths[jsonConfigIndex];
 
                     fs.writeFileSync(filePath, '{');
                     consoleWrapper.wrap();
 
-                    return testCafeConfiguration.init()
-                        .then(() => {
-                            consoleWrapper.unwrap();
+                    await testCafeConfiguration.init();
 
-                            expect(testCafeConfiguration.getOption('hostname')).eql(void 0);
-                            expect(consoleWrapper.messages.log).contains(`Failed to parse the '${testCafeConfiguration.defaultPaths[jsonConfigIndex]}' file.`);
-                        });
+                    consoleWrapper.unwrap();
+
+                    expect(testCafeConfiguration.getOption('hostname')).eql(void 0);
+                    expect(consoleWrapper.messages.log).contains(`Failed to parse the '${testCafeConfiguration.defaultPaths[jsonConfigIndex]}' file.`);
                 });
 
                 it('Options', () => {
@@ -359,15 +358,14 @@ describe('TestCafeConfiguration', function () {
                 });
             });
 
-            it("File doesn't exists", () => {
+            it("File doesn't exists", async () => {
                 fs.unlinkSync(TestCafeConfiguration.FILENAMES[jsonConfigIndex]);
 
                 const defaultOptions = cloneDeep(testCafeConfiguration._options);
 
-                return testCafeConfiguration.init()
-                    .then(() => {
-                        expect(testCafeConfiguration._options).to.deep.equal(defaultOptions);
-                    });
+                await testCafeConfiguration.init();
+
+                expect(testCafeConfiguration._options).to.deep.equal(defaultOptions);
             });
 
             it('Explicitly specified configuration file doesn\'t exist', async () => {
@@ -672,18 +670,17 @@ describe('TypeScriptConfiguration', function () {
         expect(message).eql(`"${nonExistingConfiguration.defaultPaths[jsConfigIndex]}" is not a valid TypeScript configuration file.`);
     });
 
-    it('Config is not well-formed', () => {
+    it('Config is not well-formed', async () => {
         fs.writeFileSync(tsConfigPath, '{');
         consoleWrapper.wrap();
 
-        return typeScriptConfiguration.init()
-            .then(() => {
-                consoleWrapper.unwrap();
-                fs.unlinkSync(tsConfigPath);
+        await typeScriptConfiguration.init();
 
-                expect(typeScriptConfiguration.getOption('hostname')).eql(void 0);
-                expect(consoleWrapper.messages.log).contains(`Failed to parse the '${typeScriptConfiguration.filePath}' file.`);
-            });
+        consoleWrapper.unwrap();
+        fs.unlinkSync(tsConfigPath);
+
+        expect(typeScriptConfiguration.getOption('hostname')).eql(void 0);
+        expect(consoleWrapper.messages.log).contains(`Failed to parse the '${typeScriptConfiguration.filePath}' file.`);
     });
 
     describe('With configuration file', () => {

--- a/test/server/data/expected-test-run-errors/multiple-windows-mode-is-not-supported-in-native-automation-error
+++ b/test/server/data/expected-test-run-errors/multiple-windows-mode-is-not-supported-in-native-automation-error
@@ -1,4 +1,4 @@
-The Native Automation mode does not support the use of multiple browser windows. Remove the "native automation" option to continue.
+The Native Automation mode does not support the use of multiple browser windows. Use the "disable native automation" option to continue.
 
 Browser: Chrome 15.0.874.120 / macOS 10.15
 Screenshot: /unix/path/with/<tag>

--- a/test/server/helpers/mocks.js
+++ b/test/server/helpers/mocks.js
@@ -31,7 +31,14 @@ class BrowserSetMock extends EventEmitter {
 const configurationMock = {
     getOption:         noop,
     calculateHostname: noop,
-    mergeOptions:      noop,
+
+    mergeOptions (options) {
+        this._mergedOptions = options;
+    },
+
+    clear () {
+        delete this._mergedOptions;
+    },
 
     startOptions: {
         hostname: 'localhost',

--- a/test/server/test-controller-test.js
+++ b/test/server/test-controller-test.js
@@ -42,7 +42,6 @@ describe('TestController', () => {
             });
     });
 
-
     describe('Preparing cookies arguments', () => {
         it('Should prepare name and url arguments', () => {
             const args = ['cookie', 'url'];

--- a/test/server/test-run-controller-test.js
+++ b/test/server/test-run-controller-test.js
@@ -32,7 +32,7 @@ describe('TestRunController', () => {
             await testRunController.start(browserConnectionMock);
         }
         catch (err) {
-            expect(err.message).to.equal('The "testBrowser" do not support the Native Automation mode. Remove the "native automation" option to continue.');
+            expect(err.message).to.equal('The "testBrowser" do not support the Native Automation mode. Use the "disable native automation" option to continue.');
         }
     });
 });

--- a/ts-defs-src/runner-api/options.d.ts
+++ b/ts-defs-src/runner-api/options.d.ts
@@ -268,9 +268,9 @@ interface RunOptions {
      */
     disableMultipleWindows: boolean;
     /**
-     * Enables native automation of Chromium-based browsers. Use this option to speed up browser automation and increase test stability.
+     * Disables native automation of Chromium-based browsers. Use this option to speed up browser automation and increase test stability.
      */
-    nativeAutomation: boolean;
+    disableNativeAutomation: boolean;
 }
 
 interface StartOptions {


### PR DESCRIPTION
Closes https://github.com/DevExpress/testcafe-private/issues/170 Closes https://github.com/DevExpress/testcafe-private/issues/169

Changes:
* run nativeAutomation by default
* rewrtie logging for the `testRunController` class
* switch to the legacy run mode if there are browsers that don't support the native automation mode
* refactorings

<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
_Describe the problem you want to address or the feature you want to implement._

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
