### PR TITLE
added normalize all filenames to typescript compiler and tests

### DIFF
--- a/src/compiler/test-file/formats/typescript/compiler.ts
+++ b/src/compiler/test-file/formats/typescript/compiler.ts
@@ -178,8 +178,15 @@ export default class TypeScriptTestFileCompiler extends APIBasedTestFileCompiler
             });
     }
 
+    protected _normalizeFilenames (filenames: string[]): string[] {
+        return filenames.map(name => TypeScriptTestFileCompiler._normalizeFilename(name));
+    }
+
     private _compileFilesToCache (ts: TypeScriptInstance, filenames: string[]): void {
         const opts    = this._tsConfig.getOptions() as Dictionary<CompilerOptionsValue>;
+
+        filenames = this._normalizeFilenames(filenames);
+
         const program = ts.createProgram([TypeScriptTestFileCompiler.tsDefsPath, ...filenames], opts);
 
         DEBUG_LOGGER('version: %s', ts.version);
@@ -225,7 +232,7 @@ export default class TypeScriptTestFileCompiler extends APIBasedTestFileCompiler
         // NOTE: lazy load the compiler
         const ts: TypeScriptInstance = this._loadTypeScriptCompiler();
         const filenames              = testFilesInfo.map(({ filename }) => filename);
-        const normalizedFilenames    = filenames.map(filename => TypeScriptTestFileCompiler._normalizeFilename(filename));
+        const normalizedFilenames    = this._normalizeFilenames(filenames);
         const normalizedFilenamesMap = zipObject(normalizedFilenames, filenames);
 
         const uncachedFiles = normalizedFilenames

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -1,24 +1,24 @@
-const { exec }            = require('child_process');
-const fs                  = require('fs');
-const os                  = require('os');
-const path                = require('path');
-const { promisify }       = require('util');
-const { expect }          = require('chai');
-const proxyquire          = require('proxyquire');
-const sinon               = require('sinon');
-const globby              = require('globby');
-const { nanoid }          = require('nanoid');
-const dedent              = require('dedent');
-const { TEST_RUN_ERRORS } = require('../../lib/errors/types');
-const exportableLib       = require('../../lib/api/exportable-lib');
-const createStackFilter   = require('../../lib/errors/create-stack-filter.js');
-const TestController      = require('../../lib/api/test-controller');
-const { assertError }     = require('./helpers/assert-runtime-error');
-const compile             = require('./helpers/compile');
-const Module              = require('module');
-const toPosixPath         = require('../../lib/utils/to-posix-path');
-const BaseTestRunMock     = require('./helpers/base-test-run-mock');
-const getTestCafeVersion  = require('../../lib/utils/get-testcafe-version');
+const { exec }                             = require('child_process');
+const fs                                   = require('fs');
+const os                                   = require('os');
+const path                                 = require('path');
+const { promisify }                        = require('util');
+const { expect }                           = require('chai');
+const proxyquire                           = require('proxyquire');
+const sinon                                = require('sinon');
+const globby                               = require('globby');
+const { nanoid }                           = require('nanoid');
+const dedent                               = require('dedent');
+const { TEST_RUN_ERRORS }                  = require('../../lib/errors/types');
+const exportableLib                        = require('../../lib/api/exportable-lib');
+const createStackFilter                    = require('../../lib/errors/create-stack-filter.js');
+const TestController                       = require('../../lib/api/test-controller');
+const { assertError }                      = require('./helpers/assert-runtime-error');
+const { compile, typeScriptTestFilenames } = require('./helpers/compile');
+const Module                               = require('module');
+const toPosixPath                          = require('../../lib/utils/to-posix-path');
+const BaseTestRunMock                      = require('./helpers/base-test-run-mock');
+const getTestCafeVersion                   = require('../../lib/utils/get-testcafe-version');
 
 const copy      = promisify(fs.copyFile);
 const remove    = promisify(fs.unlink);
@@ -255,6 +255,20 @@ describe('Compiler', function () {
                     expect(tests[0].name).eql('test');
                     expect(fixtures[0].name).eql('Library tests');
                 });
+        });
+
+        it('Should compile filename path to lower case', function () {
+            let sources = [
+                'test/server/data/tesT-suites/TypescriPt-basic/Testfile2.ts',
+                'test/sErver/data/tesT-suites/Typescript-Basic/Testfile2.ts',
+                'test/serveR/data/tesT-suites/Typescript-basic/Testfile2.ts'.toUpperCase(),
+            ];
+
+            sources = typeScriptTestFilenames(sources);
+
+            const isAllLetterLowerCase = sources.every(name => !/[A-Z]/gm.test(name));
+
+            expect(isAllLetterLowerCase).eql(true);
         });
 
         it('Should compile test files and their dependencies', function () {

--- a/test/server/helpers/compile.js
+++ b/test/server/helpers/compile.js
@@ -1,8 +1,9 @@
-const { sortBy, castArray } = require('lodash');
-const { resolve }           = require('path');
-const Compiler              = require('../../../lib/compiler');
+const { sortBy, castArray }      = require('lodash');
+const { resolve }                = require('path');
+const Compiler                   = require('../../../lib/compiler');
+const TypeScriptTestFileCompiler = require('../../../lib/compiler/test-file/formats/typescript/compiler');
 
-module.exports = function compile (sources, compilerOptions, optionalCompilerArgs) {
+function compile (sources, compilerOptions, optionalCompilerArgs) {
     sources = castArray(sources).map(filename => resolve(filename));
 
     const compiler = new Compiler(sources, compilerOptions, optionalCompilerArgs );
@@ -22,4 +23,25 @@ module.exports = function compile (sources, compilerOptions, optionalCompilerArg
                 fixtures: sortBy(fixtures, 'name'),
             };
         });
+}
+
+class TypeScriptTestFileCompilerAnother extends TypeScriptTestFileCompiler {
+    constructor (compilerOptions = null, { baseUrl, esm } = {}) {
+        super(compilerOptions, { baseUrl, esm });
+    }
+
+    getFilesName (filenames) {
+        return this._normalizeFilenames(filenames);
+    }
+}
+
+function typeScriptTestFilenames (filenames) {
+    const typeScriptTestFileCompiler = new TypeScriptTestFileCompilerAnother();
+
+    return typeScriptTestFileCompiler.getFilesName(filenames);
+}
+
+module.exports = {
+    compile,
+    typeScriptTestFilenames,
 };


### PR DESCRIPTION

## Purpose
TypeScript compilation fails when using Yarn PnP

## Approach
added normalize all filenames to typescript compiler which solve TypeScript compilation fails when using Yarn PnP

## References
[issue 7412](https://github.com/DevExpress/testcafe/issues/7412)

