### PR TITLE
fix: `Hide Picker` button fixed for Mac

### DIFF
--- a/src/client/ui/selector-inspector-panel/descriptors.js
+++ b/src/client/ui/selector-inspector-panel/descriptors.js
@@ -30,10 +30,14 @@ export const copyButton = {
     value: 'Copy',
 };
 
+export const hideButtonContainer = {
+   class: 'selector-panel-toggle-button-container'
+};
+
 export const hideButton = {
-    tag:   'button',
+    tag:   'input',
     type:  'button',
-    class: 'selector-panel-toggle-button',
+    class: 'selector-panel-toggle-button'
 };
 
 export const selectorsList = {

--- a/src/client/ui/selector-inspector-panel/descriptors.js
+++ b/src/client/ui/selector-inspector-panel/descriptors.js
@@ -31,13 +31,13 @@ export const copyButton = {
 };
 
 export const hideButtonContainer = {
-   class: 'selector-panel-toggle-button-container'
+    class: 'selector-panel-toggle-button-container',
 };
 
 export const hideButton = {
     tag:   'input',
     type:  'button',
-    class: 'selector-panel-toggle-button'
+    class: 'selector-panel-toggle-button',
 };
 
 export const selectorsList = {

--- a/src/client/ui/selector-inspector-panel/hide-button.js
+++ b/src/client/ui/selector-inspector-panel/hide-button.js
@@ -9,8 +9,11 @@ const SELECTOR_INSPECTOR_PANEL_HIDDEN_CLASSNAME = 'selector-inspector-panel--hid
 
 export class HideButton {
     constructor (selectorInspectorPanel) {
-        this.element = createElementFromDescriptor(descriptors.hideButton);
 
+        const hideButton = createElementFromDescriptor(descriptors.hideButton);
+        this.element     = createElementFromDescriptor(descriptors.hideButtonContainer);
+
+        this.element.appendChild(hideButton);
         this.element.appendChild(createElementFromDescriptor(descriptors.span));
 
         eventUtils.bind(this.element, 'click', () => this._showAndHide(selectorInspectorPanel));

--- a/src/client/ui/selector-inspector-panel/hide-button.js
+++ b/src/client/ui/selector-inspector-panel/hide-button.js
@@ -11,7 +11,8 @@ export class HideButton {
     constructor (selectorInspectorPanel) {
 
         const hideButton = createElementFromDescriptor(descriptors.hideButton);
-        this.element     = createElementFromDescriptor(descriptors.hideButtonContainer);
+
+        this.element = createElementFromDescriptor(descriptors.hideButtonContainer);
 
         this.element.appendChild(hideButton);
         this.element.appendChild(createElementFromDescriptor(descriptors.span));

--- a/src/client/ui/styles.less
+++ b/src/client/ui/styles.less
@@ -578,24 +578,36 @@
             flex-direction: row;
             position: relative;
 
-            .selector-panel-toggle-button {
-                cursor: pointer;
-                background: white;
-                padding: 1px 8px 3px 8px;
-                top: 2px;
-                border-radius: 4px;
-                overflow: hidden;
+            .selector-panel-toggle-button-container {
+                position: relative;
 
-                &:hover {
-                    background-color: #cfcfcf;
+                .selector-panel-toggle-button {
+                    cursor: pointer;
+                    background: white;
+                    padding: 1px 8px 3px 8px;
+                    top: -1px;
+                    border-radius: 4px;
+                    overflow: hidden;
+                    position: absolute;
+                    width: 100%;
+                    box-sizing: border-box;
+
+                    &:hover {
+                        background-color: #cfcfcf;
+                    }
+                }
+
+                span {
+                    cursor: pointer;
+                    padding: 1px 8px 3px 8px;
+                    pointer-events: none;
+                    z-index: 1;
                 }
 
                 span::after {
                     content: "Hide Picker";
-                    width: 100%;
-                    height: 100%;
 
-                    @media(max-width: 470px) {
+                    @media screen and (max-width: 500px) {
                         content: "Hide";
                     }
                 }
@@ -704,17 +716,23 @@
             &--hidden {
                 padding: 0;
 
-                .selector-panel-toggle-button {
-                    background-color: #283545;
-                    color: white;
-                    font-weight: bold;
+                .selector-panel-toggle-button-container {
                     position: absolute;
                     top: -26px;
                     right: 3px;
                     z-index: @rootZIndex - 2;
 
-                    &:hover {
-                        background-color: #36B6E5;
+                    .selector-panel-toggle-button {
+                        background-color: #283545;
+                        font-weight: bold;
+
+                        &:hover {
+                            background-color: #36B6E5;
+                        }
+                    }
+
+                    span {
+                        color: white;
                     }
 
                     span::after {

--- a/src/client/ui/styles.less
+++ b/src/client/ui/styles.less
@@ -585,7 +585,7 @@
                     cursor: pointer;
                     background: white;
                     padding: 1px 8px 3px 8px;
-                    top: -1px;
+                    top: 0;
                     border-radius: 4px;
                     overflow: hidden;
                     position: absolute;
@@ -602,6 +602,8 @@
                     padding: 1px 8px 3px 8px;
                     pointer-events: none;
                     z-index: 1;
+                    color:rgb(0, 0, 0);
+                    line-height: 16px;
                 }
 
                 span::after {
@@ -719,15 +721,14 @@
                 .selector-panel-toggle-button-container {
                     position: absolute;
                     top: -26px;
-                    right: 3px;
+                    right: 2px;
                     z-index: @rootZIndex - 2;
 
                     .selector-panel-toggle-button {
                         background-color: #283545;
-                        font-weight: bold;
 
                         &:hover {
-                            background-color: #36B6E5;
+                            background-color: #36B6E5!important;
                         }
                     }
 

--- a/test/functional/fixtures/ui/utils/selector-inspector.js
+++ b/test/functional/fixtures/ui/utils/selector-inspector.js
@@ -218,7 +218,7 @@ Object.assign(window, {
 
     async getHideButtonElements () {
         const hideButton = await this.getElement('.selector-panel-toggle-button-hammerhead-shadow-ui');
-        const hideButtonSpan = await this.getElement('.selector-panel-toggle-button-hammerhead-shadow-ui span');
+        const hideButtonSpan = await this.getElement('.selector-panel-toggle-button-container-hammerhead-shadow-ui span');
 
         return {
             hideButton,


### PR DESCRIPTION
`input` tag with type button used for Hide Picker button rendering