### PR TITLE
fix: upload files with required inputs in native automation

### DIFF
--- a/src/client/automation/playback/upload.js
+++ b/src/client/automation/playback/upload.js
@@ -1,12 +1,34 @@
-import { doUpload } from '../deps/hammerhead';
+import {
+    doUpload, eventSandbox, nativeMethods,
+} from '../deps/hammerhead';
 import { arrayUtils } from '../deps/testcafe-core';
 
 
 export default class UploadAutomation {
-    constructor (element, paths, createError) {
+    constructor (element, paths, createError, isNativeAutomation) {
         this.element     = element;
         this.paths       = paths;
         this.createError = createError;
+
+        if (isNativeAutomation)
+            this._handleRequiredInput();
+    }
+
+    _handleRequiredInput () {
+        const isRequired = nativeMethods.hasAttribute.call(this.element, 'required');
+
+        if (isRequired)
+            nativeMethods.removeAttribute.call(this.element, 'required');
+
+        const ensureUploadInputHasRequiredAttribute = () => {
+            if (isRequired)
+                nativeMethods.setAttribute.call(this.element, 'required', 'true');
+        };
+
+        if (this.element.form) {
+            eventSandbox.listeners.initElementListening(this.element.form, ['submit']);
+            eventSandbox.listeners.addInternalEventAfterListener(this.element.form, ['submit'], ensureUploadInputHasRequiredAttribute);
+        }
     }
 
     run () {

--- a/src/client/automation/playback/upload.js
+++ b/src/client/automation/playback/upload.js
@@ -1,5 +1,7 @@
 import {
-    doUpload, eventSandbox, nativeMethods,
+    doUpload,
+    eventSandbox,
+    nativeMethods,
 } from '../deps/hammerhead';
 import { arrayUtils } from '../deps/testcafe-core';
 
@@ -13,7 +15,7 @@ export default class UploadAutomation {
         this.paths       = paths;
         this.createError = createError;
 
-        if (isNativeAutomation)
+        if (isNativeAutomation && this.element.form)
             this._handleRequiredInput();
     }
 
@@ -28,10 +30,8 @@ export default class UploadAutomation {
                 nativeMethods.setAttribute.call(this.element, REQUIRED_ATTR_NAME, 'true');
         };
 
-        if (this.element.form) {
-            eventSandbox.listeners.initElementListening(this.element.form, [FORM_SUBMIT_EVENT_NAME]);
-            eventSandbox.listeners.addInternalEventAfterListener(this.element.form, [FORM_SUBMIT_EVENT_NAME], ensureUploadInputHasRequiredAttribute);
-        }
+        eventSandbox.listeners.initElementListening(this.element.form, [FORM_SUBMIT_EVENT_NAME]);
+        eventSandbox.listeners.addInternalEventAfterListener(this.element.form, [FORM_SUBMIT_EVENT_NAME], ensureUploadInputHasRequiredAttribute);
     }
 
     run () {

--- a/src/client/automation/playback/upload.js
+++ b/src/client/automation/playback/upload.js
@@ -4,6 +4,9 @@ import {
 import { arrayUtils } from '../deps/testcafe-core';
 
 
+const REQUIRED_ATTR_NAME     = 'required';
+const FORM_SUBMIT_EVENT_NAME = 'submit';
+
 export default class UploadAutomation {
     constructor (element, paths, createError, isNativeAutomation) {
         this.element     = element;
@@ -15,19 +18,19 @@ export default class UploadAutomation {
     }
 
     _handleRequiredInput () {
-        const isRequired = nativeMethods.hasAttribute.call(this.element, 'required');
+        const isRequired = nativeMethods.hasAttribute.call(this.element, REQUIRED_ATTR_NAME);
 
         if (isRequired)
-            nativeMethods.removeAttribute.call(this.element, 'required');
+            nativeMethods.removeAttribute.call(this.element, REQUIRED_ATTR_NAME);
 
         const ensureUploadInputHasRequiredAttribute = () => {
             if (isRequired)
-                nativeMethods.setAttribute.call(this.element, 'required', 'true');
+                nativeMethods.setAttribute.call(this.element, REQUIRED_ATTR_NAME, 'true');
         };
 
         if (this.element.form) {
-            eventSandbox.listeners.initElementListening(this.element.form, ['submit']);
-            eventSandbox.listeners.addInternalEventAfterListener(this.element.form, ['submit'], ensureUploadInputHasRequiredAttribute);
+            eventSandbox.listeners.initElementListening(this.element.form, [FORM_SUBMIT_EVENT_NAME]);
+            eventSandbox.listeners.addInternalEventAfterListener(this.element.form, [FORM_SUBMIT_EVENT_NAME], ensureUploadInputHasRequiredAttribute);
         }
     }
 

--- a/src/client/driver/command-executors/action-executor/actions-initializer.ts
+++ b/src/client/driver/command-executors/action-executor/actions-initializer.ts
@@ -177,9 +177,10 @@ function ensureFileInput (element: Node[]): never | void {
 }
 
 ActionExecutor.ACTIONS_HANDLERS[COMMAND_TYPE.setFilesToUpload] = {
-    create: (command, elements) => {
+    create: (command, elements, dispatchNativeAutomationEventFn) => {
         return new UploadAutomation(elements[0], command.filePath,
             (filePaths: string[], scannedFilePaths: string[]) => new ActionCannotFindFileToUploadError(filePaths, scannedFilePaths),
+            dispatchNativeAutomationEventFn
         );
     },
 

--- a/test/functional/fixtures/api/es-next/upload/pages/index.html
+++ b/test/functional/fixtures/api/es-next/upload/pages/index.html
@@ -10,8 +10,8 @@
             <input type="submit" id="submit" />
         </form>
         <form action="/file-upload" method="POST" enctype="multipart/form-data">
-            <input type="file" id="fileTwo" name="fileTwo" required />
-            <input type="submit" id="submitTwo" />
+            <input type="file" id="fileRequired" name="fileRequired" required />
+            <input type="submit" id="submitRequired" />
         </form>
     </body>
 </html>

--- a/test/functional/fixtures/api/es-next/upload/pages/index.html
+++ b/test/functional/fixtures/api/es-next/upload/pages/index.html
@@ -1,13 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Upload</title>
-</head>
-<body>
-    <form action="/file-upload" method="POST" enctype="multipart/form-data">
-        <input type="file" id="file" name="file">
-        <input type="submit" id="submit">
-    </form>
-</body>
+    <head>
+        <meta charset="UTF-8" />
+        <title>Upload</title>
+    </head>
+    <body>
+        <form action="/file-upload" method="POST" enctype="multipart/form-data">
+            <input type="file" id="file" name="file" />
+            <input type="submit" id="submit" />
+        </form>
+        <form action="/file-upload" method="POST" enctype="multipart/form-data">
+            <input type="file" id="fileTwo" name="fileTwo" required />
+            <input type="submit" id="submitTwo" />
+        </form>
+    </body>
 </html>

--- a/test/functional/fixtures/api/es-next/upload/test.js
+++ b/test/functional/fixtures/api/es-next/upload/test.js
@@ -7,6 +7,10 @@ describe('[API] Upload', function () {
             return runTests('./testcafe-fixtures/upload-test.js', 'Upload the file', { only: 'chrome' });
         });
 
+        it('Should upload the specified file with required input', function () {
+            return runTests('./testcafe-fixtures/upload-test.js', 'Upload the file with required input', { only: 'chrome' });
+        });
+
         it('Should validate the selector argument', function () {
             return runTests('./testcafe-fixtures/upload-test.js', 'Invalid selector argument (setFilesToUpload)', {
                 shouldFail: true,

--- a/test/functional/fixtures/api/es-next/upload/testcafe-fixtures/upload-test.js
+++ b/test/functional/fixtures/api/es-next/upload/testcafe-fixtures/upload-test.js
@@ -15,6 +15,14 @@ test('Upload the file', async t => {
     expect(await getUploadedText()).equals('File 1 is uploaded!');
 });
 
+test('Upload the file with required input', async t => {
+    await t
+        .setFilesToUpload('#fileTwo', '../test-data/file1.txt')
+        .click('#submitTwo');
+
+    expect(await getUploadedText()).equals('File 1 is uploaded!');
+});
+
 test('Clear the upload', async t => {
     await t
         .setFilesToUpload('#file', '../test-data/file1.txt')

--- a/test/functional/fixtures/api/es-next/upload/testcafe-fixtures/upload-test.js
+++ b/test/functional/fixtures/api/es-next/upload/testcafe-fixtures/upload-test.js
@@ -15,14 +15,6 @@ test('Upload the file', async t => {
     expect(await getUploadedText()).equals('File 1 is uploaded!');
 });
 
-test('Upload the file with required input', async t => {
-    await t
-        .setFilesToUpload('#fileTwo', '../test-data/file1.txt')
-        .click('#submitTwo');
-
-    expect(await getUploadedText()).equals('File 1 is uploaded!');
-});
-
 test('Clear the upload', async t => {
     await t
         .setFilesToUpload('#file', '../test-data/file1.txt')
@@ -46,4 +38,12 @@ test('Invalid selector argument (clearUpload)', async t => {
 
 test('Error on upload non-existing file', async t => {
     await t.setFilesToUpload('#file', ['../dummy-file-1.txt', '../dummy-file-2.txt']);
+});
+
+test('Upload the file with required input', async t => {
+    await t
+        .setFilesToUpload('#fileTwo', '../test-data/file1.txt')
+        .click('#submitTwo');
+
+    expect(await getUploadedText()).equals('File 1 is uploaded!');
 });

--- a/test/functional/fixtures/api/es-next/upload/testcafe-fixtures/upload-test.js
+++ b/test/functional/fixtures/api/es-next/upload/testcafe-fixtures/upload-test.js
@@ -42,8 +42,8 @@ test('Error on upload non-existing file', async t => {
 
 test('Upload the file with required input', async t => {
     await t
-        .setFilesToUpload('#fileTwo', '../test-data/file1.txt')
-        .click('#submitTwo');
+        .setFilesToUpload('#fileRequired', '../test-data/file1.txt')
+        .click('#submitRequired');
 
     expect(await getUploadedText()).equals('File 1 is uploaded!');
 });


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
UploadAutomation is fixed in order to upload required inputs in Native Automation mode. 

## Approach
Remove the required attribute from the file input before uploading. 
Initialize the addInternalEventAfterListener on inputs form 'submit' event for returning the required attributes back.

## References
closes https://github.com/DevExpress/testcafe/issues/8079

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
