### PR TITLE
skip: should rais reportTaskDone handler if browser disconnects for safari

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -83,7 +83,9 @@ gulp.task('clean', () => {
 
 
 // Lint
-gulp.task('lint', () => {
+gulp.task('lint', (done) => {
+    return done();
+
     const eslint = require('gulp-eslint');
 
     return gulp
@@ -266,7 +268,9 @@ gulp.step('clean-functional-tests', async () => {
 
 gulp.step('prepare-tests', gulp.registry().get(SKIP_BUILD ? 'lint' : 'build'));
 
-gulp.step('test-server-run', () => {
+gulp.step('test-server-run', (done) => {
+    return done();
+
     const chai = require('chai');
 
     chai.use(require('chai-string'));
@@ -291,7 +295,9 @@ gulp.step('test-server-bootstrap', gulp.series('prepare-tests', 'test-server-run
 
 gulp.task('test-server', gulp.parallel('check-licenses', 'test-server-bootstrap'));
 
-gulp.step('test-client-run', () => {
+gulp.step('test-client-run', (done) => {
+    return done();
+
     const testClient                = require('./gulp/helpers/test-client');
     const { CLIENT_TESTS_SETTINGS } = require('./gulp/constants/client-test-settings');
 
@@ -300,7 +306,9 @@ gulp.step('test-client-run', () => {
 
 gulp.task('test-client', gulp.series('prepare-tests', 'test-client-run'));
 
-gulp.step('test-client-local-run', () => {
+gulp.step('test-client-local-run', (done) => {
+    return done();
+
     const testClient                      = require('./gulp/helpers/test-client');
     const { CLIENT_TESTS_LOCAL_SETTINGS } = require('./gulp/constants/client-test-settings');
 
@@ -309,7 +317,9 @@ gulp.step('test-client-local-run', () => {
 
 gulp.task('test-client-local', gulp.series('prepare-tests', 'test-client-local-run'));
 
-gulp.step('test-client-legacy-run', () => {
+gulp.step('test-client-legacy-run', (done) => {
+    return done();
+
     const testClient                       = require('./gulp/helpers/test-client');
     const { CLIENT_TESTS_LEGACY_SETTINGS } = require('./gulp/constants/client-test-settings');
 
@@ -318,7 +328,9 @@ gulp.step('test-client-legacy-run', () => {
 
 gulp.task('test-client-legacy', gulp.series('prepare-tests', 'test-client-legacy-run'));
 
-gulp.step('test-client-travis-run', () => {
+gulp.step('test-client-travis-run', (done) => {
+    return done();
+
     const testClient = require('./gulp/helpers/test-client');
 
     const {
@@ -337,7 +349,9 @@ gulp.step('test-client-travis-run', () => {
 
 gulp.task('test-client-travis', gulp.series('prepare-tests', 'test-client-travis-run'));
 
-gulp.step('test-client-travis-mobile-run', () => {
+gulp.step('test-client-travis-mobile-run', (done) => {
+    return done();
+
     const testClient = require('./gulp/helpers/test-client');
 
     const {
@@ -356,7 +370,9 @@ gulp.step('test-client-travis-mobile-run', () => {
 
 gulp.task('test-client-travis-mobile', gulp.series('prepare-tests', 'test-client-travis-mobile-run'));
 
-gulp.step('test-client-legacy-travis-run', () => {
+gulp.step('test-client-legacy-travis-run', (done) => {
+    return done();
+
     const testClient = require('./gulp/helpers/test-client');
 
     const {
@@ -374,7 +390,9 @@ gulp.step('test-client-legacy-travis-run', () => {
 
 gulp.task('test-client-legacy-travis', gulp.series('prepare-tests', 'test-client-legacy-travis-run'));
 
-gulp.step('test-client-legacy-travis-mobile-run', () => {
+gulp.step('test-client-legacy-travis-mobile-run', (done) => {
+    return done();
+
     const testClient = require('./gulp/helpers/test-client');
 
     const {
@@ -392,13 +410,17 @@ gulp.step('test-client-legacy-travis-mobile-run', () => {
 
 gulp.task('test-client-legacy-travis-mobile', gulp.series('prepare-tests', 'test-client-legacy-travis-mobile-run'));
 
-gulp.step('test-functional-travis-mobile-run', () => {
+gulp.step('test-functional-travis-mobile-run', (done) => {
+    return done();
+
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.mobileBrowsers);
 });
 
 gulp.task('test-functional-travis-mobile', gulp.series('prepare-tests', 'test-functional-travis-mobile-run'));
 
-gulp.step('test-functional-local-run', () => {
+gulp.step('test-functional-local-run', (done) => {
+    return done();
+
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localBrowsers);
 });
 
@@ -410,31 +432,41 @@ gulp.step('test-functional-local-safari-run', () => {
 
 gulp.task('test-functional-local-safari', gulp.series('prepare-tests', 'test-functional-local-safari-run'));
 
-gulp.step('test-functional-local-chrome-firefox-run', () => {
+gulp.step('test-functional-local-chrome-firefox-run', (done) => {
+    return done();
+
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localBrowsersChromeFirefox);
 });
 
 gulp.task('test-functional-local-chrome-firefox', gulp.series('prepare-tests', 'test-functional-local-chrome-firefox-run'));
 
-gulp.step('test-functional-local-headless-chrome-run', () => {
+gulp.step('test-functional-local-headless-chrome-run', (done) => {
+    return done();
+
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localHeadlessChrome);
 });
 
 gulp.task('test-functional-local-headless-chrome', gulp.series('prepare-tests', 'prepare-functional-tests', 'test-functional-local-headless-chrome-run', 'clean-functional-tests'));
 
-gulp.step('test-functional-local-headless-edge-run', () => {
+gulp.step('test-functional-local-headless-edge-run', (done) => {
+    return done();
+
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localHeadlessEdge);
 });
 
 gulp.task('test-functional-local-headless-edge', gulp.series('prepare-tests', 'test-functional-local-headless-edge-run'));
 
-gulp.step('test-functional-local-headless-firefox-run', () => {
+gulp.step('test-functional-local-headless-firefox-run', (done) => {
+    return done();
+
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localHeadlessFirefox);
 });
 
 gulp.task('test-functional-local-headless-firefox', gulp.series('prepare-tests', 'test-functional-local-headless-firefox-run'));
 
-gulp.step('test-functional-remote-run', () => {
+gulp.step('test-functional-remote-run', (done) => {
+    return done();
+
     if (QR_CODE)
         process.env.QR_CODE = 'true';
 
@@ -446,25 +478,33 @@ gulp.step('test-functional-remote-run', () => {
 
 gulp.task('test-functional-remote', gulp.series('prepare-tests', 'test-functional-remote-run'));
 
-gulp.step('test-functional-local-legacy-run', () => {
+gulp.step('test-functional-local-legacy-run', (done) => {
+    return done();
+
     return testFunctional(LEGACY_TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.legacy);
 });
 
 gulp.task('test-functional-local-legacy', gulp.series('prepare-tests', 'test-functional-local-legacy-run'));
 
-gulp.step('test-functional-local-multiple-windows-run', () => {
+gulp.step('test-functional-local-multiple-windows-run', (done) => {
+    return done();
+
     return testFunctional(MULTIPLE_WINDOWS_TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localBrowsersChromeFirefox);
 });
 
 gulp.task('test-functional-local-multiple-windows', gulp.series('prepare-tests', 'test-functional-local-multiple-windows-run'));
 
-gulp.step('test-functional-local-chrome-firefox-headed-run', () => {
+gulp.step('test-functional-local-chrome-firefox-headed-run', (done) => {
+    return done();
+
     return testFunctional(HEADED_CHROME_FIREFOX_TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localBrowsersChromeFirefox);
 });
 
 gulp.task('test-functional-local-chrome-firefox-headed', gulp.series('prepare-tests', 'test-functional-local-chrome-firefox-headed-run'));
 
-gulp.step('test-functional-local-native-automation-run', () => {
+gulp.step('test-functional-local-native-automation-run', (done) => {
+    return done();
+
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localHeadlessChrome, { nativeAutomation: true });
 });
 
@@ -485,6 +525,8 @@ gulp.task('docker-build', done => {
 });
 
 gulp.step('docker-server-test-run', done => {
+    return done();
+
     ensureDockerEnvironment();
 
     childProcess.execSync(`docker build --no-cache --build-arg tag=${packageInfo.version} -t docker-server-tests -f test/docker/Dockerfile .`,
@@ -495,7 +537,9 @@ gulp.step('docker-server-test-run', done => {
     done();
 });
 
-gulp.step('docker-functional-test-run', () => {
+gulp.step('docker-functional-test-run', (done) => {
+    return done();
+
     ensureDockerEnvironment();
 
     return runFunctionalTestInDocker(PUBLISH_REPO, packageInfo);

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -83,9 +83,7 @@ gulp.task('clean', () => {
 
 
 // Lint
-gulp.task('lint', (done) => {
-    return done();
-
+gulp.task('lint', () => {
     const eslint = require('gulp-eslint');
 
     return gulp
@@ -268,9 +266,7 @@ gulp.step('clean-functional-tests', async () => {
 
 gulp.step('prepare-tests', gulp.registry().get(SKIP_BUILD ? 'lint' : 'build'));
 
-gulp.step('test-server-run', (done) => {
-    return done();
-
+gulp.step('test-server-run', () => {
     const chai = require('chai');
 
     chai.use(require('chai-string'));
@@ -295,9 +291,7 @@ gulp.step('test-server-bootstrap', gulp.series('prepare-tests', 'test-server-run
 
 gulp.task('test-server', gulp.parallel('check-licenses', 'test-server-bootstrap'));
 
-gulp.step('test-client-run', (done) => {
-    return done();
-
+gulp.step('test-client-run', () => {
     const testClient                = require('./gulp/helpers/test-client');
     const { CLIENT_TESTS_SETTINGS } = require('./gulp/constants/client-test-settings');
 
@@ -306,9 +300,7 @@ gulp.step('test-client-run', (done) => {
 
 gulp.task('test-client', gulp.series('prepare-tests', 'test-client-run'));
 
-gulp.step('test-client-local-run', (done) => {
-    return done();
-
+gulp.step('test-client-local-run', () => {
     const testClient                      = require('./gulp/helpers/test-client');
     const { CLIENT_TESTS_LOCAL_SETTINGS } = require('./gulp/constants/client-test-settings');
 
@@ -317,9 +309,7 @@ gulp.step('test-client-local-run', (done) => {
 
 gulp.task('test-client-local', gulp.series('prepare-tests', 'test-client-local-run'));
 
-gulp.step('test-client-legacy-run', (done) => {
-    return done();
-
+gulp.step('test-client-legacy-run', () => {
     const testClient                       = require('./gulp/helpers/test-client');
     const { CLIENT_TESTS_LEGACY_SETTINGS } = require('./gulp/constants/client-test-settings');
 
@@ -328,9 +318,7 @@ gulp.step('test-client-legacy-run', (done) => {
 
 gulp.task('test-client-legacy', gulp.series('prepare-tests', 'test-client-legacy-run'));
 
-gulp.step('test-client-travis-run', (done) => {
-    return done();
-
+gulp.step('test-client-travis-run', () => {
     const testClient = require('./gulp/helpers/test-client');
 
     const {
@@ -349,9 +337,7 @@ gulp.step('test-client-travis-run', (done) => {
 
 gulp.task('test-client-travis', gulp.series('prepare-tests', 'test-client-travis-run'));
 
-gulp.step('test-client-travis-mobile-run', (done) => {
-    return done();
-
+gulp.step('test-client-travis-mobile-run', () => {
     const testClient = require('./gulp/helpers/test-client');
 
     const {
@@ -370,9 +356,7 @@ gulp.step('test-client-travis-mobile-run', (done) => {
 
 gulp.task('test-client-travis-mobile', gulp.series('prepare-tests', 'test-client-travis-mobile-run'));
 
-gulp.step('test-client-legacy-travis-run', (done) => {
-    return done();
-
+gulp.step('test-client-legacy-travis-run', () => {
     const testClient = require('./gulp/helpers/test-client');
 
     const {
@@ -390,9 +374,7 @@ gulp.step('test-client-legacy-travis-run', (done) => {
 
 gulp.task('test-client-legacy-travis', gulp.series('prepare-tests', 'test-client-legacy-travis-run'));
 
-gulp.step('test-client-legacy-travis-mobile-run', (done) => {
-    return done();
-
+gulp.step('test-client-legacy-travis-mobile-run', () => {
     const testClient = require('./gulp/helpers/test-client');
 
     const {
@@ -410,17 +392,13 @@ gulp.step('test-client-legacy-travis-mobile-run', (done) => {
 
 gulp.task('test-client-legacy-travis-mobile', gulp.series('prepare-tests', 'test-client-legacy-travis-mobile-run'));
 
-gulp.step('test-functional-travis-mobile-run', (done) => {
-    return done();
-
+gulp.step('test-functional-travis-mobile-run', () => {
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.mobileBrowsers);
 });
 
 gulp.task('test-functional-travis-mobile', gulp.series('prepare-tests', 'test-functional-travis-mobile-run'));
 
-gulp.step('test-functional-local-run', (done) => {
-    return done();
-
+gulp.step('test-functional-local-run', () => {
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localBrowsers);
 });
 
@@ -432,41 +410,31 @@ gulp.step('test-functional-local-safari-run', () => {
 
 gulp.task('test-functional-local-safari', gulp.series('prepare-tests', 'test-functional-local-safari-run'));
 
-gulp.step('test-functional-local-chrome-firefox-run', (done) => {
-    return done();
-
+gulp.step('test-functional-local-chrome-firefox-run', () => {
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localBrowsersChromeFirefox);
 });
 
 gulp.task('test-functional-local-chrome-firefox', gulp.series('prepare-tests', 'test-functional-local-chrome-firefox-run'));
 
-gulp.step('test-functional-local-headless-chrome-run', (done) => {
-    return done();
-
+gulp.step('test-functional-local-headless-chrome-run', () => {
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localHeadlessChrome);
 });
 
 gulp.task('test-functional-local-headless-chrome', gulp.series('prepare-tests', 'prepare-functional-tests', 'test-functional-local-headless-chrome-run', 'clean-functional-tests'));
 
-gulp.step('test-functional-local-headless-edge-run', (done) => {
-    return done();
-
+gulp.step('test-functional-local-headless-edge-run', () => {
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localHeadlessEdge);
 });
 
 gulp.task('test-functional-local-headless-edge', gulp.series('prepare-tests', 'test-functional-local-headless-edge-run'));
 
-gulp.step('test-functional-local-headless-firefox-run', (done) => {
-    return done();
-
+gulp.step('test-functional-local-headless-firefox-run', () => {
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localHeadlessFirefox);
 });
 
 gulp.task('test-functional-local-headless-firefox', gulp.series('prepare-tests', 'test-functional-local-headless-firefox-run'));
 
-gulp.step('test-functional-remote-run', (done) => {
-    return done();
-
+gulp.step('test-functional-remote-run', () => {
     if (QR_CODE)
         process.env.QR_CODE = 'true';
 
@@ -478,33 +446,25 @@ gulp.step('test-functional-remote-run', (done) => {
 
 gulp.task('test-functional-remote', gulp.series('prepare-tests', 'test-functional-remote-run'));
 
-gulp.step('test-functional-local-legacy-run', (done) => {
-    return done();
-
+gulp.step('test-functional-local-legacy-run', () => {
     return testFunctional(LEGACY_TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.legacy);
 });
 
 gulp.task('test-functional-local-legacy', gulp.series('prepare-tests', 'test-functional-local-legacy-run'));
 
-gulp.step('test-functional-local-multiple-windows-run', (done) => {
-    return done();
-
+gulp.step('test-functional-local-multiple-windows-run', () => {
     return testFunctional(MULTIPLE_WINDOWS_TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localBrowsersChromeFirefox);
 });
 
 gulp.task('test-functional-local-multiple-windows', gulp.series('prepare-tests', 'test-functional-local-multiple-windows-run'));
 
-gulp.step('test-functional-local-chrome-firefox-headed-run', (done) => {
-    return done();
-
+gulp.step('test-functional-local-chrome-firefox-headed-run', () => {
     return testFunctional(HEADED_CHROME_FIREFOX_TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localBrowsersChromeFirefox);
 });
 
 gulp.task('test-functional-local-chrome-firefox-headed', gulp.series('prepare-tests', 'test-functional-local-chrome-firefox-headed-run'));
 
-gulp.step('test-functional-local-native-automation-run', (done) => {
-    return done();
-
+gulp.step('test-functional-local-native-automation-run', () => {
     return testFunctional(TESTS_GLOB, functionalTestConfig.testingEnvironmentNames.localHeadlessChrome, { nativeAutomation: true });
 });
 
@@ -525,8 +485,6 @@ gulp.task('docker-build', done => {
 });
 
 gulp.step('docker-server-test-run', done => {
-    return done();
-
     ensureDockerEnvironment();
 
     childProcess.execSync(`docker build --no-cache --build-arg tag=${packageInfo.version} -t docker-server-tests -f test/docker/Dockerfile .`,
@@ -537,9 +495,7 @@ gulp.step('docker-server-test-run', done => {
     done();
 });
 
-gulp.step('docker-functional-test-run', (done) => {
-    return done();
-
+gulp.step('docker-functional-test-run', () => {
     ensureDockerEnvironment();
 
     return runFunctionalTestInDocker(PUBLISH_REPO, packageInfo);

--- a/test/functional/fixtures/browser-provider/browser-reconnect/test.js
+++ b/test/functional/fixtures/browser-provider/browser-reconnect/test.js
@@ -82,7 +82,7 @@ function run (pathToTest, filter, initializeConnection = initializeConnectionLow
 
 if (config.useLocalBrowsers) {
     // TODO: make tests stable for IE and Windows
-    (config.hasBrowser('ie') ? describe.skip : describe.only)('Browser reconnect', function () {
+    (config.hasBrowser('ie') ? describe.skip : describe)('Browser reconnect', function () {
         it('Should restart browser when it does not respond', function () {
             return run('./testcafe-fixtures/index-test.js', 'Should restart browser when it does not respond')
                 .then(() => {
@@ -107,7 +107,7 @@ if (config.useLocalBrowsers) {
                 });
         });
 
-        it.skip('Should raise reporter reportTaskDone event on browser disconnect', function () {
+        (config.hasBrowser('safari') ? it.skip : it)('Should raise reporter reportTaskDone event on browser disconnect', function () {
 
             let reporterLog = '';
 

--- a/test/functional/fixtures/browser-provider/browser-reconnect/test.js
+++ b/test/functional/fixtures/browser-provider/browser-reconnect/test.js
@@ -82,7 +82,7 @@ function run (pathToTest, filter, initializeConnection = initializeConnectionLow
 
 if (config.useLocalBrowsers) {
     // TODO: make tests stable for IE and Windows
-    (config.hasBrowser('ie') ? describe.skip : describe)('Browser reconnect', function () {
+    (config.hasBrowser('ie') ? describe.skip : describe.only)('Browser reconnect', function () {
         it('Should restart browser when it does not respond', function () {
             return run('./testcafe-fixtures/index-test.js', 'Should restart browser when it does not respond')
                 .then(() => {
@@ -107,7 +107,7 @@ if (config.useLocalBrowsers) {
                 });
         });
 
-        it('Should raise reporter reportTaskDone event on browser disconnect', function () {
+        it.skip('Should raise reporter reportTaskDone event on browser disconnect', function () {
 
             let reporterLog = '';
 


### PR DESCRIPTION
## Purpose
This test hangs on CI. Locally it works as expected. We need to temporarily skip.

## Approach
skip test for safari

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
