### PR TITLE
fix: skip request hooks initialization for skiped tests

### DIFF
--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -545,7 +545,8 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     private async _initRequestHooks (): Promise<void> {
-        await Promise.all(this.test.requestHooks.map(hook => this._initRequestHook(hook)));
+        if (!this.test.skip)
+            await Promise.all(this.test.requestHooks.map(hook => this._initRequestHook(hook)));
     }
 
     private _prepareSkipJsErrorsOption (): boolean | ExecuteClientFunctionCommand {

--- a/src/test-run/index.ts
+++ b/src/test-run/index.ts
@@ -545,8 +545,7 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     private async _initRequestHooks (): Promise<void> {
-        if (!this.test.skip)
-            await Promise.all(this.test.requestHooks.map(hook => this._initRequestHook(hook)));
+        await Promise.all(this.test.requestHooks.map(hook => this._initRequestHook(hook)));
     }
 
     private _prepareSkipJsErrorsOption (): boolean | ExecuteClientFunctionCommand {
@@ -1444,8 +1443,10 @@ export default class TestRun extends AsyncEventEmitter {
     }
 
     public async initialize (): Promise<void> {
-        await this._clearCookiesAndStorages();
-        await this._initRequestHooks();
+        if (!this.test.skip) {
+            await this._clearCookiesAndStorages();
+            await this._initRequestHooks();
+        }
     }
 
     private async _clearCookiesAndStorages (): Promise<void> {

--- a/test/functional/fixtures/api/es-next/request-hooks/test.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/test.js
@@ -127,5 +127,9 @@ describe('Request Hooks', () => {
         it('Set custom header on "onRequest" method (GH-7846)', () => {
             return runTests('./testcafe-fixtures/api/7846.js', null, { only: 'chrome' });
         });
+
+        it('Request hook on skipped test should not affect next test (GH-8229)', () => {
+            return runTests('./testcafe-fixtures/api/8229.js', null, { only: 'chrome' });
+        });
     });
 });

--- a/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/8229.js
+++ b/test/functional/fixtures/api/es-next/request-hooks/testcafe-fixtures/api/8229.js
@@ -1,0 +1,20 @@
+import { RequestMock, Selector } from 'testcafe';
+
+const PAGE_URL = 'http://localhost:3000/fixtures/api/es-next/request-hooks/pages/api/empty.html';
+
+fixture('Fixture')
+    .page(PAGE_URL);
+
+test('before the skipped', async t => {
+    await t.expect(Selector('h1').exists).ok();
+});
+
+test.skip.requestHooks(
+    RequestMock().onRequestTo(/.*empty*/).respond('', 404)
+)('skipped', async t => {
+    await t.expect(Selector('h1').exists).ok();
+});
+
+test('after the skipped', async t => {
+    await t.expect(Selector('h1').exists).ok();
+});


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Request hooks are initialized even though the test is skipped

## Approach
check if test is skipped before initialization

## References
closes https://github.com/DevExpress/testcafe/issues/8229

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
