### PR TITLE
fix: native print dialog is not handled(closes #2331)

### DIFF
--- a/src/client/driver/native-dialog-tracker/index.js
+++ b/src/client/driver/native-dialog-tracker/index.js
@@ -12,6 +12,7 @@ const APPEARED_DIALOGS                  = 'testcafe|native-dialog-tracker|appear
 const UNEXPECTED_DIALOG                 = 'testcafe|native-dialog-tracker|unexpected-dialog';
 const ERROR_IN_HANDLER                  = 'testcafe|native-dialog-tracker|error-in-handler';
 const GETTING_PAGE_URL_PROCESSED_SCRIPT = processScript('window.location.href');
+const NATIVE_DIALOG_TYPES               = ['alert', 'confirm', 'prompt', 'print'];
 
 
 export default class NativeDialogTracker {
@@ -97,6 +98,7 @@ export default class NativeDialogTracker {
         window.alert   = () => this._defaultDialogHandler('alert');
         window.confirm = () => this._defaultDialogHandler('confirm');
         window.prompt  = () => this._defaultDialogHandler('prompt');
+        window.print   = () => this._defaultDialogHandler('print');
     }
 
     _createDialogHandler (type) {
@@ -106,7 +108,7 @@ export default class NativeDialogTracker {
             this._addAppearedDialogs(type, text, url);
 
             const executor = new ClientFunctionExecutor(this.dialogHandler);
-            let result   = null;
+            let result     = null;
 
             try {
                 result = executor.fn.apply(window, [type, text, url]);
@@ -138,7 +140,7 @@ export default class NativeDialogTracker {
     setHandler (dialogHandler) {
         this.dialogHandler = dialogHandler;
 
-        ['alert', 'confirm', 'prompt'].forEach(dialogType => {
+        NATIVE_DIALOG_TYPES.forEach(dialogType => {
             window[dialogType] = this.dialogHandler ?
                 this._createDialogHandler(dialogType) :
                 () => this._defaultDialogHandler(dialogType);

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/pages/index.html
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/pages/index.html
@@ -7,6 +7,7 @@
 <body>
 <button id="buttonAlert">Alert</button>
 <button id="buttonConfirm">Confirm</button>
+<button id="buttonPrint">Print</button>
 
 <button id="buttonDialogAfterTimeoutWithRedirect">DialogAfterTimeoutWithRedirect</button>
 <button id="buttonDialogAfterTimeout">DialogAfterTimeout</button>
@@ -27,6 +28,10 @@
 
     document.getElementById('buttonConfirm').addEventListener('click', function () {
         document.getElementById('result').textContent = window.confirm('Confirm?');
+    });
+
+    document.getElementById('buttonPrint').addEventListener('click', function () {
+        window.print();
     });
 
     document.getElementById('buttonDialogAfterTimeout').addEventListener('click', function () {

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/pages/page-load.html
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/pages/page-load.html
@@ -8,17 +8,51 @@
 <div id="result"></div>
 <div style="background-color: #6ab779; width: 100px; height: 100px;;"></div>
 <script>
-    const wasReloadedFlag = 'wasReloaded';
-    const wasReloaded = sessionStorage.getItem(wasReloadedFlag);
-    sessionStorage.setItem(wasReloadedFlag, true);
+    const currentDialogItemName = 'currentDialog';
+    const promptResultItem = 'promptResult';
+    const confirmResultItem = 'confirmResult';
+    const dialogs = {
+        alert:   'alert',
+        confirm: 'confirm',
+        prompt:  'prompt',
+        print:   'print',
+    }
+    const dialogsOrder = [
+        dialogs.alert,
+        dialogs.confirm,
+        dialogs.prompt,
+        dialogs.print,
+    ];
+    const currentDialog = sessionStorage.getItem(currentDialogItemName) || dialogsOrder[0];
 
-    if (!wasReloaded) {
+    function getNextDialog (currentDialog) {
+        return dialogsOrder[dialogsOrder.indexOf(currentDialog) + 1];
+    }
+
+    window.getDialogsResult = () => {
+        return {
+            prompt: sessionStorage.getItem(promptResultItem),
+            confirm: sessionStorage.getItem(confirmResultItem),
+        }
+    }
+
+    sessionStorage.setItem(currentDialogItemName, getNextDialog(currentDialog));
+
+    if (currentDialog === dialogs.alert) {
         alert('Alert!');
         document.location.reload();
     }
-    else {
-        document.getElementById('result').textContent = window.confirm('Confirm?');
-        sessionStorage.removeItem(wasReloadedFlag);
+    else if (currentDialog === dialogs.confirm) {
+        sessionStorage.setItem(confirmResultItem, window.confirm('Confirm?'));
+        document.location.reload();
+    }
+    else if (currentDialog === dialogs.prompt) {
+        sessionStorage.setItem(promptResultItem, window.prompt('Prompt'));
+        document.location.reload();
+    }
+    else if (currentDialog === dialogs.print) {
+        window.print();
+        sessionStorage.removeItem(currentDialogItemName);
     }
 </script>
 </body>

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/test.js
@@ -14,7 +14,7 @@ describe('Native dialogs handling', function () {
         return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Null handler', { shouldFail: true })
             .catch(function (errs) {
                 errorInEachBrowserContains(errs, getNativeDialogNotHandledErrorText('alert', pageUrl), 0);
-                errorInEachBrowserContains(errs, '> 193 |        .click(\'#buttonAlert\');', 0);
+                errorInEachBrowserContains(errs, '> 226 |        .click(\'#buttonAlert\');', 0);
             });
     });
 
@@ -24,7 +24,7 @@ describe('Native dialogs handling', function () {
                 { shouldFail: true, skipJsErrors: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, getNativeDialogNotHandledErrorText('confirm', pageUrl), 0);
-                    errorInEachBrowserContains(errs, '> 18 |    await t.click(\'#buttonConfirm\'); ', 0);
+                    errorInEachBrowserContains(errs, '> 17 |    await t.click(\'#buttonConfirm\'); ', 0);
                 });
         });
 
@@ -48,7 +48,7 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Confirm dialog with wrong text', { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, getUncaughtErrorInNativeDialogHandlerText('confirm', 'Wrong dialog text', pageUrl), 0);
-                    errorInEachBrowserContains(errs, '> 83 |        .click(\'#buttonConfirm\');', 0);
+                    errorInEachBrowserContains(errs, '> 116 |        .click(\'#buttonConfirm\');', 0);
                 });
         });
 
@@ -56,8 +56,8 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'No expected confirm after an action',
                 { shouldFail: true })
                 .catch(function (errs) {
-                    errorInEachBrowserContains(errs, 'AssertionError: expected 0 to equal 1', 0);
-                    errorInEachBrowserContains(errs, ' >  95 |    expect(info.length).equals(1);', 0);
+                    errorInEachBrowserContains(errs, 'AssertionError: expected 0 to deeply equal 1', 0);
+                    errorInEachBrowserContains(errs, ' > 128 |    await t.expect(info.length).eql(1);', 0);
                 });
         });
 
@@ -67,10 +67,23 @@ describe('Native dialogs handling', function () {
                 skip: 'safari,iphone,ipad',
             });
         });
+
+        it('Should fail if an unexpected print dialog appears after an action', function () {
+            return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Print without handler',
+                { shouldFail: true, skipJsErrors: true })
+                .catch(function (errs) {
+                    errorInEachBrowserContains(errs, getNativeDialogNotHandledErrorText('print', pageUrl), 0);
+                    errorInEachBrowserContains(errs, '> 26 |    await t.click(\'#buttonPrint\'); ', 0);
+                });
+        });
+
+        it('Should pass if the expected print dialog appears after an action', function () {
+            return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Expected print after an action');
+        });
     });
 
     describe('Dialogs appear after page load', function () {
-        it('Should pass if the expected confirm dialog appears after page load', function () {
+        it('Should pass if the expected confirm and print dialogs appear after page load', function () {
             return runTests('./testcafe-fixtures/page-load-test.js', 'Expected dialogs after page load');
         });
 
@@ -80,7 +93,7 @@ describe('Native dialogs handling', function () {
                 { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, getNativeDialogNotHandledErrorText('alert', pageLoadingUrl), 0);
-                    errorInEachBrowserContains(errs, '> 42 |        await t.click(\'body\');', 0);
+                    errorInEachBrowserContains(errs, '> 56 |        await t.click(\'body\');', 0);
                 });
         });
     });
@@ -110,8 +123,8 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'No expected alert during a wait action',
                 { shouldFail: true })
                 .catch(function (errs) {
-                    errorInEachBrowserContains(errs, 'AssertionError: expected 0 to equal 1', 0);
-                    errorInEachBrowserContains(errs, '> 163 |    expect(info.length).equals(1);', 0);
+                    errorInEachBrowserContains(errs, 'AssertionError: expected 0 to deeply equal 1', 0);
+                    errorInEachBrowserContains(errs, '> 196 |    await t.expect(info.length).eql(1);', 0);
                 });
         });
 
