### PR TITLE
build: Set @babel/plugin-transform-runtime to a 7.23.3 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@babel/plugin-transform-async-to-generator": "^7.22.5",
     "@babel/plugin-transform-exponentiation-operator": "^7.22.5",
     "@babel/plugin-transform-for-of": "^7.22.15",
-    "@babel/plugin-transform-runtime": "^7.23.2",
+    "@babel/plugin-transform-runtime": "7.23.3",
     "@babel/preset-env": "^7.23.2",
     "@babel/preset-flow": "^7.22.15",
     "@babel/preset-react": "^7.22.15",

--- a/test/functional/fixtures/regression/gh-8091/imports/script.js
+++ b/test/functional/fixtures/regression/gh-8091/imports/script.js
@@ -1,0 +1,10 @@
+export default async function testFunction () {
+    try {
+        await fetch('');
+    }
+    catch {
+        return true;
+    }
+
+    return true;
+}

--- a/test/functional/fixtures/regression/gh-8091/test.js
+++ b/test/functional/fixtures/regression/gh-8091/test.js
@@ -1,0 +1,9 @@
+const config = require('../../../config');
+
+describe('[Regression](GH-8091)', function () {
+    if (!config.esm) {
+        it('Should prepare and execute typescript test', function () {
+            return runTests('./testcafe-fixtures/index.ts');
+        });
+    }
+});

--- a/test/functional/fixtures/regression/gh-8091/testcafe-fixtures/index.ts
+++ b/test/functional/fixtures/regression/gh-8091/testcafe-fixtures/index.ts
@@ -1,0 +1,9 @@
+import testFunction from "../imports/script";
+
+fixture `[Regression](GH-8091)`
+
+test('simple test', async t => {
+    const test = await testFunction();
+    
+    await t.expect(test).eql(true);
+})


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Error in compilation typescript test files.

## Approach
Set Babel dependancies to a 7.23.3 version

## References
Closes #8091 

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
