### PR TITLE
disabled restart browser in devmode

### DIFF
--- a/src/browser/connection/index.ts
+++ b/src/browser/connection/index.ts
@@ -319,6 +319,9 @@ export default class BrowserConnection extends EventEmitter {
     }
 
     private _waitForHeartbeat (): void {
+        if (this._options.developmentMode)
+            return;
+
         this.heartbeatTimeout = setTimeout(() => {
             const err = this._createBrowserDisconnectedError();
 

--- a/test/functional/fixtures/browser-provider/browser-reconnect/testcafe-fixtures/index-test.js
+++ b/test/functional/fixtures/browser-provider/browser-reconnect/testcafe-fixtures/index-test.js
@@ -69,3 +69,15 @@ test('Should log error on browser disconnect', async t => {
         t.testRun.browserConnection.emit('error', new Error('force error'));
     }, 5000);
 });
+
+test('Shouldn\'t restart browser when it does not respond and developmentMode on', async t => {
+    const userAgent = await getUserAgent();
+
+    counter[userAgent] = counter[userAgent] || 0;
+
+    counter[userAgent]++;
+
+    await hang();
+
+    await t.expect(counter[userAgent]).eql(1);
+});


### PR DESCRIPTION
If development mode turned on, the heartbeat continues to work and _waitHeartBeat doesn't assign promises responsible for reloading. 
HeartBeat responsible for fast stopping application when pressed ctr + c

