### PR TITLE
fix: disableConcurrency with quarantine mode (closes #8087)

### DIFF
--- a/src/runner/browser-job.ts
+++ b/src/runner/browser-job.ts
@@ -138,8 +138,10 @@ export default class BrowserJob extends AsyncEventEmitter {
     }
 
     private async _onTestRunRestart (testRunController: TestRunController): Promise<void> {
+        const conectionId = testRunController.testRun.browserConnection.id;
+
         this._removeFromCompletionQueue(testRunController);
-        this._testRunControllerQueue.unshift(testRunController);
+        this._getTestControllerQueue(conectionId).unshift(testRunController);
 
         await this.emit('test-run-restart', testRunController);
     }

--- a/test/functional/fixtures/regression/gh-8087/pages/index.html
+++ b/test/functional/fixtures/regression/gh-8087/pages/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>gh-8087</title>
+</head>
+<body>
+</body>
+</html>

--- a/test/functional/fixtures/regression/gh-8087/test.js
+++ b/test/functional/fixtures/regression/gh-8087/test.js
@@ -1,0 +1,43 @@
+const path               = require('path');
+const createTestCafe     = require('../../../../../lib');
+const { createReporter } = require('../../../utils/reporter');
+const { expect }         = require('chai');
+
+let testCafe = null;
+let runner   = null;
+let errors   = null;
+
+const reporter = createReporter({
+    reportTestDone (_, testRunInfo) {
+        errors = testRunInfo.errs;
+    },
+});
+
+
+const run = (pathToTest, concurrency) => {
+    const src = path.join(__dirname, pathToTest);
+
+    return createTestCafe('127.0.0.1', 1335, 1336)
+        .then(tc => {
+            testCafe = tc;
+        })
+        .then(() => {
+            runner = testCafe.createRunner();
+            return runner
+                .src(src)
+                .browsers(`chrome:headless`)
+                .reporter(reporter)
+                .concurrency(concurrency)
+                .run({ quarantineMode: { successThreshold: 1, attemptLimit: 3 } });
+        })
+        .then(() => {
+            testCafe.close();
+        });
+};
+
+describe('[Regression](GH-8087)', function () {
+    it('Should execute all fixture\'s test in one browser with quarantine Mode', function () {
+        return run('./testcafe-fixtures/index.js', 3)
+            .then(() => expect(errors.length).eql(0));
+    });
+});

--- a/test/functional/fixtures/regression/gh-8087/test.js
+++ b/test/functional/fixtures/regression/gh-8087/test.js
@@ -37,7 +37,7 @@ const run = (pathToTest, concurrency) => {
 
 describe('[Regression](GH-8087)', function () {
     it('Should execute all fixture\'s test in one browser with quarantine Mode', function () {
-        return run('./testcafe-fixtures/index.js', 3)
+        return run('./testcafe-fixtures/index.js', 2)
             .then(() => expect(errors.length).eql(0));
     });
 });

--- a/test/functional/fixtures/regression/gh-8087/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-8087/testcafe-fixtures/index.js
@@ -1,0 +1,33 @@
+const connectionsFixture = {};
+
+let attempt = 0;
+
+const addConnection = (connections, connectionId) => {
+    if (!connections[connectionId])
+        connections[connectionId] = 1;
+    else
+        connections[connectionId]++;
+};
+
+const getAttempts = () => attempt++;
+
+fixture `disableConcurrency fixture`
+    .beforeEach(async t => {
+        addConnection(connectionsFixture, t.testRun.browserConnection.id);
+    })
+    .afterEach(async t => {
+        await t.expect(Object.keys(connectionsFixture).length).eql(1);
+    })
+    .after(() => {
+        if (Object.values(connectionsFixture)[0] !== 7)
+            throw new Error();
+    })
+    .disableConcurrency;
+
+for (let i = 1; i <= 5; i++) {
+    test(`test ${i}`, async (t) => {
+        await t.wait(1000);
+        if (i === 1 && getAttempts() < 2)
+            throw new Error();
+    });
+}

--- a/test/functional/fixtures/regression/gh-8087/testcafe-fixtures/index.js
+++ b/test/functional/fixtures/regression/gh-8087/testcafe-fixtures/index.js
@@ -1,6 +1,9 @@
-const connectionsFixture = {};
 
-let attempt = 0;
+
+const testRunInfo = {
+    attemptCount: 0,
+    connections:  {},
+};
 
 const addConnection = (connections, connectionId) => {
     if (!connections[connectionId])
@@ -9,25 +12,24 @@ const addConnection = (connections, connectionId) => {
         connections[connectionId]++;
 };
 
-const getAttempts = () => attempt++;
 
 fixture `disableConcurrency fixture`
     .beforeEach(async t => {
-        addConnection(connectionsFixture, t.testRun.browserConnection.id);
+        addConnection(testRunInfo.connections, t.testRun.browserConnection.id);
     })
     .afterEach(async t => {
-        await t.expect(Object.keys(connectionsFixture).length).eql(1);
+        await t.expect(Object.keys(testRunInfo.connections).length).eql(1);
     })
     .after(() => {
-        if (Object.values(connectionsFixture)[0] !== 7)
+        if (Object.keys(testRunInfo.connections).length !== 1 || Object.values(testRunInfo.connections)[0] !== 3)
             throw new Error();
     })
     .disableConcurrency;
 
-for (let i = 1; i <= 5; i++) {
-    test(`test ${i}`, async (t) => {
-        await t.wait(1000);
-        if (i === 1 && getAttempts() < 2)
+for (let i = 0; i <= 1; i++) {
+    test(`test ${i}`, async () => {
+        testRunInfo.attemptCount++;
+        if (testRunInfo.attemptCount < 2)
             throw new Error();
     });
 }


### PR DESCRIPTION

## Purpose
Disabling concurrency with quarantine mode led to unexpected behavior.

## Approach
Updated method `_onTestRunRestart` in browser job.
Previously, we added a quarantine test to the general queue. Now we change the queue, if before this the test was executed in a fixture with the `disable concurrency` flag.

## References
#8087 

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
