### PR TITLE
feat: add possibility to handle access geolocation dialog(closes #3224)

### DIFF
--- a/src/client/driver/native-dialog-tracker/index.js
+++ b/src/client/driver/native-dialog-tracker/index.js
@@ -121,8 +121,8 @@ export default class NativeDialogTracker {
     _createGeolocationHandler () {
         return (successCallback, failCallback) => {
             const url                       = NativeDialogTracker._getPageUrl();
-            const isFirstGeolocationRequest = !this.appearedDialogs
-                .some(dialog => dialog.type === GEOLOCATION_DIALOG_TYPE && dialog.url === url);
+            const isFirstGeolocationRequest = !nativeMethods.arraySome
+                .call(this.appearedDialogs, dialog => dialog.type === GEOLOCATION_DIALOG_TYPE && dialog.url === url);
 
             if (isFirstGeolocationRequest)
                 this._addAppearedDialogs(GEOLOCATION_DIALOG_TYPE, void 0, url);

--- a/src/client/driver/native-dialog-tracker/index.js
+++ b/src/client/driver/native-dialog-tracker/index.js
@@ -120,9 +120,9 @@ export default class NativeDialogTracker {
 
     _createGeolocationHandler () {
         return (successCallback, failCallback) => {
-            const url  = NativeDialogTracker._getPageUrl();
-
-            const isFirstGeolocationRequest = !this.appearedDialogs.some(dialog => dialog.type === GEOLOCATION_DIALOG_TYPE && dialog.url === url);
+            const url                       = NativeDialogTracker._getPageUrl();
+            const isFirstGeolocationRequest = !this.appearedDialogs
+                .some(dialog => dialog.type === GEOLOCATION_DIALOG_TYPE && dialog.url === url);
 
             if (isFirstGeolocationRequest)
                 this._addAppearedDialogs(GEOLOCATION_DIALOG_TYPE, void 0, url);

--- a/src/client/driver/native-dialog-tracker/index.js
+++ b/src/client/driver/native-dialog-tracker/index.js
@@ -94,19 +94,18 @@ export default class NativeDialogTracker {
                 this.contextStorage.save();
         });
 
-        this._overrideDialogMethods();
+        this._setDefaultDialogHandlers();
     }
 
-    _overrideDialogMethods () {
-        window.alert   = () => this._defaultDialogHandler('alert');
-        window.confirm = () => this._defaultDialogHandler('confirm');
-        window.prompt  = () => this._defaultDialogHandler('prompt');
-        window.print   = () => this._defaultDialogHandler('print');
+    _setDefaultDialogHandlers () {
+        NATIVE_DIALOG_TYPES.forEach(dialogType => {
+            window[dialogType] = () => this._defaultDialogHandler(dialogType);
+        });
 
-        this._overrideGeolocationDialog(() => this._defaultDialogHandler('geolocation'));
+        this._setGeolocationDialogHandler(() => this._defaultDialogHandler('geolocation'));
     }
 
-    _overrideGeolocationDialog (handler) {
+    _setGeolocationDialogHandler (handler) {
         const geolocation = window.navigator.geolocation;
 
         if (geolocation?.getCurrentPosition)
@@ -185,10 +184,10 @@ export default class NativeDialogTracker {
                 () => this._defaultDialogHandler(dialogType);
         });
 
-        this._overrideGeolocationDialog(this.dialogHandler
+        this._setGeolocationDialogHandler(this.dialogHandler
             ? this._createGeolocationHandler()
             : () => this._defaultDialogHandler('geolocation')
-        )
+        );
     }
 
     getUnexpectedDialogError () {

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/pages/index.html
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/pages/index.html
@@ -30,7 +30,10 @@
     document.getElementById('buttonGeo').addEventListener('click', function () {
         window.navigator.geolocation.getCurrentPosition(
             (geo) => document.getElementById('result').textContent = JSON.stringify(geo),
-            (err) => document.getElementById('result').textContent = err.message,
+            (err) => document.getElementById('result').textContent = JSON.stringify({
+                message: err.message,
+                code:    err.code
+            }),
         )
     });
 

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/pages/index.html
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/pages/index.html
@@ -8,6 +8,7 @@
 <button id="buttonAlert">Alert</button>
 <button id="buttonConfirm">Confirm</button>
 <button id="buttonPrint">Print</button>
+<button id="buttonGeo">Geolocation</button>
 
 <button id="buttonDialogAfterTimeoutWithRedirect">DialogAfterTimeoutWithRedirect</button>
 <button id="buttonDialogAfterTimeout">DialogAfterTimeout</button>
@@ -24,6 +25,13 @@
 <script>
     document.getElementById('buttonAlert').addEventListener('click', function () {
         window.alert('Alert!');
+    });
+
+    document.getElementById('buttonGeo').addEventListener('click', function () {
+        window.navigator.geolocation.getCurrentPosition(
+            (geo) => document.getElementById('result').textContent = JSON.stringify(geo),
+            (err) => document.getElementById('result').textContent = err.message,
+        )
     });
 
     document.getElementById('buttonConfirm').addEventListener('click', function () {

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/pages/page-load.html
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/pages/page-load.html
@@ -9,19 +9,23 @@
 <div style="background-color: #6ab779; width: 100px; height: 100px;;"></div>
 <script>
     const currentDialogItemName = 'currentDialog';
-    const promptResultItem = 'promptResult';
-    const confirmResultItem = 'confirmResult';
-    const dialogs = {
-        alert:   'alert',
-        confirm: 'confirm',
-        prompt:  'prompt',
-        print:   'print',
-    }
-    const dialogsOrder = [
+    const promptResultItem      = 'promptResult';
+    const confirmResultItem     = 'confirmResult';
+    const geolocationResultItem = 'geoResult';
+
+    const dialogs       = {
+        alert:       'alert',
+        confirm:     'confirm',
+        prompt:      'prompt',
+        print:       'print',
+        geolocation: 'geolocation',
+    };
+    const dialogsOrder  = [
         dialogs.alert,
         dialogs.confirm,
         dialogs.prompt,
         dialogs.print,
+        dialogs.geolocation,
     ];
     const currentDialog = sessionStorage.getItem(currentDialogItemName) || dialogsOrder[0];
 
@@ -31,10 +35,11 @@
 
     window.getDialogsResult = () => {
         return {
-            prompt: sessionStorage.getItem(promptResultItem),
-            confirm: sessionStorage.getItem(confirmResultItem),
-        }
-    }
+            prompt:      sessionStorage.getItem(promptResultItem),
+            confirm:     sessionStorage.getItem(confirmResultItem),
+            geolocation: sessionStorage.getItem(geolocationResultItem),
+        };
+    };
 
     sessionStorage.setItem(currentDialogItemName, getNextDialog(currentDialog));
 
@@ -52,6 +57,10 @@
     }
     else if (currentDialog === dialogs.print) {
         window.print();
+        document.location.reload();
+    }
+    else if (currentDialog === dialogs.geolocation) {
+        window.navigator.geolocation.getCurrentPosition(geo => sessionStorage.setItem(geolocationResultItem, JSON.stringify(geo)));
         sessionStorage.removeItem(currentDialogItemName);
     }
 </script>

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/test.js
@@ -32,6 +32,10 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Expected confirm after an action');
         });
 
+        it('Should pass if the expected geolocation dialog appears after an action', function () {
+            return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Expected geolocation object and geolocation error returned after an action');
+        });
+
         it('Should pass if the expected confirm dialog appears after an action (with dependencies)', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Expected confirm after an action (with dependencies)');
         });

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/test.js
@@ -8,13 +8,12 @@ const pageUrl        = 'http://localhost:3000/fixtures/api/es-next/native-dialog
 const pageLoadingUrl = 'http://localhost:3000/fixtures/api/es-next/native-dialogs-handling/pages/page-load.html';
 const pagePromptUrl  = 'http://localhost:3000/fixtures/api/es-next/native-dialogs-handling/pages/prompt.html';
 
-
 describe('Native dialogs handling', function () {
     it('Should remove dialog handler if `null` specified', function () {
         return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Null handler', { shouldFail: true })
             .catch(function (errs) {
                 errorInEachBrowserContains(errs, getNativeDialogNotHandledErrorText('alert', pageUrl), 0);
-                errorInEachBrowserContains(errs, '> 216 |        .click(\'#buttonAlert\');', 0);
+                errorInEachBrowserContains(errs, '> 243 |        .click(\'#buttonAlert\');', 0);
             });
     });
 
@@ -24,7 +23,7 @@ describe('Native dialogs handling', function () {
                 { shouldFail: true, skipJsErrors: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, getNativeDialogNotHandledErrorText('confirm', pageUrl), 0);
-                    errorInEachBrowserContains(errs, '> 17 |    await t.click(\'#buttonConfirm\'); ', 0);
+                    errorInEachBrowserContains(errs, '> 15 |    await t.click(\'#buttonConfirm\'); ', 0);
                 });
         });
 
@@ -52,7 +51,7 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Confirm dialog with wrong text', { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, getUncaughtErrorInNativeDialogHandlerText('confirm', 'Wrong dialog text', pageUrl), 0);
-                    errorInEachBrowserContains(errs, '> 106 |        .click(\'#buttonConfirm\');', 0);
+                    errorInEachBrowserContains(errs, '> 133 |        .click(\'#buttonConfirm\');', 0);
                 });
         });
 
