### PR TITLE
should log concurrent requests (closes #7977)

### DIFF
--- a/src/api/request-hooks/request-logger.ts
+++ b/src/api/request-hooks/request-logger.ts
@@ -80,6 +80,10 @@ class RequestLoggerImplementation extends RequestHook {
             throw new APIError('RequestLogger', RUNTIME_ERRORS.requestHookConfigureAPIError, 'RequestLogger', 'Cannot stringify the response body because it is not logged. Specify { logResponseBody: true } in log options.');
     }
 
+    private static _getInternalRequestKey ({ requestId, sessionId }: any): string {
+        return `${sessionId}:${requestId}`;
+    }
+
     public async onRequest (event: RequestEvent): Promise<void> {
         const loggedReq: LoggedRequest = {
             id:        event._requestInfo.requestId,
@@ -98,11 +102,11 @@ class RequestLoggerImplementation extends RequestHook {
         if (this._options.logRequestBody)
             loggedReq.request.body = this._options.stringifyRequestBody ? event._requestInfo.body.toString() : event._requestInfo.body;
 
-        this._internalRequests[loggedReq.id] = loggedReq;
+        this._internalRequests[RequestLoggerImplementation._getInternalRequestKey(event._requestInfo)] = loggedReq;
     }
 
     public async onResponse (event: ResponseEvent): Promise<void> {
-        const loggedReq = this._internalRequests[event.requestId];
+        const loggedReq = this._internalRequests[RequestLoggerImplementation._getInternalRequestKey(event)];
 
         // NOTE: If the 'clear' method is called during a long running request,
         // we should not save a response part - request part has been already removed.

--- a/src/native-automation/request-hooks/event-factory/request-paused-event-based.ts
+++ b/src/native-automation/request-hooks/event-factory/request-paused-event-based.ts
@@ -121,7 +121,7 @@ export default class RequestPausedEventBasedEventFactory extends BaseRequestHook
             statusCode:               this._event.responseStatusCode || StatusCodes.OK,
             headers:                  convertToOutgoingHttpHeaders(this._event.responseHeaders),
             body:                     this._responseBody,
-            sessionId:                '',
+            sessionId:                this._sessionId,
             requestId:                this._event.requestId,
             isSameOriginPolicyFailed: false,
         });

--- a/test/functional/fixtures/regression/gh-7977/pages/index.html
+++ b/test/functional/fixtures/regression/gh-7977/pages/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>gh-7977</title>
+</head>
+<body>
+<button>click me</button>
+<script>
+    function handler () {
+        for (let i = 0; i < 100; i++) {
+            fetch('http://localhost:3000/api/data');
+        }
+    }
+
+    document.querySelector('button').addEventListener('click', handler);
+</script>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-7977/test.js
+++ b/test/functional/fixtures/regression/gh-7977/test.js
@@ -1,0 +1,30 @@
+const createTestCafe             = require('../../../../../lib');
+const { onlyInNativeAutomation } = require('../../../utils/skip-in');
+const path                       = require('path');
+const expect                     = require('chai').expect;
+
+const EXPECTED_REQUEST_COUNT = 300;
+
+let testcafe = null;
+
+describe('[Regression](GH-7977)', function () {
+    onlyInNativeAutomation('Should log all concurrent requests', function () {
+        return createTestCafe('127.0.0.1', 1335, 1336)
+            .then(tc => {
+                testcafe = tc;
+            })
+            .then(() => {
+                return testcafe.createRunner()
+                    .browsers(`chrome:headless`)
+                    .concurrency(3)
+                    .src(path.join(__dirname, './testcafe-fixtures/index.js'))
+                    .run();
+            })
+            .then(() => {
+                return testcafe.close();
+            })
+            .then(() => {
+                expect(require('./testcafe-fixtures/requestCounter').get()).eql(EXPECTED_REQUEST_COUNT);
+            });
+    });
+});

--- a/test/functional/fixtures/regression/gh-7977/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-7977/testcafe-fixtures/index.js
@@ -1,0 +1,21 @@
+import { RequestLogger } from 'testcafe';
+
+const logger = new RequestLogger(/api\/data/, {
+    logResponseBody:       true,
+    logRequestHeaders:     true,
+    stringifyResponseBody: true,
+});
+
+fixture `Concurrent request loggers`
+    .page `http://localhost:3000/fixtures/regression/gh-7977/pages/index.html`
+    .requestHooks(logger);
+
+for (let i = 0; i < 3; i++) {
+    test(`send multiple requests - ${i}`, async t => {
+        await t.click('button');
+
+        require('./requestCounter').add(logger.requests.filter(r => !!r.response.body).length);
+    });
+}
+
+

--- a/test/functional/fixtures/regression/gh-7977/testcafe-fixtures/requestCounter.js
+++ b/test/functional/fixtures/regression/gh-7977/testcafe-fixtures/requestCounter.js
@@ -1,0 +1,12 @@
+let count = 0;
+
+const requestCounter = {
+    add (value) {
+        count += value;
+    },
+    get () {
+        return count;
+    },
+};
+
+module.exports = requestCounter;


### PR DESCRIPTION
Using only requestId for the key is not enough, since in concurrent tests the keys can be the same. I added the `sessionId` (testRunId) to the key.