### PR TITLE
fix: The 'WebSocket connection closed' error on Chrome 130

### DIFF
--- a/src/browser/provider/built-in/dedicated/chrome/cdp-client/utils.ts
+++ b/src/browser/provider/built-in/dedicated/chrome/cdp-client/utils.ts
@@ -1,11 +1,17 @@
 import remoteChrome, { TargetInfo } from 'chrome-remote-interface';
 
 const DEVTOOLS_TAB_URL_REGEX = /^devtools:\/\/devtools/;
+// NOTE: Github issue: https://github.com/DevExpress/testcafe/issues/8286
+const CHROME_EXTENSION_TAB_URL_REGEX = /^chrome-extension:\/\//;
+
+function isInternalUrl (url: string): boolean {
+    return DEVTOOLS_TAB_URL_REGEX.test(url) || CHROME_EXTENSION_TAB_URL_REGEX.test(url);
+}
 
 export async function getTabs (port: number): Promise<TargetInfo[]> {
     const tabs = await remoteChrome.List({ port });
 
-    return tabs.filter(t => t.type === 'page' && !DEVTOOLS_TAB_URL_REGEX.test(t.url));
+    return tabs.filter(t => t.type === 'page' && !isInternalUrl(t.url));
 }
 
 export async function getTabById (port: number, id: string): Promise<TargetInfo> {


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
When requesting active tabs in Chrome 130.0.6723.6, a chrome-extension tab is included in the list. A CDP client is created based on this tab, but the tab gets closed, which results in the error.

## Approach
Excluded tabs with `^chrome-extension` URLs from the list of tabs.

## References
closes #8286 

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
