### PR TITLE
native automation: header names should be lowercased

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.25",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/11830521/testcafe-hammerhead-31.4.6.zip",
+    "testcafe-hammerhead": "31.4.6",
     "testcafe-legacy-api": "5.1.6",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.25",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/11754015/testcafe-hammerhead-31.4.6.zip",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/11766975/testcafe-hammerhead-31.4.6.zip",
     "testcafe-legacy-api": "5.1.6",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.25",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/11766975/testcafe-hammerhead-31.4.6.zip",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/11830521/testcafe-hammerhead-31.4.6.zip",
     "testcafe-legacy-api": "5.1.6",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.25",
-    "testcafe-hammerhead": "31.4.5",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/11754015/testcafe-hammerhead-31.4.6.zip",
     "testcafe-legacy-api": "5.1.6",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.2.0",

--- a/src/api/request-hooks/request-logger.ts
+++ b/src/api/request-hooks/request-logger.ts
@@ -18,7 +18,6 @@ import {
 } from './interfaces';
 
 import { Dictionary } from '../../configuration/interfaces';
-import lowercaseObjectKeys from '../../utils/lowercase-object-keys';
 
 
 const DEFAULT_OPTIONS: RequestHookLogOptions = {
@@ -94,7 +93,7 @@ class RequestLoggerImplementation extends RequestHook {
         };
 
         if (this._options.logRequestHeaders)
-            loggedReq.request.headers = Object.assign({}, lowercaseObjectKeys(event._requestInfo.headers as Dictionary<string>));
+            loggedReq.request.headers = Object.assign({}, event._requestInfo.headers);
 
         if (this._options.logRequestBody)
             loggedReq.request.body = this._options.stringifyRequestBody ? event._requestInfo.body.toString() : event._requestInfo.body;

--- a/src/native-automation/request-hooks/event-factory/request-paused-event-based.ts
+++ b/src/native-automation/request-hooks/event-factory/request-paused-event-based.ts
@@ -109,7 +109,7 @@ export default class RequestPausedEventBasedEventFactory extends BaseRequestHook
         if (parsedUrl.username)
             requestParams.auth = parsedUrl.username + ':' + parsedUrl.password;
 
-        return new RequestOptions(requestParams);
+        return new RequestOptions(requestParams, true);
     }
 
     public createConfigureResponseEvent (rule: RequestFilterRule): ConfigureResponseEvent {

--- a/src/native-automation/request-hooks/event-factory/request-paused-event-based.ts
+++ b/src/native-automation/request-hooks/event-factory/request-paused-event-based.ts
@@ -15,6 +15,7 @@ import Request = Protocol.Network.Request;
 import HeaderEntry = Protocol.Fetch.HeaderEntry;
 import { StatusCodes } from 'http-status-codes';
 import { convertToOutgoingHttpHeaders } from '../../utils/headers';
+import lowercaseObjectKeys from '../../../utils/lowercase-object-keys';
 
 
 export default class RequestPausedEventBasedEventFactory extends BaseRequestHookEventFactory {
@@ -83,7 +84,7 @@ export default class RequestPausedEventBasedEventFactory extends BaseRequestHook
             userAgent: RequestInfo.getUserAgent(request.headers),
             url:       request.url,
             method:    request.method.toLowerCase(),
-            headers:   request.headers,
+            headers:   Object.assign({}, lowercaseObjectKeys(request.headers)),
             body:      RequestPausedEventBasedEventFactory._getRequestData(request),
             isAjax:    RequestPausedEventBasedEventFactory._getIsAjaxRequest(this._event),
         });
@@ -100,7 +101,7 @@ export default class RequestPausedEventBasedEventFactory extends BaseRequestHook
             host:     parsedUrl.host,
             port:     parsedUrl.port,
             path:     parsedUrl.pathname,
-            headers:  this._event.request.headers,
+            headers:  Object.assign({}, lowercaseObjectKeys(this._event.request.headers)),
             body:     RequestPausedEventBasedEventFactory._getRequestData(this._event.request),
             isAjax:   RequestPausedEventBasedEventFactory._getIsAjaxRequest(this._event),
         };

--- a/src/native-automation/request-pipeline/index.ts
+++ b/src/native-automation/request-pipeline/index.ts
@@ -489,7 +489,7 @@ export default class NativeAutomationRequestPipeline extends NativeAutomationApi
         }
 
         for (const removedHeader of reqOpts._removedHeaders)