@@ -61,7 +60,7 @@ describe('Native dialogs handling', function () {
                 { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'AssertionError: expected 0 to deeply equal 1', 0);
-                    errorInEachBrowserContains(errs, ' > 118 |    await t.expect(info.length).eql(1);', 0);
+                    errorInEachBrowserContains(errs, ' > 145 |    await t.expect(info.length).eql(1);', 0);
                 });
         });
 
@@ -77,7 +76,7 @@ describe('Native dialogs handling', function () {
                 { shouldFail: true, skipJsErrors: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, getNativeDialogNotHandledErrorText('print', pageUrl), 0);
-                    errorInEachBrowserContains(errs, '> 26 |    await t.click(\'#buttonPrint\'); ', 0);
+                    errorInEachBrowserContains(errs, '> 23 |    await t.click(\'#buttonPrint\'); ', 0);
                 });
         });
 
@@ -97,7 +96,7 @@ describe('Native dialogs handling', function () {
                 { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, getNativeDialogNotHandledErrorText('alert', pageLoadingUrl), 0);
-                    errorInEachBrowserContains(errs, '> 56 |        await t.click(\'body\');', 0);
+                    errorInEachBrowserContains(errs, '> 64 |        await t.click(\'body\');', 0);
                 });
         });
     });
@@ -128,7 +127,7 @@ describe('Native dialogs handling', function () {
                 { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'AssertionError: expected 0 to deeply equal 1', 0);
-                    errorInEachBrowserContains(errs, '> 186 |    await t.expect(info.length).eql(1);', 0);
+                    errorInEachBrowserContains(errs, '> 213 |    await t.expect(info.length).eql(1);', 0);
                 });
         });
 
