### PR TITLE
fix babel-plugin-module-resolver version to 5.0.0

### DIFF
--- a/.publishrc
+++ b/.publishrc
@@ -8,7 +8,7 @@
     "gitTag": true
   },
   "confirm": false,
-  "publishTag": "latest",
+  "publishTag": "rc",
   "prePublishScript": "gulp test-server",
   "postPublishScript": "gulp docker-publish"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "testcafe",
-  "version": "3.6.1",
+  "version": "3.6.1-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "testcafe",
-      "version": "3.6.1",
+      "version": "3.6.1-rc.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.23.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "elegant-spinner": "^1.0.1",
         "email-validator": "^2.0.4",
         "emittery": "^0.4.1",
-        "endpoint-utils": "1.0.0",
+        "endpoint-utils": "^1.0.2",
         "error-stack-parser": "^2.1.4",
         "execa": "^4.0.3",
         "get-os-info": "^1.0.2",
@@ -5920,10 +5920,11 @@
       }
     },
     "node_modules/endpoint-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/endpoint-utils/-/endpoint-utils-1.0.0.tgz",
-      "integrity": "sha512-ACGxrdwluxqfzcYa03No5RGkFppZCyMATLs8nhVBbMkMz1C27bTg0KzeVi5hD4pGmhM4wLwaYz/1WTPMKsHHmA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/endpoint-utils/-/endpoint-utils-1.0.2.tgz",
+      "integrity": "sha512-s5IrlLvx7qVXPOjcxjF00CRBlybiQWOoGCNiIZ/Vin2WeJ3SHtfkWHRsyu7C1+6QAwYXf0ULoweylxUa19Khjg==",
       "dependencies": {
+        "ip": "^1.1.3",
         "pinkie-promise": "^1.0.0"
       }
     },
@@ -9584,6 +9585,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ip": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ=="
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -21396,10 +21402,11 @@
       }
     },
     "endpoint-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/endpoint-utils/-/endpoint-utils-1.0.0.tgz",
-      "integrity": "sha512-ACGxrdwluxqfzcYa03No5RGkFppZCyMATLs8nhVBbMkMz1C27bTg0KzeVi5hD4pGmhM4wLwaYz/1WTPMKsHHmA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/endpoint-utils/-/endpoint-utils-1.0.2.tgz",
+      "integrity": "sha512-s5IrlLvx7qVXPOjcxjF00CRBlybiQWOoGCNiIZ/Vin2WeJ3SHtfkWHRsyu7C1+6QAwYXf0ULoweylxUa19Khjg==",
       "requires": {
+        "ip": "^1.1.3",
         "pinkie-promise": "^1.0.0"
       },
       "dependencies": {
@@ -24268,6 +24275,11 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
       "dev": true
+    },
+    "ip": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ=="
     },
     "ipaddr.js": {
       "version": "1.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "testcafe",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "testcafe",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.23.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@devexpress/callsite-record": "^4.1.6",
         "@types/node": "^12.20.10",
         "async-exit-hook": "^1.1.2",
-        "babel-plugin-module-resolver": "^5.0.0",
+        "babel-plugin-module-resolver": "5.0.0",
         "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
         "bowser": "^2.8.1",
         "callsite": "^1.0.0",
@@ -4032,15 +4032,18 @@
       "dev": true
     },
     "node_modules/babel-plugin-module-resolver": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.2.tgz",
-      "integrity": "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.0.tgz",
+      "integrity": "sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==",
       "dependencies": {
-        "find-babel-config": "^2.1.1",
-        "glob": "^9.3.3",
+        "find-babel-config": "^2.0.0",
+        "glob": "^8.0.3",
         "pkg-up": "^3.1.0",
         "reselect": "^4.1.7",
-        "resolve": "^1.22.8"
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -19905,15 +19908,15 @@
       "dev": true
     },
     "babel-plugin-module-resolver": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.2.tgz",
-      "integrity": "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.0.tgz",
+      "integrity": "sha512-g0u+/ChLSJ5+PzYwLwP8Rp8Rcfowz58TJNCe+L/ui4rpzE/mg//JVX0EWBUYoxaextqnwuGHzfGp2hh0PPV25Q==",
       "requires": {
-        "find-babel-config": "^2.1.1",
+        "find-babel-config": "^2.0.0",
         "glob": "8.1.0",
         "pkg-up": "^3.1.0",
         "reselect": "^4.1.7",
-        "resolve": "^1.22.8"
+        "resolve": "^1.22.1"
       }
     },
     "babel-plugin-polyfill-corejs2": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "elegant-spinner": "^1.0.1",
         "email-validator": "^2.0.4",
         "emittery": "^0.4.1",
