### PR TITLE
Quality: getTabById returns undefined when tab not found despite non-nullable return type

### DIFF
--- a/src/browser/provider/built-in/dedicated/chrome/cdp-client/utils.ts
+++ b/src/browser/provider/built-in/dedicated/chrome/cdp-client/utils.ts
@@ -16,8 +16,12 @@ export async function getTabs (port: number): Promise<TargetInfo[]> {
 
 export async function getTabById (port: number, id: string): Promise<TargetInfo> {
     const tabs = await getTabs(port);
+    const tab = tabs.find(tab => tab.id === id);
 
-    return tabs.find(tab => tab.id === id) as TargetInfo;
+    if (!tab)
+        throw new Error(`Tab with id "${id}" not found`);
+
+    return tab;
 }
 
 export async function getFirstTab (port: number): Promise<TargetInfo> {


### PR DESCRIPTION
## ✨ Code Quality

### Problem
`Array.prototype.find()` returns `undefined` when no element matches, but the function declares its return type as `Promise<TargetInfo>` (non-nullable). The `as TargetInfo` cast silences the compiler but doesn't prevent `undefined` at runtime. Any caller accessing properties on the result (e.g., `tab.url`, `tab.webSocketDebuggerUrl`) will get a TypeError: "Cannot read properties of undefined". This is especially likely during race conditions where a tab closes between `getTabs` and the caller using the result.


**Severity**: `high`
**File**: `src/browser/provider/built-in/dedicated/chrome/cdp-client/utils.ts`

### Solution
export async function getTabById (port: number, id: string): Promise<TargetInfo | undefined> {
    const tabs = await getTabs(port);

    return tabs.find(tab => tab.id === id);
}

// Or throw explicitly:
export async function getTabById (port: number, id: string): Promise<TargetInfo> {
    const tabs = await getTabs(port);
    const tab = tabs.find(tab => tab.id === id);

    if (!tab)
        throw new Error(`Tab with id "${id}" not found`);

    return tab;
}


### Changes
- `src/browser/provider/built-in/dedicated/chrome/cdp-client/utils.ts` (modified)



## Purpose
_Describe the problem you want to address or the feature you want to implement._

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._

## References
_Provide a link to the existing issue(s), if any._

## Pre-Merge TODO
- [ ] Write tests for your proposed changes
- [ ] Make sure that existing tests do not fail

---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #8542