-            remove(headers, header => header.name === removedHeader.name);
+            remove(headers, header => header.name.toLowerCase() === removedHeader.name);
 
         return {
             url:    modifierUrl,

--- a/src/native-automation/request-pipeline/index.ts
+++ b/src/native-automation/request-pipeline/index.ts
@@ -319,7 +319,7 @@ export default class NativeAutomationRequestPipeline extends NativeAutomationApi
             else {
                 requestPipelineMockLogger('begin mocking request %r', event);
 
-                const mockedResponse = await this._getMockResponse(pipelineContext);
+                const mockedResponse = await pipelineContext.getMockResponse();
 
                 await this._handleMockErrorIfNecessary(pipelineContext, event);
 
@@ -519,14 +519,5 @@ export default class NativeAutomationRequestPipeline extends NativeAutomationApi
             result.push({ name: header, value: headers[header] });
 
         return result;
-    }
-
-    private async _getMockResponse (pipelineContext: NativeAutomationPipelineContext): Promise<IncomingMessageLike> {
-        const response = await pipelineContext.getMockResponse();
-
-        if (typeof response.statusCode !== 'number')
-            response.statusCode = Number(response.statusCode);
-
-        return response;
     }
 }

--- a/src/native-automation/request-pipeline/index.ts
+++ b/src/native-automation/request-pipeline/index.ts
@@ -474,8 +474,8 @@ export default class NativeAutomationRequestPipeline extends NativeAutomationApi
         if (reqOpts._changedUrlProperties.length) {
             modifierUrl = new URL(event.request.url);
 
-            for (const propName of reqOpts._changedUrlProperties)
-                modifierUrl[propName] = reqOpts[propName];
+            for (const changedUrlProperty of reqOpts._changedUrlProperties)
+                modifierUrl[changedUrlProperty.name] = changedUrlProperty.value;
 
             modifierUrl = modifierUrl.toString();
         }

--- a/src/utils/lowercase-object-keys.ts
+++ b/src/utils/lowercase-object-keys.ts
@@ -1,10 +1,10 @@
 import { Dictionary } from '../configuration/interfaces';
 
-export default function (headers: Dictionary<string>): Dictionary<string> {
+export default function (obj: Dictionary<string>): Dictionary<string> {
     const result: Dictionary<string> = {};
 
-    Object.keys(headers).forEach(name => {
-        result[name.toLowerCase()] = headers[name];
+    Object.keys(obj).forEach(name => {
+        result[name.toLowerCase()] = obj[name];
     });
 
     return result;

--- a/test/functional/fixtures/api/es-next/request-hooks/test.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/test.js
@@ -115,5 +115,9 @@ describe('Request Hooks', () => {
                     expect(testReport.errs[0]).contains('The hook (string) is not of expected type (RequestHook subclass).');
                 });
         });
+
+        it('Header names should be lowercased', () => {
+            return runTests('./testcafe-fixtures/api/header-names.js', null, { only: 'chrome' });
+        });
     });
 });

--- a/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/header-names.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/header-names.js
@@ -1,0 +1,79 @@
+import {
+    RequestMock,
+    RequestLogger,
+    ClientFunction,
+    RequestHook,
+} from 'testcafe';
+
+import ReExecutablePromise from '../../../../../../../../lib/utils/re-executable-promise.js';
+
+const SERVICE_URL = 'https://external-service.com/api/';
+
+const filterRequestPredicate = req => {
+    return req.url === SERVICE_URL
+        && req.headers['x-custom-request-header'] === 'value1';
+};
+
+const logger = RequestLogger(filterRequestPredicate, {
+    logRequestHeaders:  true,
+    logResponseHeaders: true,
+});
+
+const mock = RequestMock()
+    .onRequestTo(SERVICE_URL)
+    .respond((req, res) => {
+        res.headers['access-control-allow-origin']  = '*';
+        res.headers['access-control-allow-headers'] = '*';
+        res.headers['X-custom-response-HEADER']     = 'value2';
+
+        res.setBody(JSON.stringify({ data: 1 }));
+    });
+
+class CustomRequestHook extends RequestHook {
+    constructor () {
+        super(filterRequestPredicate);
+
+        this.onResponseCallCountInternal = 0;
+        this.requestHeaders             = null;
+        this.responseHeaders            = null;
+    }
+
+    async onRequest (e) {
+        this.requestHeaders = e.requestOptions.headers;
+    }
+    async onResponse (e) {
+        this.responseHeaders = e.headers;
+
+        this.onResponseCallCountInternal++;
+    }
+
+    get onResponseCallCount () {
+        return ReExecutablePromise.fromFn(async () => this.onResponseCallCountInternal);
+    }
+}
+
+const customRequestHook = new CustomRequestHook();
+
+fixture `Fixture`
+    .requestHooks(mock, logger, customRequestHook);
+
+test('header names should be lowercased', async t => {
+    const result = await ClientFunction(() => {
+        return fetch(SERVICE_URL, {
+            method:  'POST',
+            headers: { 'X-Custom-Request-Header': 'value1' },
+        }).then(res => res.json());
+    }, { dependencies: { SERVICE_URL } })();
+
+    await t
+        .expect(result).eql({ data: 1 })
+        .expect(logger.contains(req => req.request.url === SERVICE_URL)).ok()
+        .expect(customRequestHook.onResponseCallCount).eql(1);
+
+    const req1 = logger.requests[0];
+
+    await t
+        .expect(req1.request.headers['x-custom-request-header']).eql('value1')
+        .expect(req1.response.headers['x-custom-response-header']).eql('value2')
+        .expect(customRequestHook.requestHeaders['x-custom-request-header']).eql('value1');
+});

