### PR TITLE
fix 'Local storage is cleared on every t.navigateTo in Safari'

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.26",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/12026314/testcafe-hammerhead-31.4.6.zip",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/12026358/testcafe-hammerhead-31.4.9.zip",
     "testcafe-legacy-api": "5.1.6",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.26",
-    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/12026358/testcafe-hammerhead-31.4.9.zip",
+    "testcafe-hammerhead": "31.4.10",
     "testcafe-legacy-api": "5.1.6",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "source-map-support": "^0.5.16",
     "strip-bom": "^2.0.0",
     "testcafe-browser-tools": "2.0.26",
-    "testcafe-hammerhead": "31.4.8",
+    "testcafe-hammerhead": "https://github.com/miherlosev/tmp/files/12026314/testcafe-hammerhead-31.4.6.zip",
     "testcafe-legacy-api": "5.1.6",
     "testcafe-reporter-json": "^2.1.0",
     "testcafe-reporter-list": "^2.2.0",

--- a/test/functional/fixtures/api/es-next/iframe-switching/test.js
+++ b/test/functional/fixtures/api/es-next/iframe-switching/test.js
@@ -75,7 +75,7 @@ describe('[API] t.switchToIframe(), t.switchToMainWindow()', function () {
     });
 
     it('Correct execution order of "message" events in cross-domain iframe', function () {
-        return runTests('./testcafe-fixtures/message-event.js', null, { skip: 'ie', ...DEFAULT_RUN_OPTIONS });
+        return runTests('./testcafe-fixtures/message-event.js', null, { skip: ['iphone', 'ipad'], ...DEFAULT_RUN_OPTIONS });
     });
 
     describe('Unavailable iframe errors', function () {

--- a/test/functional/fixtures/regression/gh-5992/pages/page1.html
+++ b/test/functional/fixtures/regression/gh-5992/pages/page1.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <h1>Page 1</h1>
+    <a href="page2.html">Go to page 2</a>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-5992/pages/page2.html
+++ b/test/functional/fixtures/regression/gh-5992/pages/page2.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <h1>Page 2</h1>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-5992/test.js
+++ b/test/functional/fixtures/regression/gh-5992/test.js
@@ -1,0 +1,5 @@
+describe('Should store localStorage values between pages (GH-5992)', () => {
+    it('Should store localStorage values between pages (GH-5992)', () => {
+        return runTests('testcafe-fixtures/index.js');
+    });
+});

--- a/test/functional/fixtures/regression/gh-5992/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-5992/testcafe-fixtures/index.js
@@ -1,0 +1,24 @@
+import { ClientFunction } from 'testcafe';
+
+fixture('Fixture')
+    .page('http://localhost:3000/fixtures/regression/gh-5992/page1.html');
+
+const setLocalStorageItem = ClientFunction(() => {
+    window.localStorage.setItem('foo', 'bar');
+});
+
+const getLocalStorageItem = ClientFunction(() => {
+    return window.localStorage.getItem('foo');
+});
+
+test('test', async t => {
+    await setLocalStorageItem();
+
+    const valueOnPage1 = await getLocalStorageItem();
+
+    await t.navigateTo('page2.html');
+
+    const valueOnPage2 = await getLocalStorageItem();
+
+    await t.expect(valueOnPage1).eql(valueOnPage2);
+});


### PR DESCRIPTION
Connected [PR](https://github.com/DevExpress/testcafe-hammerhead/pull/2923) in the `testcafe-hammerhead` repository.