@@ -146,7 +145,7 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Dialog handler has wrong type', { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'The native dialog handler is expected to be a function, ClientFunction or null, but it was number.', 0);
-                    errorInEachBrowserContains(errs, ' > 197 |    await t.setNativeDialogHandler(42);', 0);
+                    errorInEachBrowserContains(errs, ' > 224 |    await t.setNativeDialogHandler(42);', 0);
                 });
         });
 
@@ -154,7 +153,7 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Client function argument wrong type', { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'Cannot initialize a ClientFunction because ClientFunction is number, and not a function.', 0);
-                    errorInEachBrowserContains(errs, ' > 201 |    await t.setNativeDialogHandler(ClientFunction(42));', 0);
+                    errorInEachBrowserContains(errs, ' > 228 |    await t.setNativeDialogHandler(ClientFunction(42));', 0);
                 });
         });
 
@@ -162,7 +161,7 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Selector as dialogHandler', { shouldFail: true })
                 .catch(function (errs) {
                     errorInEachBrowserContains(errs, 'The native dialog handler is expected to be a function, ClientFunction or null, but it was Selector.', 0);
-                    errorInEachBrowserContains(errs, '> 207 |    await t.setNativeDialogHandler(dialogHandler);', 0);
+                    errorInEachBrowserContains(errs, '> 234 |    await t.setNativeDialogHandler(dialogHandler);', 0);
                 });
         });
     });

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
@@ -1,7 +1,7 @@
 import { ClientFunction, Selector } from 'testcafe';
 
-fixture`Native dialogs`
-    .page`http://localhost:3000/fixtures/api/es-next/native-dialogs-handling/pages/index.html`;
+fixture `Native dialogs`
+    .page `http://localhost:3000/fixtures/api/es-next/native-dialogs-handling/pages/index.html`;
 
 const getResult     = ClientFunction(() => document.getElementById('result').textContent);
 const pageUrl       = 'http://localhost:3000/fixtures/api/es-next/native-dialogs-handling/pages/index.html';
@@ -55,7 +55,7 @@ test('Expected geolocation object and geolocation error returned after an action
             return err;
         })
         .click('#buttonGeo')
-        .expect(getResult()).eql('Some error');
+        .expect(getResult()).eql('{"message":"Some error","code":1}');
 
     const history = await t.getNativeDialogHistory();
 

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
@@ -1,13 +1,11 @@
 import { ClientFunction, Selector } from 'testcafe';
 
-fixture `Native dialogs`
-    .page `http://localhost:3000/fixtures/api/es-next/native-dialogs-handling/pages/index.html`;
-
+fixture`Native dialogs`
+    .page`http://localhost:3000/fixtures/api/es-next/native-dialogs-handling/pages/index.html`;
 
 const getResult     = ClientFunction(() => document.getElementById('result').textContent);
 const pageUrl       = 'http://localhost:3000/fixtures/api/es-next/native-dialogs-handling/pages/index.html';
 const promptPageUrl = 'http://localhost:3000/fixtures/api/es-next/native-dialogs-handling/pages/prompt.html';