@@ -129,7 +142,7 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Dialog handler has wrong type', { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'The native dialog handler is expected to be a function, ClientFunction or null, but it was number.', 0);
-                    errorInEachBrowserContains(errs, ' > 174 |    await t.setNativeDialogHandler(42);', 0);
+                    errorInEachBrowserContains(errs, ' > 207 |    await t.setNativeDialogHandler(42);', 0);
                 });
         });
 
@@ -137,7 +150,7 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Client function argument wrong type', { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'Cannot initialize a ClientFunction because ClientFunction is number, and not a function.', 0);
-                    errorInEachBrowserContains(errs, ' > 178 |    await t.setNativeDialogHandler(ClientFunction(42));', 0);
+                    errorInEachBrowserContains(errs, ' > 211 |    await t.setNativeDialogHandler(ClientFunction(42));', 0);
                 });
         });
 
@@ -145,7 +158,7 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Selector as dialogHandler', { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'The native dialog handler is expected to be a function, ClientFunction or null, but it was Selector.', 0);
-                    errorInEachBrowserContains(errs, '> 184 |    await t.setNativeDialogHandler(dialogHandler);', 0);
+                    errorInEachBrowserContains(errs, '> 217 |    await t.setNativeDialogHandler(dialogHandler);', 0);
                 });
         });
     });

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/test.js
@@ -14,7 +14,7 @@ describe('Native dialogs handling', function () {
         return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Null handler', { shouldFail: true })
             .catch(function (errs) {
                 errorInEachBrowserContains(errs, getNativeDialogNotHandledErrorText('alert', pageUrl), 0);
-                errorInEachBrowserContains(errs, '> 226 |        .click(\'#buttonAlert\');', 0);
+                errorInEachBrowserContains(errs, '> 216 |        .click(\'#buttonAlert\');', 0);
             });
     });
 
