### PR TITLE
fix: fixed regression on basic http authentication

### DIFF
--- a/src/native-automation/request-pipeline/index.ts
+++ b/src/native-automation/request-pipeline/index.ts
@@ -273,9 +273,10 @@ export default class NativeAutomationRequestPipeline extends NativeAutomationApi
         const authRequest = await resendAuthRequest(event.request, credentials);
 
         if (typeof authRequest !== 'string' && !isUnauthorized(authRequest.status)) {
-            fulfillInfo.responseCode = authRequest.status;
-            fulfillInfo.body = authRequest.body.toString();
-            fulfillInfo.responsePhrase = authRequest.statusText;
+            fulfillInfo.responseCode    = authRequest.status;
+            fulfillInfo.body            = authRequest.body.toString();
+            fulfillInfo.responsePhrase  = authRequest.statusText;
+            fulfillInfo.responseHeaders = convertToHeaderEntries(authRequest.headers);
         }
     }
 

--- a/src/test-run/request/interfaces.ts
+++ b/src/test-run/request/interfaces.ts
@@ -1,4 +1,8 @@
-import { IncomingMessage, OutgoingHttpHeaders } from 'http';
+import {
+    IncomingHttpHeaders,
+    IncomingMessage,
+    OutgoingHttpHeaders,
+} from 'http';
 import { Dictionary } from '../../configuration/interfaces';
 import { Buffer } from 'buffer';
 
@@ -36,6 +40,6 @@ export type ResponseBody = IncomingMessage | Buffer | object | string;
 export interface ResponseOptions {
     status: number;
     statusText: string;
-    headers: object;
+    headers: IncomingHttpHeaders;
     body: ResponseBody;
 }

--- a/test/functional/fixtures/api/es-next/auth/test.js
+++ b/test/functional/fixtures/api/es-next/auth/test.js
@@ -10,7 +10,11 @@ describe('Basic and NTLM authentications', function () {
     });
 
     it('Should authenticate on a "basic" server with correct credentials', function () {
-        return runTests('./testcafe-fixtures/basic-auth-with-correct-credentials-test.js');
+        return runTests('./testcafe-fixtures/basic-auth-with-correct-credentials-test.js', 'Authenticate with correct credintials');
+    });
+
+    it('Should authenticate on a "basic" server with correct credentials and redirect', function () {
+        return runTests('./testcafe-fixtures/basic-auth-with-correct-credentials-test.js', 'Authenticate with correct credintials and redirect');
     });
 
     // NOTE: NTLM authentication is not supported yet

--- a/test/functional/fixtures/api/es-next/auth/testcafe-fixtures/basic-auth-with-correct-credentials-test.js
+++ b/test/functional/fixtures/api/es-next/auth/testcafe-fixtures/basic-auth-with-correct-credentials-test.js
@@ -1,9 +1,12 @@
 import { Selector } from 'testcafe';
 
 fixture `Basic authentication - correct credentials`
-    .page `http://localhost:3002`
     .httpAuth({ username: 'username', password: 'password' });
 
 test('Authenticate with correct credintials', async t => {
     await t.expect(Selector('#result').innerText).eql('authorized');
-});
+}).page `http://localhost:3002`;
+
+test('Authenticate with correct credintials and redirect', async t => {
+    await t.expect(Selector('#result').innerText).eql('authorized');
+}).page `http://localhost:3002/redirect`;

--- a/test/functional/site/basic-auth-server.js
+++ b/test/functional/site/basic-auth-server.js
@@ -7,6 +7,18 @@ class BasicAuthServer extends BasicHttpServer {
     start (port) {
         const app = express();
 
+        app.all('/redirect', function (req, res) {
+            const credentials = basicAuth(req);
+
+            if (!credentials || credentials.name !== 'username' || credentials.pass !== 'password') {
+                res.statusCode = 401;
+                res.setHeader('WWW-Authenticate', 'Basic realm="example"');
+                res.end('<html><body><div id="result">not authorized</div></body></html>');
+            }
+            else
+                res.redirect('/');
+        });
+
         app.all('*', function (req, res) {
             const credentials = basicAuth(req);
 


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->
[closes #7852]

## Purpose
Fix regression on basic http authentication

## Approach
1. Research issue. TestCafe in NA mode won't redirect if the authorization request returns redirection. It happens because headers from the response don't affect the result. 
2. Add a test.
3. Inherit headers from the response to the `fulfillInfo`

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
