### PR TITLE
Introducing TestCafe Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 <a href="https://github.com/DevExpress/testcafe/commits/master"><img alt="Tests" src="https://img.shields.io/github/checks-status/DevExpress/testcafe/master?label=Tests"></a>
 <a href="https://github.com/DevExpress/testcafe/actions/workflows/test-dependencies.yml"><img alt="Test Dependencies" src="https://github.com/DevExpress/testcafe/actions/workflows/test-dependencies.yml/badge.svg" /></a>
 <a href="https://www.npmjs.com/package/testcafe"><img alt="NPM Version" src="https://img.shields.io/npm/v/testcafe.svg" data-canonical-src="https://img.shields.io/npm/v/testcafe.svg" style="max-width:100%;"></a>
+<a href="https://gurubase.io/g/testcafe"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20TestCafe%20Guru-006BFF"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [TestCafe Guru](https://gurubase.io/g/testcafe) to Gurubase. TestCafe Guru uses the data from this repo and data from the [docs](https://testcafe.io) to answer questions by leveraging the LLM.

In this PR, I showcased the "TestCafe Guru", which highlights that TestCafe now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable TestCafe Guru in Gurubase, just let me know that's totally fine.
