### PR TITLE
fix: support custom geolocation dialog mocks

### DIFF
--- a/src/client/driver/native-dialog-tracker/index.js
+++ b/src/client/driver/native-dialog-tracker/index.js
@@ -172,7 +172,7 @@ export default class NativeDialogTracker {
     }
 
     _overrideGeolocationDialogIfNecessary () {
-        const geolocation = window.navigator.geolocation;
+        const geolocation = window.Geolocation?.prototype;
 
         if (!geolocation?.getCurrentPosition)
             return;

--- a/src/client/driver/native-dialog-tracker/index.js
+++ b/src/client/driver/native-dialog-tracker/index.js
@@ -173,7 +173,7 @@ export default class NativeDialogTracker {
 
     _setGeolocationDialogHandler () {
         const geolocationPrototype = window.Geolocation?.prototype;
-        const geolocationObject = window.navigator?.geolocation;
+        const geolocationObject    = window.navigator?.geolocation;
 
         // NOTE: We need to check if any mock already used by user because a lot of users used our workarounds before we introduced this dialog
         // If such a mock is specified in geolocationPrototype or geolocationObject we need to skip our overriding

--- a/src/client/driver/native-dialog-tracker/index.js
+++ b/src/client/driver/native-dialog-tracker/index.js
@@ -96,9 +96,6 @@ export default class NativeDialogTracker {
     }
 
     _createDialogHandler (type) {
-        if (type === GEOLOCATION_DIALOG_TYPE)
-            return this._createGeolocationHandler();
-
         return text => {
             const url = NativeDialogTracker._getPageUrl();
 
@@ -118,30 +115,35 @@ export default class NativeDialogTracker {
         };
     }
 
-    _createGeolocationHandler () {
-        return (successCallback, failCallback) => {
-            const url                       = NativeDialogTracker._getPageUrl();
-            const isFirstGeolocationRequest = !nativeMethods.arraySome
-                .call(this.appearedDialogs, dialog => dialog.type === GEOLOCATION_DIALOG_TYPE && dialog.url === url);
+    _geolocationDialogHandler (successCallback, failCallback) {
+        if (!this.dialogHandler) {
+            this._defaultDialogHandler(GEOLOCATION_DIALOG_TYPE);
 
-            if (isFirstGeolocationRequest)
-                this._addAppearedDialogs(GEOLOCATION_DIALOG_TYPE, void 0, url);
+            successCallback();
+            return;
+        }
 
-            const executor = new ClientFunctionExecutor(this.dialogHandler);
-            let result     = null;
+        const url                       = NativeDialogTracker._getPageUrl();
+        const isFirstGeolocationRequest = !nativeMethods.arraySome
+            .call(this.appearedDialogs, dialog => dialog.type === GEOLOCATION_DIALOG_TYPE && dialog.url === url);
 
-            try {
-                result = executor.fn.apply(window, [GEOLOCATION_DIALOG_TYPE, void 0, url]);
-            }
-            catch (err) {
-                this._onHandlerError(GEOLOCATION_DIALOG_TYPE, err.message || String(err), url);
-            }
+        if (isFirstGeolocationRequest)
+            this._addAppearedDialogs(GEOLOCATION_DIALOG_TYPE, void 0, url);
 
-            if (result instanceof Error)
-                failCallback(result);
-            else
-                successCallback(result);
-        };
+        const executor = new ClientFunctionExecutor(this.dialogHandler);
+        let result     = null;
+
+        try {
+            result = executor.fn.apply(window, [GEOLOCATION_DIALOG_TYPE, void 0, url]);
+        }
+        catch (err) {
+            this._onHandlerError(GEOLOCATION_DIALOG_TYPE, err.message || String(err), url);
+        }
+
+        if (result instanceof Error)
+            failCallback(result);
+        else
+            successCallback(result);
     }
 
     // Overridable methods
@@ -160,17 +162,26 @@ export default class NativeDialogTracker {
     }
 
     _setCustomOrDefaultHandler () {
-        const geolocation      = window.navigator.geolocation;
-        const createDialogCtor = this.dialogHandler
-            ? dialogType => this._createDialogHandler(dialogType)
-            : dialogType => () => this._defaultDialogHandler(dialogType);
-
         NATIVE_DIALOG_TYPES.forEach(dialogType => {
-            window[dialogType] = createDialogCtor(dialogType);
+            window[dialogType] = this.dialogHandler
+                ? this._createDialogHandler(dialogType)
+                : () => this._defaultDialogHandler(dialogType);
         });
 
-        if (geolocation?.getCurrentPosition)
-            geolocation.getCurrentPosition = createDialogCtor(GEOLOCATION_DIALOG_TYPE);
+        this._overrideGeolocationDialogIfNecessary();
+    }
+
+    _overrideGeolocationDialogIfNecessary () {
+        const geolocation = window.navigator.geolocation;
+
+        if (!geolocation?.getCurrentPosition)
+            return;
+
+        const isNativeMethod = nativeMethods.isNativeCode(geolocation.getCurrentPosition);
+        const isNativeDialogHandler = geolocation.getCurrentPosition === this._geolocationDialogHandler;
+
+        if (isNativeMethod || isNativeDialogHandler)
+            geolocation.getCurrentPosition = this._geolocationDialogHandler.bind(this);
     }
 
     // API

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/pages/geolocation-overrided.html
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/pages/geolocation-overrided.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+<script>
+    window.navigator.geolocation.getCurrentPosition = success => success('on-page');
+</script>
+</body>
+</html>

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/test.js
@@ -39,6 +39,10 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Should not override getCurrentPosition method if it is overrided via client function');
         });
 
+        it('Should not override getCurrentPosition method if prototype is overrided via client scripts', function () {
+            return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Should not override getCurrentPosition method if prototype is overrided via client scripts');
+        });
+
         it('Should not override getCurrentPosition method if it is overrided via client scripts', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Should not override getCurrentPosition method if it is overrided via client scripts');
         });

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/test.js
@@ -35,6 +35,18 @@ describe('Native dialogs handling', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Expected geolocation object and geolocation error returned after an action');
         });
 
+        it('Should not override getCurrentPosition method if it is overrided via client function', function () {
+            return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Should not override getCurrentPosition method if it is overrided via client function');
+        });
+
+        it('Should not override getCurrentPosition method if it is overrided via client scripts', function () {
+            return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Should not override getCurrentPosition method if it is overrided via client scripts');
+        });
+
+        it('Should not override getCurrentPosition method if it is overrided on a page', function () {
+            return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Should not override getCurrentPosition method if it is overrided on a page');
+        });
+
         it('Should pass if the expected confirm dialog appears after an action (with dependencies)', function () {
             return runTests('./testcafe-fixtures/native-dialogs-test.js', 'Expected confirm after an action (with dependencies)');
         });

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
@@ -242,3 +242,35 @@ test('Null handler', async t => {
         .setNativeDialogHandler(null)
         .click('#buttonAlert');
 });
+
+const getGeolocation = ClientFunction(() => new Promise((resolve, reject) =>
+    navigator.geolocation.getCurrentPosition(resolve, reject),
+));
+
+test('Should not override getCurrentPosition method if it is overrided via client function', async t => {
+    const overrideMethod = ClientFunction(() => {
+        window.navigator.geolocation.getCurrentPosition = success => success('client-function');
+    });
+
+    await overrideMethod();
+
+    await t.setNativeDialogHandler(() => 'handler value')
+        .expect(getGeolocation()).eql('client-function');
+});
+
+test
+    .clientScripts({
+        content: 'window.navigator.geolocation.getCurrentPosition = success => success("client-scripts");',
+    })
+    ('Should not override getCurrentPosition method if it is overrided via client scripts', async t => {
+
+        await t.setNativeDialogHandler(() => 'handler value')
+            .expect(getGeolocation()).eql('client-scripts');
+    });
+
+test
+    .page('http://localhost:3000/fixtures/api/es-next/native-dialogs-handling/pages/geolocation-overrided.html')
+    ('Should not override getCurrentPosition method if it is overrided on a page', async t => {
+        await t.setNativeDialogHandler(() => 'handler value')
+            .expect(getGeolocation()).eql('on-page');
+    });

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
@@ -260,7 +260,7 @@ test('Should not override getCurrentPosition method if it is overrided via clien
 
 test
     .clientScripts({
-        content: 'window.navigator.geolocation.getCurrentPosition = success => success("client-scripts");',
+        content: 'Geolocation.prototype.getCurrentPosition = success => success("client-scripts");',
     })
     ('Should not override getCurrentPosition method if it is overrided via client scripts', async t => {
 

--- a/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
+++ b/test/functional/fixtures/api/es-next/native-dialogs-handling/testcafe-fixtures/native-dialogs-test.js
@@ -260,9 +260,19 @@ test('Should not override getCurrentPosition method if it is overrided via clien
 
 test
     .clientScripts({
-        content: 'Geolocation.prototype.getCurrentPosition = success => success("client-scripts");',
+        content: 'window.navigator.geolocation.getCurrentPosition = success => success("client-scripts");',
     })
     ('Should not override getCurrentPosition method if it is overrided via client scripts', async t => {
+
+        await t.setNativeDialogHandler(() => 'handler value')
+            .expect(getGeolocation()).eql('client-scripts');
+    });
+
+test
+    .clientScripts({
+        content: 'Geolocation.prototype.getCurrentPosition = success => success("client-scripts");',
+    })
+    ('Should not override getCurrentPosition method if prototype is overrided via client scripts', async t => {
 
         await t.setNativeDialogHandler(() => 'handler value')
             .expect(getGeolocation()).eql('client-scripts');


### PR DESCRIPTION
## Purpose
If the user mocks the geolocation dialog via page/client-scripts/client-function we will override it with default native dialog handler. That will lead to unexpected behavior. 
This PR also handles the case when the user "promisified" the getCurrentPosition method which may lead to test hanging.

## Approach
Do not override the getCurrentPosition method in case when it is already overridden.

## References
https://github.com/DevExpress/testcafe/pull/7791

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
