### PR TITLE
Browsers with "userProfile" option in Native Automation (closes #7925)

### DIFF
--- a/src/errors/runtime/templates.js
+++ b/src/errors/runtime/templates.js
@@ -154,5 +154,5 @@ export default {
     [RUNTIME_ERRORS.cannotImportESMInCommonsJS]:                     'Cannot import the {esModule} ECMAScript module from {targetFile}. Use a dynamic import() statement or enable the --esm CLI flag.',
     [RUNTIME_ERRORS.setNativeAutomationForUnsupportedBrowsers]:      'The "{browser}" do not support the Native Automation mode. Use the "disable native automation" option to continue.',
     [RUNTIME_ERRORS.cannotRunLegacyTestsInNativeAutomationMode]:     'TestCafe cannot run legacy tests in Native Automation mode. Disable native automation to continue.',
-    [RUNTIME_ERRORS.setUserProfileInNativeAutomation]:               'The "userProfile" option is enabled for the following browsers: "chrome, edge".\nThe "userProfile" option is not supported in the Native Automation mode.\nUse the "disable native automation" option or remove "userProfile" option to continue.',
+    [RUNTIME_ERRORS.setUserProfileInNativeAutomation]:               'The "userProfile" option is enabled for the following browsers: "{browsers}".\nThe "userProfile" option is not supported in the Native Automation mode.\nUse the "disable native automation" option or remove "userProfile" option to continue.',
 };

--- a/src/errors/runtime/templates.js
+++ b/src/errors/runtime/templates.js
@@ -154,4 +154,5 @@ export default {
     [RUNTIME_ERRORS.cannotImportESMInCommonsJS]:                     'Cannot import the {esModule} ECMAScript module from {targetFile}. Use a dynamic import() statement or enable the --esm CLI flag.',
     [RUNTIME_ERRORS.setNativeAutomationForUnsupportedBrowsers]:      'The "{browser}" do not support the Native Automation mode. Use the "disable native automation" option to continue.',
     [RUNTIME_ERRORS.cannotRunLegacyTestsInNativeAutomationMode]:     'TestCafe cannot run legacy tests in Native Automation mode. Disable native automation to continue.',
+    [RUNTIME_ERRORS.setUserProfileInNativeAutomation]:               'The "userProfile" option is enabled for the following browsers: "chrome, edge".\nThe "userProfile" option is not supported in the Native Automation mode.\nUse the "disable native automation" option or remove "userProfile" option to continue.',
 };

--- a/src/errors/types.js
+++ b/src/errors/types.js
@@ -189,4 +189,5 @@ export const RUNTIME_ERRORS = {
     cannotReadConfigFile:                               'E1083',
     cannotParseConfigFile:                              'E1084',
     cannotRunLegacyTestsInNativeAutomationMode:         'E1085',
+    setUserProfileInNativeAutomation:                   'E1086',
 };

--- a/test/functional/fixtures/regression/gh-7925/pages/index.html
+++ b/test/functional/fixtures/regression/gh-7925/pages/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>gh-7925</title>
+</head>
+<body>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-7925/test.js
+++ b/test/functional/fixtures/regression/gh-7925/test.js
@@ -1,0 +1,50 @@
+const path                       = require('path');
+const { expect }                 = require('chai');
+const createTestCafe             = require('../../../../../lib');
+const { onlyInNativeAutomation } = require('../../../utils/skip-in');
+
+const EXPECTED_ERROR = 'The "userProfile" option is enabled for the following browsers: "chrome:userProfile".\n' +
+                       'The "userProfile" option is not supported in the Native Automation mode.\n' +
+                       'Use the "disable native automation" option or remove "userProfile" option to continue.';
+
+let testcafe = null;
+let error = null;
+
+function runTests (browsers) {
+    error = null;
+
+    return createTestCafe('127.0.0.1', 1335, 1336)
+        .then(tc => {
+            testcafe = tc;
+        })
+        .then(() => {
+            return testcafe.createRunner()
+                .browsers(browsers)
+                .src(path.join(__dirname, './testcafe-fixtures/index.js'))
+                .run();
+        })
+        .catch(err => {
+            error = err;
+        })
+        .finally(() => {
+            return testcafe.close();
+        });
+}
+
+describe('[Regression](GH-7925) Browsers with "userProfile" option in Native Automation', function () {
+    onlyInNativeAutomation('chrome:userProfile', function () {
+        return runTests(['chrome:userProfile'])
+            .then(() => {
+                expect(error.message).contains(EXPECTED_ERROR);
+            });
+    });
+
+    onlyInNativeAutomation('chrome:userProfile + firefox', function () {
+        return runTests(['chrome:userProfile', 'firefox'])
+            .then(() => {
+                expect(error).eql(null);
+            });
+    });
+});
+
+

--- a/test/functional/fixtures/regression/gh-7925/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-7925/testcafe-fixtures/index.js
@@ -1,0 +1,6 @@
+fixture `GH-7925 - Browsers with "userProfile" option in Native Automation`
+    .page `http://localhost:3000/fixtures/regression/gh-7925/pages/index.html`;
+
+test('dummy', async () => {
+});
+

--- a/test/server/bootstrapper-test.js
+++ b/test/server/bootstrapper-test.js
@@ -160,5 +160,35 @@ describe('Bootstrapper', () => {
             expect(bootstrapper.configuration._mergedOptions).eql({ disableNativeAutomation: true });
             bootstrapper.configuration.clear();
         });
+
+        it('Should throw an error if browser is opened with the "userProfile" option in the Native Automation mode', async function () {
+            try {
+                bootstrapper.browsers = [{
+                    alias:         'chrome',
+                    browserOption: { userProfile: true },
+                    provider:      {
+                        isLocalBrowser:          () => true,
+                        supportNativeAutomation: () => true,
+                    },
+                }, {
+                    alias:         'edge',
+                    browserOption: { userProfile: true },
+                    provider:      {
+                        isLocalBrowser:          () => true,
+                        supportNativeAutomation: () => true,
+                    },
+                }];
+
+                await bootstrapper.createRunnableConfiguration();
+
+                throw new Error('Promise rejection expected');
+            }
+            catch (err) {
+                expect(err.message).eql('The "userProfile" option is enabled for the following browsers: "chrome, edge".\n' +
+                                        'The "userProfile" option is not supported in the Native Automation mode.\n' +
+                                        'Use the "disable native automation" option or remove "userProfile" option to continue.'
+                );
+            }
+        });
     });
 });


### PR DESCRIPTION
We decided to not support the `userProfile` option in Native Automation mode.
Native Automation mode clears all cookies and local storages between test runs. If we use `:userProfile` the Native Automation mode will clear all cookies in current user profile.