### PR TITLE
fix: workflow artifact upload updated to have different names

### DIFF
--- a/.github/workflows/test-functional.yml
+++ b/.github/workflows/test-functional.yml
@@ -161,7 +161,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-            name: testcafe-debug-log
+            name: testcafe-debug-log-${{ matrix.test-group }}
             path: testcafe-debug-log-${{ matrix.test-group }}.log
 
       - uses: DevExpress/testcafe-build-system/actions/save-matrix-status@main


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes
v4 upload-artifact breaks with same named Artifact

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail
