### PR TITLE
fix unstable client scripts test on remote browsers

### DIFF
--- a/src/custom-client-scripts/client-script.ts
+++ b/src/custom-client-scripts/client-script.ts
@@ -138,4 +138,8 @@ export default class ClientScript {
     public static get URL_UNIQUE_PART_LENGTH (): number {
         return URL_UNIQUE_PART_LENGTH;
     }
+
+    public getResultUrl (folderName: string): string {
+        return `/custom-client-scripts/${folderName}/${this.url}`;
+    }
 }

--- a/src/custom-client-scripts/get-url.ts
+++ b/src/custom-client-scripts/get-url.ts
@@ -1,5 +1,0 @@
-import ClientScript from './client-script';
-
-export default function (script: ClientScript): string {
-    return `/custom-client-scripts/${script.url}`;
-}

--- a/src/custom-client-scripts/routing.ts
+++ b/src/custom-client-scripts/routing.ts
@@ -1,4 +1,3 @@
-import getCustomClientScriptUrl from './get-url';
 import getCustomClientScriptCode from './get-code';
 import CONTENT_TYPES from '../assets/content-types';
 import ClientScript from './client-script';
@@ -15,18 +14,25 @@ interface LegacyTest {
 
 type TestItem = Test | LegacyTest;
 
+interface RegisterClientScriptsInfo {
+    proxy: Proxy;
+    test: Test;
+    nativeAutomation: boolean;
+    folderName: string;
+}
+
 export function isLegacyTest (test: TestItem): test is LegacyTest {
     return !!(test as LegacyTest).isLegacy;
 }
 
-export function register (proxy: Proxy, test: Test, nativeAutomation: boolean): string[] {
+export function register ({ proxy, test, nativeAutomation, folderName }: RegisterClientScriptsInfo): string[] {
     const routes: string[] = [];
 
     if (isLegacyTest(test))
         return routes;
 
     test.clientScripts.forEach((script: ClientScriptInit) => {
-        const route = getCustomClientScriptUrl(script as ClientScript);
+        const route = (script as ClientScript).getResultUrl(folderName);
 
         proxy.GET(route, {
             content:     getCustomClientScriptCode(script as ClientScript, nativeAutomation),

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -50,7 +50,6 @@ import {
 
 import * as INJECTABLES from '../assets/injectables';
 import { findProblematicScripts } from '../custom-client-scripts/utils';
-import getCustomClientScriptUrl from '../custom-client-scripts/get-url';
 import { getPluralSuffix, getConcatenatedValuesString } from '../utils/string';
 
 import {
@@ -461,7 +460,7 @@ export default class TestRun extends AsyncEventEmitter {
         this.injectable.scripts.push(...INJECTABLES.SCRIPTS);
         this.injectable.userScripts.push(...this.test.clientScripts.map(script => {
             return {
-                url:  getCustomClientScriptUrl(script as ClientScript),
+                url:  (script as ClientScript).getResultUrl(this.id),
                 page: script.page as RequestFilterRule,
             };
         }));

--- a/test/server/custom-client-scripts-test.js
+++ b/test/server/custom-client-scripts-test.js
@@ -1,7 +1,6 @@
 const { expect }                                = require('chai');
 const ClientScript                              = require('../../lib/custom-client-scripts/client-script');
 const loadClientScripts                         = require('../../lib/custom-client-scripts/load');
-const getCustomClientScriptURL                  = require('../../lib/custom-client-scripts/get-url');
 const { RequestFilterRule }                     = require('testcafe-hammerhead');
 const tmp                                       = require('tmp');
 const fs                                        = require('fs');
@@ -292,13 +291,11 @@ describe('Client scripts', () => {
         expect(is.clientScriptInitializer.predicate({ module: 'module-name' })).to.be.true;
     });
 
-    it('Get URL', () => {
+    it('Get URL', async () => {
         const script = new ClientScript({ content: testScriptContent });
 
-        return script
-            .load()
-            .then(() => {
-                expect(getCustomClientScriptURL(script)).eql('/custom-client-scripts/' + script.url);
-            });
+        await script.load();
+
+        expect(script.getResultUrl('123')).eql('/custom-client-scripts/123/' + script.url);
     });
 });


### PR DESCRIPTION
There are two issues:
* the cached tested web page can request the client script URL from a previous test run
* in parallel execution, the client script can be unregistered before its usage.

Solution - make a unique client script URL for each test run.