-
 
 test('Without handler', async t => {
     const info = await t.getNativeDialogHistory();
@@ -16,7 +14,6 @@ test('Without handler', async t => {
 
     await t.click('#buttonConfirm');
 });
-
 
 test('Print without handler', async t => {
     const info = await t.getNativeDialogHistory();
@@ -59,6 +56,11 @@ test('Expected geolocation object and geolocation error returned after an action
         })
         .click('#buttonGeo')
         .expect(getResult()).eql('Some error');
+
+    const history = await t.getNativeDialogHistory();
+
+    // NOTE: Only one record must be added to the history, since dialog appears only on the first geolocation request
+    await t.expect(history).eql([{ type: 'geolocation', url: pageUrl }]);
 });
 
 test('Expected confirm after an action', async t => {

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
@@ -36,6 +36,31 @@ test('Expected print after an action', async t => {
     await t.expect(dialogs).eql([{ type: 'print', url: pageUrl }]);
 });
 
+
+test('Expected geolocation object and geolocation error returned after an action', async t => {
+    await t
+        .setNativeDialogHandler((type) => {
+            if (type === 'geolocation')
+                return { timestamp: 12356, coords: {} };
+
+            return null;
+        })
+        .click('#buttonGeo')
+        .expect(getResult()).eql('{"timestamp":12356,"coords":{}}')
+        .setNativeDialogHandler((type) => {
+            if (type !== 'geolocation')
+                return null;
+
+            const err = new Error('Some error');
+
+            err.code = 1;
+
+            return err;
+        })
+        .click('#buttonGeo')
+        .expect(getResult()).eql('Some error');
+});
+
 test('Expected confirm after an action', async t => {
     await t
         .setNativeDialogHandler((type, text) => {

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/page-load-test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/page-load-test.js
@@ -1,6 +1,6 @@
 import { ClientFunction } from 'testcafe';
 
-fixture `Page load`;
+fixture`Page load`;
 
 
 const getResult = ClientFunction(() => window.getDialogsResult());
@@ -16,18 +16,26 @@ test('Expected dialogs after page load', async t => {
             if (type === 'prompt')
                 return 'PromptMsg';
 
+            if (type === 'geolocation')
+                return { geo: 'location' };
+
             return null;
         })
         .navigateTo(pageUrl);
 
     await t.expect(await getResult()).eql({
-        prompt:  'PromptMsg',
-        confirm: 'true',
+        prompt:      'PromptMsg',
+        confirm:     'true',
+        geolocation: '{"geo":"location"}',
     });
 
     const info = await t.getNativeDialogHistory();
 
     await t.expect(info).eql([
+        {
+            type: 'geolocation',
+            url:  pageUrl,
+        },
         {
             type: 'print',
             url:  pageUrl,


### PR DESCRIPTION
## Purpose
#3224

In some cases, you need to handle access geolocation dialog and provide a corresponding result.

## Approach
The geolocation window can be invoked when the user call [window.navigator.geolocation.getCurrentPosition](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition) or watchPosition.
We cannot emulate watchPosition method because it invokes callbacks on changing user geolocation. So, this PR only handles getCurrentPosition method. When this method is called on the page for the first time, the Geolocation access dialog must be shown. All subsequent calls will lead to returning geolocation in the case when the user allowed access, or an error in the case when the user denied access. 
This handler allows you to return a geolocation or an error when calling getCurrentPosition. If an instance of an Error object was returned, the failCallback function will be called with that error. If any other value is returned, then successCallback will be called with that value.
Since this dialog is only shown the first time getCurrentPosition is called, the history contains only one record per URL.


## API
```js

// Test
test('Expected geolocation object and geolocation error returned after an action', async t => {
  await t
    .setNativeDialogHandler((type) => {
        if (type === 'geolocation')
            return { timestamp: 12356, coords: {} };
    
        return null;
    });
    .click('#buttonGeo')
    .setNativeDialogHandler((type) => {
        if (type !== 'geolocation')
            return null;
    
        const err = new Error('Some error');
    
        err.code = 1;
    
        return err;
    })
    .click('#buttonGeo');
    
  const history = await t.getNativeDialogHistory();
  
  // NOTE: Only one record will be added to the history, since dialog appears only on the first geolocation request
  await t.expect(history).eql([{ type: 'geolocation', url: pageUrl }]);
});

// Aplication code:
function successCallback(geolocation) {
    console.log(geolocation) // { timestamp: 12356, coords: {} }
}
function failCallback(err) {
    console.log(err.message); //  "Some error"
    console.log(err.code); // 1
}

function onGeoButtonClick () {
    window.navigator.geolocation.getCurrentPosition(successCallback, failCallback)
}
```

## References
#3224 

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
