### PR TITLE
fix: durationMs value is incorrect for skipped tests(closes #7731)

### DIFF
--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -346,16 +346,19 @@ export default class Reporter {
         return task.tests.map(test => Reporter._createTestItem(test, runsPerTest));
     }
 
-    private static _createTestRunInfo (reportItem: TestInfo): TestRunInfo {
-        const durationMs = !reportItem.test.skip
-            ? +new Date() - (reportItem.startTime as number) //eslint-disable-line  @typescript-eslint/no-extra-parens
-            : 0;
+    private static _getTestDuration (reportItem: TestInfo): number {
+        if (reportItem.test.skip)
+            return 0;
 
+        return +new Date() - (reportItem.startTime as number);
+    }
+
+    private static _createTestRunInfo (reportItem: TestInfo): TestRunInfo {
         return {
-            durationMs,
             errs:           sortBy(reportItem.errs, [ 'userAgent', 'code' ]),
             warnings:       reportItem.warnings,
             reportData:     reportItem.reportData,
+            durationMs:     Reporter._getTestDuration(reportItem),
             unstable:       reportItem.unstable,
             screenshotPath: reportItem.screenshotPath as string,
             screenshots:    reportItem.screenshots,

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -347,11 +347,15 @@ export default class Reporter {
     }
 
     private static _createTestRunInfo (reportItem: TestInfo): TestRunInfo {
+        const durationMs = !reportItem.test.skip
+            ? +new Date() - (reportItem.startTime as number) //eslint-disable-line  @typescript-eslint/no-extra-parens
+            : 0;
+
         return {
-            errs:           sortBy(reportItem.errs, ['userAgent', 'code']),
+            durationMs,
+            errs:           sortBy(reportItem.errs, [ 'userAgent', 'code' ]),
             warnings:       reportItem.warnings,
             reportData:     reportItem.reportData,
-            durationMs:     +new Date() - (reportItem.startTime as number), //eslint-disable-line  @typescript-eslint/no-extra-parens
             unstable:       reportItem.unstable,
             screenshotPath: reportItem.screenshotPath as string,
             screenshots:    reportItem.screenshots,

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -1377,4 +1377,31 @@ const del                = require('del');
             expect(testCafe.runner._hasTaskErrors).eql(true);
         }
     });
+
+    it('[gh-7731] Should pass duration 0 for skipped tests', function () {
+        const reportTestDoneReporter = result => createReporter({
+            reportTestDone (name, { durationMs, skipped }) {
+                result.skipped    = result.skipped || [];
+                result.nonSkipped = result.nonSkipped || [];
+
+                if (skipped)
+                    result.skipped.push(durationMs);
+                else
+                    result.nonSkipped.push(durationMs);
+            },
+        });
+
+        const result = {};
+
+        return runTests('testcafe-fixtures/skipped-tests.js', null, {
+            reporter: [reportTestDoneReporter(result)],
+        })
+            .then(() => {
+                expect(result.skipped.length).eql(5);
+                expect(result.nonSkipped.length).eql(1);
+
+                result.skipped.forEach(dur => expect(dur).eql(0));
+                result.nonSkipped.forEach(dur => expect(dur).gt(0));
+            });
+    });
 });

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -1397,7 +1397,7 @@ const del                = require('del');
             reporter: [reportTestDoneReporter(result)],
         })
             .then(() => {
-                expect(result.skipped.length).eql(5);
+                expect(result.skipped.length).eql(4);
                 expect(result.nonSkipped.length).eql(1);
 
                 result.skipped.forEach(dur => expect(dur).eql(0));

--- a/test/functional/fixtures/reporter/testcafe-fixtures/skipped-tests.js
+++ b/test/functional/fixtures/reporter/testcafe-fixtures/skipped-tests.js
@@ -4,19 +4,15 @@ test('Simple test', async t => {
     await t.wait(1);
     await t.report();
 });
-test.skip('Simple command err test', async t => {
+test.skip('Skipped test 1', async t => {
     await t.click('#non-existing-target');
 });
 
-test.skip('Complex command test', async () => {
+test.skip('Skipped test 2', async () => {
 });
 
-test.skip('Complex nested command test', async () => {
+test.skip('Skipped test 3', async () => {
 });
 
-test.skip('Complex nested command error', async () => {
-});
-
-test.skip('Simple assertion', async t => {
-    await t.expect(true).eql(true, 'assertion message', { timeout: 100 });
+test.skip('Skipped test 4', async () => {
 });

--- a/test/functional/fixtures/reporter/testcafe-fixtures/skipped-tests.js
+++ b/test/functional/fixtures/reporter/testcafe-fixtures/skipped-tests.js
@@ -1,0 +1,22 @@
+fixture `Skipped tests`
+    .page `http://localhost:3000/fixtures/reporter/pages/index.html`;
+test('Simple test', async t => {
+    await t.wait(1);
+    await t.report();
+});
+test.skip('Simple command err test', async t => {
+    await t.click('#non-existing-target');
+});
+
+test.skip('Complex command test', async () => {
+});
+
+test.skip('Complex nested command test', async () => {
+});
+
+test.skip('Complex nested command error', async () => {
+});
+
+test.skip('Simple assertion', async t => {
+    await t.expect(true).eql(true, 'assertion message', { timeout: 100 });
+});


### PR DESCRIPTION
## Purpose
#7731

## Approach
Set the durationMs value to 0 for skipped tests

## References
#7731

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