-        "endpoint-utils": "^1.0.2",
+        "endpoint-utils": "1.0.0",
         "error-stack-parser": "^2.1.4",
         "execa": "^4.0.3",
         "get-os-info": "^1.0.2",
@@ -5920,11 +5920,10 @@
       }
     },
     "node_modules/endpoint-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/endpoint-utils/-/endpoint-utils-1.0.2.tgz",
-      "integrity": "sha512-s5IrlLvx7qVXPOjcxjF00CRBlybiQWOoGCNiIZ/Vin2WeJ3SHtfkWHRsyu7C1+6QAwYXf0ULoweylxUa19Khjg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/endpoint-utils/-/endpoint-utils-1.0.0.tgz",
+      "integrity": "sha512-ACGxrdwluxqfzcYa03No5RGkFppZCyMATLs8nhVBbMkMz1C27bTg0KzeVi5hD4pGmhM4wLwaYz/1WTPMKsHHmA==",
       "dependencies": {
-        "ip": "^1.1.3",
         "pinkie-promise": "^1.0.0"
       }
     },
@@ -9585,11 +9584,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/ip": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ=="
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -21402,11 +21396,10 @@
       }
     },
     "endpoint-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/endpoint-utils/-/endpoint-utils-1.0.2.tgz",
-      "integrity": "sha512-s5IrlLvx7qVXPOjcxjF00CRBlybiQWOoGCNiIZ/Vin2WeJ3SHtfkWHRsyu7C1+6QAwYXf0ULoweylxUa19Khjg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/endpoint-utils/-/endpoint-utils-1.0.0.tgz",
+      "integrity": "sha512-ACGxrdwluxqfzcYa03No5RGkFppZCyMATLs8nhVBbMkMz1C27bTg0KzeVi5hD4pGmhM4wLwaYz/1WTPMKsHHmA==",
       "requires": {
-        "ip": "^1.1.3",
         "pinkie-promise": "^1.0.0"
       },
       "dependencies": {
@@ -24275,11 +24268,6 @@
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ==",
       "dev": true
-    },
-    "ip": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ=="
     },
     "ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "3.6.1",
+  "version": "3.6.1-rc.1",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "testcafe",
   "description": "Automated browser testing for the modern web development stack.",
   "license": "MIT",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "author": {
     "name": "Developer Express Inc.",
     "url": "https://www.devexpress.com/"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@devexpress/callsite-record": "^4.1.6",
     "@types/node": "^12.20.10",
     "async-exit-hook": "^1.1.2",
-    "babel-plugin-module-resolver": "^5.0.0",
+    "babel-plugin-module-resolver": "5.0.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
     "bowser": "^2.8.1",
     "callsite": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "elegant-spinner": "^1.0.1",
     "email-validator": "^2.0.4",
     "emittery": "^0.4.1",
-    "endpoint-utils": "^1.0.2",
+    "endpoint-utils": "1.0.0",
     "error-stack-parser": "^2.1.4",
     "execa": "^4.0.3",
     "get-os-info": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "elegant-spinner": "^1.0.1",
     "email-validator": "^2.0.4",
     "emittery": "^0.4.1",
-    "endpoint-utils": "1.0.0",
+    "endpoint-utils": "^1.0.2",
     "error-stack-parser": "^2.1.4",
     "execa": "^4.0.3",
     "get-os-info": "^1.0.2",


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Version **5.0.2** of babel-plugin-module-resolver has glob version **^9.3.3** with vulnerability. 
By fixing to version **5.0.0** babel-plugin-module-resolver we avoid vulnerability with glob version **^8.0.3**.

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._

## References
[Link to discussion](https://teams.microsoft.com/l/message/19:5eb4e942f0f946188ab14b3d8bf960f3@thread.skype/1717393430400?tenantId=e4d60396-9352-4ae8-b84c-e69244584fa4&groupId=f74b7d18-34a4-4c78-b7d5-b56e55ce3236&parentMessageId=1717393430400&teamName=Teams%20Collaborations&channelName=TestCafe&createdTime=1717393430400)

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