@@ -48,7 +48,7 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Confirm dialog with wrong text', { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, getUncaughtErrorInNativeDialogHandlerText('confirm', 'Wrong dialog text', pageUrl), 0);
-                    errorInEachBrowserContains(errs, '> 116 |        .click(\'#buttonConfirm\');', 0);
+                    errorInEachBrowserContains(errs, '> 106 |        .click(\'#buttonConfirm\');', 0);
                 });
         });
 
@@ -57,7 +57,7 @@ describe('Native dialogs handling', function () {
                 { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'AssertionError: expected 0 to deeply equal 1', 0);
-                    errorInEachBrowserContains(errs, ' > 128 |    await t.expect(info.length).eql(1);', 0);
+                    errorInEachBrowserContains(errs, ' > 118 |    await t.expect(info.length).eql(1);', 0);
                 });
         });
 
@@ -124,7 +124,7 @@ describe('Native dialogs handling', function () {
                 { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'AssertionError: expected 0 to deeply equal 1', 0);
-                    errorInEachBrowserContains(errs, '> 196 |    await t.expect(info.length).eql(1);', 0);
+                    errorInEachBrowserContains(errs, '> 186 |    await t.expect(info.length).eql(1);', 0);
                 });
         });
 
@@ -142,7 +142,7 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Dialog handler has wrong type', { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'The native dialog handler is expected to be a function, ClientFunction or null, but it was number.', 0);
-                    errorInEachBrowserContains(errs, ' > 207 |    await t.setNativeDialogHandler(42);', 0);
+                    errorInEachBrowserContains(errs, ' > 197 |    await t.setNativeDialogHandler(42);', 0);
                 });
         });
 
