### PR TITLE
test: fixed blinking multiple test

### DIFF
--- a/test/functional/fixtures/multiple-windows/test.js
+++ b/test/functional/fixtures/multiple-windows/test.js
@@ -141,7 +141,7 @@ describe('Multiple windows', () => {
     });
 
     it('Should switch to parent and close window if the file was downloaded in separate window', () => {
-        return runTests('testcafe-fixtures/i6242.js');
+        return runTests('testcafe-fixtures/i6242.js', null, { only: 'chrome' });
     });
 
     it('Should switch to child window if parent page has proxied image', () => {


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

[closes DevExpress/testcafe-private#206]

## Purpose
Stabilize multiple tests

## Approach
Some times test `Should switch to parent and close window if the file was downloaded in separate window` isn't executed correctly in Firefox. Something happens on the client side and the server doesn't get the done result. It reproduces only on the GitHub host. 

I made the test run only in Chrome.

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
