### PR TITLE
chore: add more logging for the 3456 functional test

### DIFF
--- a/test/functional/assertion-helper.js
+++ b/test/functional/assertion-helper.js
@@ -322,13 +322,28 @@ exports.isScreenshotsEqual = function (customPath, referenceImagePathGetter) {
     });
 };
 
-exports.checkScreenshotsDimensions = function (dimensions, screenshotCount) {
-    return checkScreenshotImages(false, '', function (screenshotFilePath) {
+exports.checkScreenshotsDimensions = async function (dimensions, screenshotCount) {
+    const comparisonInfo = {
+        screenshots: [],
+    };
+
+    comparisonInfo.result = await checkScreenshotImages(false, '', function (screenshotFilePath) {
         return readPngFile(screenshotFilePath)
             .then(png => {
-                return dimensions.width === png.width && dimensions.height === png.height;
+                comparisonInfo.screenshots.push({
+                    path:       screenshotFilePath,
+                    dimensions: {
+                        width:  png.width,
+                        height: png.height,
+                    },
+                });
+
+                return dimensions.width === png.width
+                    && dimensions.height === png.height;
             });
     }, screenshotCount);
+
+    return comparisonInfo;
 };
 
 function removeDir (dirPath) {

--- a/test/functional/fixtures/regression/gh-3456/test.js
+++ b/test/functional/fixtures/regression/gh-3456/test.js
@@ -34,8 +34,8 @@ if (config.useLocalBrowsers) {
 
                     return assertionHelper.checkScreenshotsDimensions({ width: 501, height: 602 }, 2);
                 })
-                .then(dimensionsCorrect => {
-                    expect(dimensionsCorrect).eql(true);
+                .then(comparisonInfo => {
+                    expect(comparisonInfo.result).eql(true, JSON.stringify(comparisonInfo));
 
                     return assertionHelper.removeScreenshotDir();
                 })


### PR DESCRIPTION
At last time, the `3456` test became stable. However, I added additional logging to it.