@@ -150,7 +150,7 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Client function argument wrong type', { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'Cannot initialize a ClientFunction because ClientFunction is number, and not a function.', 0);
-                    errorInEachBrowserContains(errs, ' > 211 |    await t.setNativeDialogHandler(ClientFunction(42));', 0);
+                    errorInEachBrowserContains(errs, ' > 201 |    await t.setNativeDialogHandler(ClientFunction(42));', 0);
                 });
         });
 
@@ -158,7 +158,7 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Selector as dialogHandler', { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'The native dialog handler is expected to be a function, ClientFunction or null, but it was Selector.', 0);
-                    errorInEachBrowserContains(errs, '> 217 |    await t.setNativeDialogHandler(dialogHandler);', 0);
+                    errorInEachBrowserContains(errs, '> 207 |    await t.setNativeDialogHandler(dialogHandler);', 0);
                 });
         });
     });

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
@@ -36,16 +36,6 @@ test('Expected print after an action', async t => {
     await t.expect(dialogs).eql([{ type: 'print', url: pageUrl }]);
 });
 
-test('No expected print after an action', async t => {
-    await t
-        .click('#withoutDialog')
-        .setNativeDialogHandler(() => true);
-
-    const info = await t.getNativeDialogHistory();
-
-    await t.expect(info.length).eql(1);
-});
-
 test('Expected confirm after an action', async t => {
     await t
         .setNativeDialogHandler((type, text) => {

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/page-load-test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/page-load-test.js
@@ -1,10 +1,9 @@
 import { ClientFunction } from 'testcafe';
-import { expect } from 'chai';
 
 fixture `Page load`;
 
 
-const getResult = ClientFunction(() => document.getElementById('result').textContent);
+const getResult = ClientFunction(() => window.getDialogsResult());
 const pageUrl   = 'http://localhost:3000/fixtures/api/es-next/native-dialogs-handling/pages/page-load.html';
 
 
@@ -14,15 +13,30 @@ test('Expected dialogs after page load', async t => {
             if (type === 'confirm' && text === 'Confirm?')
                 return true;
 
+            if (type === 'prompt')
+                return 'PromptMsg';
+
             return null;
         })
         .navigateTo(pageUrl);
 
-    expect(await getResult()).equals('true');
+    await t.expect(await getResult()).eql({
+        prompt:  'PromptMsg',
+        confirm: 'true',
+    });
 
     const info = await t.getNativeDialogHistory();
 
-    expect(info).to.deep.equal([
+    await t.expect(info).eql([
+        {
+            type: 'print',
+            url:  pageUrl,
+        },
+        {
+            type: 'prompt',
+            text: 'Prompt',
+            url:  pageUrl,
+        },
         {
             type: 'confirm',
             text: 'Confirm?',


### PR DESCRIPTION
## Purpose
The native print dialog cannot be handled and page hangs

## Approach
Handle it as other dialogs

## References
#2331 

## API
```js
await t
    .setNativeDialogHandler((type, text, url) => {
        // type = 'print'
        // text = undefined
        // url  = pageUrl
    })
```

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
