### PR TITLE
Remove SauceLabs provider from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,6 @@ TestCafe developers and community members made these plugins:
 
 * **Browser Providers**<br/>
   Use TestCafe with cloud browser providers and emulators.
-  * [SauceLabs provider](https://github.com/DevExpress/testcafe-browser-provider-saucelabs) (by [@AndreyBelym](https://github.com/AndreyBelym))
   * [BrowserStack provider](https://github.com/DevExpress/testcafe-browser-provider-browserstack) (by [@AndreyBelym](https://github.com/AndreyBelym))
   * [CrossBrowserTesting provider](https://github.com/sijosyn/testcafe-browser-provider-crossbrowsertesting) (by [@sijosyn](https://github.com/sijosyn))
   * [LambdaTest provider](https://github.com/LambdaTest/testcafe-browser-provider-lambdatest) (by [@kanhaiya15](https://github.com/kanhaiya15))


### PR DESCRIPTION
Removed SauceLabs provider from the list of TestCafe plugins.
