### PR TITLE
update typescript compiler

### DIFF
--- a/src/compiler/test-file/formats/typescript/compiler.ts
+++ b/src/compiler/test-file/formats/typescript/compiler.ts
@@ -179,7 +179,10 @@ export default class TypeScriptTestFileCompiler extends APIBasedTestFileCompiler
     }
 
     private _compileFilesToCache (ts: TypeScriptInstance, filenames: string[]): void {
-        const opts    = this._tsConfig.getOptions() as Dictionary<CompilerOptionsValue>;
+        const opts = this._tsConfig.getOptions() as Dictionary<CompilerOptionsValue>;
+
+        filenames = filenames.map(name => TypeScriptTestFileCompiler._normalizeFilename(name));
+
         const program = ts.createProgram([TypeScriptTestFileCompiler.tsDefsPath, ...filenames], opts);
 
         DEBUG_LOGGER('version: %s', ts.version);


### PR DESCRIPTION


## Purpose
TypeScript compilation fails when using Yarn PnP

## Approach
Added file's path normalization for typescript test.
Couldn't add test due to OS specificity

## References
[7412](https://github.com/DevExpress/testcafe/issues/7412)




