### PR TITLE
[WIP] fix: `sellectaAll` command added to `ctrl+a` combination in NA mode

### DIFF
--- a/src/native-automation/client/event-descriptor.ts
+++ b/src/native-automation/client/event-descriptor.ts
@@ -92,6 +92,7 @@ export default class CDPEventDescriptor {
             modifiers:             options.modifiers || 0,
             windowsVirtualKeyCode: options.keyCode,
             key:                   options.keyProperty,
+            commands:              options.commands,
             text,
         };
     }

--- a/src/native-automation/client/key-press/utils.ts
+++ b/src/native-automation/client/key-press/utils.ts
@@ -1,4 +1,5 @@
 import getKeyInfo from '../../../client/automation/playback/press/get-key-info';
+import SHORTCUT_TYPE from '../../../client/automation/playback/press/shortcut-type';
 // @ts-ignore
 import { utils } from '../../../client/core/deps/hammerhead';
 // @ts-ignore
@@ -6,6 +7,10 @@ import { getKeyArray, arrayUtils } from '../../../client/automation/deps/testcaf
 import { changeLetterCase, getActualKeysAndEventKeyProperties } from '../../../client/automation/playback/press/utils';
 import { getModifiersState } from '../utils';
 import getKeyCode from '../../../client/automation/utils/get-key-code';
+
+const SHORTCUT_TO_COMMANDS_MAP = {
+    [SHORTCUT_TYPE.ctrlA]: 'selectAll',
+};
 
 export interface SimulatedKeyInfo {
     key: string;
@@ -16,6 +21,14 @@ export interface SimulatedKeyInfo {
     isLetter: boolean;
     isChar: boolean;
     isNewLine: boolean;
+    commands: string[];
+}
+
+function getKeyCombinationCommands (keyCombination: string, keyIndex: number): string[] {
+    if (keyIndex === 1 && SHORTCUT_TO_COMMANDS_MAP[keyCombination])
+        return [SHORTCUT_TO_COMMANDS_MAP[keyCombination]];
+
+    return [];
 }
 
 export function getSimulatedKeyInfo (keyCombination: string): SimulatedKeyInfo[] {
@@ -23,7 +36,9 @@ export function getSimulatedKeyInfo (keyCombination: string): SimulatedKeyInfo[]
     const { actualKeys, eventKeyProperties } = getActualKeysAndEventKeyProperties(keysArray);
 
     return arrayUtils.map(actualKeys, (key: string, index: number) => {
-        return utils.extend({ key }, getKeyInfo(key, eventKeyProperties[index]));
+        const commands = getKeyCombinationCommands(keyCombination, index);
+
+        return utils.extend({ key, commands }, getKeyInfo(key, eventKeyProperties[index]));
     });
 }
 


### PR DESCRIPTION
Part of https://github.com/DevExpress/testcafe/issues/7667