### PR TITLE
refactor: use Array.includes() instead of indexOf() > -1

### DIFF
--- a/src/browser/provider/built-in/locally-installed.js
+++ b/src/browser/provider/built-in/locally-installed.js
@@ -31,6 +31,6 @@ export default {
 
         browserName = browserName.toLowerCase().split(' ')[0];
 
-        return browserNames.indexOf(browserName) > -1;
+        return browserNames.includes(browserName);
     },
 };

--- a/src/client-functions/selectors/add-api.js
+++ b/src/client-functions/selectors/add-api.js
@@ -35,7 +35,7 @@ const filterNodes = new ClientFunctionBuilder((nodes, filter, querySelectorRoot,
         for (let i = 0; i < matching.length; i++)
             matchingArr.push(matching[i]);
 
-        filter = node => matchingArr.indexOf(node) > -1;
+        filter = node => matchingArr.includes(node);
     }
 
     if (typeof filter === 'function') {
@@ -61,7 +61,7 @@ const expandSelectorResults = new ClientFunctionBuilder((selector, populateDeriv
 
         if (derivativeNodes) {
             for (let j = 0; j < derivativeNodes.length; j++) {
-                if (result.indexOf(derivativeNodes[j]) < 0)
+                if (!result.includes(derivativeNodes[j]))
                     result.push(derivativeNodes[j]);
             }
         }

--- a/src/client-functions/selectors/create-snapshot-methods.js
+++ b/src/client-functions/selectors/create-snapshot-methods.js
@@ -2,7 +2,7 @@ export default function createSnapshotMethods (snapshot) {
     const isElementSnapshot = !!snapshot.tagName;
 
     if (isElementSnapshot) {
-        snapshot.hasClass                      = name => snapshot.classNames.indexOf(name) > -1;
+        snapshot.hasClass                      = name => snapshot.classNames.includes(name);
         snapshot.getStyleProperty              = prop => snapshot.style[prop];
         snapshot.getAttribute                  = attrName => snapshot.attributes[attrName];
         snapshot.hasAttribute                  = attrName => snapshot.attributes.hasOwnProperty(attrName);

--- a/src/client/ui/select-element.js
+++ b/src/client/ui/select-element.js
@@ -43,7 +43,7 @@ function onWindowClick (e, dispatched, preventDefault) {
 
     preventDefault();
 
-    const isDisabled = target.className.indexOf(DISABLED_CLASS) > -1;
+    const isDisabled = target.className.includes(DISABLED_CLASS);
 
     if (isDisabled && browserUtils.isWebKit)
         return;

--- a/src/compiler/test-file/formats/es-next/get-test-list.js
+++ b/src/compiler/test-file/formats/es-next/get-test-list.js
@@ -45,7 +45,7 @@ export class EsNextTestFileParser extends TestFileParserBase {
     getStringValue (token) {
         const stringTypes = [this.tokenType.StringLiteral, this.tokenType.TemplateLiteral, this.tokenType.Identifier];
 
-        if (stringTypes.indexOf(token.type) > -1)
+        if (stringTypes.includes(token.type))
             return this.formatFnArg(token);
 
         return null;

--- a/src/compiler/test-file/formats/typescript/get-test-list.js
+++ b/src/compiler/test-file/formats/typescript/get-test-list.js
@@ -5,7 +5,7 @@ import TypescriptConfiguration from '../../../../configuration/typescript-config
 
 function replaceComments (code) {
     return code.replace(/\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$/gm, match => {
-        const lastSymbol = match.indexOf('\n') > -1 ? '\n' : ' ';
+        const lastSymbol = match.includes('\n') ? '\n' : ' ';
 
         return repeat(' ', match.length + lastSymbol);
     });
@@ -85,7 +85,7 @@ class TypeScriptTestFileParser extends TestFileParserBase {
     getStringValue (token) {
         const stringTypes = [this.tokenType.StringLiteral, this.tokenType.TemplateExpression];
 
-        if (stringTypes.indexOf(token.kind) > -1 || token.text && token.kind !== this.tokenType.NumericLiteral)
+        if (stringTypes.includes(token.kind) || token.text && token.kind !== this.tokenType.NumericLiteral)
             return this.formatFnArg(token);
 
         return null;

--- a/src/compiler/test-file/test-file-parser-base.js
+++ b/src/compiler/test-file/test-file-parser-base.js
@@ -189,7 +189,7 @@ export class TestFileParserBase {
 
         //NOTE: fixture.skip('fixtureName'), test.only('testName') etc.
         const isMemberCall = type === this.tokenType.PropertyAccessExpression &&
-                             METHODS_SPECIFYING_NAME.indexOf(apiFn) > -1;
+                             METHODS_SPECIFYING_NAME.includes(apiFn);
 
         //NOTE: fixture.before().after()('fixtureName'), test.before()`testName`.after() etc.
         const isTailCall = type === this.tokenType.CallExpression;

--- a/src/utils/handle-errors.js
+++ b/src/utils/handle-errors.js
@@ -6,7 +6,7 @@ let handlingTestErrors = false;
 
 function printErrorMessagesAndTerminate (...messages) {
     // eslint-disable-next-line no-console
-    messages.map(msg => console.log(msg));
+    messages.forEach(msg => console.log(msg));
 
     // eslint-disable-next-line no-process-exit
     setTimeout(() => process.exit(1), 0);

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -61,7 +61,7 @@ export function splitQuotedText (str, splitChar, quotes = '"\'') {
                 currentPart = '';
             }
         }
-        else if (quotes.indexOf(currentChar) > -1) {
+        else if (quotes.includes(currentChar)) {
             if (quoteChar === currentChar)
                 quoteChar = null;
             else if (!quoteChar)
@@ -90,7 +90,7 @@ function getDisplayedItemText (item, quote) {
 export function getConcatenatedValuesString (array, separator = DEFAULT_CONCATENATED_VALUES.SEPARATOR, quoteChar = DEFAULT_CONCATENATED_VALUES.QUOTE_CHAR) {
     const clonedArray = [...array];
 
-    if (separator.indexOf('\n') > -1)
+    if (separator.includes('\n'))
         return clonedArray.map(item => getDisplayedItemText(item, quoteChar)).join(separator);
 
     else if (clonedArray.length === 1)


### PR DESCRIPTION
## Description
Replace legacy `indexOf() > -1` pattern with more readable `Array.includes()` method across multiple files. Also replace `map()` with `forEach()` when the return value is not used (side-effect only).

## Changes Made
- `src/utils/handle-errors.js`: Changed `map()` to `forEach()` for `console.log` side effects
- `src/client-functions/selectors/create-snapshot-methods.js`: `hasClass` method now uses `includes()`
- `src/client-functions/selectors/add-api.js`: `filterNodes` and `expandSelectorResults` now use `includes()`
- `src/utils/string.js`: `splitQuotedText` and `getConcatenatedValuesString` now use `includes()`
- `src/browser/provider/built-in/locally-installed.js`: `isValidBrowserName` now uses `includes()`
- `src/client/ui/select-element.js`: `onWindowClick` disabled class check now uses `includes()`
- `src/compiler/test-file/formats/typescript/get-test-list.js`: `replaceComments` and `getStringValue` now use `includes()`
- `src/compiler/test-file/formats/es-next/get-test-list.js`: `getStringValue` now uses `includes()`
- `src/compiler/test-file/test-file-parser-base.js`: `checkExpDefineTargetName` now uses `includes()`

## Benefits
1. **Improved readability**: `includes()` is more semantic and self-documenting than `indexOf() > -1`
2. **Modern JavaScript**: Follows ES6+ best practices
3. **Correctness**: Using `forEach()` instead of `map()` when return value is not used makes intent clearer and avoids confusion

Total: 9 files changed, 12 insertions(+), 12 deletions(-)