### PR TITLE
github-actions: added running remote tests via the github host

### DIFF
--- a/.github/workflows/test-functional-remote-mobile.yml
+++ b/.github/workflows/test-functional-remote-mobile.yml
@@ -16,7 +16,8 @@ jobs:
     uses: ./.github/workflows/test-functional.yml
     with:
       test-script: 'npx gulp test-functional-travis-mobile-run --steps-as-tasks'
-      os: 'browserstack'
+      os: 'ubuntu-latest'
       use-public-hostname: true
       timeout: 35
+      is-browserstack: true
     secrets: inherit

--- a/.github/workflows/test-functional.yml
+++ b/.github/workflows/test-functional.yml
@@ -38,6 +38,10 @@ on:
         required: false
         type: boolean
         default: false
+      is-browserstack:
+        required: false
+        type: boolean
+        default: false
 env:
   NO_CACHE: ${{ secrets.NO_CACHE }}
 
@@ -64,6 +68,7 @@ jobs:
     env:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      BROWSERSTACK_BUILD_NAME: ${{ format('{0} ({1})', github.workflow, github.run_id) }}
       USE_PUBLIC_HOSTNAME: ${{ inputs.use-public-hostname }}
       RETRY_FAILED_TESTS: ${{ inputs.retry_failed_tests }}
       TEST_GROUPS_COUNT: ${{ inputs.matrix-jobs-count }}
@@ -121,8 +126,22 @@ jobs:
       - run: npm install
         if: ${{ inputs.is-docker }}
 
+      - name: 'Start BrowserStackLocal Tunnel'
+        if: ${{ inputs.is-browserstack }}
+        uses: 'browserstack/github-actions/setup-local@master'
+        with:
+          local-testing: start
+          local-logging-level: all-logs
+          local-identifier: random
+
       - run: ${{ inputs.test-script }}
         timeout-minutes: ${{ inputs.timeout }}
+
+      - name: 'Stop BrowserStackLocal'
+        if: ${{ inputs.is-browserstack }}
+        uses: 'browserstack/github-actions/setup-local@master'
+        with:
+          local-testing: stop
         
       - name: Save result
         id: save-result


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Increase BrowserStack runners count for remote tests

## Approach
Currently, we use only 2 self-hosted runners to execute remote tests. These runners don't use all runners in the BrowserStack. Find out the way to use all BrowserStack runners.

## References
https://github.com/DevExpress/testcafe-private/issues/202

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
