### PR TITLE
fix: In concurrent test run fixed awaiting of fixture before hook

### DIFF
--- a/src/runner/fixture-hook-controller.ts
+++ b/src/runner/fixture-hook-controller.ts
@@ -61,7 +61,7 @@ export default class FixtureHookController {
         return !!item && item.blockedUntilFixtureBeforeHookIsExecuted;
     }
 
-    public unblockTest (test: Test): void {
+    public unblockWhenBeforeHooksComplete (test: Test): void {
         const item = this._getFixtureMapItem(test);
 
         if (item)

--- a/src/runner/fixture-hook-controller.ts
+++ b/src/runner/fixture-hook-controller.ts
@@ -61,12 +61,11 @@ export default class FixtureHookController {
         return !!item && item.blockedUntilFixtureBeforeHookIsExecuted;
     }
 
-    private _blockTest (item: FixtureState): void {
-        item.blockedUntilFixtureBeforeHookIsExecuted = true;
-    }
+    public unblockTest (test: Test): void {
+        const item = this._getFixtureMapItem(test);
 
-    private _unblockTest (item: FixtureState): void {
-        item.blockedUntilFixtureBeforeHookIsExecuted = false;
+        if (item)
+            item.blockedUntilFixtureBeforeHookIsExecuted = false;
     }
 
     public blockIfBeforeHooksExist (test: Test): void {
@@ -74,7 +73,7 @@ export default class FixtureHookController {
         const item = this._getFixtureMapItem(test);
 
         if (item && (fixture.globalBeforeFn || fixture.beforeFn))
-            this._blockTest(item);
+            item.blockedUntilFixtureBeforeHookIsExecuted = true;
     }
 
     private async _runFixtureBeforeHook (item: FixtureState, fn: Function, testRun: TestRun): Promise<boolean> {
@@ -117,8 +116,6 @@ export default class FixtureHookController {
             const success = shouldRunBeforeHook
                             && await this._runFixtureBeforeHook(item, fixture.globalBeforeFn as Function, testRun)
                             && await this._runFixtureBeforeHook(item, fixture.beforeFn as Function, testRun);
-
-            this._unblockTest(item);
 
             // NOTE: fail all tests in fixture if fixture.before hook has error
             if (!success && item.fixtureBeforeHookErr) {

--- a/src/runner/fixture-hook-controller.ts
+++ b/src/runner/fixture-hook-controller.ts
@@ -25,14 +25,16 @@ export default class FixtureHookController {
 
     private static _ensureFixtureMapItem (fixtureMap: Map<Fixture, FixtureState>, fixture: Fixture): void {
         if (!fixtureMap.has(fixture)) {
+            const beforeHookPromise = Promise.resolve(true);
+
             const item = {
                 started:                        false,
                 runningFixtureBeforeHook:       false,
                 fixtureBeforeHookErr:           null,
                 pendingTestRunCount:            0,
                 fixtureCtx:                     Object.create(null),
-                fixtureGlobalBeforeHookPromise: Promise.resolve(true),
-                fixtureBeforeHookPromise:       Promise.resolve(true),
+                fixtureGlobalBeforeHookPromise: beforeHookPromise,
+                fixtureBeforeHookPromise:       beforeHookPromise,
             };
 
             fixtureMap.set(fixture, item);
@@ -110,8 +112,10 @@ export default class FixtureHookController {
             if (shouldRunBeforeHook) {
                 item.fixtureGlobalBeforeHookPromise = this._runFixtureBeforeHook(item, fixture.globalBeforeFn as Function, testRun);
                 success                             = await item.fixtureGlobalBeforeHookPromise;
-                item.fixtureBeforeHookPromise       = this._runFixtureBeforeHook(item, fixture.beforeFn as Function, testRun);
-                success                             = await item.fixtureBeforeHookPromise;
+                if (success) {
+                    item.fixtureBeforeHookPromise = this._runFixtureBeforeHook(item, fixture.beforeFn as Function, testRun);
+                    success                       = await item.fixtureBeforeHookPromise;
+                }
             }
             else {
                 success = await item.fixtureGlobalBeforeHookPromise &&

--- a/src/runner/fixture-hook-controller.ts
+++ b/src/runner/fixture-hook-controller.ts
@@ -101,22 +101,26 @@ export default class FixtureHookController {
 
         if (item) {
             const shouldRunBeforeHook = !item.started;
-            let success = false;
+            // let success = false;
 
             item.started = true;
 
-            if (shouldRunBeforeHook) {
-                item.fixtureBeforeHookPromise = this._runFixtureBeforeHook(item, fixture.globalBeforeFn as Function, testRun)
-                    .then(isGlobalBeforeHookSuccess => {
-                        if (isGlobalBeforeHookSuccess)
-                            return this._runFixtureBeforeHook(item, fixture.beforeFn as Function, testRun);
+            // if (shouldRunBeforeHook) {
+            //     item.fixtureBeforeHookPromise = this._runFixtureBeforeHook(item, fixture.globalBeforeFn as Function, testRun)
+            //         .then(isGlobalBeforeHookSuccess => {
+            //             if (isGlobalBeforeHookSuccess)
+            //                 return this._runFixtureBeforeHook(item, fixture.beforeFn as Function, testRun);
 
-                        return isGlobalBeforeHookSuccess;
-                    });
-                success = await item.fixtureBeforeHookPromise;
-            }
-            else
-                success = await item.fixtureBeforeHookPromise;
+            //             return isGlobalBeforeHookSuccess;
+            //         });
+            //     success = await item.fixtureBeforeHookPromise;
+            // }
+            // else
+            //     success = await item.fixtureBeforeHookPromise;
+
+            const success = shouldRunBeforeHook
+            && await this._runFixtureBeforeHook(item, fixture.globalBeforeFn as Function, testRun)
+            && await this._runFixtureBeforeHook(item, fixture.beforeFn as Function, testRun);
 
             // NOTE: fail all tests in fixture if fixture.before hook has error
             if (!success && item.fixtureBeforeHookErr) {

--- a/src/runner/fixture-hook-controller.ts
+++ b/src/runner/fixture-hook-controller.ts
@@ -8,7 +8,7 @@ import { getFixtureInfo } from '../utils/get-test-and-fixture-info';
 
 interface FixtureState {
     started: boolean;
-    blockedUntilFixtureBeforeHookIsExecuted: boolean;
+    testIsBlocked: boolean;
     fixtureBeforeHookErr: null | Error;
     pendingTestRunCount: number;
     fixtureCtx: object;
@@ -24,11 +24,11 @@ export default class FixtureHookController {
     private static _ensureFixtureMapItem (fixtureMap: Map<Fixture, FixtureState>, fixture: Fixture): void {
         if (!fixtureMap.has(fixture)) {
             const item = {
-                started:                                 false,
-                blockedUntilFixtureBeforeHookIsExecuted: false,
-                fixtureBeforeHookErr:                    null,
-                pendingTestRunCount:                     0,
-                fixtureCtx:                              Object.create(null),
+                started:              false,
+                testIsBlocked:        false,
+                fixtureBeforeHookErr: null,
+                pendingTestRunCount:  0,
+                fixtureCtx:           Object.create(null),
             };
 
             fixtureMap.set(fixture, item);
@@ -58,22 +58,22 @@ export default class FixtureHookController {
     public isTestBlocked (test: Test): boolean {
         const item = this._getFixtureMapItem(test);
 
-        return !!item && item.blockedUntilFixtureBeforeHookIsExecuted;
+        return !!item && item.testIsBlocked;
     }
 
-    public unblockWhenBeforeHooksComplete (test: Test): void {
+    public unblockTest (test: Test): void {
         const item = this._getFixtureMapItem(test);
 
         if (item)
-            item.blockedUntilFixtureBeforeHookIsExecuted = false;
+            item.testIsBlocked = false;
     }
 
-    public blockIfBeforeHooksExist (test: Test): void {
+    public blockTestIfNecessary (test: Test): void {
         const fixture = test.fixture as Fixture;
-        const item = this._getFixtureMapItem(test);
+        const item    = this._getFixtureMapItem(test);
 
         if (item && (fixture.globalBeforeFn || fixture.beforeFn))
-            item.blockedUntilFixtureBeforeHookIsExecuted = true;
+            item.testIsBlocked = true;
     }
 
     private async _runFixtureBeforeHook (item: FixtureState, fn: Function, testRun: TestRun): Promise<boolean> {

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -95,8 +95,6 @@ export default class TestRunController extends AsyncEventEmitter {
             startRunExecutionTime,
         });
 
-        this._fixtureHookController.blockIfBeforeHooksExist(this.testRun.test);
-
         this.clientScriptRoutes = clientScriptsRouting.register({
             proxy:            this._proxy,
             test:             this.test,
@@ -272,10 +270,14 @@ export default class TestRunController extends AsyncEventEmitter {
 
         await this._handleNativeAutomationMode(connection);
 
+        this._fixtureHookController.blockIfBeforeHooksExist(this.test);
+
         const testRun = await this._createTestRun(connection, startRunExecutionTime);
 
         const hookOk = await this._testRunHook.runTestRunBeforeHookIfNecessary(testRun)
                        && await this._fixtureHookController.runFixtureBeforeHookIfNecessary(testRun);
+
+        this._fixtureHookController.unblockTest(this.test);
 
         if (this.test.skip || !hookOk) {
             await this._emitTestRunStart();

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -6,6 +6,7 @@ import SessionController from '../test-run/session-controller';
 import BrowserConnection from '../browser/connection';
 import { Proxy, generateUniqueId } from 'testcafe-hammerhead';
 import Test from '../api/structure/test';
+import Fixture from '../api/structure/fixture';
 import Screenshots from '../screenshots';
 import WarningLog from '../notifications/warning-log';
 import FixtureHookController from './fixture-hook-controller';
@@ -94,6 +95,11 @@ export default class TestRunController extends AsyncEventEmitter {
             screenshotCapturer,
             startRunExecutionTime,
         });
+
+        const fixture = this.testRun.test.fixture as Fixture;
+
+        if (fixture.globalBeforeFn || fixture.beforeFn)
+            this._fixtureHookController.blockTest(this.testRun);
 
         this.clientScriptRoutes = clientScriptsRouting.register({
             proxy:            this._proxy,

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -277,7 +277,7 @@ export default class TestRunController extends AsyncEventEmitter {
         const hookOk = await this._testRunHook.runTestRunBeforeHookIfNecessary(testRun)
                        && await this._fixtureHookController.runFixtureBeforeHookIfNecessary(testRun);
 
-        this._fixtureHookController.unblockTest(this.test);
+        this._fixtureHookController.unblockWhenBeforeHooksComplete(this.test);
 
         if (this.test.skip || !hookOk) {
             await this._emitTestRunStart();

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -102,10 +102,7 @@ export default class TestRunController extends AsyncEventEmitter {
             folderName:       this.testRun.id,
         });
 
-        await this.testRun.initialize();
-
         this._screenshots.addTestRun(this.test, this.testRun);
-
         if (this.testRun.addQuarantineInfo)
             this.testRun.addQuarantineInfo(this._quarantine);
 
@@ -285,6 +282,7 @@ export default class TestRunController extends AsyncEventEmitter {
 
         this._assignTestRunEvents(testRun, connection);
 
+        await testRun.initialize();
         testRun.start();
 
         return SessionController.getSessionUrl(testRun, this._proxy);

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -6,7 +6,6 @@ import SessionController from '../test-run/session-controller';
 import BrowserConnection from '../browser/connection';
 import { Proxy, generateUniqueId } from 'testcafe-hammerhead';
 import Test from '../api/structure/test';
-import Fixture from '../api/structure/fixture';
 import Screenshots from '../screenshots';
 import WarningLog from '../notifications/warning-log';
 import FixtureHookController from './fixture-hook-controller';
@@ -96,10 +95,7 @@ export default class TestRunController extends AsyncEventEmitter {
             startRunExecutionTime,
         });
 
-        const fixture = this.testRun.test.fixture as Fixture;
-
-        if (fixture.globalBeforeFn || fixture.beforeFn)
-            this._fixtureHookController.blockTest(this.testRun);
+        this._fixtureHookController.blockIfBeforeHooksExist(this.testRun.test);
 
         this.clientScriptRoutes = clientScriptsRouting.register({
             proxy:            this._proxy,
@@ -108,7 +104,10 @@ export default class TestRunController extends AsyncEventEmitter {
             folderName:       this.testRun.id,
         });
 
+        await this.testRun.initialize();
+
         this._screenshots.addTestRun(this.test, this.testRun);
+
         if (this.testRun.addQuarantineInfo)
             this.testRun.addQuarantineInfo(this._quarantine);
 
@@ -288,7 +287,6 @@ export default class TestRunController extends AsyncEventEmitter {
 
         this._assignTestRunEvents(testRun, connection);
 
-        await testRun.initialize();
         testRun.start();
 
         return SessionController.getSessionUrl(testRun, this._proxy);

--- a/src/runner/test-run-controller.ts
+++ b/src/runner/test-run-controller.ts
@@ -270,14 +270,14 @@ export default class TestRunController extends AsyncEventEmitter {
 
         await this._handleNativeAutomationMode(connection);
 
-        this._fixtureHookController.blockIfBeforeHooksExist(this.test);
+        this._fixtureHookController.blockTestIfNecessary(this.test);
 
         const testRun = await this._createTestRun(connection, startRunExecutionTime);
 
         const hookOk = await this._testRunHook.runTestRunBeforeHookIfNecessary(testRun)
                        && await this._fixtureHookController.runFixtureBeforeHookIfNecessary(testRun);
 
-        this._fixtureHookController.unblockWhenBeforeHooksComplete(this.test);
+        this._fixtureHookController.unblockTest(this.test);
 
         if (this.test.skip || !hookOk) {
             await this._emitTestRunStart();

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -9,14 +9,13 @@ const { skipInNativeAutomation } = require('../../utils/skip-in');
 
 if (config.useLocalBrowsers) {
     describe('Concurrency', function () {
-        const concurrencyWithBeforeHook = 5;
         let data = '';
 
         function resolvePath (file) {
             return path.join(__dirname, file);
         }
 
-        function run (browsers, concurrency, files, reporter) {
+        function run (browsers, concurrency, files, reporter, isBeforeHookUsed) {
             let src = null;
 
             reporter = reporter || 'json';
@@ -44,7 +43,7 @@ if (config.useLocalBrowsers) {
                 .concurrency(concurrency)
                 .run({
                     disableNativeAutomation: !config.nativeAutomation,
-                    hooks:                   concurrency === concurrencyWithBeforeHook ? {
+                    hooks:                   isBeforeHookUsed ? {
                         testRun: {
                             before: async () => {
                                 await new Promise(r => setTimeout(r, 3000));
@@ -122,7 +121,7 @@ if (config.useLocalBrowsers) {
         });
 
         it('Should run tests concurrently after fixture before hook', function () {
-            return run('chrome:headless --no-sandbox', concurrencyWithBeforeHook, './testcafe-fixtures/concurrent-fixture-before-test.js')
+            return run('chrome:headless --no-sandbox', 5, './testcafe-fixtures/concurrent-fixture-before-test.js', 'json', true)
                 .then(failedCount => {
                     expect(failedCount).eql(0);
                 });

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -112,6 +112,13 @@ if (config.useLocalBrowsers) {
                 });
         });
 
+        it('Should run tests concurrently after fixture before hook', function () {
+            return run('chrome:headless --no-sandbox', 3, './testcafe-fixtures/concurrent-fixture-before-test.js')
+                .then(() => {
+                    expect(testInfo.getData()).eql(['fixture before hook started', 'fixture before hook finished', 'test finished', 'test finished', 'test finished']);
+                });
+        });
+
         it('Report TaskStart event handler should contain links to all opened browsers', async () => {
             const concurrency = 2;
             const scope       = {};

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -15,7 +15,7 @@ if (config.useLocalBrowsers) {
             return path.join(__dirname, file);
         }
 
-        function run (browsers, concurrency, files, reporter, isBeforeHookUsed) {
+        function run (browsers, concurrency, files, reporter, hooks) {
             let src = null;
 
             reporter = reporter || 'json';
@@ -43,13 +43,7 @@ if (config.useLocalBrowsers) {
                 .concurrency(concurrency)
                 .run({
                     disableNativeAutomation: !config.nativeAutomation,
-                    hooks:                   isBeforeHookUsed ? {
-                        testRun: {
-                            before: async () => {
-                                await new Promise(r => setTimeout(r, 3000));
-                            },
-                        },
-                    } : null,
+                    hooks,
                 });
         }
 
@@ -121,7 +115,13 @@ if (config.useLocalBrowsers) {
         });
 
         it('Should run tests concurrently after fixture before hook', function () {
-            return run('chrome:headless --no-sandbox', 5, './testcafe-fixtures/concurrent-fixture-before-test.js', 'json', true)
+            return run('chrome:headless --no-sandbox', 5, './testcafe-fixtures/concurrent-fixture-before-test.js', 'json', {
+                testRun: {
+                    before: async () => {
+                        await new Promise(r => setTimeout(r, 3000));
+                    },
+                },
+            })
                 .then(failedCount => {
                     expect(failedCount).eql(0);
                 });

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -8,7 +8,7 @@ const { skipInNativeAutomation } = require('../../utils/skip-in');
 
 
 if (config.useLocalBrowsers) {
-    describe('Concurrency', function () {
+    describe.only('Concurrency', function () {
         let data = '';
 
         function resolvePath (file) {
@@ -114,8 +114,8 @@ if (config.useLocalBrowsers) {
 
         it('Should run tests concurrently after fixture before hook', function () {
             return run('chrome:headless --no-sandbox', 3, './testcafe-fixtures/concurrent-fixture-before-test.js')
-                .then(() => {
-                    expect(testInfo.getData()).eql(['fixture before hook started', 'fixture before hook finished', 'test finished', 'test finished', 'test finished']);
+                .then(failedCount => {
+                    expect(failedCount).eql(0);
                 });
         });
 

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -117,12 +117,12 @@ if (config.useLocalBrowsers) {
                 });
         });
 
-        // it.only('Should run tests concurrently after fixture before hook', function () {
-        //     return run('chrome:headless --no-sandbox', 5, './testcafe-fixtures/concurrent-fixture-before-test.js')
-        //         .then(failedCount => {
-        //             expect(failedCount).eql(0);
-        //         });
-        // });
+        it('Should run tests concurrently after fixture before hook', function () {
+            return run('chrome:headless --no-sandbox', 5, './testcafe-fixtures/concurrent-fixture-before-test.js')
+                .then(failedCount => {
+                    expect(failedCount).eql(0);
+                });
+        });
 
         it('Report TaskStart event handler should contain links to all opened browsers', async () => {
             const concurrency = 2;

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -117,12 +117,12 @@ if (config.useLocalBrowsers) {
                 });
         });
 
-        it('Should run tests concurrently after fixture before hook', function () {
-            return run('chrome:headless --no-sandbox', 5, './testcafe-fixtures/concurrent-fixture-before-test.js')
-                .then(failedCount => {
-                    expect(failedCount).eql(0);
-                });
-        });
+        // it.only('Should run tests concurrently after fixture before hook', function () {
+        //     return run('chrome:headless --no-sandbox', 5, './testcafe-fixtures/concurrent-fixture-before-test.js')
+        //         .then(failedCount => {
+        //             expect(failedCount).eql(0);
+        //         });
+        // });
 
         it('Report TaskStart event handler should contain links to all opened browsers', async () => {
             const concurrency = 2;

--- a/test/functional/fixtures/concurrency/test.js
+++ b/test/functional/fixtures/concurrency/test.js
@@ -8,7 +8,7 @@ const { skipInNativeAutomation } = require('../../utils/skip-in');
 
 
 if (config.useLocalBrowsers) {
-    describe.only('Concurrency', function () {
+    describe('Concurrency', function () {
         let data = '';
 
         function resolvePath (file) {

--- a/test/functional/fixtures/concurrency/testcafe-fixtures/concurrent-fixture-before-test.js
+++ b/test/functional/fixtures/concurrency/testcafe-fixtures/concurrent-fixture-before-test.js
@@ -1,0 +1,31 @@
+import testInfo from '../test-info.js';
+
+let value = 0;
+
+fixture('Concurrent fixture before hook')
+    .before(async () => {
+        testInfo.add('fixture before hook started');
+        await new Promise(r => setTimeout(r, 10000));
+        // Value should be set before any test starts
+        value = 10;
+        testInfo.add('fixture before hook finished');
+    })
+    .after(() => {
+        testInfo.save();
+        testInfo.clear();
+    });
+
+test('test1', async t => {
+    await t.expect(value).eql(10);
+    testInfo.add('test finished');
+});
+
+test('test2', async t => {
+    await t.expect(value).eql(10);
+    testInfo.add('test finished');
+});
+
+test('test3', async t => {
+    await t.expect(value).eql(10);
+    testInfo.add('test finished');
+});

--- a/test/functional/fixtures/concurrency/testcafe-fixtures/concurrent-fixture-before-test.js
+++ b/test/functional/fixtures/concurrency/testcafe-fixtures/concurrent-fixture-before-test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 
+
 let beforeHookCallNumber = 0;
 
 fixture('Concurrent fixture before hook')
@@ -20,5 +21,13 @@ test('test2', async t => {
 });
 
 test('test3', async t => {
+    await t.expect(beforeHookCallNumber).eql(1);
+});
+
+test('test4', async t => {
+    await t.expect(beforeHookCallNumber).eql(1);
+});
+
+test('test5', async t => {
     await t.expect(beforeHookCallNumber).eql(1);
 });

--- a/test/functional/fixtures/concurrency/testcafe-fixtures/concurrent-fixture-before-test.js
+++ b/test/functional/fixtures/concurrency/testcafe-fixtures/concurrent-fixture-before-test.js
@@ -1,31 +1,24 @@
-import testInfo from '../test-info.js';
+import { expect } from 'chai';
 
-let value = 0;
+let beforeHookCallNumber = 0;
 
 fixture('Concurrent fixture before hook')
     .before(async () => {
-        testInfo.add('fixture before hook started');
         await new Promise(r => setTimeout(r, 10000));
-        // Value should be set before any test starts
-        value = 10;
-        testInfo.add('fixture before hook finished');
+        beforeHookCallNumber += 1;
     })
     .after(() => {
-        testInfo.save();
-        testInfo.clear();
+        expect(beforeHookCallNumber).eql(1);
     });
 
 test('test1', async t => {
-    await t.expect(value).eql(10);
-    testInfo.add('test finished');
+    await t.expect(beforeHookCallNumber).eql(1);
 });
 
 test('test2', async t => {
-    await t.expect(value).eql(10);
-    testInfo.add('test finished');
+    await t.expect(beforeHookCallNumber).eql(1);
 });
 
 test('test3', async t => {
-    await t.expect(value).eql(10);
-    testInfo.add('test finished');
+    await t.expect(beforeHookCallNumber).eql(1);
 });

--- a/test/server/capturer-test.js
+++ b/test/server/capturer-test.js
@@ -84,9 +84,6 @@ function createTestRunControllerMock (screenshots, warningLog) {
         _opts: {
             nativeAutomation: false,
         },
-        _fixtureHookController: {
-            blockIfBeforeHooksExist: noop,
-        },
     };
 }
 

--- a/test/server/capturer-test.js
+++ b/test/server/capturer-test.js
@@ -84,6 +84,9 @@ function createTestRunControllerMock (screenshots, warningLog) {
         _opts: {
             nativeAutomation: false,
         },
+        _fixtureHookController: {
+            blockIfBeforeHooksExist: noop,
+        },
     };
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Fixed the bug when the concurrent tests did not wait until the finish of the fixture and global before hook.

## Approach
Updated the method runFixtureBeforeHookIfNecessary in src/runner/fixture-hook-controller.ts. Now we store the promises of hooks in item from _getFixtureMapItem and await them in concurrent tests.

## References
closes https://github.com/DevExpress/testcafe/issues/6999

## Pre-Merge TODO
- [x] Write tests for your proposed changes
- [x] Make sure that existing tests do not fail
