### PR TITLE
feat: debug with selector option added

### DIFF
--- a/src/api/skip-js-errors/index.ts
+++ b/src/api/skip-js-errors/index.ts
@@ -2,7 +2,7 @@ import {
     Dictionary, SkipJsErrorsCallback, SkipJsErrorsCallbackWithOptionsObject, SkipJsErrorsOptionsObject,
 } from '../../configuration/interfaces';
 import { parseRegExpString } from '../../utils/make-reg-exp';
-import { ExecuteClientFunctionCommand } from '../../test-run/commands/observation';
+import { ExecuteClientFunctionCommand } from '../../test-run/commands/execute-client-function';
 import ClientFunctionBuilder from '../../client-functions/client-function-builder';
 
 const SKIP_JS_ERRORS_OBJECT_FUNCTION = `

--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -57,6 +57,7 @@ import {
     AddRequestHooksCommand,
     RemoveRequestHooksCommand,
     ReportCommand,
+    DebugCommand,
 } from '../../test-run/commands/actions';
 
 import {
@@ -67,7 +68,7 @@ import {
     MaximizeWindowCommand,
 } from '../../test-run/commands/browser-manipulation';
 
-import { WaitCommand, DebugCommand } from '../../test-run/commands/observation';
+import { WaitCommand } from '../../test-run/commands/observation';
 import { createExecutionContext as createContext } from './execution-context';
 import { isSelector } from '../../client-functions/types';
 
@@ -602,8 +603,8 @@ export default class TestController {
         return new Assertion(actual, this, callsite);
     }
 
-    [delegatedAPI(DebugCommand.methodName)] () {
-        return this.enqueueCommand(DebugCommand);
+    [delegatedAPI(DebugCommand.methodName)] (selector) {
+        return this.enqueueCommand(DebugCommand, { selector });
     }
 
     [delegatedAPI(SetTestSpeedCommand.methodName)] (speed) {

--- a/src/api/test-controller/index.js
+++ b/src/api/test-controller/index.js
@@ -57,7 +57,6 @@ import {
     AddRequestHooksCommand,
     RemoveRequestHooksCommand,
     ReportCommand,
-    DebugCommand,
 } from '../../test-run/commands/actions';
 
 import {
@@ -68,7 +67,7 @@ import {
     MaximizeWindowCommand,
 } from '../../test-run/commands/browser-manipulation';
 
-import { WaitCommand } from '../../test-run/commands/observation';
+import { WaitCommand, DebugCommand } from '../../test-run/commands/observation';
 import { createExecutionContext as createContext } from './execution-context';
 import { isSelector } from '../../client-functions/types';
 

--- a/src/client-functions/client-function-builder.js
+++ b/src/client-functions/client-function-builder.js
@@ -2,7 +2,7 @@ import { isNil as isNullOrUndefined, assign } from 'lodash';
 import testRunTracker from '../api/test-run-tracker';
 import functionBuilderSymbol from './builder-symbol';
 import { createReplicator, FunctionTransform } from './replicator';
-import { ExecuteClientFunctionCommand } from '../test-run/commands/observation';
+import { ExecuteClientFunctionCommand } from '../test-run/commands/execute-client-function';
 import compileClientFunction from '../compiler/compile-client-function';
 import { APIError, ClientFunctionAPIError } from '../errors/runtime';
 import { assertType, is } from '../errors/runtime/type-assertions';

--- a/src/client-functions/selectors/selector-builder.js
+++ b/src/client-functions/selectors/selector-builder.js
@@ -6,7 +6,7 @@ import { ClientFunctionAPIError } from '../../errors/runtime';
 import functionBuilderSymbol from '../builder-symbol';
 import { RUNTIME_ERRORS } from '../../errors/types';
 import { assertType, is } from '../../errors/runtime/type-assertions';
-import { ExecuteSelectorCommand } from '../../test-run/commands/observation';
+import { ExecuteSelectorCommand } from '../../test-run/commands/execute-client-function';
 import defineLazyProperty from '../../utils/define-lazy-property';
 import { addAPI, addCustomMethods } from './add-api';
 import createSnapshotMethods from './create-snapshot-methods';

--- a/src/client/driver/command-executors/action-executor/elements-retriever.ts
+++ b/src/client/driver/command-executors/action-executor/elements-retriever.ts
@@ -1,4 +1,4 @@
-import { ExecuteSelectorCommand } from '../../../../test-run/commands/observation';
+import { ExecuteSelectorCommand } from '../../../../test-run/commands/execute-client-function';
 import { ExecuteSelectorFn } from '../../../../shared/types';
 import NODE_TYPE_DESCRIPTIONS from '../../node-type-descriptions';
 import {

--- a/src/client/driver/command-executors/client-functions/client-function-executor.ts
+++ b/src/client/driver/command-executors/client-functions/client-function-executor.ts
@@ -4,7 +4,7 @@ import ClientFunctionNodeTransform from './replicator/transforms/client-function
 import evalFunction from './eval-function';
 import { UncaughtErrorInClientFunctionCode } from '../../../../shared/errors/index';
 import Replicator from 'replicator';
-import { ExecuteClientFunctionCommand, ExecuteClientFunctionCommandBase } from '../../../../test-run/commands/observation';
+import { ExecuteClientFunctionCommand, ExecuteClientFunctionCommandBase } from '../../../../test-run/commands/execute-client-function';
 import { Dictionary } from '../../../../configuration/interfaces';
 // @ts-ignore
 import { Promise } from '../../deps/hammerhead';

--- a/src/client/driver/command-executors/client-functions/selector-executor/index.ts
+++ b/src/client/driver/command-executors/client-functions/selector-executor/index.ts
@@ -2,7 +2,7 @@ import ClientFunctionExecutor from '../client-function-executor';
 import createReplicator from '../replicator/index';
 import FunctionTransform from '../replicator/transforms/function-transform';
 import SelectorNodeTransform from '../replicator/transforms/selector-node-transform';
-import { ExecuteSelectorCommand } from '../../../../../test-run/commands/observation';
+import { ExecuteSelectorCommand } from '../../../../../test-run/commands/execute-client-function';
 import {
     SelectorErrorParams,
     SelectorDependencies,

--- a/src/client/driver/driver.js
+++ b/src/client/driver/driver.js
@@ -1481,10 +1481,10 @@ export default class Driver extends serviceUtils.EventEmitter {
             });
     }
 
-    _onSetBreakpointCommand ({ isTestError }) {
+    _onSetBreakpointCommand ({ isTestError, selector }) {
         const showDebuggingStatusPromise = this.statusBar.showDebuggingStatus(isTestError);
 
-        this.selectorInspectorPanel.show();
+        this.selectorInspectorPanel.show(selector);
 
         showDebuggingStatusPromise.then(debug => {
             const stopAfterNextAction = debug === STATUS_BAR_DEBUG_ACTION.step;

--- a/src/client/ui/selector-inspector-panel/index.js
+++ b/src/client/ui/selector-inspector-panel/index.js
@@ -15,7 +15,6 @@ export default class SelectorInspectorPanel {
 
     constructor () {
         this.element = createElementFromDescriptor(panel);
-
         const pickButton             = new PickButton();
 
         this.selectorInputContainer = new SelectorInputContainer();
@@ -28,7 +27,8 @@ export default class SelectorInspectorPanel {
     }
 
     show (selector) {
-        this.selectorInputContainer._debugSelector(selector);
+        this.selectorInputContainer.debugSelector(selector);
+
         if (!this.element.parentElement)
             uiRoot.insertFirstChildToPanelsContainer(this.element);
 

--- a/src/client/ui/selector-inspector-panel/index.js
+++ b/src/client/ui/selector-inspector-panel/index.js
@@ -14,10 +14,9 @@ export default class SelectorInspectorPanel {
     elementPicker = elementPicker;
 
     constructor () {
-        this.element = createElementFromDescriptor(panel);
+        this.element                 = createElementFromDescriptor(panel);
+        this.selectorInputContainer  = new SelectorInputContainer();
         const pickButton             = new PickButton();
-
-        this.selectorInputContainer = new SelectorInputContainer();
         const copyButton             = new CopyButton(this.selectorInputContainer);
         const container              = new MainContainer(pickButton.element, this.selectorInputContainer.element, copyButton.element);
         const hideButton             = new HideButton(this.element);

--- a/src/client/ui/selector-inspector-panel/index.js
+++ b/src/client/ui/selector-inspector-panel/index.js
@@ -17,16 +17,18 @@ export default class SelectorInspectorPanel {
         this.element = createElementFromDescriptor(panel);
 
         const pickButton             = new PickButton();
-        const selectorInputContainer = new SelectorInputContainer();
-        const copyButton             = new CopyButton(selectorInputContainer);
-        const container              = new MainContainer(pickButton.element, selectorInputContainer.element, copyButton.element);
+
+        this.selectorInputContainer = new SelectorInputContainer();
+        const copyButton             = new CopyButton(this.selectorInputContainer);
+        const container              = new MainContainer(pickButton.element, this.selectorInputContainer.element, copyButton.element);
         const hideButton             = new HideButton(this.element);
 
         this.element.appendChild(container.element);
         this.element.appendChild(hideButton.element);
     }
 
-    show () {
+    show (selector) {
+        this.selectorInputContainer._debugSelector(selector);
         if (!this.element.parentElement)
             uiRoot.insertFirstChildToPanelsContainer(this.element);
 

--- a/src/client/ui/selector-inspector-panel/selector-input-container.js
+++ b/src/client/ui/selector-inspector-panel/selector-input-container.js
@@ -164,7 +164,7 @@ export class SelectorInputContainer {
     async debugSelector (selector) {
         highlighter.stopHighlighting();
 
-        this.value = selector.apiFnChain.join('');
+        this.value     = selector.apiFnChain.join('');
         const elements = castArray(await executeSelector(selector));
 
         this._indicateMatches(elements);

--- a/src/client/ui/selector-inspector-panel/selector-input-container.js
+++ b/src/client/ui/selector-inspector-panel/selector-input-container.js
@@ -3,7 +3,7 @@ import hammerhead from './../deps/hammerhead';
 import testCafeCore from './../deps/testcafe-core';
 
 import { createElementFromDescriptor } from './utils/create-element-from-descriptor';
-import { getElementsBySelector } from './utils/get-elements-by-selector';
+import { getElementsBySelector, executeSelector } from './utils/get-elements-by-selector';
 
 import * as descriptors from './descriptors';
 import { elementPicker, ELEMENT_PICKED } from './element-picker';
@@ -156,6 +156,18 @@ export class SelectorInputContainer {
 
         const elements = await getElementsBySelector(this.value);
 
+        this._indicateMatches(elements);
+        this._highlightElements(elements);
+    }
+
+    async _debugSelector (selector) {
+        highlighter.stopHighlighting();
+        const selectorValue = selector.apiFnChain.join('');
+
+        this.value = selectorValue;
+        let elements = await executeSelector(selector).catch(() => null);
+
+        elements = nativeMethods.isArray(elements) ? elements : [elements];
         this._indicateMatches(elements);
         this._highlightElements(elements);
     }

--- a/src/client/ui/selector-inspector-panel/selector-input-container.js
+++ b/src/client/ui/selector-inspector-panel/selector-input-container.js
@@ -4,6 +4,7 @@ import testCafeCore from './../deps/testcafe-core';
 
 import { createElementFromDescriptor } from './utils/create-element-from-descriptor';
 import { getElementsBySelector, executeSelector } from './utils/get-elements-by-selector';
+import { castArray } from './utils/cast-array';
 
 import * as descriptors from './descriptors';
 import { elementPicker, ELEMENT_PICKED } from './element-picker';
@@ -160,14 +161,12 @@ export class SelectorInputContainer {
         this._highlightElements(elements);
     }
 
-    async _debugSelector (selector) {
+    async debugSelector (selector) {
         highlighter.stopHighlighting();
-        const selectorValue = selector.apiFnChain.join('');
 
-        this.value = selectorValue;
-        let elements = await executeSelector(selector).catch(() => null);
+        this.value = selector.apiFnChain.join('');
+        const elements = castArray(await executeSelector(selector));
 
-        elements = nativeMethods.isArray(elements) ? elements : [elements];
         this._indicateMatches(elements);
         this._highlightElements(elements);
     }

--- a/src/client/ui/selector-inspector-panel/utils/cast-array.js
+++ b/src/client/ui/selector-inspector-panel/utils/cast-array.js
@@ -1,0 +1,7 @@
+import hammerhead from '../../deps/hammerhead';
+
+const nativeMethods = hammerhead.nativeMethods;
+
+export function castArray (elements) {
+    return nativeMethods.isArray(elements) ? elements : [elements];
+}

--- a/src/client/ui/selector-inspector-panel/utils/get-elements-by-selector.js
+++ b/src/client/ui/selector-inspector-panel/utils/get-elements-by-selector.js
@@ -20,7 +20,7 @@ async function parseSelector (selector) {
     return browser.parseSelector(communicationUrls.parseSelector, createNativeXHR, selector);
 }
 
-async function executeSelector (parsedSelector) {
+export async function executeSelector (parsedSelector) {
     const startTime        = nativeMethods.date();
     const selectorExecutor = new SelectorExecutor(parsedSelector, GLOBAL_TIMEOUT, startTime, createNotFoundError, createIsInvisibleError);
     const elements         = await selectorExecutor.getResult();

--- a/src/reporter/command/command-formatter.ts
+++ b/src/reporter/command/command-formatter.ts
@@ -1,5 +1,5 @@
 import { isEmpty } from 'lodash';
-import { ExecuteSelectorCommand, ExecuteClientFunctionCommand } from '../../test-run/commands/observation';
+import { ExecuteSelectorCommand, ExecuteClientFunctionCommand } from '../../test-run/commands/execute-client-function';
 import {
     NavigateToCommand,
     PressKeyCommand,

--- a/src/shared/types.d.ts
+++ b/src/shared/types.d.ts
@@ -1,6 +1,6 @@
 /* global globalThis */
 
-import { ExecuteSelectorCommand } from '../test-run/commands/observation';
+import { ExecuteSelectorCommand } from '../test-run/commands/execute-client-function';
 
 export interface NativeMethods {
     setTimeout: typeof globalThis.setTimeout;

--- a/src/test-run/bookmark.ts
+++ b/src/test-run/bookmark.ts
@@ -12,7 +12,7 @@ import {
 
 import { CurrentIframeNotFoundError, CurrentIframeIsNotLoadedError } from '../errors/test-run';
 import TestRun from './index';
-import { ExecuteClientFunctionCommand, ExecuteSelectorCommand } from './commands/observation';
+import { ExecuteClientFunctionCommand, ExecuteSelectorCommand } from './commands/execute-client-function';
 import Role, { RedirectUrl } from '../role/role';
 import { DEFAULT_SPEED_VALUE } from '../configuration/default-values';
 import BrowserConsoleMessages from './browser-console-messages';

--- a/src/test-run/commands/actions.d.ts
+++ b/src/test-run/commands/actions.d.ts
@@ -1,5 +1,5 @@
 import { ActionCommandBase, CommandBase } from './base';
-import { ExecuteClientFunctionCommand, ExecuteSelectorCommand } from './observation';
+import { ExecuteClientFunctionCommand, ExecuteSelectorCommand } from './execute-client-function';
 
 import {
     ActionOptions,

--- a/src/test-run/commands/actions.js
+++ b/src/test-run/commands/actions.js
@@ -48,7 +48,7 @@ import {
 } from './validations/argument';
 
 import { SetNativeDialogHandlerCodeWrongTypeError } from '../../errors/test-run';
-import { ExecuteClientFunctionCommand } from './observation';
+import { ExecuteClientFunctionCommand } from './execute-client-function';
 import { camelCase } from 'lodash';
 import {
     prepareSkipJsErrorsOptions,
@@ -171,24 +171,6 @@ export class ClickCommand extends ActionCommandBase {
         return [
             { name: 'selector', init: initSelector, required: true },
             { name: 'options', type: actionOptions, init: initClickOptions, required: true },
-        ];
-    }
-}
-
-export class DebugCommand extends ActionCommandBase {
-    static methodName = camelCase(TYPE.debug);
-
-    constructor (obj, testRun,) {
-        super(obj, testRun, TYPE.debug);
-    }
-
-    getAssignableProperties () {
-        return [
-            { name: 'selector', init: (name, val, options) => {
-                return initSelector(name, val, Object.assign({}, options,
-                    { skipVisibilityCheck: true, collectionMode: true }
-                ));
-            }, required: false },
         ];
     }
 }

--- a/src/test-run/commands/actions.js
+++ b/src/test-run/commands/actions.js
@@ -175,6 +175,24 @@ export class ClickCommand extends ActionCommandBase {
     }
 }
 
+export class DebugCommand extends ActionCommandBase {
+    static methodName = camelCase(TYPE.debug);
+
+    constructor (obj, testRun,) {
+        super(obj, testRun, TYPE.debug);
+    }
+
+    getAssignableProperties () {
+        return [
+            { name: 'selector', init: (name, val, options) => {
+                return initSelector(name, val, Object.assign({}, options,
+                    { skipVisibilityCheck: true, collectionMode: true }
+                ));
+            }, required: false },
+        ];
+    }
+}
+
 export class RightClickCommand extends ActionCommandBase {
     static methodName = camelCase(TYPE.rightClick);
 

--- a/src/test-run/commands/base.d.ts
+++ b/src/test-run/commands/base.d.ts
@@ -4,6 +4,7 @@ export class CommandBase {
     public constructor(obj?: object, testRun?: TestRun, type?: string, validateProperties?: boolean);
     public actionId: string;
     public type: string;
+    public selector: object;
     [key: string]: unknown;
     public getAssignableProperties(): { name: string }[];
     public getAllAssignableProperties(): { name: string }[];

--- a/src/test-run/commands/base.d.ts
+++ b/src/test-run/commands/base.d.ts
@@ -4,7 +4,6 @@ export class CommandBase {
     public constructor(obj?: object, testRun?: TestRun, type?: string, validateProperties?: boolean);
     public actionId: string;
     public type: string;
-    public selector: object;
     [key: string]: unknown;
     public getAssignableProperties(): { name: string }[];
     public getAllAssignableProperties(): { name: string }[];

--- a/src/test-run/commands/execute-client-function.d.ts
+++ b/src/test-run/commands/execute-client-function.d.ts
@@ -1,0 +1,24 @@
+import { CommandBase } from './base';
+import TestRun from '../index';
+
+declare class ExecuteClientFunctionCommandBase extends CommandBase {
+    public constructor(obj: object, testRun: TestRun, type: string);
+    public instantiationCallsiteName: string;
+    public fnCode: string;
+    public args: string[];
+    public dependencies: string[];
+}
+
+export class ExecuteClientFunctionCommand extends ExecuteClientFunctionCommandBase {
+    public constructor(obj: object, testRun: TestRun);
+}
+
+export class ExecuteSelectorCommand extends ExecuteClientFunctionCommandBase {
+    public constructor(obj: object, testRun: TestRun);
+    public visibilityCheck: boolean;
+    public timeout?: number;
+    public apiFnChain: string[];
+    public needError: boolean;
+    public index: number;
+    public strictError: boolean;
+}

--- a/src/test-run/commands/execute-client-function.js
+++ b/src/test-run/commands/execute-client-function.js
@@ -1,0 +1,44 @@
+import TYPE from './type';
+import { ActionCommandBase } from './base';
+
+export class ExecuteClientFunctionCommandBase extends ActionCommandBase {
+    constructor (obj, testRun, type) {
+        super(obj, testRun, type, false);
+    }
+
+    getAssignableProperties () {
+        return [
+            { name: 'instantiationCallsiteName', defaultValue: '' },
+            { name: 'fnCode', defaultValue: '' },
+            { name: 'args', defaultValue: [] },
+            { name: 'dependencies', defaultValue: [] },
+        ];
+    }
+}
+
+export class ExecuteClientFunctionCommand extends ExecuteClientFunctionCommandBase {
+    static methodName = TYPE.executeClientFunction;
+
+    constructor (obj, testRun) {
+        super(obj, testRun, TYPE.executeClientFunction);
+    }
+}
+
+export class ExecuteSelectorCommand extends ExecuteClientFunctionCommandBase {
+    static methodName = TYPE.executeSelector;
+
+    constructor (obj, testRun) {
+        super(obj, testRun, TYPE.executeSelector);
+    }
+
+    getAssignableProperties () {
+        return [
+            { name: 'visibilityCheck', defaultValue: false },
+            { name: 'timeout', defaultValue: null },
+            { name: 'apiFnChain' },
+            { name: 'needError' },
+            { name: 'index', defaultValue: 0 },
+            { name: 'strictError' },
+        ];
+    }
+}

--- a/src/test-run/commands/observation.d.ts
+++ b/src/test-run/commands/observation.d.ts
@@ -1,27 +1,5 @@
-import { CommandBase, ActionCommandBase } from './base';
+import { ActionCommandBase } from './base';
 import TestRun from '../index';
-
-declare class ExecuteClientFunctionCommandBase extends CommandBase {
-    public constructor(obj: object, testRun: TestRun, type: string);
-    public instantiationCallsiteName: string;
-    public fnCode: string;
-    public args: string[];
-    public dependencies: string[];
-}
-
-export class ExecuteClientFunctionCommand extends ExecuteClientFunctionCommandBase {
-    public constructor(obj: object, testRun: TestRun);
-}
-
-export class ExecuteSelectorCommand extends ExecuteClientFunctionCommandBase {
-    public constructor(obj: object, testRun: TestRun);
-    public visibilityCheck: boolean;
-    public timeout?: number;
-    public apiFnChain: string[];
-    public needError: boolean;
-    public index: number;
-    public strictError: boolean;
-}
 
 export class WaitCommand extends ActionCommandBase {
     public constructor(obj: object, testRun: TestRun);

--- a/src/test-run/commands/observation.d.ts
+++ b/src/test-run/commands/observation.d.ts
@@ -1,4 +1,5 @@
 import { ActionCommandBase } from './base';
+import { ExecuteClientFunctionCommand } from './execute-client-function';
 import TestRun from '../index';
 
 export class WaitCommand extends ActionCommandBase {
@@ -6,4 +7,7 @@ export class WaitCommand extends ActionCommandBase {
     public timeout: number;
 }
 
-export class DebugCommand extends ActionCommandBase { }
+export class DebugCommand extends ActionCommandBase {
+    public constructor(obj: object, testRun: TestRun, validateProperties?: boolean);
+    public selector?: ExecuteClientFunctionCommand;
+}

--- a/src/test-run/commands/observation.js
+++ b/src/test-run/commands/observation.js
@@ -4,6 +4,7 @@ import { positiveIntegerArgument } from './validations/argument';
 import { camelCase } from 'lodash';
 import { initSelector } from './validations/initializers';
 
+
 // Initializers
 function initDebugOptions (name, val, options) {
     return initSelector(name, val, Object.assign({}, options,

--- a/src/test-run/commands/observation.js
+++ b/src/test-run/commands/observation.js
@@ -2,6 +2,9 @@ import TYPE from './type';
 import { ActionCommandBase } from './base';
 import { positiveIntegerArgument } from './validations/argument';
 import { camelCase } from 'lodash';
+import {
+    initSelector,
+} from './validations/initializers';
 
 // Commands
 export class WaitCommand extends ActionCommandBase {
@@ -18,52 +21,20 @@ export class WaitCommand extends ActionCommandBase {
     }
 }
 
-export class ExecuteClientFunctionCommandBase extends ActionCommandBase {
-    constructor (obj, testRun, type) {
-        super(obj, testRun, type, false);
-    }
-
-    getAssignableProperties () {
-        return [
-            { name: 'instantiationCallsiteName', defaultValue: '' },
-            { name: 'fnCode', defaultValue: '' },
-            { name: 'args', defaultValue: [] },
-            { name: 'dependencies', defaultValue: [] },
-        ];
-    }
-}
-
-export class ExecuteClientFunctionCommand extends ExecuteClientFunctionCommandBase {
-    static methodName = TYPE.executeClientFunction;
-
-    constructor (obj, testRun) {
-        super(obj, testRun, TYPE.executeClientFunction);
-    }
-}
-
-export class ExecuteSelectorCommand extends ExecuteClientFunctionCommandBase {
-    static methodName = TYPE.executeSelector;
-
-    constructor (obj, testRun) {
-        super(obj, testRun, TYPE.executeSelector);
-    }
-
-    getAssignableProperties () {
-        return [
-            { name: 'visibilityCheck', defaultValue: false },
-            { name: 'timeout', defaultValue: null },
-            { name: 'apiFnChain' },
-            { name: 'needError' },
-            { name: 'index', defaultValue: 0 },
-            { name: 'strictError' },
-        ];
-    }
-}
-
 export class DebugCommand extends ActionCommandBase {
     static methodName = camelCase(TYPE.debug);
 
-    constructor () {
-        super(null, null, TYPE.debug);
+    constructor (obj, testRun,) {
+        super(obj, testRun, TYPE.debug);
+    }
+
+    getAssignableProperties () {
+        return [
+            { name: 'selector', init: (name, val, options) => {
+                return initSelector(name, val, Object.assign({}, options,
+                    { skipVisibilityCheck: true, collectionMode: true }
+                ));
+            }, required: false },
+        ];
     }
 }

--- a/src/test-run/commands/observation.js
+++ b/src/test-run/commands/observation.js
@@ -2,9 +2,14 @@ import TYPE from './type';
 import { ActionCommandBase } from './base';
 import { positiveIntegerArgument } from './validations/argument';
 import { camelCase } from 'lodash';
-import {
-    initSelector,
-} from './validations/initializers';
+import { initSelector } from './validations/initializers';
+
+// Initializers
+function initDebugOptions (name, val, options) {
+    return initSelector(name, val, Object.assign({}, options,
+        { skipVisibilityCheck: true, collectionMode: true }
+    ));
+}
 
 // Commands
 export class WaitCommand extends ActionCommandBase {
@@ -24,17 +29,13 @@ export class WaitCommand extends ActionCommandBase {
 export class DebugCommand extends ActionCommandBase {
     static methodName = camelCase(TYPE.debug);
 
-    constructor (obj, testRun,) {
+    constructor (obj, testRun) {
         super(obj, testRun, TYPE.debug);
     }
 
     getAssignableProperties () {
         return [
-            { name: 'selector', init: (name, val, options) => {
-                return initSelector(name, val, Object.assign({}, options,
-                    { skipVisibilityCheck: true, collectionMode: true }
-                ));
-            }, required: false },
+            { name: 'selector', init: initDebugOptions, required: false },
         ];
     }
 }

--- a/src/test-run/commands/service.js
+++ b/src/test-run/commands/service.js
@@ -16,9 +16,10 @@ export class HideAssertionRetriesStatusCommand {
 }
 
 export class SetBreakpointCommand {
-    constructor (isTestError) {
+    constructor (isTestError, selector) {
         this.type        = TYPE.setBreakpoint;
         this.isTestError = isTestError;
+        this.selector = selector;
     }
 }
 

--- a/src/test-run/commands/service.js
+++ b/src/test-run/commands/service.js
@@ -19,7 +19,7 @@ export class SetBreakpointCommand {
     constructor (isTestError, selector) {
         this.type        = TYPE.setBreakpoint;
         this.isTestError = isTestError;
-        this.selector = selector;
+        this.selector    = selector;
     }
 }
 

--- a/src/test-run/commands/validations/initializers.js
+++ b/src/test-run/commands/validations/initializers.js
@@ -1,7 +1,7 @@
 import SelectorBuilder from '../../../client-functions/selectors/selector-builder';
 import { ActionSelectorError } from '../../../errors/test-run';
 import { APIError } from '../../../errors/runtime';
-import { ExecuteSelectorCommand } from '../observation';
+import { ExecuteSelectorCommand } from '../execute-client-function';
 import { executeJsExpression } from '../../execute-js-expression';
 import { isJSExpression } from '../utils';
 

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -698,7 +698,7 @@ export default class TestRun extends AsyncEventEmitter {
         if (this.errs.length && this.debugOnFail) {
             const errStr = this.debugReporterPluginHost.formatError(this.errs[0]);
 
-            await this._enqueueSetBreakpointCommand(void 0, errStr);
+            await this._enqueueSetBreakpointCommand(void 0, null, errStr);
         }
 
         await this.emit('before-done');
@@ -821,11 +821,11 @@ export default class TestRun extends AsyncEventEmitter {
         return this.cookieProvider.deleteCookies(cookies, urls);
     }
 
-    private async _enqueueSetBreakpointCommand (callsite: CallsiteRecord | undefined, error?: string): Promise<void> {
+    private async _enqueueSetBreakpointCommand (callsite: CallsiteRecord | undefined, selector?: object | null, error?: string): Promise<void> {
         if (this.debugLogger)
             this.debugLogger.showBreakpoint(this.session.id, this.browserConnection.userAgent, callsite, error);
 
-        this.debugging = await this._internalExecuteCommand(new serviceCommands.SetBreakpointCommand(!!error), callsite) as boolean;
+        this.debugging = await this._internalExecuteCommand(new serviceCommands.SetBreakpointCommand(!!error, selector), callsite) as boolean;
     }
 
     private _removeAllNonServiceTasks (): void {
@@ -1154,7 +1154,7 @@ export default class TestRun extends AsyncEventEmitter {
             const canDebug = !this.browserConnection.isHeadlessBrowser();
 
             if (canDebug)
-                return await this._enqueueSetBreakpointCommand(callsite as CallsiteRecord, void 0);
+                return await this._enqueueSetBreakpointCommand(callsite as CallsiteRecord, command?.selector, void 0);
 
             this.debugging = false;
 

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -107,7 +107,7 @@ import TestRunPhase from './phase';
 import {
     ExecuteClientFunctionCommand,
     ExecuteSelectorCommand,
-} from './commands/observation';
+} from './commands/execute-client-function';
 
 import addRenderedWarning from '../notifications/add-rendered-warning';
 import getBrowser from '../utils/get-browser';
@@ -142,7 +142,7 @@ const TestRunBookmark             = lazyRequire('./bookmark');
 const actionCommands              = lazyRequire('./commands/actions');
 const browserManipulationCommands = lazyRequire('./commands/browser-manipulation');
 const serviceCommands             = lazyRequire('./commands/service');
-const observationCommands         = lazyRequire('./commands/observation');
+const executeClientFunctionCommands         = lazyRequire('./commands/execute-client-function');
 
 const { executeJsExpression, executeAsyncJsExpression } = lazyRequire('./execute-js-expression');
 
@@ -880,7 +880,7 @@ export default class TestRun extends AsyncEventEmitter {
     private _shouldResolveCurrentDriverTask (driverStatus: DriverStatus): boolean {
         const currentCommand = this.currentDriverTask.command;
 
-        const isExecutingObservationCommand = currentCommand instanceof observationCommands.ExecuteSelectorCommand ||
+        const isExecutingObservationCommand = currentCommand instanceof executeClientFunctionCommands.ExecuteSelectorCommand ||
             currentCommand instanceof ExecuteClientFunctionCommand;
 
         const isDebugActive = currentCommand instanceof serviceCommands.SetBreakpointCommand;

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -75,6 +75,7 @@ import {
     RemoveRequestHooksCommand,
     RunCustomActionCommand,
 } from './commands/actions';
+import { DebugCommand } from './commands/observation';
 
 import { RUNTIME_ERRORS, TEST_RUN_ERRORS } from '../errors/types';
 import processTestFnError from '../errors/process-test-fn-error';
@@ -1154,7 +1155,7 @@ export default class TestRun extends AsyncEventEmitter {
             const canDebug = !this.browserConnection.isHeadlessBrowser();
 
             if (canDebug)
-                return await this._enqueueSetBreakpointCommand(callsite as CallsiteRecord, command?.selector, void 0);
+                return await this._enqueueSetBreakpointCommand(callsite as CallsiteRecord, (command as DebugCommand)?.selector, void 0);
 
             this.debugging = false;
 

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -137,13 +137,13 @@ import NativeAutomationRequestPipeline from '../native-automation/request-pipeli
 import NativeAutomation from '../native-automation';
 import ReportDataLog from '../reporter/report-data-log';
 
-const lazyRequire                 = require('import-lazy')(require);
-const ClientFunctionBuilder       = lazyRequire('../client-functions/client-function-builder');
-const TestRunBookmark             = lazyRequire('./bookmark');
-const actionCommands              = lazyRequire('./commands/actions');
-const browserManipulationCommands = lazyRequire('./commands/browser-manipulation');
-const serviceCommands             = lazyRequire('./commands/service');
-const executeClientFunctionCommands         = lazyRequire('./commands/execute-client-function');
+const lazyRequire                   = require('import-lazy')(require);
+const ClientFunctionBuilder         = lazyRequire('../client-functions/client-function-builder');
+const TestRunBookmark               = lazyRequire('./bookmark');
+const actionCommands                = lazyRequire('./commands/actions');
+const browserManipulationCommands   = lazyRequire('./commands/browser-manipulation');
+const serviceCommands               = lazyRequire('./commands/service');
+const executeClientFunctionCommands = lazyRequire('./commands/execute-client-function');
 
 const { executeJsExpression, executeAsyncJsExpression } = lazyRequire('./execute-js-expression');
 

--- a/test/functional/fixtures/ui/test.js
+++ b/test/functional/fixtures/ui/test.js
@@ -43,5 +43,9 @@ describe('TestCafe UI', () => {
         runTestCafeTest('should copy selector');
 
         runTestCafeTest('should hide panel');
+
+        runTestCafeTest('should indicate the correct number of elements matching the TestCafe selector passed in debug');
+
+        runTestCafeTest('should indicate single element matching the TestCafe selector passed in debug');
     });
 });

--- a/test/functional/fixtures/ui/testcafe-fixtures/selector-inspector-test.js
+++ b/test/functional/fixtures/ui/testcafe-fixtures/selector-inspector-test.js
@@ -285,7 +285,6 @@ test('should hide panel', async t => {
 });
 
 test('should indicate the correct number of elements matching the TestCafe selector passed in debug', async t => {
-
     await ClientFunction(() => {
         const { getMatchIndicatorInnerText, resumeTest } = window;
 
@@ -300,7 +299,6 @@ test('should indicate the correct number of elements matching the TestCafe selec
 });
 
 test('should indicate single element matching the TestCafe selector passed in debug', async t => {
-
     await ClientFunction(() => {
         const { getMatchIndicatorInnerText, resumeTest } = window;
 

--- a/test/functional/fixtures/ui/testcafe-fixtures/selector-inspector-test.js
+++ b/test/functional/fixtures/ui/testcafe-fixtures/selector-inspector-test.js
@@ -283,3 +283,33 @@ test('should hide panel', async t => {
 
     await t.debug();
 });
+
+test('should indicate the correct number of elements matching the TestCafe selector passed in debug', async t => {
+
+    await ClientFunction(() => {
+        const { getMatchIndicatorInnerText, resumeTest } = window;
+
+        getMatchIndicatorInnerText()
+            .then(text => {
+                if (text === 'Found: 5')
+                    resumeTest();
+            });
+    })();
+
+    await t.debug('p');
+});
+
+test('should indicate single element matching the TestCafe selector passed in debug', async t => {
+
+    await ClientFunction(() => {
+        const { getMatchIndicatorInnerText, resumeTest } = window;
+
+        getMatchIndicatorInnerText()
+            .then(text => {
+                if (text === 'Found: 1')
+                    resumeTest();
+            });
+    })();
+
+    await t.debug('#container');
+});

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -1011,7 +1011,7 @@ describe('Compiler', function () {
         });
 
         it('Should raise an error if test file has a TypeScript error', function () {
-            const testfile = posixResolve('test/server/data/test-suites/typescript-compile-errors/testfile.ts').toLowerCase();
+            const testfile = posixResolve('test/server/data/test-suites/typescript-compile-errors/testfile.ts');
 
             return compile(testfile)
                 .then(function () {

--- a/test/server/compiler-test.js
+++ b/test/server/compiler-test.js
@@ -1011,7 +1011,7 @@ describe('Compiler', function () {
         });
 
         it('Should raise an error if test file has a TypeScript error', function () {
-            const testfile = posixResolve('test/server/data/test-suites/typescript-compile-errors/testfile.ts');
+            const testfile = posixResolve('test/server/data/test-suites/typescript-compile-errors/testfile.ts').toLowerCase();
 
             return compile(testfile)
                 .then(function () {

--- a/test/server/data/test-controller-reporter-expected/index.js
+++ b/test/server/data/test-controller-reporter-expected/index.js
@@ -747,6 +747,7 @@ module.exports = {
             name:      'debug',
             command:   {
                 type:     'debug',
+                selector: undefined,
                 actionId: 'DebugCommand',
             },
             test:      {


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
The purpose of this PR is to allow passing selector to a t.debug call. Something like this t.debug(Selector). Then the selector will be shown in debug mode and highlighted.

## Approach
So overall, the main goal was to pass the selector argument from server-side debug call to client-side selector-input-contaner. 
1) src/test-run/index.ts Inside this file we have _internalExecuteCommand method. There is debug command type handling block. Inside of it we call _enqueueSetBreakpointCommand to which we pass command.selector as a second argument. This way we transfer Selector from debugCommand to breakpointCommand.
2) After the breakpointCommand is added to driverTaskQueue we can work with it on client-side.
3) On client-side we pass selector to _debugSelector  method of SelectorInputContainer class.
4) In _debugSelector method we:
           -   remove any previously highlighted elements,
           -  get Selector name and assign it to this.value for SelectorInputContainer,
           -  execute Selector to get elements for highlighting and indication,
           -  highlight and indicate elements of the Selector

## References
https://github.com/DevExpress/testcafe-private/issues/163

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
