### PR TITLE
fix The Test Client (Mobile)

### DIFF
--- a/.github/workflows/test-client-mobile.yml
+++ b/.github/workflows/test-client-mobile.yml
@@ -16,5 +16,5 @@ jobs:
     uses: ./.github/workflows/test-client.yml
     with:
       test-script: 'npx gulp test-client-travis-mobile-run --steps-as-tasks'
-      browsers: '["android", "safari"]'
+      browsers: '["chrome", "safari"]'
     secrets: inherit

--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -22,6 +22,10 @@ jobs:
       SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
       SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
       CLIENT_TESTS_CURRENT_BROWSER: ${{ matrix.browser }}
+      # NOTE: Test server on Android Emulator 7.1 and later can be accessed only via hostname.
+      # We are forced to add this variable to say the 'qunit-harness' module uses the hostname for the test server URL.
+      # https://github.com/AlexanderMoskovkin/qunit-harness/blob/master/src/index.js#L119
+      TRAVIS: true
     steps:
       - uses: DevExpress/testcafe-build-system/actions/set-status@main
         with:

--- a/gulp/constants/client-test-settings.js
+++ b/gulp/constants/client-test-settings.js
@@ -48,10 +48,10 @@ const CLIENT_TESTS_DESKTOP_BROWSERS = [
 
 const CLIENT_TESTS_MOBILE_BROWSERS = [
     {
-        platform:    'Linux',
-        browserName: 'android',
-        version:     '6.0',
-        deviceName:  'Android Emulator',
+        deviceName:      'Android GoogleAPI Emulator',
+        browserName:     'Chrome',
+        platformVersion: '7.1',
+        platformName:    'Android',
     },
     {
         platform:    'iOS',


### PR DESCRIPTION

## Purpose
The Test Client (Mobile) tests task fails for android

## Approach
Updated workflow and client test settings
Last settings for mobile browser on android fails on Saucelabs server. This has been confirmed by Saucelab support.
For solve took settings from testcafe-hammerhead and added variable in workflow.


## References
[issue 329](https://github.com/DevExpress/testcafe-private/issues/329)

