### PR TITLE
Support Basic Authentication on Content-Type: text/plain pages

### DIFF
--- a/src/native-automation/request-pipeline/index.ts
+++ b/src/native-automation/request-pipeline/index.ts
@@ -257,11 +257,22 @@ export default class NativeAutomationRequestPipeline extends NativeAutomationApi
         return true;
     }
 
+    private static _isTextPage (responseHeaders: HeaderEntry[] | undefined): boolean {
+        const contentType = responseHeaders
+            ?.find(header => header.name.toLowerCase() === 'content-type')
+            ?.value;
+
+        if (contentType)
+            return contentTypeUtils.isTextPage(contentType);
+
+        return true;
+    }
+
     private _needInjectResources (event: Protocol.Fetch.RequestPausedEvent): boolean {
         if (event.resourceType !== 'Document')
             return false;
 
-        return NativeAutomationRequestPipeline._isPage(event.responseHeaders);
+        return NativeAutomationRequestPipeline._isPage(event.responseHeaders) || NativeAutomationRequestPipeline._isTextPage(event.responseHeaders);
     }
 
     private async _tryAuthorizeWithHttpBasicAuthCredentials (event: RequestPausedEvent, fulfillInfo: FulfillRequestRequest): Promise<void> {

--- a/test/functional/fixtures/api/es-next/auth/testcafe-fixtures/basic-auth-with-correct-credentials-test.js
+++ b/test/functional/fixtures/api/es-next/auth/testcafe-fixtures/basic-auth-with-correct-credentials-test.js
@@ -10,3 +10,7 @@ test('Authenticate with correct credintials', async t => {
 test('Authenticate with correct credintials and redirect', async t => {
     await t.expect(Selector('#result').innerText).eql('authorized');
 }).page `http://localhost:3002/redirect`;
+
+test('Authenticate with correct credintials with Content-Type: text/plain', async t => {
+    await t.expect(Selector('#result').innerText).eql('authorized');
+}).page `http://localhost:3002/text`;

--- a/test/functional/site/basic-auth-server.js
+++ b/test/functional/site/basic-auth-server.js
@@ -19,6 +19,20 @@ class BasicAuthServer extends BasicHttpServer {
                 res.redirect('/');
         });
 
+        app.all('/text', function (req, res) {
+            const credentials = basicAuth(req);
+
+            res.header('Content-Type', 'text/plain');
+
+            if (!credentials || credentials.name !== 'username' || credentials.pass !== 'password') {
+                res.statusCode = 401;
+                res.setHeader('WWW-Authenticate', 'Basic realm="example"');
+                res.end('not authorizaed');
+            }
+            else
+                res.redirect('/');
+        });
+
         app.all('*', function (req, res) {
             const credentials = basicAuth(req);
 


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose

Fix issue Basic Authentication fails on pages with `Content-Type: text/plain`.
As a use case, if a proxy in front of the application is responsible for Basic Authentication, proxy may return a `text/plain` response.

## Approach

Even on a page with `Content-Type: text/plain`, the `_tryAuthorizeWithHttpBasicAuthCredentials` function will be called to authorize Basic Authentication.

## References

N/A

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
