### PR TITLE
Fix maximizeWindow after resize

### DIFF
--- a/src/browser/provider/built-in/dedicated/chrome/cdp-client/index.ts
+++ b/src/browser/provider/built-in/dedicated/chrome/cdp-client/index.ts
@@ -244,7 +244,7 @@ export class BrowserClient {
     }
 
     public async resizeBounds (newDimensions: Size): Promise<void> {
-        const { viewportSize, config } = this._runtimeInfo;
+        const { viewportSize } = this._runtimeInfo;
 
         let nonClientWidth  = 0;
         let nonClientHeight = 0;
@@ -258,7 +258,7 @@ export class BrowserClient {
         const client = await this.getActiveClient();
 
         if (client) {
-            await this._setDeviceMetricsOverride(client, newDimensions.width, newDimensions.height, 1, config.mobile);
+            //await this._setDeviceMetricsOverride(client, newDimensions.width, newDimensions.height, 1, config.mobile);
 
             const windowParams = await client.Browser.getWindowForTarget({ targetId: target.id });
 

--- a/src/browser/provider/built-in/dedicated/chrome/cdp-client/index.ts
+++ b/src/browser/provider/built-in/dedicated/chrome/cdp-client/index.ts
@@ -258,8 +258,6 @@ export class BrowserClient {
         const client = await this.getActiveClient();
 
         if (client) {
-            //await this._setDeviceMetricsOverride(client, newDimensions.width, newDimensions.height, 1, config.mobile);
-
             const windowParams = await client.Browser.getWindowForTarget({ targetId: target.id });
 
             if (windowParams.bounds.windowState !== 'normal') {

--- a/test/functional/fixtures/api/es-next/resize-window/test.js
+++ b/test/functional/fixtures/api/es-next/resize-window/test.js
@@ -34,6 +34,10 @@ describe('[API] Resize window actions', function () {
             it('Should resize the window after maximizeWindow', function () {
                 return runTests('./testcafe-fixtures/resize-window-test.js', 'Resize the window after maximizeWindow', { only: 'chrome' });
             });
+
+            it('Should maximizeWindow after resize', function () {
+                return runTests('./testcafe-fixtures/resize-window-test.js', 'Correctly maximizeWindow after resize', { only: 'chrome' });
+            });
         });
 
         describe('t.resizeWindowToFitDevice', function () {

--- a/test/functional/fixtures/api/es-next/resize-window/testcafe-fixtures/resize-window-test.js
+++ b/test/functional/fixtures/api/es-next/resize-window/testcafe-fixtures/resize-window-test.js
@@ -100,3 +100,15 @@ test('Resize the window after maximizeWindow', async t => {
     expect(await getWindowWidth()).equals(640);
     expect(await getWindowHeight()).equals(480);
 });
+
+test('Correctly maximizeWindow after resize', async t => {
+    await t.resizeWindow(640, 480);
+
+    expect(await getWindowWidth()).equals(640);
+    expect(await getWindowHeight()).equals(480);
+
+    await t.maximizeWindow();
+
+    expect(await getWindowWidth()).to.be.above(640);
+    expect(await getWindowHeight()).to.be.above(480);
+});


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
Window did not maximize properly after resizing. 

## Approach
Remove redundant use of _setDeviceMetricsOverride in resize window using CDP.

## References
closes https://github.com/DevExpress/testcafe/issues/8360

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
