### PR TITLE
github-actions: added running remote tests via the github host

### DIFF
--- a/.github/workflows/test-functional-remote-mobile.yml
+++ b/.github/workflows/test-functional-remote-mobile.yml
@@ -20,7 +20,8 @@ jobs:
     uses: ./.github/workflows/test-functional.yml
     with:
       test-script: 'npx gulp test-functional-travis-mobile-run --steps-as-tasks'
-      os: 'browserstack'
+      os: 'ubuntu-latest'
       use-public-hostname: true
       timeout: 35
+      is-browserstack: true
     secrets: inherit

--- a/.github/workflows/test-functional.yml
+++ b/.github/workflows/test-functional.yml
@@ -38,6 +38,10 @@ on:
         required: false
         type: boolean
         default: false
+      is-browserstack:
+        required: false
+        type: boolean
+        default: false
 env:
   NO_CACHE: ${{ secrets.NO_CACHE }}
 
@@ -64,6 +68,7 @@ jobs:
     env:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      BROWSERSTACK_BUILD_NAME: ${{ format('{0} ({1})', github.workflow, github.run_id) }}
       USE_PUBLIC_HOSTNAME: ${{ inputs.use-public-hostname }}
       RETRY_FAILED_TESTS: ${{ inputs.retry_failed_tests }}
       TEST_GROUPS_COUNT: ${{ inputs.matrix-jobs-count }}
@@ -129,8 +134,22 @@ jobs:
           sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "INSERT OR REPLACE INTO access VALUES('kTCCServiceScreenCapture','com.devexpress.testcafe-browser-tools',0,2,3,1,X'fade0c0000000068000000010000000700000007000000080000001443fa4ca5141baeda21aeca1f50894673b440d4690000000800000014f8afcf6e69791b283e55bd0b03e39e422745770e0000000800000014bf4fc1aed64c871a49fc6bc9dd3878ce5d4d17c6',NULL,0,'UNUSED',NULL,0,1687952810);"
         if: ${{ contains(inputs.os, 'mac') }}
 
+      - name: 'Start BrowserStackLocal Tunnel'
+        if: ${{ inputs.is-browserstack }}
+        uses: 'browserstack/github-actions/setup-local@master'
+        with:
+          local-testing: start
+          local-logging-level: all-logs
+          local-identifier: random
+
       - run: ${{ inputs.test-script }} 2> testcafe-debug-log.log
         timeout-minutes: ${{ inputs.timeout }}
+
+      - name: 'Stop BrowserStackLocal'
+        if: ${{ inputs.is-browserstack }}
+        uses: 'browserstack/github-actions/setup-local@master'
+        with:
+          local-testing: stop
 
       - name: Save debug log
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Increase BrowserStack runners count for remote tests

## Approach
Currently, we use only 2 self-hosted runners to execute remote tests. These runners don't use all runners in the BrowserStack. Find out the way to use all BrowserStack runners.

## References
https://github.com/DevExpress/testcafe-private/issues/202

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
