### PR TITLE
Add "--unsafely-disable-devtools-self-xss-warnings" to default Chrome args.

### DIFF
--- a/src/browser/provider/built-in/dedicated/chrome/build-chrome-args.js
+++ b/src/browser/provider/built-in/dedicated/chrome/build-chrome-args.js
@@ -23,6 +23,7 @@ export function buildChromeArgs ({ config, cdpPort, platformArgs, tempProfileDir
         '--force-color-profile=srgb',
         '--metrics-recording-only',
         '--no-first-run',
+        '--unsafely-disable-devtools-self-xss-warnings'
     ];
 
     let chromeArgs = []


### PR DESCRIPTION
PR for https://github.com/DevExpress/testcafe/issues/8431