### PR TITLE
chore: update error-stack-parser to avoid licensing issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "email-validator": "^2.0.4",
     "emittery": "^0.4.1",
     "endpoint-utils": "^1.0.2",
-    "error-stack-parser": "^1.3.6",
+    "error-stack-parser": "^2.1.4",
     "execa": "^4.0.3",
     "get-os-info": "^1.0.2",
     "globby": "^11.0.4",


### PR DESCRIPTION
Closes https://github.com/DevExpress/testcafe/issues/7918

<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Closes https://github.com/DevExpress/testcafe/issues/7918 so that more dependencies of testcafe have better defined licenses using SPDX identifiers (before this commit, the `stackframe` dependency has `SEE LICENSE IN LICENSE`, and after it has license: MIT)

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._
Well, there's not much to explain. I just updated the dependency so the dependency chain has permissive licenses defined SPDX identifiers.

## References
Closes https://github.com/DevExpress/testcafe/issues/7918

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
