### PR TITLE
feat: add testcafe version logging, add version export(closes #6591)

### DIFF
--- a/src/api/exportable-lib/index.js
+++ b/src/api/exportable-lib/index.js
@@ -1,11 +1,11 @@
-const lazyRequire            = require('import-lazy')(require);
-const ClientFunctionBuilder  = lazyRequire('../../client-functions/client-function-builder');
-const SelectorBuilder        = lazyRequire('../../client-functions/selectors/selector-builder');
-const role                   = lazyRequire('../../role');
-const createRequestLogger    = lazyRequire('../request-hooks/request-logger');
-const createRequestMock      = lazyRequire('../request-hooks/request-mock/create-request-mock');
-const userVariables          = lazyRequire('../user-variables');
-const { getTestCafeVersion } = lazyRequire('../../utils/get-testcafe-version');
+const lazyRequire           = require('import-lazy')(require);
+const ClientFunctionBuilder = lazyRequire('../../client-functions/client-function-builder');
+const SelectorBuilder       = lazyRequire('../../client-functions/selectors/selector-builder');
+const role                  = lazyRequire('../../role');
+const createRequestLogger   = lazyRequire('../request-hooks/request-logger');
+const createRequestMock     = lazyRequire('../request-hooks/request-mock/create-request-mock');
+const userVariables         = lazyRequire('../user-variables');
+const getTestCafeVersion    = lazyRequire('../../utils/get-testcafe-version');
 
 // NOTE: We can't use lazy require for RequestHook, because it will break base class detection for inherited classes
 let RequestHook = null;

--- a/src/api/exportable-lib/index.js
+++ b/src/api/exportable-lib/index.js
@@ -1,10 +1,11 @@
-const lazyRequire           = require('import-lazy')(require);
-const ClientFunctionBuilder = lazyRequire('../../client-functions/client-function-builder');
-const SelectorBuilder       = lazyRequire('../../client-functions/selectors/selector-builder');
-const role                  = lazyRequire('../../role');
-const createRequestLogger   = lazyRequire('../request-hooks/request-logger');
-const createRequestMock     = lazyRequire('../request-hooks/request-mock/create-request-mock');
-const userVariables         = lazyRequire('../user-variables');
+const lazyRequire            = require('import-lazy')(require);
+const ClientFunctionBuilder  = lazyRequire('../../client-functions/client-function-builder');
+const SelectorBuilder        = lazyRequire('../../client-functions/selectors/selector-builder');
+const role                   = lazyRequire('../../role');
+const createRequestLogger    = lazyRequire('../request-hooks/request-logger');
+const createRequestMock      = lazyRequire('../request-hooks/request-mock/create-request-mock');
+const userVariables          = lazyRequire('../user-variables');
+const { getTestCafeVersion } = lazyRequire('../../utils/get-testcafe-version');
 
 // NOTE: We can't use lazy require for RequestHook, because it will break base class detection for inherited classes
 let RequestHook = null;
@@ -67,6 +68,10 @@ const exportableLib = {
 
     get userVariables () {
         return userVariables.value;
+    },
+
+    get version () {
+        return getTestCafeVersion();
     },
 };
 

--- a/src/cli/argument-parser/index.ts
+++ b/src/cli/argument-parser/index.ts
@@ -32,7 +32,7 @@ import {
 } from '../../configuration/interfaces';
 import QUARANTINE_OPTION_NAMES from '../../configuration/quarantine-option-names';
 import { extractNodeProcessArguments } from '../node-arguments-filter';
-import getTestcafeVersion from '../../utils/get-testcafe-version';
+import { getTestCafeVersion } from '../../utils/get-testcafe-version';
 import { parsePortNumber, parseList } from './parse-utils';
 import COMMAND_NAMES from './command-names';
 import { SKIP_JS_ERRORS_OPTIONS_OBJECT_OPTION_NAMES } from '../../configuration/skip-js-errors-option-names';
@@ -138,7 +138,7 @@ export default class CLIArgumentParser {
 
         return (program as unknown as Command)
             .command(COMMAND_NAMES.TestCafe, { isDefault: true })
-            .version(getTestcafeVersion(), '-v, --version')
+            .version(getTestCafeVersion(), '-v, --version')
             .usage('[options] <comma-separated-browser-list> <file-or-glob ...>')
             .description(CLIArgumentParser._getDescription())
 

--- a/src/cli/argument-parser/index.ts
+++ b/src/cli/argument-parser/index.ts
@@ -32,7 +32,7 @@ import {
 } from '../../configuration/interfaces';
 import QUARANTINE_OPTION_NAMES from '../../configuration/quarantine-option-names';
 import { extractNodeProcessArguments } from '../node-arguments-filter';
-import { getTestCafeVersion } from '../../utils/get-testcafe-version';
+import getTestCafeVersion from '../../utils/get-testcafe-version';
 import { parsePortNumber, parseList } from './parse-utils';
 import COMMAND_NAMES from './command-names';
 import { SKIP_JS_ERRORS_OPTIONS_OBJECT_OPTION_NAMES } from '../../configuration/skip-js-errors-option-names';

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import TestCafeConfiguration from './configuration/testcafe-configuration';
 import OPTION_NAMES from './configuration/option-names';
 import userVariables from './api/user-variables';
 import { getValidPort } from './configuration/utils';
+import { logTestCafeVersion } from './utils/get-testcafe-version';
 
 const lazyRequire   = require('import-lazy')(require);
 const TestCafe      = lazyRequire('./testcafe');
@@ -43,6 +44,8 @@ async function getConfiguration (args) {
 
 // API
 async function createTestCafe (...args) {
+    logTestCafeVersion();
+
     const configuration = await getConfiguration(args);
 
     const [port1, port2] = await Promise.all([

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,8 @@ import TestCafeConfiguration from './configuration/testcafe-configuration';
 import OPTION_NAMES from './configuration/option-names';
 import userVariables from './api/user-variables';
 import { getValidPort } from './configuration/utils';
-import { logTestCafeVersion } from './utils/get-testcafe-version';
+import getTestCafeVersion from './utils/get-testcafe-version';
+import { versionLogger } from './utils/debug-loggers';
 
 const lazyRequire   = require('import-lazy')(require);
 const TestCafe      = lazyRequire('./testcafe');
@@ -44,7 +45,7 @@ async function getConfiguration (args) {
 
 // API
 async function createTestCafe (...args) {
-    logTestCafeVersion();
+    versionLogger(getTestCafeVersion());
 
     const configuration = await getConfiguration(args);
 

--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -34,6 +34,7 @@ import MessageBus from '../utils/message-bus';
 import BrowserConnection from '../browser/connection';
 import { Dictionary } from '../configuration/interfaces';
 import { reporterLogger } from '../utils/debug-loggers';
+import getTestCafeVersion from '../utils/get-testcafe-version';
 
 interface PendingPromise {
     resolve: Function | null;
@@ -186,10 +187,12 @@ export default class Reporter {
     }
 
     public async init (): Promise<void> {
+        const testcafeVersion = getTestCafeVersion();
+
         await this.dispatchToPlugin({
             method:        ReporterPluginMethod.init,
             initialObject: null,
-            args:          [{}],
+            args:          [testcafeVersion],
         });
     }
 

--- a/src/reporter/plugin-host.ts
+++ b/src/reporter/plugin-host.ts
@@ -222,7 +222,7 @@ export default class ReporterPluginHost {
     }
 
     // NOTE: It's an optional method
-    public async init (): Promise<void> { // eslint-disable-line @typescript-eslint/no-empty-function
+    public async init (/* testcafeVersion */): Promise<void> { // eslint-disable-line @typescript-eslint/no-empty-function
         // Optional
     }
 

--- a/src/utils/debug-loggers.ts
+++ b/src/utils/debug-loggers.ts
@@ -38,5 +38,5 @@ export {
     requestPipelineContextLogger,
     testRunControllerLogger,
     reporterLogger,
-    versionLogger
+    versionLogger,
 };

--- a/src/utils/debug-loggers.ts
+++ b/src/utils/debug-loggers.ts
@@ -23,6 +23,8 @@ const testRunControllerLogger = runnerLogger.extend('test-run-controller');
 
 const reporterLogger = testcafeLogger.extend('reporter');
 
+const versionLogger = testcafeLogger.extend('version');
+
 export {
     nativeAutomationLogger,
     requestPipelineLogger,
@@ -36,4 +38,5 @@ export {
     requestPipelineContextLogger,
     testRunControllerLogger,
     reporterLogger,
+    versionLogger
 };

--- a/src/utils/get-testcafe-version.ts
+++ b/src/utils/get-testcafe-version.ts
@@ -1,19 +1,3 @@
-import logEntry from './log-entry';
-import debug from 'debug';
-
-const LOGGER = debug('testcafe:version');
-
-export function logTestCafeVersion (): void {
-    logEntry(LOGGER, getTestCafeVersion());
-}
-
-export function getTestCafeVersion (): string {
-    try {
-        return require('../../package.json').version;
-    }
-    catch (err) {
-        logEntry(LOGGER, err);
-
-        return '';
-    }
+export default function getTestCafeVersion (): string {
+    return require('../../package.json').version;
 }

--- a/src/utils/get-testcafe-version.ts
+++ b/src/utils/get-testcafe-version.ts
@@ -1,3 +1,19 @@
-export default function (): string {
-    return require('../../package.json').version;
+import logEntry from './log-entry';
+import debug from 'debug';
+
+const LOGGER = debug('testcafe:version');
+
+export function logTestCafeVersion (): void {
+    logEntry(LOGGER, getTestCafeVersion());
+}
+
+export function getTestCafeVersion (): string {
+    try {
+        return require('../../package.json').version;
+    }
+    catch (err) {
+        logEntry(LOGGER, err);
+
+        return '';
+    }
 }

--- a/test/functional/fixtures/reporter/test.js
+++ b/test/functional/fixtures/reporter/test.js
@@ -1,14 +1,15 @@
 const { expect }                 = require('chai');
 const fs                         = require('fs');
+const path                       = require('path');
+const { noop }                   = require('lodash');
 const generateReporter           = require('./reporter');
 const { createReporter }         = require('../../utils/reporter');
 const { createWarningReporter }  = require('../../utils/warning-reporter');
 const ReporterPluginMethod       = require('../../../../lib/reporter/plugin-methods');
 const assertionHelper            = require('../../assertion-helper.js');
-const path                       = require('path');
 const config                     = require('../../config');
 const { skipInNativeAutomation } = require('../../utils/skip-in');
-const { noop }                   = require('lodash');
+const getTestCafeVersion         = require('../../../../lib/utils/get-testcafe-version');
 
 const {
     createSimpleTestStream,
@@ -668,7 +669,7 @@ const del                = require('del');
             return runTests(
                 'testcafe-fixtures/index-test.js',
                 'The "typeText" action with the input[type=text] and the "confidential" flag set to true',
-                { reporter: generateReporter(log, { includeCommandInfo: true }) }
+                { reporter: generateReporter(log, { includeCommandInfo: true }) },
             ).then(() => {
                 expect(log).to.include.deep.members([
                     {
@@ -1160,7 +1161,7 @@ const del                = require('del');
                 });
             }
 
-            const actionIds = [];
+            const actionIds   = [];
             const screenshots = {};
 
             await runTests('./testcafe-fixtures/index-test.js', 'Take a screenshot on action and on error', {
@@ -1288,8 +1289,9 @@ const del                = require('del');
 
     it('Should call the "init" method of reporters if it\'s defined', function () {
         const reportInitSuccess = result => createReporter({
-            init () {
-                result.init = result.init || [];
+            init (version) {
+                result.init    = result.init || [];
+                result.version = version;
 
                 result.init.push(true);
             },
@@ -1316,6 +1318,7 @@ const del                = require('del');
             .then(() => {
                 expect(result.init).eql([true]);
                 expect(result.done).eql([true, true]);
+                expect(result.version).eql(getTestCafeVersion());
             });
     });
 
@@ -1345,7 +1348,7 @@ const del                = require('del');
                         reporter:     createReporterWithBrokenMethod(method),
                         shouldFail:   true,
                         tsConfigPath: 'path-to-ts-config',
-                    }
+                    },
                 );
 
                 throw new Error('Promise rejection expected');
@@ -1361,7 +1364,7 @@ const del                = require('del');
         return runTestsWithConfig('Simple test', './test/functional/fixtures/reporter/configs/xunit-config.js')
             .then(() => {
                 const pathReport = path.resolve(__dirname, 'report.xml');
-                const report = fs.readFileSync(pathReport).toString();
+                const report     = fs.readFileSync(pathReport).toString();
 
                 expect(report).contains('<?xml version="1.0" encoding="UTF-8" ?>');
 

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -18,7 +18,7 @@ const compile             = require('./helpers/compile');
 const Module              = require('module');
 const toPosixPath         = require('../../lib/utils/to-posix-path');
 const BaseTestRunMock     = require('./helpers/base-test-run-mock');
-const getTestCafeVersion = require('../../lib/utils/get-testcafe-version');
+const getTestCafeVersion  = require('../../lib/utils/get-testcafe-version');
 
 const copy      = promisify(fs.copyFile);
 const remove    = promisify(fs.unlink);

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -18,6 +18,7 @@ const compile             = require('./helpers/compile');
 const Module              = require('module');
 const toPosixPath         = require('../../lib/utils/to-posix-path');
 const BaseTestRunMock     = require('./helpers/base-test-run-mock');
+const getTestCafeVersion = require('../../lib/utils/get-testcafe-version');
 
 const copy      = promisify(fs.copyFile);
 const remove    = promisify(fs.unlink);
@@ -96,7 +97,7 @@ describe('Compiler', function () {
                 'test/server/data/test-suites/basic/testfile4.js',
             ];
 
-            const versionRegex = new RegExp(/.\..\..*/);
+            const testcafeVersion = getTestCafeVersion();
 
             return compile(sources)
                 .then(function (compiled) {
@@ -137,15 +138,14 @@ describe('Compiler', function () {
                     }));
                 })
                 .then(function (results) {
-                    const resultVersion = results.pop();
-
                     expect(results).eql([
                         'F1T1: Hey from dep1',
                         'F1T2',
                         'F2T1',
                         'F3T1: Hey from dep1 and dep2',
+                        testcafeVersion,
                     ]);
-                    expect(versionRegex.test(resultVersion), 'returned version doesnt match the version pattern').eql(true);
+                    expect(results[results.length - 1]).to.be.a('string');
                 });
         });
 

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -93,7 +93,10 @@ describe('Compiler', function () {
             const sources = [
                 'test/server/data/test-suites/basic/testfile1.js',
                 'test/server/data/test-suites/basic/testfile2.js',
+                'test/server/data/test-suites/basic/testfile4.js',
             ];
+
+            const versionRegex = new RegExp(/.\..\..*/);
 
             return compile(sources)
                 .then(function (compiled) {
@@ -102,8 +105,8 @@ describe('Compiler', function () {
                     const tests     = compiled.tests;
                     const fixtures  = compiled.fixtures;
 
-                    expect(tests.length).eql(4);
-                    expect(fixtures.length).eql(3);
+                    expect(tests.length).eql(5);
+                    expect(fixtures.length).eql(4);
 
                     expect(fixtures[0].name).eql('Fixture1');
                     expect(fixtures[0].path).eql(testfile1);
@@ -134,12 +137,15 @@ describe('Compiler', function () {
                     }));
                 })
                 .then(function (results) {
+                    const resultVersion = results.pop();
+
                     expect(results).eql([
                         'F1T1: Hey from dep1',
                         'F1T2',
                         'F2T1',
                         'F3T1: Hey from dep1 and dep2',
                     ]);
+                    expect(versionRegex.test(resultVersion), 'returned version doesnt match the version pattern').eql(true);
                 });
         });
 

--- a/test/server/data/test-suites/basic/testfile4.js
+++ b/test/server/data/test-suites/basic/testfile4.js
@@ -1,0 +1,7 @@
+import {version} from 'testcafe';
+
+fixture('Fixture5')
+
+test('Fixture5Test1', async () => {
+    return version;
+});

--- a/test/server/data/test-suites/typescript-defs/version.ts
+++ b/test/server/data/test-suites/typescript-defs/version.ts
@@ -1,0 +1,9 @@
+/// <reference path="../../../../../ts-defs/index.d.ts" />
+import { version } from 'testcafe';
+
+fixture `Version`;
+
+test('test', async (t) => {
+    await t
+        .expect(!!version).ok();
+});

--- a/test/server/parse-fixture-test.js
+++ b/test/server/parse-fixture-test.js
@@ -102,6 +102,13 @@ describe('Should get structure of files (esnext and typescript common cases)', f
                     ]
                 ),
             ],
+            [
+                new Fixture('Fixture5', 35, 54, new Loc(3, 0, 3, 19), {},
+                    [
+                        new Test('Fixture5Test1', 56, 114, new Loc(5, 0, 7, 2), {}),
+                    ]
+                ),
+            ],
         ];
 
         return testJSFilesParser('./data/test-suites/basic', expectedStructure);

--- a/test/server/runner-test.js
+++ b/test/server/runner-test.js
@@ -515,6 +515,7 @@ describe('Runner', () => {
                 'test/server/data/test-suites/basic/testfile1.js',
                 'test/server/data/test-suites/basic/testfile2.js',
                 'test/server/data/test-suites/basic/testfile3.js',
+                'test/server/data/test-suites/basic/testfile4.js',
             ].map(file => path.resolve(cwd, file));
 
             runner.bootstrapper._getBrowserConnections = () => {

--- a/ts-defs-src/helpers/test-api-exports.d.ts
+++ b/ts-defs-src/helpers/test-api-exports.d.ts
@@ -42,5 +42,10 @@ export const t: TestController;
  */
 export const userVariables: UserVariables;
 
+/**
+ * String which represents TestCafe version
+ */
+export const version: string;
+
 export const fixture: FixtureFn;
 export const test: TestFn;


### PR DESCRIPTION
## Purpose
Add version logging on TestCafe start.
export DEBUG="testcafe:version"
Add ability to check version in reporter: #6591 

## Approach
Add logging
Add version export

## API
```ts
// Any script file:
import {version} from 'testcafe';

console.log(version);
```
```js
//reporter method:

{
   init (testcafeVersion) { 
      this.write(`Using TestCafe v${testcafeVersion}`).newline()
   }
}

```


## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
