### PR TITLE
✨ Quality: Port 0 treated as falsy in getValidPort validation

### DIFF
--- a/src/configuration/utils.ts
+++ b/src/configuration/utils.ts
@@ -25,7 +25,7 @@ export async function getValidHostname (hostname: string): Promise<string> {
 }
 
 export async function getValidPort (port: number): Promise<number> {
-    if (port) {
+    if (port >= 0) {
         const isFree = await isFreePort(port);
 
         if (!isFree)


### PR DESCRIPTION
## ✨ Code Quality

### Problem
The condition `if (port)` treats port 0 as falsy, causing it to bypass port validation and call getFreePort() instead. Port 0 is a valid network port (meaning 'any available port'), but this logic incorrectly treats it as 'no port specified'. Users explicitly configuring port 0 will get unexpected behavior.

**Severity**: `medium`
**File**: `src/configuration/utils.ts`

### Solution
Change condition to `if (port !== undefined && port !== null)` or `if (typeof port === 'number' && port > 0)` depending on intended behavior for port 0.

### Changes
- `src/configuration/utils.ts` (modified)



## Purpose
_Describe the problem you want to address or the feature you want to implement._

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #8500