### PR TITLE
fix: duration is calculated incorrectly in concurrency mode(closes #1816)

### DIFF
--- a/src/reporter/index.ts
+++ b/src/reporter/index.ts
@@ -64,6 +64,7 @@ interface TestInfo {
     warnings: string[];
     unstable: boolean;
     startTime: null | number;
+    finishTime: null | number;
     testRunInfo: null | TestRunInfo;
     pendingRuns: number;
     pendingStarts: number;
@@ -330,6 +331,7 @@ export default class Reporter {
             warnings:                   [],
             unstable:                   false,
             startTime:                  null,
+            finishTime:                 null,
             testRunInfo:                null,
             pendingRuns:                runsPerTest,
             pendingStarts:              runsPerTest,
@@ -350,7 +352,9 @@ export default class Reporter {
         if (reportItem.test.skip)
             return 0;
 
-        return +new Date() - (reportItem.startTime as number);
+        const finishTime = reportItem.finishTime || +new Date();
+
+        return finishTime - (reportItem.startTime as number);
     }
 
     private static _createTestRunInfo (reportItem: TestInfo): TestRunInfo {
@@ -447,6 +451,9 @@ export default class Reporter {
 
             Object.assign(testItem.quarantine as object, testItemQuarantine);
         }
+
+        if (!testItem.finishTime)
+            testItem.finishTime = testRun.finishTime?.getTime() || null;
 
         if (!testItem.testRunInfo) {
             testItem.testRunInfo = Reporter._createTestRunInfo(testItem);

--- a/src/runner/browser-job.ts
+++ b/src/runner/browser-job.ts
@@ -143,6 +143,8 @@ export default class BrowserJob extends AsyncEventEmitter {
     }
 
     private async _onTestRunDone (testRunController: TestRunController): Promise<void> {
+        testRunController.testRun.finishTime = new Date();
+
         this._total++;
 
         if (!testRunController.testRun.errs.length)

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -265,6 +265,7 @@ export default class TestRun extends AsyncEventEmitter {
     public readonly cookieProvider: CookieProvider;
     private _storagesProvider: StoragesProvider;
     public readonly startRunExecutionTime?: Date;
+    public finishTime?: Date;
     private readonly _requestHookEventProvider: RequestHookEventProvider;
     private readonly _roleProvider: RoleProvider;
     public readonly isNativeAutomation: boolean;

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -193,6 +193,29 @@ if (config.useLocalBrowsers) {
                     expect(error.message).eql('The number of remote browsers should be divisible by the concurrency factor.');
                 });
         });
+
+        it('Should display correct duration for the tests run in concurrency', function () {
+            const durationsInfo = [];
+
+            const durationReporter = createReporter({
+                reportTestDone: function (name, {durationMs}) {
+                    durationsInfo.push({ name, durationMs });
+                },
+            });
+
+            return run('chrome:headless --no-sandbox', 3, './testcafe-fixtures/duration-test.js', durationReporter)
+                .then(() => {
+                    const sortedByDuration = durationsInfo
+                        .sort((info1, info2) => info1.durationMs - info2.durationMs)
+                        .map(info => info.name);
+
+                    expect(sortedByDuration).eql([
+                        'Test 2',
+                        'Test 1',
+                        'Test 3',
+                    ]);
+                });
+        });
     });
 }
 

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -198,7 +198,7 @@ if (config.useLocalBrowsers) {
             const durationsInfo = [];
 
             const durationReporter = createReporter({
-                reportTestDone: function (name, {durationMs}) {
+                reportTestDone: function (name, { durationMs }) {
                     durationsInfo.push({ name, durationMs });
                 },
             });

--- a/test/functional/fixtures/concurrency/testcafe-fixtures/duration-test.js
+++ b/test/functional/fixtures/concurrency/testcafe-fixtures/duration-test.js
@@ -1,0 +1,15 @@
+fixture`Concurrent duration`
+    .page`../pages/index.html`;
+
+test('Test 1', async t => {
+    await t.wait(2000);
+});
+
+test('Test 2', async t => {
+    await t.wait(1000);
+});
+test('Test 3', async t => {
+    await t.wait(1000);
+}).after(async t => {
+    await t.wait(2000);
+});


### PR DESCRIPTION
## Purpose
The duration is calculated incorrectly because it was calculated at the moment when testrun-done event is raised. We cannot change the order of the testCompletionQueue, but we can calculate the correct duration.
https://github.com/DevExpress/testcafe/issues/1816

## Approach
Calculate the finish time at the moment when TestRun is finished instead of the moment when the corresponding event has been raised.

## References
https://github.com/DevExpress/testcafe/issues/1816

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