--- a/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/header-names.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/header-names.js
@@ -31,7 +31,7 @@ const mock = RequestMock()
 
 class CustomRequestHook extends RequestHook {
     constructor () {
-        super(filterRequestPredicate);
+        super(filterRequestPredicate, { includeHeaders: true } );
 
         this.onResponseCallCountInternal = 0;
         this.requestHeaders             = null;
@@ -41,6 +41,7 @@ class CustomRequestHook extends RequestHook {
     async onRequest (e) {
         this.requestHeaders = e.requestOptions.headers;
     }
+
     async onResponse (e) {
         this.responseHeaders = e.headers;
 
@@ -75,5 +76,6 @@ test('header names should be lowercased', async t => {
     await t
         .expect(req1.request.headers['x-custom-request-header']).eql('value1')
         .expect(req1.response.headers['x-custom-response-header']).eql('value2')
-        .expect(customRequestHook.requestHeaders['x-custom-request-header']).eql('value1');
+        .expect(customRequestHook.requestHeaders['x-custom-request-header']).eql('value1')
+        .expect(customRequestHook.responseHeaders['x-custom-response-header']).eql('value2');
 });

--- a/test/functional/fixtures/regression/gh-7640/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-7640/testcafe-fixtures/index.js
@@ -7,7 +7,7 @@ class MyRequestHook extends RequestHook {
 
     async onRequest (e) {
         e.requestOptions.hostname = 'localhost';
-        e.requestOptions.port = 3001;
+        e.requestOptions.port     = 3001;
     }
 
     async onResponse () {

--- a/test/functional/fixtures/regression/gh-7748/test.js
+++ b/test/functional/fixtures/regression/gh-7748/test.js
@@ -1,7 +1,5 @@
-const { onlyInNativeAutomation } = require('../../../utils/skip-in');
-
 describe('[Regression](GH-7747)', function () {
-    onlyInNativeAutomation('Should modify header on RequestHook', function () {
+    it('Should modify header on RequestHook', function () {
         return runTests('testcafe-fixtures/index.js');
     });
 });

--- a/test/functional/fixtures/regression/gh-7764/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-7764/testcafe-fixtures/index.js
@@ -24,6 +24,6 @@ const logger = RequestLogger('http://localhost:3000/fixtures/regression/gh-7764/
 
 test
     .requestHooks([hook, logger])
-    ('Request logger should contain actual headers if RequestHook modified themd', async t => {
+    ('Request logger should contain actual headers if RequestHook modified them', async t => {
         await t.expect(logger.requests[0].request.headers['referer']).eql('http://my-modified-referer.com');
     });

--- a/test/functional/fixtures/regression/gh-7787/test.js
+++ b/test/functional/fixtures/regression/gh-7787/test.js
@@ -1,7 +1,5 @@
-const { onlyInNativeAutomation } = require('../../../utils/skip-in');
-
 describe('[Regression](GH-7787)', function () {
-    onlyInNativeAutomation('Should not fail if `statusCode` is set as string', function () {
+    it('Should not fail if `statusCode` is set as string', function () {
         return runTests('testcafe-fixtures/index.js');
     });
 });


### PR DESCRIPTION
Changes:
* lowercase header names for all RequestHooks (not only for the `RequestLogger` class)
* move `statusCode` calculation for the custom respond function into `testcafe-hammerhead`
* add change tracking for `RequestOptions` class

Connected PR in the `testcafe-hammerhead` repository - https://github.com/DevExpress/testcafe-hammerhead/pull/2909.