### PR TITLE
fix: title node textContent returns incorrect value in native automation mode(closes #7833)

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.26",
-    "testcafe-hammerhead": "31.4.7",
+    "testcafe-hammerhead": "31.4.8",
     "testcafe-legacy-api": "5.1.6",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.2.0",

--- a/test/functional/fixtures/regression/gh-7833/pages/index.html
+++ b/test/functional/fixtures/regression/gh-7833/pages/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>gh-7833</title>
+</head>
+<body>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-7833/test.js
+++ b/test/functional/fixtures/regression/gh-7833/test.js
@@ -1,0 +1,5 @@
+describe('[Regression](GH-7833)', function () {
+    it('Should return correct title value', function () {
+        return runTests('testcafe-fixtures/index.js');
+    });
+});

--- a/test/functional/fixtures/regression/gh-7833/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-7833/testcafe-fixtures/index.js
@@ -1,0 +1,13 @@
+import { Selector, ClientFunction } from 'testcafe';
+
+const getTitle      = ClientFunction(() => document.title);
+const titleSelector = Selector('title');
+
+fixture`Should return correct page title`
+    .page`http://localhost:3000/fixtures/regression/gh-7833/pages/index.html`;
+
+test('Should click element if it\'s overlapped by StatusBar', async t => {
+    await t
+        .expect(titleSelector.textContent).eql('gh-7833')
+        .expect(await getTitle()).eql('gh-7833');
+});

--- a/test/functional/fixtures/regression/hammerhead/gh-2350/test.js
+++ b/test/functional/fixtures/regression/hammerhead/gh-2350/test.js
@@ -4,7 +4,7 @@ describe("Should provide a valid value for the 'document.title' property", () =>
     describe('Initial value', () => {
         // NOTE: in the proxy mode we have some additional scripts for processing document.title
         // we do not have these scripts in the nativeAutomation mode yet
-        skipInNativeAutomation('script before and after <title>', () => {
+        it('script before and after <title>', () => {
             return runTests('./testcafe-fixtures/index.js', 'script before and after <title>');
         });
 

--- a/test/functional/fixtures/regression/hammerhead/gh-2350/testcafe-fixtures/iframes.js
+++ b/test/functional/fixtures/regression/hammerhead/gh-2350/testcafe-fixtures/iframes.js
@@ -10,8 +10,15 @@ const getNativeTitle = ClientFunction(() => {
 });
 
 test('test', async t => {
+    const nativeAutomation = t.testRun.opts.nativeAutomation;
+    const nativeTitle      = await getNativeTitle();
+
+    if (nativeAutomation)
+        await t.expect(nativeTitle).eql('Index page title');
+    else
+        await t.expect(nativeTitle).notEql('Index page title');
+
     await t
-        .expect(getNativeTitle()).notEql('Index page title')
         .switchToIframe('#withSrc')
         .expect(getNativeTitle()).eql('Iframe page title')
         .switchToMainWindow()


### PR DESCRIPTION
## Purpose
Regression after disabling overrides(https://github.com/DevExpress/testcafe-hammerhead/pull/2877). 

## Approach
Remove extra overridings from hammerhead(https://github.com/DevExpress/testcafe-hammerhead/pull/2919)

## References
#7833 
https://github.com/DevExpress/testcafe-hammerhead/pull/2919


## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
