### PR TITLE
fix: esm loader fix

### DIFF
--- a/src/compiler/compilers.js
+++ b/src/compiler/compilers.js
@@ -20,9 +20,9 @@ function createTestFileCompilers (compilerOptions = {}, { baseUrl, esm } = {}) {
 
 let testFileCompilers = [];
 
-export function getTestFileCompilers () {
+export function getTestFileCompilers (esm) {
     if (!testFileCompilers.length)
-        initTestFileCompilers();
+        initTestFileCompilers({}, { baseUrl: '', esm });
 
     return testFileCompilers;
 }

--- a/src/compiler/esm-loader.ts
+++ b/src/compiler/esm-loader.ts
@@ -32,7 +32,7 @@ export async function load (url: string, context: Context, defaultLoad: Function
     if (isNodeModulesDep || isTestcafeLibDep || !filename)
         return defaultLoad(url, context, defaultLoad);
 
-    const testFilesInfo = await Compiler.createTestFileInfo(filename);
+    const testFilesInfo = await Compiler.createTestFileInfo(filename, true);
 
     if (testFilesInfo?.compiler) {
         const [compiledCode] = await testFilesInfo.compiler.precompile([testFilesInfo]);

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -26,7 +26,7 @@ export default class Compiler {
         return uniq(flattenDeep(getTestFileCompilers().map(compiler => compiler.getSupportedExtension())));
     }
 
-    static async createTestFileInfo (filename) {
+    static async createTestFileInfo (filename, esm = false) {
         let code = null;
 
         try {
@@ -38,7 +38,7 @@ export default class Compiler {
 
         code = stripBom(code).toString();
 
-        const compiler = find(getTestFileCompilers(), someCompiler => someCompiler.canCompile(code, filename));
+        const compiler = find(getTestFileCompilers(esm), someCompiler => someCompiler.canCompile(code, filename));
 
         if (!compiler)
             return null;


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Starting from Node version 20 Hooks like `load` run in a separate thread, isolated from the main thread.
https://nodejs.org/docs/latest-v20.x/api/module.html#hooks.

Our current implementation relies on main thread in `getTestFileCompilers`.
Because the `load` hook is now running in a separate thread the `testFileCompilers` was never initialized before, and `getTestFileCompilers` calls `initTestFileCompilers` with no parameters. That is why the `esm` flag is lost in Node version 20 and above.

## Approach
Pass the `esm` flag from `load` hook to getTestFileCompilers` in order to initialize the correct compilers.

The test 'Should import ESM without errors in ESM mode' also works for this fix in node 20 and above.

## References
closes [#8132](https://github.com/DevExpress/testcafe/issues/8132)

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
